### PR TITLE
🔀 :: (#424) 결재·문서·알림·프로필·검색 API + Prisma 스키마 확장

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -13,7 +13,11 @@ model User {
   email        String   @unique
   name         String
   passwordHash String
+  // 총관리자 전용 step-up 비밀번호 (일반 로그인 비밀번호와 분리).
+  // null 이면 일반 비밀번호로 fallback (초기 설정용).
+  superPasswordHash String?
   role         String   @default("MEMBER") // ADMIN | MANAGER | MEMBER
+  superAdmin   Boolean  @default(false)    // 최상위 관리자 - DM/팀 채팅 감사 권한 보유
   position     String?  // 사원/대리/과장/팀장/이사 등
   team         String?
   active       Boolean  @default(true)
@@ -31,6 +35,43 @@ model User {
   memberships  RoomMember[]
   logs         AuditLog[]
   cardExpenses CardExpense[]
+  notifications Notification[]
+  documents    Document[]       @relation("DocumentAuthor")
+  approvalsRequested Approval[] @relation("ApprovalRequester")
+  approvalReviews    ApprovalStep[] @relation("ApprovalReviewer")
+  passkeys     Passkey[]
+  desktopBios  DesktopBiometric[]
+  reactions    MessageReaction[]
+}
+
+/// Electron 데스크톱 앱에서 OS Touch ID 로 총관리자 잠금 해제할 수 있게 등록된 기기.
+/// Chromium WebAuthn 이 Electron 에서 플랫폼 인증기를 노출하지 않기 때문에 별도 관리.
+model DesktopBiometric {
+  id         String   @id @default(cuid())
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  deviceId   String   // Electron 이 userData 폴더에 생성한 안정적인 기기 UUID
+  deviceName String?
+  createdAt  DateTime @default(now())
+  lastUsedAt DateTime?
+
+  @@unique([userId, deviceId])
+  @@index([userId])
+}
+
+model Passkey {
+  id           String    @id @default(cuid())
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  credentialId String    @unique
+  publicKey    Bytes
+  counter      Int       @default(0)
+  transports   String?
+  deviceName   String?
+  createdAt    DateTime  @default(now())
+  lastUsedAt   DateTime?
+
+  @@index([userId])
 }
 
 model InviteKey {
@@ -51,17 +92,19 @@ model InviteKey {
 }
 
 model Event {
-  id        String   @id @default(cuid())
-  title     String
-  content   String?
-  scope     String   @default("COMPANY") // COMPANY | TEAM | PERSONAL
-  team      String?
-  startAt   DateTime
-  endAt     DateTime
-  color     String   @default("#36D7B7")
-  createdBy String
-  author    User     @relation(fields: [createdBy], references: [id], onDelete: Cascade)
-  createdAt DateTime @default(now())
+  id            String   @id @default(cuid())
+  title         String
+  content       String?
+  scope         String   @default("COMPANY") // COMPANY | TEAM | PERSONAL | TARGETED
+  team          String?
+  category      String   @default("OTHER") // MEETING | DEADLINE | OUT | HOLIDAY | EVENT | BIRTHDAY | TASK | OTHER
+  targetUserIds String?  // comma separated userIds (scope=TARGETED or mention targets)
+  startAt       DateTime
+  endAt         DateTime
+  color         String   @default("#3B5CF0")
+  createdBy     String
+  author        User     @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+  createdAt     DateTime @default(now())
 }
 
 model Leave {
@@ -130,13 +173,51 @@ model RoomMember {
 }
 
 model ChatMessage {
+  id          String    @id @default(cuid())
+  roomId      String
+  senderId    String
+  content     String
+  kind        String    @default("TEXT") // TEXT | IMAGE | VIDEO | FILE
+  fileUrl     String?
+  fileName    String?
+  fileType    String?
+  fileSize    Int?
+  mentions    String?   // comma-separated userIds
+  editedAt    DateTime?
+  deletedAt   DateTime?
+  scheduledAt DateTime?
+  createdAt   DateTime  @default(now())
+  room        ChatRoom  @relation(fields: [roomId], references: [id], onDelete: Cascade)
+  sender      User      @relation("Sender", fields: [senderId], references: [id], onDelete: Cascade)
+  reactions   MessageReaction[]
+
+  @@index([roomId, scheduledAt])
+}
+
+model MessageReaction {
+  id        String      @id @default(cuid())
+  messageId String
+  message   ChatMessage @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  userId    String
+  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  emoji     String
+  createdAt DateTime    @default(now())
+
+  @@unique([messageId, userId, emoji])
+  @@index([messageId])
+}
+
+model Team {
   id        String   @id @default(cuid())
-  roomId    String
-  senderId  String
-  content   String
+  name      String   @unique
   createdAt DateTime @default(now())
-  room      ChatRoom @relation(fields: [roomId], references: [id], onDelete: Cascade)
-  sender    User     @relation("Sender", fields: [senderId], references: [id], onDelete: Cascade)
+}
+
+model Position {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  rank      Int      @default(0)
+  createdAt DateTime @default(now())
 }
 
 model CardExpense {
@@ -152,6 +233,81 @@ model CardExpense {
   status     String   @default("PENDING") // PENDING | APPROVED | REJECTED
   reviewer   String?
   createdAt  DateTime @default(now())
+}
+
+model Notification {
+  id        String    @id @default(cuid())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  type      String    // NOTICE | DM | APPROVAL_REQUEST | APPROVAL_REVIEW | MENTION | SYSTEM
+  title     String
+  body      String?
+  linkUrl   String?
+  actorName String?   // 알림 유발자 이름 (ex. 메시지 발신자)
+  actorColor String?
+  readAt    DateTime?
+  createdAt DateTime  @default(now())
+
+  @@index([userId, readAt])
+}
+
+model Folder {
+  id        String     @id @default(cuid())
+  name      String
+  parentId  String?
+  parent    Folder?    @relation("FolderChildren", fields: [parentId], references: [id], onDelete: Cascade)
+  children  Folder[]   @relation("FolderChildren")
+  documents Document[]
+  createdAt DateTime   @default(now())
+}
+
+model Document {
+  id          String   @id @default(cuid())
+  title       String
+  description String?
+  folderId    String?
+  folder      Folder?  @relation(fields: [folderId], references: [id], onDelete: SetNull)
+  fileUrl     String?
+  fileName    String?
+  fileType    String?
+  fileSize    Int?
+  tags        String?  // comma separated
+  authorId    String
+  author      User     @relation("DocumentAuthor", fields: [authorId], references: [id], onDelete: Cascade)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
+model Approval {
+  id          String   @id @default(cuid())
+  type        String   // TRIP | EXPENSE | PURCHASE | GENERAL | OFFSITE | OTHER
+  title       String
+  content     String?
+  data        String?  // JSON
+  status      String   @default("PENDING") // PENDING | APPROVED | REJECTED | CANCELED
+  requesterId String
+  requester   User     @relation("ApprovalRequester", fields: [requesterId], references: [id], onDelete: Cascade)
+  startDate   DateTime?
+  endDate     DateTime?
+  amount      Int?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  steps       ApprovalStep[]
+}
+
+model ApprovalStep {
+  id         String   @id @default(cuid())
+  approvalId String
+  approval   Approval @relation(fields: [approvalId], references: [id], onDelete: Cascade)
+  reviewerId String
+  reviewer   User     @relation("ApprovalReviewer", fields: [reviewerId], references: [id], onDelete: Cascade)
+  order      Int
+  status     String   @default("PENDING") // PENDING | APPROVED | REJECTED | SKIPPED
+  comment    String?
+  actedAt    DateTime?
+
+  @@unique([approvalId, order])
+  @@index([reviewerId, status])
 }
 
 model AuditLog {

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -4,7 +4,7 @@ import bcrypt from "bcryptjs";
 const prisma = new PrismaClient();
 
 async function main() {
-  // 기본 관리자
+  // 기본 관리자 (Super Admin)
   const email = "admin@hinest.local";
   let admin = await prisma.user.findUnique({ where: { email } });
   if (!admin) {
@@ -15,6 +15,7 @@ async function main() {
         name: "관리자",
         passwordHash,
         role: "ADMIN",
+        superAdmin: true,
         position: "시스템관리자",
         team: "경영지원",
         avatarColor: "#36D7B7",
@@ -50,28 +51,75 @@ async function main() {
 
     console.log("Seeded admin:", email, "/ password: admin1234");
   } else {
-    console.log("Admin already exists:", email);
+    // 기존 admin 계정을 Super Admin 으로 승격(멱등)
+    if (!admin.superAdmin) {
+      await prisma.user.update({ where: { id: admin.id }, data: { superAdmin: true } });
+      console.log("Promoted admin to Super Admin:", email);
+    } else {
+      console.log("Admin already exists (Super Admin):", email);
+    }
   }
 
-  // 임시 테스트 관리자 계정
-  const testEmail = "test1234@hinest.local";
-  const testExisting = await prisma.user.findUnique({ where: { email: testEmail } });
-  if (!testExisting) {
-    const hash = await bcrypt.hash("test1234!", 10);
-    await prisma.user.create({
-      data: {
-        email: testEmail,
-        name: "테스트관리자",
+  // --- 테스트 계정 3종 ---
+  const accounts = [
+    {
+      email: "admin1",
+      name: "김하나",
+      password: "admin1234",
+      role: "ADMIN" as const,
+      superAdmin: true,
+      position: "이사",
+      team: "경영지원",
+      avatarColor: "#273990",
+    },
+    {
+      email: "admin2",
+      name: "이관리",
+      password: "admin1234",
+      role: "ADMIN" as const,
+      superAdmin: false,
+      position: "팀장",
+      team: "경영지원",
+      avatarColor: "#3D54C4",
+    },
+    {
+      email: "admin3",
+      name: "박직원",
+      password: "admin1234",
+      role: "MEMBER" as const,
+      superAdmin: false,
+      position: "사원",
+      team: "개발",
+      avatarColor: "#6278D0",
+    },
+  ];
+
+  for (const a of accounts) {
+    const hash = await bcrypt.hash(a.password, 10);
+    await prisma.user.upsert({
+      where: { email: a.email },
+      update: {
+        name: a.name,
         passwordHash: hash,
-        role: "ADMIN",
-        position: "테스터",
-        team: "QA",
-        avatarColor: "#1fbda0",
+        role: a.role,
+        superAdmin: a.superAdmin,
+        position: a.position,
+        team: a.team,
+        avatarColor: a.avatarColor,
+        active: true,
+      },
+      create: {
+        email: a.email,
+        name: a.name,
+        passwordHash: hash,
+        role: a.role,
+        superAdmin: a.superAdmin,
+        position: a.position,
+        team: a.team,
+        avatarColor: a.avatarColor,
       },
     });
-    console.log("Seeded test admin:", testEmail, "/ password: test1234!");
-  } else {
-    console.log("Test admin already exists:", testEmail);
+    console.log(`Upserted ${a.email} / ${a.password} (${a.role}${a.superAdmin ? "+SUPER" : ""})`);
   }
 }
 

--- a/server/scripts/checkSuper.ts
+++ b/server/scripts/checkSuper.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from "@prisma/client";
+const db = new PrismaClient();
+(async () => {
+  const all = await db.user.findMany({
+    select: { id: true, email: true, name: true, role: true, superAdmin: true, superPasswordHash: true, active: true },
+    orderBy: { createdAt: "asc" },
+  });
+  for (const u of all) {
+    console.log(`- ${u.email.padEnd(24)} name=${u.name}  role=${u.role}  super=${u.superAdmin}  superPwSet=${!!u.superPasswordHash}  active=${u.active}`);
+  }
+  await db.$disconnect();
+})();

--- a/server/scripts/createTestNotice.ts
+++ b/server/scripts/createTestNotice.ts
@@ -1,0 +1,48 @@
+import { prisma } from "../src/lib/db.js";
+import { notifyAllUsers } from "../src/lib/notify.js";
+
+async function main() {
+  // admin1(슈퍼관리자) 명의로 발송
+  const author = await prisma.user.findFirst({
+    where: { OR: [{ email: "admin1" }, { role: "ADMIN" }] },
+    orderBy: { createdAt: "asc" },
+  });
+  if (!author) {
+    console.error("관리자 계정을 찾을 수 없어요");
+    process.exit(1);
+  }
+
+  const title = "📌 4월 26일 금요일 조기퇴근 안내";
+  const content = [
+    "안녕하세요, 하이비츠 임직원 여러분.",
+    "",
+    "4월 26일(금)은 전사 봄맞이 행사로 16시 조기퇴근입니다.",
+    "일정을 참고하셔서 업무 마감 부탁드려요.",
+    "",
+    "감사합니다.",
+    "— 경영지원팀",
+  ].join("\n");
+
+  const notice = await prisma.notice.create({
+    data: { title, content, pinned: true, authorId: author.id },
+  });
+  await notifyAllUsers(
+    {
+      type: "NOTICE",
+      title: `📌 ${title}`,
+      body: content.slice(0, 120),
+      linkUrl: `/notice`,
+      actorName: author.name,
+    },
+    author.id // 작성자 본인은 제외
+  );
+
+  console.log("공지 생성 완료:", notice.id);
+  console.log("작성자:", author.name, `(${author.email})`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/scripts/sendTestDM.ts
+++ b/server/scripts/sendTestDM.ts
@@ -1,0 +1,75 @@
+import { prisma } from "../src/lib/db.js";
+import { notifyMany } from "../src/lib/notify.js";
+
+async function main() {
+  // CLI args: from / to / message
+  const args = Object.fromEntries(
+    process.argv.slice(2).map((a) => {
+      const [k, ...rest] = a.split("=");
+      return [k.replace(/^--/, ""), rest.join("=")];
+    })
+  ) as Record<string, string>;
+
+  const fromEmail = args.from ?? "admin2";
+  const toEmail = args.to ?? "admin1";
+  const content = args.msg ?? "안녕하세요 admin1님, 잠깐 얘기 가능하실까요? 🙂";
+
+  const sender = await prisma.user.findUnique({ where: { email: fromEmail } });
+  const receiver = await prisma.user.findUnique({ where: { email: toEmail } });
+  if (!sender || !receiver) {
+    console.error("유저를 찾을 수 없어요:", fromEmail, toEmail);
+    process.exit(1);
+  }
+
+  // 기존 DM 찾기
+  let room = await prisma.chatRoom.findFirst({
+    where: {
+      type: "DIRECT",
+      AND: [
+        { members: { some: { userId: sender.id } } },
+        { members: { some: { userId: receiver.id } } },
+      ],
+    },
+  });
+  if (!room) {
+    room = await prisma.chatRoom.create({
+      data: {
+        name: `DM:${sender.id}:${receiver.id}`,
+        type: "DIRECT",
+        members: { create: [{ userId: sender.id }, { userId: receiver.id }] },
+      },
+    });
+  }
+
+  const msg = await prisma.chatMessage.create({
+    data: {
+      roomId: room.id,
+      senderId: sender.id,
+      content,
+      kind: "TEXT",
+    },
+  });
+
+  await notifyMany([
+    {
+      userId: receiver.id,
+      type: "DM",
+      title: sender.name,
+      body: content.slice(0, 140),
+      linkUrl: `/chat?room=${room.id}`,
+      actorName: sender.name,
+    },
+  ]);
+
+  console.log("DM 전송 완료");
+  console.log("  발신:", sender.name, `(${sender.email})`);
+  console.log("  수신:", receiver.name, `(${receiver.email})`);
+  console.log("  방 ID:", room.id);
+  console.log("  메시지:", content);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/scripts/sendTestNotification.ts
+++ b/server/scripts/sendTestNotification.ts
@@ -1,0 +1,24 @@
+import { prisma } from "../src/lib/db.js";
+import { notifyAllUsers } from "../src/lib/notify.js";
+
+async function main() {
+  const users = await prisma.user.findMany({
+    where: { active: true },
+    select: { id: true, email: true },
+  });
+  await notifyAllUsers({
+    type: "SYSTEM",
+    title: "🔔 HiNest 테스트 알림",
+    body: "전 구성원에게 발송된 시스템 테스트 알림입니다. 탭이 비활성 상태면 OS 토스트로도 표시돼요.",
+    linkUrl: "/",
+    actorName: "시스템",
+  });
+  console.log("Notified:", users.length, "users");
+  users.forEach((u) => console.log("  -", u.email));
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/scripts/setSuperPassword.ts
+++ b/server/scripts/setSuperPassword.ts
@@ -1,0 +1,24 @@
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
+const NEW_SUPER_PASSWORD = process.argv[2] ?? "";
+if (!NEW_SUPER_PASSWORD) {
+  console.error("usage: npx tsx scripts/setSuperPassword.ts <password>");
+  process.exit(1);
+}
+
+const db = new PrismaClient();
+(async () => {
+  const hash = await bcrypt.hash(NEW_SUPER_PASSWORD, 10);
+  const admins = await db.user.findMany({
+    where: { superAdmin: true },
+    select: { id: true, email: true, name: true },
+  });
+  console.log("super admins:", admins);
+  const r = await db.user.updateMany({
+    where: { superAdmin: true },
+    data: { superPasswordHash: hash },
+  });
+  console.log(`updated ${r.count} super admin(s) — length=${NEW_SUPER_PASSWORD.length}`);
+  await db.$disconnect();
+})();

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -1,0 +1,66 @@
+import { prisma } from "./db.js";
+import { publish } from "./sse.js";
+
+export type NotifyType =
+  | "NOTICE"
+  | "DM"
+  | "APPROVAL_REQUEST"
+  | "APPROVAL_REVIEW"
+  | "MENTION"
+  | "SYSTEM";
+
+export interface NotifyInput {
+  userId: string;
+  type: NotifyType;
+  title: string;
+  body?: string;
+  linkUrl?: string;
+  actorName?: string;
+  actorColor?: string;
+}
+
+export async function notify(input: NotifyInput) {
+  try {
+    const created = await prisma.notification.create({ data: input });
+    publish(input.userId, "notification", created);
+  } catch (e) {
+    console.error("notify failed", e);
+  }
+}
+
+export async function notifyMany(inputs: NotifyInput[]) {
+  if (!inputs.length) return;
+  try {
+    await prisma.notification.createMany({ data: inputs });
+    // createMany 는 ID를 반환 안 하므로, userId 별 최신 한 건씩 가져와서 푸시
+    const byUser = new Map<string, NotifyInput>();
+    for (const i of inputs) byUser.set(i.userId, i);
+    const latest = await prisma.notification.findMany({
+      where: { userId: { in: Array.from(byUser.keys()) } },
+      orderBy: { createdAt: "desc" },
+      take: inputs.length,
+    });
+    // user별로 최신 1건만 푸시 (createMany 배치 안의 것 = 방금 생성된 것일 확률 높음)
+    const picked = new Map<string, (typeof latest)[number]>();
+    for (const n of latest) {
+      if (!picked.has(n.userId)) picked.set(n.userId, n);
+    }
+    for (const [uid, n] of picked) publish(uid, "notification", n);
+  } catch (e) {
+    console.error("notifyMany failed", e);
+  }
+}
+
+/** 전사 공지 — 총관리자 제외 모든 활성 유저에게 발송 */
+export async function notifyAllUsers(
+  tpl: Omit<NotifyInput, "userId">,
+  excludeUserId?: string
+) {
+  const users = await prisma.user.findMany({
+    where: { active: true, ...(excludeUserId ? { id: { not: excludeUserId } } : {}) },
+    select: { id: true },
+  });
+  await notifyMany(
+    users.map((u) => ({ ...tpl, userId: u.id }))
+  );
+}

--- a/server/src/lib/sse.ts
+++ b/server/src/lib/sse.ts
@@ -1,0 +1,54 @@
+import type { Response } from "express";
+
+/**
+ * Server-Sent Events 허브.
+ * - 유저별로 여러 커넥션(다른 탭/데스크톱 앱) 유지
+ * - publish(userId, event) 로 해당 유저의 모든 커넥션에 즉시 push
+ */
+
+type Client = {
+  id: number;
+  userId: string;
+  res: Response;
+};
+
+let seq = 0;
+const clients = new Map<string, Set<Client>>();
+
+export function addClient(userId: string, res: Response): Client {
+  const client: Client = { id: ++seq, userId, res };
+  if (!clients.has(userId)) clients.set(userId, new Set());
+  clients.get(userId)!.add(client);
+  return client;
+}
+
+export function removeClient(client: Client) {
+  const set = clients.get(client.userId);
+  if (!set) return;
+  set.delete(client);
+  if (set.size === 0) clients.delete(client.userId);
+}
+
+export function publish(userId: string, event: string, data: unknown) {
+  const set = clients.get(userId);
+  if (!set) return;
+  const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  for (const c of set) {
+    try {
+      c.res.write(payload);
+    } catch {
+      // ignore broken pipe
+    }
+  }
+}
+
+export function publishMany(userIds: string[], event: string, data: unknown) {
+  for (const u of userIds) publish(u, event, data);
+}
+
+/** 디버깅용 */
+export function clientCount() {
+  let n = 0;
+  for (const s of clients.values()) n += s.size;
+  return n;
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -2,12 +2,12 @@ import { Router } from "express";
 import { z } from "zod";
 import crypto from "node:crypto";
 import { prisma } from "../lib/db.js";
-import { requireAdmin, requireAuth, writeLog } from "../lib/auth.js";
+import { requireAdmin, requireAuth, requireSuperAdmin, requireSuperAdminStepUp, writeLog } from "../lib/auth.js";
 
 const router = Router();
 router.use(requireAuth, requireAdmin);
 
-// 초대키 목록
+/* ===== 초대키 ===== */
 router.get("/invites", async (_req, res) => {
   const keys = await prisma.inviteKey.findMany({
     orderBy: { createdAt: "desc" },
@@ -44,9 +44,7 @@ router.post("/invites", async (req, res) => {
       role: d.role,
       team: d.team || null,
       position: d.position || null,
-      expiresAt: d.expiresInDays
-        ? new Date(Date.now() + d.expiresInDays * 86400000)
-        : null,
+      expiresAt: d.expiresInDays ? new Date(Date.now() + d.expiresInDays * 86400000) : null,
       createdById: u.id,
     },
   });
@@ -61,9 +59,11 @@ router.delete("/invites/:id", async (req, res) => {
   res.json({ ok: true });
 });
 
-// 유저 목록
-router.get("/users", async (_req, res) => {
+/* ===== 유저 ===== */
+router.get("/users", async (req, res) => {
+  const u = (req as any).user;
   const users = await prisma.user.findMany({
+    where: u.superAdmin ? {} : { superAdmin: false }, // 일반 관리자에겐 총관리자 계정 은닉
     orderBy: { createdAt: "desc" },
     select: {
       id: true,
@@ -75,6 +75,7 @@ router.get("/users", async (_req, res) => {
       active: true,
       avatarColor: true,
       createdAt: true,
+      // superAdmin 필드는 의도적으로 반환하지 않음
     },
   });
   res.json({ users });
@@ -93,18 +94,15 @@ router.patch("/users/:id", async (req, res) => {
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
   const u = (req as any).user;
 
+  // 총관리자는 일반 관리자가 변경할 수 없음 — 404 처럼 위장해 존재를 노출하지 않음
+  const target = await prisma.user.findUnique({ where: { id: req.params.id } });
+  if (!target) return res.status(404).json({ error: "not found" });
+  if (target.superAdmin && !u.superAdmin) return res.status(404).json({ error: "not found" });
+
   const updated = await prisma.user.update({
     where: { id: req.params.id },
     data: parsed.data,
-    select: {
-      id: true,
-      email: true,
-      name: true,
-      role: true,
-      team: true,
-      position: true,
-      active: true,
-    },
+    select: { id: true, email: true, name: true, role: true, team: true, position: true, active: true },
   });
   await writeLog(u.id, "USER_UPDATE", req.params.id, JSON.stringify(parsed.data));
   res.json({ user: updated });
@@ -113,13 +111,109 @@ router.patch("/users/:id", async (req, res) => {
 router.delete("/users/:id", async (req, res) => {
   const u = (req as any).user;
   if (req.params.id === u.id) return res.status(400).json({ error: "본인은 삭제할 수 없습니다" });
+
+  const target = await prisma.user.findUnique({ where: { id: req.params.id } });
+  if (!target) return res.status(404).json({ error: "not found" });
+  if (target.superAdmin && !u.superAdmin) return res.status(404).json({ error: "not found" });
+
   await prisma.user.delete({ where: { id: req.params.id } });
   await writeLog(u.id, "USER_DELETE", req.params.id);
   res.json({ ok: true });
 });
 
-// 로그
-router.get("/logs", async (req, res) => {
+/* ===== 팀 ===== */
+router.get("/teams", async (_req, res) => {
+  const teams = await prisma.team.findMany({ orderBy: { createdAt: "asc" } });
+  res.json({ teams });
+});
+
+router.post("/teams", async (req, res) => {
+  const name = String(req.body?.name ?? "").trim();
+  if (!name) return res.status(400).json({ error: "이름을 입력해주세요" });
+  const u = (req as any).user;
+  try {
+    const team = await prisma.team.create({ data: { name } });
+    await writeLog(u.id, "TEAM_CREATE", team.id, name);
+    res.json({ team });
+  } catch (e: any) {
+    if (e?.code === "P2002") return res.status(400).json({ error: "이미 존재하는 팀" });
+    throw e;
+  }
+});
+
+router.patch("/teams/:id", async (req, res) => {
+  const name = String(req.body?.name ?? "").trim();
+  if (!name) return res.status(400).json({ error: "이름을 입력해주세요" });
+  const u = (req as any).user;
+  const prev = await prisma.team.findUnique({ where: { id: req.params.id } });
+  if (!prev) return res.status(404).json({ error: "not found" });
+  const team = await prisma.team.update({ where: { id: prev.id }, data: { name } });
+  // 사용자 team 문자열도 동기화
+  if (prev.name !== name) {
+    await prisma.user.updateMany({ where: { team: prev.name }, data: { team } });
+  }
+  await writeLog(u.id, "TEAM_UPDATE", team.id, `${prev.name} -> ${name}`);
+  res.json({ team });
+});
+
+router.delete("/teams/:id", async (req, res) => {
+  const u = (req as any).user;
+  const team = await prisma.team.findUnique({ where: { id: req.params.id } });
+  if (!team) return res.status(404).json({ error: "not found" });
+  await prisma.team.delete({ where: { id: team.id } });
+  await writeLog(u.id, "TEAM_DELETE", team.id, team.name);
+  res.json({ ok: true });
+});
+
+/* ===== 직급 ===== */
+router.get("/positions", async (_req, res) => {
+  const positions = await prisma.position.findMany({ orderBy: [{ rank: "asc" }, { createdAt: "asc" }] });
+  res.json({ positions });
+});
+
+router.post("/positions", async (req, res) => {
+  const name = String(req.body?.name ?? "").trim();
+  const rank = Number(req.body?.rank ?? 0);
+  if (!name) return res.status(400).json({ error: "이름을 입력해주세요" });
+  const u = (req as any).user;
+  try {
+    const position = await prisma.position.create({ data: { name, rank } });
+    await writeLog(u.id, "POSITION_CREATE", position.id, name);
+    res.json({ position });
+  } catch (e: any) {
+    if (e?.code === "P2002") return res.status(400).json({ error: "이미 존재하는 직급" });
+    throw e;
+  }
+});
+
+router.patch("/positions/:id", async (req, res) => {
+  const name = req.body?.name !== undefined ? String(req.body.name).trim() : undefined;
+  const rank = req.body?.rank !== undefined ? Number(req.body.rank) : undefined;
+  const u = (req as any).user;
+  const prev = await prisma.position.findUnique({ where: { id: req.params.id } });
+  if (!prev) return res.status(404).json({ error: "not found" });
+  const position = await prisma.position.update({
+    where: { id: prev.id },
+    data: { ...(name !== undefined && { name }), ...(rank !== undefined && { rank }) },
+  });
+  if (name && prev.name !== name) {
+    await prisma.user.updateMany({ where: { position: prev.name }, data: { position: name } });
+  }
+  await writeLog(u.id, "POSITION_UPDATE", position.id, `${prev.name} -> ${name ?? prev.name}`);
+  res.json({ position });
+});
+
+router.delete("/positions/:id", async (req, res) => {
+  const u = (req as any).user;
+  const position = await prisma.position.findUnique({ where: { id: req.params.id } });
+  if (!position) return res.status(404).json({ error: "not found" });
+  await prisma.position.delete({ where: { id: position.id } });
+  await writeLog(u.id, "POSITION_DELETE", position.id, position.name);
+  res.json({ ok: true });
+});
+
+/* ===== 로그 (총관리자 전용 · step-up 필요) ===== */
+router.get("/logs", requireSuperAdminStepUp, async (req, res) => {
   const limit = Math.min(Number(req.query.limit ?? 200), 500);
   const logs = await prisma.auditLog.findMany({
     orderBy: { createdAt: "desc" },

--- a/server/src/routes/approval.ts
+++ b/server/src/routes/approval.ts
@@ -1,0 +1,205 @@
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../lib/db.js";
+import { requireAuth, writeLog } from "../lib/auth.js";
+import { notify } from "../lib/notify.js";
+
+const router = Router();
+router.use(requireAuth);
+
+const approvalSchema = z.object({
+  type: z.enum(["TRIP", "EXPENSE", "PURCHASE", "GENERAL", "OFFSITE", "OTHER"]),
+  title: z.string().min(1),
+  content: z.string().optional(),
+  data: z.any().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  amount: z.number().int().optional(),
+  reviewerIds: z.array(z.string()).min(1),
+});
+
+router.get("/", async (req, res) => {
+  const u = (req as any).user;
+  const scope = String(req.query.scope ?? "mine"); // mine | pending | all
+  const where: any = {};
+  if (scope === "mine") where.requesterId = u.id;
+  else if (scope === "pending") {
+    // 내가 리뷰어이고, 아직 대기중이며 내 순번이 돌아온 것
+    where.steps = { some: { reviewerId: u.id, status: "PENDING" } };
+    where.status = "PENDING";
+  }
+  const list = await prisma.approval.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    include: {
+      requester: { select: { id: true, name: true, avatarColor: true, position: true, team: true } },
+      steps: {
+        orderBy: { order: "asc" },
+        include: { reviewer: { select: { id: true, name: true, avatarColor: true } } },
+      },
+    },
+  });
+
+  // 현재 차례(pending 중 첫 번째) 계산
+  const decorated = list.map((a) => {
+    const cur = a.steps.find((s) => s.status === "PENDING");
+    return { ...a, currentStepOrder: cur?.order ?? null, currentReviewerId: cur?.reviewerId ?? null };
+  });
+  res.json({ approvals: decorated });
+});
+
+router.get("/:id", async (req, res) => {
+  const u = (req as any).user;
+  const a = await prisma.approval.findUnique({
+    where: { id: req.params.id },
+    include: {
+      requester: { select: { id: true, name: true, avatarColor: true, position: true, team: true, email: true } },
+      steps: {
+        orderBy: { order: "asc" },
+        include: { reviewer: { select: { id: true, name: true, avatarColor: true, position: true } } },
+      },
+    },
+  });
+  if (!a) return res.status(404).json({ error: "not found" });
+  const canSee = a.requesterId === u.id || a.steps.some((s) => s.reviewerId === u.id) || u.role === "ADMIN";
+  if (!canSee) return res.status(403).json({ error: "forbidden" });
+  res.json({ approval: a });
+});
+
+router.post("/", async (req, res) => {
+  const parsed = approvalSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const u = (req as any).user;
+  const d = parsed.data;
+
+  const reviewers = Array.from(new Set(d.reviewerIds.filter((id) => id !== u.id)));
+  if (!reviewers.length) return res.status(400).json({ error: "결재자를 1명 이상 선택해주세요" });
+
+  const approval = await prisma.approval.create({
+    data: {
+      type: d.type,
+      title: d.title,
+      content: d.content,
+      data: d.data ? JSON.stringify(d.data) : null,
+      startDate: d.startDate ? new Date(d.startDate) : null,
+      endDate: d.endDate ? new Date(d.endDate) : null,
+      amount: d.amount,
+      requesterId: u.id,
+      steps: {
+        create: reviewers.map((rid, idx) => ({ reviewerId: rid, order: idx + 1 })),
+      },
+    },
+    include: { steps: true },
+  });
+  await writeLog(u.id, "APPROVAL_CREATE", approval.id, `${d.type}:${d.title}`);
+
+  const first = approval.steps.find((s) => s.order === 1);
+  if (first) {
+    await notify({
+      userId: first.reviewerId,
+      type: "APPROVAL_REQUEST",
+      title: `결재 요청 · ${labelForType(d.type)}`,
+      body: d.title,
+      linkUrl: `/approvals?id=${approval.id}`,
+      actorName: u.name,
+    });
+  }
+
+  res.json({ approval });
+});
+
+router.post("/:id/act", async (req, res) => {
+  const u = (req as any).user;
+  const action = String(req.body?.action ?? ""); // approve | reject
+  const comment = req.body?.comment ? String(req.body.comment) : undefined;
+  if (!["approve", "reject"].includes(action))
+    return res.status(400).json({ error: "invalid action" });
+
+  const a = await prisma.approval.findUnique({
+    where: { id: req.params.id },
+    include: { steps: { orderBy: { order: "asc" } } },
+  });
+  if (!a) return res.status(404).json({ error: "not found" });
+  if (a.status !== "PENDING") return res.status(400).json({ error: "이미 종결된 결재입니다" });
+
+  const currentStep = a.steps.find((s) => s.status === "PENDING");
+  if (!currentStep) return res.status(400).json({ error: "처리할 단계가 없습니다" });
+  if (currentStep.reviewerId !== u.id)
+    return res.status(403).json({ error: "본인 차례가 아닙니다" });
+
+  const newStatus = action === "approve" ? "APPROVED" : "REJECTED";
+  await prisma.approvalStep.update({
+    where: { id: currentStep.id },
+    data: { status: newStatus, comment, actedAt: new Date() },
+  });
+
+  if (action === "reject") {
+    await prisma.approval.update({ where: { id: a.id }, data: { status: "REJECTED" } });
+    await notify({
+      userId: a.requesterId,
+      type: "APPROVAL_REVIEW",
+      title: `결재 반려 · ${labelForType(a.type)}`,
+      body: `${a.title}\n${comment ?? ""}`.trim(),
+      linkUrl: `/approvals?id=${a.id}`,
+      actorName: u.name,
+    });
+  } else {
+    // approve → 다음 단계 알림 혹은 최종 승인
+    const next = a.steps.find((s) => s.order > currentStep.order && s.status === "PENDING");
+    if (next) {
+      await notify({
+        userId: next.reviewerId,
+        type: "APPROVAL_REQUEST",
+        title: `결재 요청 · ${labelForType(a.type)}`,
+        body: a.title,
+        linkUrl: `/approvals?id=${a.id}`,
+        actorName: u.name,
+      });
+    } else {
+      await prisma.approval.update({ where: { id: a.id }, data: { status: "APPROVED" } });
+      await notify({
+        userId: a.requesterId,
+        type: "APPROVAL_REVIEW",
+        title: `결재 승인 · ${labelForType(a.type)}`,
+        body: a.title,
+        linkUrl: `/approvals?id=${a.id}`,
+        actorName: u.name,
+      });
+    }
+  }
+
+  await writeLog(u.id, `APPROVAL_${action.toUpperCase()}`, a.id, a.title);
+
+  const refreshed = await prisma.approval.findUnique({
+    where: { id: a.id },
+    include: {
+      requester: { select: { id: true, name: true } },
+      steps: { orderBy: { order: "asc" }, include: { reviewer: { select: { id: true, name: true } } } },
+    },
+  });
+  res.json({ approval: refreshed });
+});
+
+router.post("/:id/cancel", async (req, res) => {
+  const u = (req as any).user;
+  const a = await prisma.approval.findUnique({ where: { id: req.params.id } });
+  if (!a) return res.status(404).json({ error: "not found" });
+  if (a.requesterId !== u.id) return res.status(403).json({ error: "forbidden" });
+  if (a.status !== "PENDING") return res.status(400).json({ error: "이미 종결되었습니다" });
+  await prisma.approval.update({ where: { id: a.id }, data: { status: "CANCELED" } });
+  await writeLog(u.id, "APPROVAL_CANCEL", a.id);
+  res.json({ ok: true });
+});
+
+function labelForType(t: string) {
+  return {
+    TRIP: "출장 신청",
+    OFFSITE: "외근 신청",
+    EXPENSE: "지출결의",
+    PURCHASE: "구매요청",
+    GENERAL: "일반 품의",
+    OTHER: "기타",
+  }[t] ?? t;
+}
+
+export default router;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -2,12 +2,24 @@ import { Router } from "express";
 import bcrypt from "bcryptjs";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
-import { signToken, setAuthCookie, clearAuthCookie, writeLog } from "../lib/auth.js";
+import {
+  signToken,
+  setAuthCookie,
+  clearAuthCookie,
+  writeLog,
+  requireAuth,
+  signSuper,
+  setSuperCookie,
+  clearSuperCookie,
+  verifySuperToken,
+  SUPER_TTL_SEC,
+  requireSuperAdminStepUp,
+} from "../lib/auth.js";
 
 const router = Router();
 
 const loginSchema = z.object({
-  email: z.string().email(),
+  email: z.string().min(1), // 이메일 형식 또는 사내 ID 모두 허용
   password: z.string().min(1),
 });
 
@@ -34,6 +46,7 @@ router.post("/login", async (req, res) => {
       team: user.team,
       position: user.position,
       avatarColor: user.avatarColor,
+      superAdmin: user.superAdmin,
     },
   });
 });
@@ -90,13 +103,132 @@ router.post("/signup", async (req, res) => {
       team: user.team,
       position: user.position,
       avatarColor: user.avatarColor,
+      superAdmin: user.superAdmin,
     },
   });
 });
 
 router.post("/logout", async (req, res) => {
   clearAuthCookie(res);
+  clearSuperCookie(res);
   res.json({ ok: true });
+});
+
+/* ===== 총관리자 step-up (비밀번호 재확인) ===== */
+router.post("/step-up", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const user = await prisma.user.findUnique({ where: { id: u.id } });
+  if (!user || !user.superAdmin) return res.status(403).json({ error: "forbidden" });
+  const password = String(req.body?.password ?? "");
+  if (!password) return res.status(400).json({ error: "비밀번호를 입력해주세요" });
+
+  // 총관리자는 반드시 별도의 super 비밀번호가 설정되어 있어야 함 — 일반 비밀번호 fallback 금지
+  if (!user.superPasswordHash) {
+    await writeLog(user.id, "SUPER_STEPUP_FAIL", undefined, "no_super_password_set", req.ip);
+    return res.status(403).json({ error: "총관리자 전용 비밀번호가 설정되어있지 않아요. 서버 관리자에게 문의하세요." });
+  }
+  const ok = await bcrypt.compare(password, user.superPasswordHash);
+  if (!ok) {
+    await writeLog(user.id, "SUPER_STEPUP_FAIL", undefined, undefined, req.ip);
+    return res.status(401).json({ error: "비밀번호가 일치하지 않습니다" });
+  }
+
+  const token = signSuper(user.id);
+  setSuperCookie(res, token);
+  await writeLog(user.id, "SUPER_STEPUP_OK", undefined, `ttl=${SUPER_TTL_SEC}s`, req.ip);
+  res.json({ ok: true, expiresAt: Date.now() + SUPER_TTL_SEC * 1000 });
+});
+
+/**
+ * ===== 데스크톱 앱 전용 생체 인증 =====
+ * Electron Chromium 이 macOS Touch ID 를 WebAuthn 플랫폼 인증기로 노출하지 못해서,
+ * main 프로세스가 직접 systemPreferences.promptTouchID 로 OS 프롬프트를 띄우는 별도 경로.
+ *
+ * 등록 플로우:
+ *   1. 총관리자가 비번으로 1차 step-up (기존 /auth/step-up)
+ *   2. step-up 상태에서 /auth/desktop-biometric/enroll 로 현재 기기의 deviceId 등록
+ * 잠금 해제:
+ *   3. 다음부터는 OS Touch ID 통과 + (userId, deviceId) 가 등록되어 있으면 super cookie 발급
+ *
+ * deviceId 는 Electron userData 폴더에 저장된 랜덤 UUID (main 프로세스가 생성).
+ * 사용자가 직접 수정할 수 없고 앱 재설치 시 재생성됨.
+ */
+router.get("/desktop-biometric", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const list = await prisma.desktopBiometric.findMany({
+    where: { userId: u.id },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, deviceId: true, deviceName: true, createdAt: true, lastUsedAt: true },
+  });
+  res.json({ devices: list });
+});
+
+router.post("/desktop-biometric/enroll", requireAuth, requireSuperAdminStepUp, async (req, res) => {
+  const u = (req as any).user;
+  const isDesktop = req.get("x-hinest-desktop") === "1";
+  if (!isDesktop) return res.status(400).json({ error: "데스크톱 앱에서만 등록할 수 있어요" });
+
+  const deviceId = String(req.body?.deviceId ?? "").trim();
+  const deviceName = String(req.body?.deviceName ?? "").trim() || null;
+  if (!deviceId || deviceId.length < 8) return res.status(400).json({ error: "invalid deviceId" });
+
+  const row = await prisma.desktopBiometric.upsert({
+    where: { userId_deviceId: { userId: u.id, deviceId } },
+    create: { userId: u.id, deviceId, deviceName },
+    update: { deviceName: deviceName ?? undefined },
+  });
+  await writeLog(u.id, "DESKTOP_BIO_ENROLL", row.id.slice(0, 8), deviceName ?? undefined, req.ip);
+  res.json({ ok: true, id: row.id });
+});
+
+router.delete("/desktop-biometric/:id", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const row = await prisma.desktopBiometric.findUnique({ where: { id: req.params.id } });
+  if (!row || row.userId !== u.id) return res.status(404).json({ error: "not found" });
+  await prisma.desktopBiometric.delete({ where: { id: row.id } });
+  await writeLog(u.id, "DESKTOP_BIO_REMOVE", row.id.slice(0, 8), row.deviceName ?? undefined, req.ip);
+  res.json({ ok: true });
+});
+
+router.post("/desktop-biometric/stepup", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const isDesktop = req.get("x-hinest-desktop") === "1";
+  if (!isDesktop) return res.status(400).json({ error: "데스크톱 앱에서만 사용할 수 있어요" });
+
+  const user = await prisma.user.findUnique({ where: { id: u.id } });
+  if (!user || !user.superAdmin) return res.status(403).json({ error: "forbidden" });
+
+  const deviceId = String(req.body?.deviceId ?? "").trim();
+  if (!deviceId) return res.status(400).json({ error: "invalid deviceId" });
+
+  const row = await prisma.desktopBiometric.findUnique({
+    where: { userId_deviceId: { userId: u.id, deviceId } },
+  });
+  if (!row) {
+    await writeLog(user.id, "SUPER_STEPUP_FAIL_DESKTOP_BIO", deviceId.slice(0, 8), "not_enrolled", req.ip);
+    return res.status(403).json({ error: "이 기기는 Touch ID 등록이 되어있지 않아요", code: "NOT_ENROLLED" });
+  }
+
+  await prisma.desktopBiometric.update({ where: { id: row.id }, data: { lastUsedAt: new Date() } });
+  const token = signSuper(user.id);
+  setSuperCookie(res, token);
+  await writeLog(user.id, "SUPER_STEPUP_OK_DESKTOP_BIO", row.id.slice(0, 8), row.deviceName ?? undefined, req.ip);
+  res.json({ ok: true, expiresAt: Date.now() + SUPER_TTL_SEC * 1000 });
+});
+
+router.post("/step-down", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  clearSuperCookie(res);
+  await writeLog(u.id, "SUPER_STEPDOWN", undefined, undefined, req.ip);
+  res.json({ ok: true });
+});
+
+router.get("/super-session", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  if (!u.superAdmin) return res.json({ active: false });
+  const v = verifySuperToken(req, u.id);
+  if (!v) return res.json({ active: false });
+  res.json({ active: true, expiresAt: v.exp });
 });
 
 export default router;

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -1,0 +1,132 @@
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../lib/db.js";
+import { requireAuth, writeLog } from "../lib/auth.js";
+
+const router = Router();
+router.use(requireAuth);
+
+/* ===== 폴더 ===== */
+router.get("/folders", async (_req, res) => {
+  const folders = await prisma.folder.findMany({
+    orderBy: [{ parentId: "asc" }, { createdAt: "asc" }],
+  });
+  res.json({ folders });
+});
+
+router.post("/folders", async (req, res) => {
+  const u = (req as any).user;
+  const name = String(req.body?.name ?? "").trim();
+  const parentId = req.body?.parentId || null;
+  if (!name) return res.status(400).json({ error: "이름이 필요합니다" });
+  const folder = await prisma.folder.create({ data: { name, parentId } });
+  await writeLog(u.id, "FOLDER_CREATE", folder.id, name);
+  res.json({ folder });
+});
+
+router.patch("/folders/:id", async (req, res) => {
+  const u = (req as any).user;
+  const name = req.body?.name !== undefined ? String(req.body.name).trim() : undefined;
+  if (!name) return res.status(400).json({ error: "이름이 필요합니다" });
+  const folder = await prisma.folder.update({ where: { id: req.params.id }, data: { name } });
+  await writeLog(u.id, "FOLDER_UPDATE", folder.id, name);
+  res.json({ folder });
+});
+
+router.delete("/folders/:id", async (req, res) => {
+  const u = (req as any).user;
+  await prisma.folder.delete({ where: { id: req.params.id } });
+  await writeLog(u.id, "FOLDER_DELETE", req.params.id);
+  res.json({ ok: true });
+});
+
+/* ===== 문서 ===== */
+const docSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  folderId: z.string().optional().nullable(),
+  fileUrl: z.string().optional(),
+  fileName: z.string().optional(),
+  fileType: z.string().optional(),
+  fileSize: z.number().int().optional(),
+  tags: z.string().optional(),
+});
+
+router.get("/", async (req, res) => {
+  const folderId = req.query.folderId ? String(req.query.folderId) : undefined;
+  const q = req.query.q ? String(req.query.q).trim() : "";
+  const where: any = {};
+  if (folderId === "root") where.folderId = null;
+  else if (folderId) where.folderId = folderId;
+  if (q) where.OR = [
+    { title: { contains: q } },
+    { description: { contains: q } },
+    { tags: { contains: q } },
+  ];
+  const docs = await prisma.document.findMany({
+    where,
+    orderBy: { updatedAt: "desc" },
+    include: {
+      author: { select: { name: true, avatarColor: true } },
+      folder: { select: { name: true } },
+    },
+  });
+  res.json({ documents: docs });
+});
+
+router.post("/", async (req, res) => {
+  const parsed = docSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const u = (req as any).user;
+  const d = parsed.data;
+  const doc = await prisma.document.create({
+    data: {
+      title: d.title,
+      description: d.description,
+      folderId: d.folderId ?? null,
+      fileUrl: d.fileUrl,
+      fileName: d.fileName,
+      fileType: d.fileType,
+      fileSize: d.fileSize,
+      tags: d.tags,
+      authorId: u.id,
+    },
+  });
+  await writeLog(u.id, "DOC_CREATE", doc.id, d.title);
+  res.json({ document: doc });
+});
+
+router.patch("/:id", async (req, res) => {
+  const parsed = docSchema.partial().safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const u = (req as any).user;
+  const exist = await prisma.document.findUnique({ where: { id: req.params.id } });
+  if (!exist) return res.status(404).json({ error: "not found" });
+  if (exist.authorId !== u.id && u.role !== "ADMIN")
+    return res.status(403).json({ error: "forbidden" });
+  const d = parsed.data;
+  const doc = await prisma.document.update({
+    where: { id: exist.id },
+    data: {
+      ...(d.title !== undefined && { title: d.title }),
+      ...(d.description !== undefined && { description: d.description }),
+      ...(d.folderId !== undefined && { folderId: d.folderId }),
+      ...(d.tags !== undefined && { tags: d.tags }),
+    },
+  });
+  await writeLog(u.id, "DOC_UPDATE", doc.id);
+  res.json({ document: doc });
+});
+
+router.delete("/:id", async (req, res) => {
+  const u = (req as any).user;
+  const exist = await prisma.document.findUnique({ where: { id: req.params.id } });
+  if (!exist) return res.status(404).json({ error: "not found" });
+  if (exist.authorId !== u.id && u.role !== "ADMIN")
+    return res.status(403).json({ error: "forbidden" });
+  await prisma.document.delete({ where: { id: exist.id } });
+  await writeLog(u.id, "DOC_DELETE", req.params.id);
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/src/routes/me.ts
+++ b/server/src/routes/me.ts
@@ -17,6 +17,7 @@ router.get("/", requireAuth, async (req, res) => {
       team: user.team,
       position: user.position,
       avatarColor: user.avatarColor,
+      superAdmin: user.superAdmin,
     },
   });
 });

--- a/server/src/routes/notice.ts
+++ b/server/src/routes/notice.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
+import { notifyAllUsers } from "../lib/notify.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -30,6 +31,16 @@ router.post("/", async (req, res) => {
     data: { title: d.title, content: d.content, pinned: !!d.pinned, authorId: u.id },
   });
   await writeLog(u.id, "NOTICE_CREATE", n.id, d.title);
+  await notifyAllUsers(
+    {
+      type: "NOTICE",
+      title: d.pinned ? `📌 ${d.title}` : d.title,
+      body: d.content.slice(0, 120),
+      linkUrl: `/notice`,
+      actorName: u.name,
+    },
+    u.id
+  );
   res.json({ notice: n });
 });
 

--- a/server/src/routes/notification.ts
+++ b/server/src/routes/notification.ts
@@ -1,0 +1,82 @@
+import { Router } from "express";
+import { prisma } from "../lib/db.js";
+import { requireAuth } from "../lib/auth.js";
+import { addClient, removeClient } from "../lib/sse.js";
+
+const router = Router();
+
+/* ===== Server-Sent Events 스트림 (인증 쿠키 사용) ===== */
+router.get("/stream", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
+  (res as any).flushHeaders?.();
+
+  res.write(`event: ready\ndata: ${JSON.stringify({ t: Date.now() })}\n\n`);
+
+  const client = addClient(u.id, res);
+
+  // 15초마다 keepalive 주석 라인 (프록시·브라우저 idle 타임아웃 방지)
+  const heartbeat = setInterval(() => {
+    try {
+      res.write(`: ping ${Date.now()}\n\n`);
+    } catch {}
+  }, 15_000);
+
+  req.on("close", () => {
+    clearInterval(heartbeat);
+    removeClient(client);
+  });
+});
+
+router.use(requireAuth);
+
+router.get("/", async (req, res) => {
+  const u = (req as any).user;
+  const scope = String(req.query.scope ?? "all"); // all | unread
+  const where: any = { userId: u.id };
+  if (scope === "unread") where.readAt = null;
+  const [items, unread] = await Promise.all([
+    prisma.notification.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: 100,
+    }),
+    prisma.notification.count({ where: { userId: u.id, readAt: null } }),
+  ]);
+  res.json({ notifications: items, unread });
+});
+
+router.post("/read", async (req, res) => {
+  const u = (req as any).user;
+  const ids: string[] | undefined = req.body?.ids;
+  const all: boolean = !!req.body?.all;
+  if (all) {
+    await prisma.notification.updateMany({
+      where: { userId: u.id, readAt: null },
+      data: { readAt: new Date() },
+    });
+  } else if (ids && ids.length) {
+    await prisma.notification.updateMany({
+      where: { userId: u.id, id: { in: ids }, readAt: null },
+      data: { readAt: new Date() },
+    });
+  }
+  const unread = await prisma.notification.count({
+    where: { userId: u.id, readAt: null },
+  });
+  res.json({ ok: true, unread });
+});
+
+router.delete("/:id", async (req, res) => {
+  const u = (req as any).user;
+  await prisma.notification.deleteMany({
+    where: { id: req.params.id, userId: u.id },
+  });
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/src/routes/passkey.ts
+++ b/server/src/routes/passkey.ts
@@ -1,0 +1,240 @@
+import { Router } from "express";
+import { prisma } from "../lib/db.js";
+import {
+  requireAuth,
+  requireSuperAdminStepUp,
+  signSuper,
+  setSuperCookie,
+  writeLog,
+  SUPER_TTL_SEC,
+} from "../lib/auth.js";
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+  type VerifiedRegistrationResponse,
+  type VerifiedAuthenticationResponse,
+} from "@simplewebauthn/server";
+
+const router = Router();
+
+/** dev 환경에선 localhost 기본값. 운영 시 환경변수로 조정. */
+const RP_ID = process.env.WEBAUTHN_RP_ID ?? "localhost";
+const RP_NAME = "HiNest";
+const ORIGINS = (process.env.WEBAUTHN_ORIGINS ?? "http://localhost:1000,http://127.0.0.1:1000").split(",");
+
+// 챌린지 임시 저장 (5분 TTL)
+type Challenge = { value: string; expiresAt: number; purpose: "register" | "auth" };
+const challenges = new Map<string, Challenge>();
+function setChallenge(userId: string, value: string, purpose: "register" | "auth") {
+  challenges.set(userId, { value, expiresAt: Date.now() + 5 * 60 * 1000, purpose });
+}
+function takeChallenge(userId: string, purpose: "register" | "auth") {
+  const c = challenges.get(userId);
+  if (!c) return null;
+  if (c.expiresAt < Date.now() || c.purpose !== purpose) {
+    challenges.delete(userId);
+    return null;
+  }
+  challenges.delete(userId);
+  return c.value;
+}
+
+function toB64Url(buf: Buffer | Uint8Array) {
+  return Buffer.from(buf).toString("base64url");
+}
+function fromB64Url(s: string) {
+  return Buffer.from(s, "base64url");
+}
+
+/* ================ 등록(registration) ================
+ * - 본인 확인된(step-up 완료) 사용자만 새 패스키 등록 가능
+ * - 총관리자든 일반 사용자든 본인 계정에 추가
+ */
+router.post("/register/options", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  // 총관리자가 새 기기 등록하려면 우선 비번 step-up 필요 (관리자 페이지에서만 표시)
+  // requireSuperAdminStepUp 는 총관리자 전용이라, 여기선 일반 유저도 등록 가능하게 allow
+  const user = await prisma.user.findUnique({ where: { id: u.id } });
+  if (!user) return res.status(404).json({ error: "not found" });
+
+  const existing = await prisma.passkey.findMany({ where: { userId: u.id } });
+  const options = await generateRegistrationOptions({
+    rpName: RP_NAME,
+    rpID: RP_ID,
+    userID: new TextEncoder().encode(user.id),
+    userName: user.email,
+    userDisplayName: user.name,
+    attestationType: "none",
+    authenticatorSelection: {
+      authenticatorAttachment: "platform", // Touch ID / Face ID 우선
+      residentKey: "preferred",
+      userVerification: "required",
+    },
+    excludeCredentials: existing.map((c) => ({
+      id: c.credentialId,
+      transports: c.transports?.split(",") as any[] | undefined,
+    })),
+    timeout: 60_000,
+  });
+
+  setChallenge(u.id, options.challenge, "register");
+  res.json(options);
+});
+
+router.post("/register/verify", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const expected = takeChallenge(u.id, "register");
+  if (!expected) return res.status(400).json({ error: "챌린지가 만료되었어요. 다시 시도해주세요." });
+
+  let verification: VerifiedRegistrationResponse;
+  try {
+    verification = await verifyRegistrationResponse({
+      response: req.body?.response,
+      expectedChallenge: expected,
+      expectedOrigin: ORIGINS,
+      expectedRPID: RP_ID,
+      requireUserVerification: true,
+    });
+  } catch (e: any) {
+    return res.status(400).json({ error: e?.message ?? "등록 실패" });
+  }
+
+  if (!verification.verified || !verification.registrationInfo) {
+    return res.status(400).json({ error: "등록을 검증하지 못했어요" });
+  }
+
+  const info = verification.registrationInfo;
+  const credential = info.credential;
+  const credentialId = credential.id;
+  const publicKey = Buffer.from(credential.publicKey);
+  const counter = credential.counter ?? 0;
+  const transports = (credential.transports ?? req.body?.response?.response?.transports)?.join(",");
+
+  const deviceName = String(req.body?.deviceName ?? inferDeviceName(req.get("user-agent") ?? ""));
+
+  await prisma.passkey.create({
+    data: {
+      userId: u.id,
+      credentialId,
+      publicKey,
+      counter,
+      transports,
+      deviceName,
+    },
+  });
+  await writeLog(u.id, "PASSKEY_REGISTER", credentialId.slice(0, 16), deviceName, req.ip);
+  res.json({ ok: true });
+});
+
+/* ================ 인증(authentication) ================ */
+router.post("/auth/options", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const list = await prisma.passkey.findMany({ where: { userId: u.id } });
+  if (list.length === 0) return res.status(400).json({ error: "등록된 패스키가 없어요", code: "NO_PASSKEY" });
+
+  const options = await generateAuthenticationOptions({
+    rpID: RP_ID,
+    allowCredentials: list.map((c) => ({
+      id: c.credentialId,
+      transports: c.transports?.split(",") as any[] | undefined,
+    })),
+    userVerification: "required",
+    timeout: 60_000,
+  });
+  setChallenge(u.id, options.challenge, "auth");
+  res.json(options);
+});
+
+router.post("/auth/verify", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const expected = takeChallenge(u.id, "auth");
+  if (!expected) return res.status(400).json({ error: "챌린지가 만료되었어요. 다시 시도해주세요." });
+
+  const responseData = req.body?.response;
+  const credentialId = responseData?.id;
+  if (!credentialId) return res.status(400).json({ error: "invalid response" });
+
+  const stored = await prisma.passkey.findUnique({ where: { credentialId } });
+  if (!stored || stored.userId !== u.id) {
+    return res.status(400).json({ error: "알 수 없는 패스키" });
+  }
+
+  let verification: VerifiedAuthenticationResponse;
+  try {
+    verification = await verifyAuthenticationResponse({
+      response: responseData,
+      expectedChallenge: expected,
+      expectedOrigin: ORIGINS,
+      expectedRPID: RP_ID,
+      credential: {
+        id: stored.credentialId,
+        publicKey: new Uint8Array(stored.publicKey),
+        counter: stored.counter,
+        transports: stored.transports?.split(",") as any[] | undefined,
+      },
+      requireUserVerification: true,
+    });
+  } catch (e: any) {
+    await writeLog(u.id, "PASSKEY_AUTH_FAIL", credentialId.slice(0, 16), e?.message, req.ip);
+    return res.status(400).json({ error: e?.message ?? "인증 실패" });
+  }
+
+  if (!verification.verified) {
+    await writeLog(u.id, "PASSKEY_AUTH_FAIL", credentialId.slice(0, 16), "verified=false", req.ip);
+    return res.status(400).json({ error: "인증 실패" });
+  }
+
+  await prisma.passkey.update({
+    where: { id: stored.id },
+    data: { counter: verification.authenticationInfo.newCounter, lastUsedAt: new Date() },
+  });
+
+  // 총관리자면 super 쿠키 발급
+  const fresh = await prisma.user.findUnique({ where: { id: u.id } });
+  if (fresh?.superAdmin) {
+    const token = signSuper(fresh.id);
+    setSuperCookie(res, token);
+    await writeLog(fresh.id, "SUPER_STEPUP_OK_PASSKEY", undefined, stored.deviceName ?? undefined, req.ip);
+    return res.json({ ok: true, super: true, expiresAt: Date.now() + SUPER_TTL_SEC * 1000 });
+  }
+  await writeLog(u.id, "PASSKEY_AUTH_OK", stored.id, stored.deviceName ?? undefined, req.ip);
+  res.json({ ok: true });
+});
+
+/* ================ 기기 관리 ================ */
+router.get("/", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const list = await prisma.passkey.findMany({
+    where: { userId: u.id },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, deviceName: true, createdAt: true, lastUsedAt: true, transports: true },
+  });
+  res.json({ passkeys: list });
+});
+
+router.delete("/:id", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const pk = await prisma.passkey.findUnique({ where: { id: req.params.id } });
+  if (!pk || pk.userId !== u.id) return res.status(404).json({ error: "not found" });
+  await prisma.passkey.delete({ where: { id: pk.id } });
+  await writeLog(u.id, "PASSKEY_DELETE", pk.id, pk.deviceName ?? undefined, req.ip);
+  res.json({ ok: true });
+});
+
+function inferDeviceName(ua: string) {
+  const u = ua.toLowerCase();
+  if (u.includes("iphone")) return "iPhone";
+  if (u.includes("ipad")) return "iPad";
+  if (u.includes("macintosh") || u.includes("mac os")) return "Mac";
+  if (u.includes("android")) return "Android";
+  if (u.includes("windows")) return "Windows";
+  return "기기";
+}
+
+// 미사용 경고 방지
+void requireSuperAdminStepUp;
+void toB64Url; void fromB64Url;
+
+export default router;

--- a/server/src/routes/profile.ts
+++ b/server/src/routes/profile.ts
@@ -1,0 +1,51 @@
+import { Router } from "express";
+import { z } from "zod";
+import bcrypt from "bcryptjs";
+import { prisma } from "../lib/db.js";
+import { requireAuth, writeLog } from "../lib/auth.js";
+
+const router = Router();
+router.use(requireAuth);
+
+const schema = z.object({
+  name: z.string().min(1).optional(),
+  avatarColor: z.string().regex(/^#([0-9A-Fa-f]{6})$/).optional(),
+});
+
+router.patch("/", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const d = parsed.data;
+  const user = await prisma.user.update({
+    where: { id: u.id },
+    data: d,
+    select: { id: true, name: true, email: true, avatarColor: true, team: true, position: true, role: true },
+  });
+  await writeLog(u.id, "PROFILE_UPDATE", u.id, JSON.stringify(d));
+  res.json({ user });
+});
+
+const pwSchema = z.object({
+  current: z.string().min(1),
+  next: z.string().min(6),
+});
+
+router.post("/password", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = pwSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "새 비밀번호는 6자 이상" });
+  const user = await prisma.user.findUnique({ where: { id: u.id } });
+  if (!user) return res.status(404).json({ error: "not found" });
+  const ok = await bcrypt.compare(parsed.data.current, user.passwordHash);
+  if (!ok) {
+    await writeLog(u.id, "PASSWORD_CHANGE_FAIL", undefined, undefined, req.ip);
+    return res.status(401).json({ error: "현재 비밀번호가 일치하지 않습니다" });
+  }
+  const hash = await bcrypt.hash(parsed.data.next, 10);
+  await prisma.user.update({ where: { id: user.id }, data: { passwordHash: hash } });
+  await writeLog(u.id, "PASSWORD_CHANGE", undefined, undefined, req.ip);
+  res.json({ ok: true });
+});
+
+export default router;

--- a/server/src/routes/schedule.ts
+++ b/server/src/routes/schedule.ts
@@ -2,10 +2,59 @@ import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
+import { notifyMany } from "../lib/notify.js";
 
 const router = Router();
 router.use(requireAuth);
 
+const CATEGORIES = [
+  "MEETING",
+  "DEADLINE",
+  "OUT",
+  "HOLIDAY",
+  "EVENT",
+  "BIRTHDAY",
+  "TASK",
+  "INTERVIEW",
+  "TRAINING",
+  "CLIENT",
+  "SOCIAL",
+  "HEALTH",
+  "PERSONAL_C",
+  "COMPANY_HOLIDAY",
+  "COMPANY_LEAVE",
+  "OTHER",
+] as const;
+
+const CATEGORY_LABEL: Record<(typeof CATEGORIES)[number], string> = {
+  MEETING: "회의",
+  DEADLINE: "마감",
+  OUT: "외근·출장",
+  HOLIDAY: "휴가",
+  EVENT: "사내행사",
+  BIRTHDAY: "기념일",
+  TASK: "업무",
+  INTERVIEW: "면접",
+  TRAINING: "교육·워크샵",
+  CLIENT: "고객·미팅",
+  SOCIAL: "회식·모임",
+  HEALTH: "건강·병원",
+  PERSONAL_C: "개인일정",
+  COMPANY_HOLIDAY: "사내 휴일",
+  COMPANY_LEAVE: "전사 휴가",
+  OTHER: "일반",
+};
+
+const ADMIN_ONLY_CATEGORIES = new Set(["COMPANY_HOLIDAY", "COMPANY_LEAVE"]);
+
+/**
+ * 일정 목록.
+ * 공유 규칙:
+ *  - COMPANY   → 모두 열람
+ *  - TEAM      → 같은 team 에 속한 유저만 열람
+ *  - PERSONAL  → 본인만 열람
+ *  - TARGETED  → 지정된 targetUserIds 에 포함되거나 본인이 만든 일정만 열람
+ */
 router.get("/", async (req, res) => {
   const u = (req as any).user;
   const meUser = await prisma.user.findUnique({ where: { id: u.id } });
@@ -17,6 +66,8 @@ router.get("/", async (req, res) => {
       { scope: "COMPANY" },
       { scope: "TEAM", team: meUser?.team ?? "" },
       { scope: "PERSONAL", createdBy: u.id },
+      { scope: "TARGETED", createdBy: u.id },
+      { scope: "TARGETED", targetUserIds: { contains: u.id } },
     ],
   };
   if (from || to) {
@@ -28,7 +79,7 @@ router.get("/", async (req, res) => {
   const events = await prisma.event.findMany({
     where,
     orderBy: { startAt: "asc" },
-    include: { author: { select: { name: true } } },
+    include: { author: { select: { name: true, avatarColor: true } } },
   });
   res.json({ events });
 });
@@ -36,8 +87,10 @@ router.get("/", async (req, res) => {
 const eventSchema = z.object({
   title: z.string().min(1),
   content: z.string().optional(),
-  scope: z.enum(["COMPANY", "TEAM", "PERSONAL"]).default("PERSONAL"),
+  scope: z.enum(["COMPANY", "TEAM", "PERSONAL", "TARGETED"]).default("PERSONAL"),
   team: z.string().optional().nullable(),
+  category: z.enum(CATEGORIES).default("OTHER"),
+  targetUserIds: z.array(z.string()).optional(),
   startAt: z.string(),
   endAt: z.string(),
   color: z.string().optional(),
@@ -52,19 +105,81 @@ router.post("/", async (req, res) => {
   if (d.scope === "COMPANY" && u.role === "MEMBER")
     return res.status(403).json({ error: "전사 일정은 관리자/매니저만 등록 가능" });
 
+  if (ADMIN_ONLY_CATEGORIES.has(d.category) && u.role === "MEMBER")
+    return res.status(403).json({ error: "해당 카테고리는 관리자/매니저만 등록 가능" });
+
+  const me = await prisma.user.findUnique({ where: { id: u.id } });
+
+  const targets = (d.targetUserIds ?? []).filter((id) => id && id !== u.id);
+
   const ev = await prisma.event.create({
     data: {
       title: d.title,
       content: d.content,
       scope: d.scope,
-      team: d.team ?? null,
+      team: d.scope === "TEAM" ? (d.team ?? me?.team ?? null) : (d.team ?? null),
+      category: d.category,
+      targetUserIds: targets.length ? targets.join(",") : null,
       startAt: new Date(d.startAt),
       endAt: new Date(d.endAt),
-      color: d.color ?? "#36D7B7",
+      color: d.color ?? "#3B5CF0",
       createdBy: u.id,
     },
   });
-  await writeLog(u.id, "EVENT_CREATE", ev.id, d.title);
+  await writeLog(u.id, "EVENT_CREATE", ev.id, `${d.category}:${d.title}`);
+
+  // 알림 대상 산정
+  //  - COMPANY : 전원(본인 제외)
+  //  - TEAM    : 같은 팀원(본인 제외)
+  //  - TARGETED: 지정된 유저 + (선택) 본인 제외
+  //  - PERSONAL: 없음
+  let recipientIds: string[] = [];
+  if (d.scope === "COMPANY") {
+    const users = await prisma.user.findMany({
+      where: { active: true, id: { not: u.id }, superAdmin: false },
+      select: { id: true },
+    });
+    recipientIds = users.map((x) => x.id);
+  } else if (d.scope === "TEAM") {
+    const team = d.team ?? me?.team;
+    if (team) {
+      const users = await prisma.user.findMany({
+        where: { active: true, team, id: { not: u.id } },
+        select: { id: true },
+      });
+      recipientIds = users.map((x) => x.id);
+    }
+  } else if (d.scope === "TARGETED") {
+    recipientIds = targets;
+  }
+
+  if (recipientIds.length) {
+    const when = new Date(d.startAt).toLocaleString("ko-KR", {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    const scopeLabel =
+      d.scope === "COMPANY"
+        ? "전사 일정"
+        : d.scope === "TEAM"
+        ? `${d.team ?? me?.team ?? "팀"} 팀 일정`
+        : "새 일정 태그";
+    const categoryLabel = CATEGORY_LABEL[d.category];
+
+    await notifyMany(
+      recipientIds.map((rid) => ({
+        userId: rid,
+        type: d.scope === "TARGETED" ? ("MENTION" as const) : ("SYSTEM" as const),
+        title: `${scopeLabel} · ${categoryLabel}`,
+        body: `${u.name} · ${when}\n${d.title}`,
+        linkUrl: `/schedule`,
+        actorName: u.name,
+      }))
+    );
+  }
+
   res.json({ event: ev });
 });
 

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -1,0 +1,97 @@
+import { Router } from "express";
+import { prisma } from "../lib/db.js";
+import { requireAuth } from "../lib/auth.js";
+
+const router = Router();
+router.use(requireAuth);
+
+/**
+ * 글로벌 검색. 결과는 섹션별로 묶어서 반환.
+ * - people : 유저 (총관리자는 제외)
+ * - notices
+ * - events (내가 볼 수 있는)
+ * - documents
+ * - messages (내가 멤버인 방만)
+ */
+router.get("/", async (req, res) => {
+  const u = (req as any).user;
+  const q = String(req.query.q ?? "").trim();
+  if (q.length < 1) return res.json({ q, results: {} });
+
+  const meUser = await prisma.user.findUnique({ where: { id: u.id } });
+
+  const [people, notices, events, documents, messages] = await Promise.all([
+    prisma.user.findMany({
+      where: {
+        active: true,
+        OR: [{ superAdmin: false }, { id: u.id }],
+        AND: [
+          {
+            OR: [
+              { name: { contains: q } },
+              { email: { contains: q } },
+              { team: { contains: q } },
+              { position: { contains: q } },
+            ],
+          },
+        ],
+      },
+      take: 8,
+      select: { id: true, name: true, email: true, team: true, position: true, avatarColor: true },
+    }),
+    prisma.notice.findMany({
+      where: {
+        OR: [{ title: { contains: q } }, { content: { contains: q } }],
+      },
+      take: 8,
+      orderBy: { createdAt: "desc" },
+      include: { author: { select: { name: true } } },
+    }),
+    prisma.event.findMany({
+      where: {
+        AND: [
+          {
+            OR: [
+              { scope: "COMPANY" },
+              { scope: "TEAM", team: meUser?.team ?? "" },
+              { scope: "PERSONAL", createdBy: u.id },
+            ],
+          },
+          {
+            OR: [{ title: { contains: q } }, { content: { contains: q } }],
+          },
+        ],
+      },
+      take: 8,
+      orderBy: { startAt: "desc" },
+    }),
+    prisma.document.findMany({
+      where: {
+        OR: [{ title: { contains: q } }, { description: { contains: q } }, { tags: { contains: q } }],
+      },
+      take: 8,
+      orderBy: { updatedAt: "desc" },
+      include: { author: { select: { name: true } }, folder: { select: { name: true } } },
+    }),
+    prisma.chatMessage.findMany({
+      where: {
+        deletedAt: null,
+        room: { members: { some: { userId: u.id } } },
+        content: { contains: q },
+      },
+      take: 8,
+      orderBy: { createdAt: "desc" },
+      include: {
+        sender: { select: { name: true, avatarColor: true } },
+        room: { select: { id: true, name: true, type: true } },
+      },
+    }),
+  ]);
+
+  res.json({
+    q,
+    results: { people, notices, events, documents, messages },
+  });
+});
+
+export default router;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -5,10 +5,14 @@ import { requireAuth } from "../lib/auth.js";
 const router = Router();
 router.use(requireAuth);
 
-// 팀원 목록 (일반 유저도 볼 수 있음)
-router.get("/", async (_req, res) => {
+// 팀원 목록 (일반 유저도 볼 수 있음) — 총관리자는 자신 외엔 보이지 않음
+router.get("/", async (req, res) => {
+  const u = (req as any).user;
   const users = await prisma.user.findMany({
-    where: { active: true },
+    where: {
+      active: true,
+      OR: [{ superAdmin: false }, { id: u.id }],
+    },
     orderBy: { name: "asc" },
     select: {
       id: true,

--- a/server/src/routes/version.ts
+++ b/server/src/routes/version.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+
+/**
+ * 데스크톱 앱 버전 관리 엔드포인트.
+ *
+ * 배포 플로우:
+ *  - 새 데스크톱 앱 빌드를 발행할 때, 아래 LATEST_DESKTOP_VERSION 을 올리고 서버 재시작
+ *  - 클라이언트는 이 값과 자기 앱 버전(preload 에서 넘겨주는 electron app.getVersion) 을 비교
+ *  - 다르면 UpdateBanner 로 "새 버전 나왔어요" 안내 후 재시작 유도
+ *
+ * 나중에 electron-updater 붙이면:
+ *  - downloadUrl 을 돌려주고 앱이 자동으로 내려받음
+ *  - hardForce 플래그가 true 면 모달을 닫을 수 없게 만들 수도 있음
+ */
+
+export const LATEST_DESKTOP_VERSION = process.env.DESKTOP_VERSION ?? "0.1.0";
+export const MIN_DESKTOP_VERSION = process.env.DESKTOP_MIN_VERSION ?? "0.0.0";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    latest: LATEST_DESKTOP_VERSION,
+    min: MIN_DESKTOP_VERSION,
+    releasedAt: new Date().toISOString(),
+    notes: "버그 수정 및 안정성 개선.",
+    // 향후 자동 업데이트 사용 시 이곳에 downloadUrl, sha512 등 추가
+  });
+});
+
+export default router;

--- a/server/src/types/multer.d.ts
+++ b/server/src/types/multer.d.ts
@@ -1,0 +1,45 @@
+declare module "multer" {
+  import { RequestHandler } from "express";
+  interface File {
+    fieldname: string;
+    originalname: string;
+    encoding: string;
+    mimetype: string;
+    size: number;
+    destination: string;
+    filename: string;
+    path: string;
+    buffer: Buffer;
+  }
+  interface StorageEngine {
+    _handleFile(req: any, file: any, cb: any): void;
+    _removeFile(req: any, file: any, cb: any): void;
+  }
+  interface MulterOptions {
+    dest?: string;
+    storage?: StorageEngine;
+    limits?: { fileSize?: number; files?: number };
+    fileFilter?(req: any, file: File, cb: (err: any, accept: boolean) => void): void;
+  }
+  interface Multer {
+    single(name: string): RequestHandler;
+    array(name: string, maxCount?: number): RequestHandler;
+    any(): RequestHandler;
+  }
+  function multer(opts?: MulterOptions): Multer;
+  namespace multer {
+    function diskStorage(opts: {
+      destination: any;
+      filename: any;
+    }): StorageEngine;
+    function memoryStorage(): StorageEngine;
+  }
+  export = multer;
+}
+
+declare namespace Express {
+  interface Request {
+    file?: any;
+    files?: any;
+  }
+}


### PR DESCRIPTION
## 증상
**결재·문서·알림·프로필·검색 API + Prisma 스키마 확장**

새 기능을 추가합니다.

## 원인
- Prisma 스키마/seed: 결재·문서·알림·조직도 도메인 추가
- 신규 라우트: approval, document, notification, passkey,
  profile, search, version
- 기존 라우트 확장: admin, auth, me, notice, schedule, users
- lib: SSE 브로드캐스터 + 알림 디스패처(notify)
- server/scripts 운영 스크립트, 공용 타입 정의

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- feat(server): 결재/문서/알림/프로필/검색 API + Prisma 스키마 확장

**변경 대상 (23개 파일)**
- `server/prisma/schema.prisma`
- `server/prisma/seed.ts`
- `server/scripts/checkSuper.ts`
- `server/scripts/createTestNotice.ts`
- `server/scripts/sendTestDM.ts`
- `server/scripts/sendTestNotification.ts`
- `server/scripts/setSuperPassword.ts`
- `server/src/lib/notify.ts`
- `server/src/lib/sse.ts`
- `server/src/routes/admin.ts`
- `server/src/routes/approval.ts`
- `server/src/routes/auth.ts`
- … 외 11개

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #4** ↔ **이슈 #424** 로 연결됩니다.

Closes #424
