### PR TITLE
🔀 :: (#426) 메시지 롱프레스 컨텍스트 메뉴 — 복사/다운로드/고정

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -67,7 +67,7 @@ function AppLayoutInner() {
             }}
           />
         )}
-        <div className="h-[56px] px-5 flex items-center border-b border-ink-150">
+        <div className="h-[48px] px-5 flex items-center border-b border-ink-150">
           <Logo size={20} />
         </div>
 
@@ -124,10 +124,9 @@ function AppLayoutInner() {
       </aside>
 
       <div className="flex-1 min-w-0 flex flex-col">
-        {/* 창모드의 상단 여백을 TopBar 배경과 통합해 자연스럽게 — 색 동일 */}
         {showTitlebarSpace && (
           <div
-            className="bg-white border-b border-ink-150"
+            className="bg-white"
             style={{
               height: 28,
               // @ts-expect-error drag region
@@ -135,7 +134,7 @@ function AppLayoutInner() {
             }}
           />
         )}
-        <TopBar />
+        <TopBar draggable={showTitlebarSpace} />
         <main className="flex-1 overflow-y-auto">
           <div className="max-w-[1400px] mx-auto px-8 py-6">
             <Outlet />
@@ -203,7 +202,7 @@ const BREADCRUMB: Record<string, string> = {
   "/profile": "내 프로필",
 };
 
-function TopBar() {
+function TopBar({ draggable = false }: { draggable?: boolean }) {
   const loc = useLocation();
   const label = BREADCRUMB[loc.pathname] ?? "";
   const [searchOpen, setSearchOpen] = useState(false);
@@ -222,13 +221,19 @@ function TopBar() {
 
   return (
     <>
-      <header className="h-[56px] flex items-center justify-between px-6 border-b border-ink-150 bg-white">
+      <header
+        className="h-[48px] flex items-center justify-between px-6 border-b border-ink-150 bg-white"
+        style={draggable ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined}
+      >
         <div className="flex items-center gap-2 text-[13px]">
           <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--c-brand)" }} />
           <span className="text-ink-900 font-bold">{label || "HiNest"}</span>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2"
+          style={draggable ? ({ WebkitAppRegion: "no-drag" } as React.CSSProperties) : undefined}
+        >
           <button
             onClick={() => setSearchOpen(true)}
             className="hidden md:flex items-center gap-2 h-[34px] px-4 rounded-full bg-ink-50 border border-ink-150 text-ink-500 text-[12px] hover:bg-ink-100 hover:border-ink-200 min-w-[260px]"

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -22,11 +22,13 @@ import type {
   RoomLocalSetting,
 } from "./chat/types";
 import {
+  ActionIcons,
   AttachmentPreview,
   LongPress,
   MessageBubble,
   ReactionPicker,
   groupReactions,
+  type MessageAction,
 } from "./chat/MessageBubble";
 
 /**
@@ -228,6 +230,21 @@ export default function ChatMiniApp({
     }
   }
 
+  async function pinMessage(messageId: string) {
+    // 낙관적: 현재 pinnedAt 상태를 토글
+    setMessages((prev) => prev.map((m) =>
+      m.id === messageId
+        ? { ...m, pinnedAt: m.pinnedAt ? null : new Date().toISOString() }
+        : m
+    ));
+    try {
+      await api(`/api/chat/messages/${messageId}/pin`, { method: "POST" });
+      if (activeId) loadMessages(activeId);
+    } catch {
+      if (activeId) loadMessages(activeId);
+    }
+  }
+
   async function send() {
     if (!activeId || sending) return;
     const content = input.trim();
@@ -342,6 +359,7 @@ export default function ChatMiniApp({
           onPickFile={pickAndUpload}
           onClearAttachment={() => setAttachment(null)}
           onReact={reactToMessage}
+          onPin={pinMessage}
         />
       ) : (
         <ListView
@@ -1026,10 +1044,55 @@ function SettingsView({
   );
 }
 
+/* 메시지 컨텍스트 메뉴 액션 빌드 — 복사 / 다운로드(파일) / 고정(토글) */
+function buildMessageActions(m: Message, onPin: (id: string) => void): MessageAction[] {
+  const actions: MessageAction[] = [];
+
+  // 복사 — 텍스트는 본문, 파일은 파일명을 복사(없으면 본문)
+  actions.push({
+    key: "copy",
+    label: "복사",
+    icon: ActionIcons.copy,
+    onSelect: () => {
+      const text = m.kind === "TEXT" ? (m.content || "") : (m.fileName || m.content || "");
+      if (!text) return;
+      navigator.clipboard?.writeText(text).catch(() => {});
+    },
+  });
+
+  // 다운로드 — 파일 종류인 경우만
+  if (m.kind !== "TEXT" && m.fileUrl) {
+    actions.push({
+      key: "download",
+      label: "다운로드",
+      icon: ActionIcons.download,
+      onSelect: () => {
+        const a = document.createElement("a");
+        a.href = m.fileUrl!;
+        a.download = m.fileName || "";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+      },
+    });
+  }
+
+  // 고정 / 고정 해제
+  const isPinned = !!m.pinnedAt;
+  actions.push({
+    key: "pin",
+    label: isPinned ? "고정 해제" : "고정",
+    icon: isPinned ? ActionIcons.unpin : ActionIcons.pin,
+    onSelect: () => onPin(m.id),
+  });
+
+  return actions;
+}
+
 /* ======================= 대화방 ======================= */
 function RoomView({
   room, messages, meId, onBack, input, setInput, onSend, sending, scrollRef,
-  attachment, uploading, onPickFile, onClearAttachment, onReact,
+  attachment, uploading, onPickFile, onClearAttachment, onReact, onPin,
 }: {
   room: Room; messages: Message[]; meId: string; onBack: () => void;
   input: string; setInput: (v: string) => void; onSend: () => void; sending: boolean;
@@ -1037,6 +1100,7 @@ function RoomView({
   attachment: Attachment | null; uploading: boolean;
   onPickFile: (file: File) => void; onClearAttachment: () => void;
   onReact: (messageId: string, emoji: string) => void;
+  onPin: (messageId: string) => void;
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [reactingId, setReactingId] = useState<string | null>(null);
@@ -1100,8 +1164,26 @@ function RoomView({
         }}
       >
         {messages.length === 0 && (
-          <div style={{ padding: "72px 0", textAlign: "center", color: C.gray500, fontSize: 14, fontWeight: 500 }}>
-            첫 메시지를 보내보세요
+          <div style={{ height: "100%", display: "grid", placeItems: "center" }}>
+            <div style={{ textAlign: "center" }}>
+              <div
+                style={{
+                  width: 44,
+                  height: 44,
+                  borderRadius: 999,
+                  background: C.gray100,
+                  display: "grid",
+                  placeItems: "center",
+                  margin: "0 auto 10px",
+                }}
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8E959E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M4 5h16v11H9l-4 4z" />
+                </svg>
+              </div>
+              <div style={{ fontSize: 13, fontWeight: 700, color: C.ink }}>아직 메시지가 없어요</div>
+              <div style={{ fontSize: 12, color: C.gray500, marginTop: 4 }}>첫 메시지를 남겨보세요.</div>
+            </div>
           </div>
         )}
         {rendered.map((m) => {
@@ -1181,12 +1263,13 @@ function RoomView({
                     </div>
                   )}
 
-                  {/* 이모지 픽커 */}
+                  {/* 컨텍스트 메뉴: 이모지 + 액션 */}
                   {isPicking && (
                     <ReactionPicker
                       mine={mine}
                       onPick={(e) => { onReact(m.id, e); setReactingId(null); }}
                       onDismiss={() => setReactingId(null)}
+                      actions={buildMessageActions(m, onPin)}
                     />
                   )}
                 </div>

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { C, FONT, formatBytes } from "./theme";
 import type { Attachment, Message, Reaction } from "./types";
 
@@ -75,16 +75,27 @@ export function LongPress({
   );
 }
 
-/* ===== 이모지 픽커 팝오버 ===== */
+/* ===== 메시지 컨텍스트 메뉴(이모지 + 액션) ===== */
 const QUICK_EMOJIS = ["👍", "❤️", "😂", "😮", "😢", "🙏"];
+
+export type MessageAction = {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  danger?: boolean;
+  onSelect: () => void;
+};
+
 export function ReactionPicker({
   mine,
   onPick,
   onDismiss,
+  actions = [],
 }: {
   mine: boolean;
   onPick: (emoji: string) => void;
   onDismiss: () => void;
+  actions?: MessageAction[];
 }) {
   // 버블 위에 띄움. 바깥 클릭 시 닫기.
   useEffect(() => {
@@ -99,23 +110,43 @@ export function ReactionPicker({
     };
   }, [onDismiss]);
 
+  // 긴 버블일 때 위쪽으로 띄우면 스크롤 컨테이너/뷰포트에서 잘리므로
+  // 렌더 직후 측정 → 잘리면 버블 하단으로 뒤집음.
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [flip, setFlip] = useState(false);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    // 가장 가까운 스크롤 가능한 조상 찾기
+    let p: HTMLElement | null = el.parentElement;
+    let limitTop = 0;
+    while (p) {
+      const style = window.getComputedStyle(p);
+      if (/(auto|scroll)/.test(style.overflowY)) {
+        limitTop = p.getBoundingClientRect().top;
+        break;
+      }
+      p = p.parentElement;
+    }
+    if (r.top < limitTop + 4) setFlip(true);
+  }, []);
+
   return (
     <div
+      ref={ref}
       onMouseDown={(e) => e.stopPropagation()}
       style={{
         position: "absolute",
-        bottom: "calc(100% + 6px)",
+        ...(flip
+          ? { top: "calc(100% + 6px)" }
+          : { bottom: "calc(100% + 6px)" }),
         [mine ? "right" : "left"]: 0,
         zIndex: 10,
-        background: "#fff",
-        border: `1px solid ${C.gray200}`,
-        borderRadius: 999,
-        padding: "4px 6px",
         display: "flex",
-        alignItems: "center",
-        gap: 2,
-        boxShadow:
-          "0 8px 24px rgba(25, 31, 40, .14), 0 2px 6px rgba(25, 31, 40, .06)",
+        flexDirection: "column",
+        alignItems: mine ? "flex-end" : "flex-start",
+        gap: 8,
         animation: "hinest-pop .14s cubic-bezier(.22,.61,.36,1)",
       } as React.CSSProperties}
     >
@@ -123,39 +154,131 @@ export function ReactionPicker({
         from { transform: scale(.85) translateY(4px); opacity: 0; }
         to   { transform: scale(1) translateY(0); opacity: 1; }
       }`}</style>
-      {QUICK_EMOJIS.map((e) => (
-        <button
-          key={e}
-          type="button"
-          onClick={() => onPick(e)}
+
+      {/* 이모지 행 */}
+      <div
+        style={{
+          background: "#fff",
+          border: `1px solid ${C.gray200}`,
+          borderRadius: 999,
+          padding: "4px 6px",
+          display: "flex",
+          alignItems: "center",
+          gap: 2,
+          boxShadow:
+            "0 8px 24px rgba(25, 31, 40, .14), 0 2px 6px rgba(25, 31, 40, .06)",
+        }}
+      >
+        {QUICK_EMOJIS.map((e) => (
+          <button
+            key={e}
+            type="button"
+            onClick={() => onPick(e)}
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 999,
+              background: "transparent",
+              border: 0,
+              cursor: "pointer",
+              fontSize: 18,
+              lineHeight: 1,
+              display: "grid",
+              placeItems: "center",
+              transition: "background .12s ease, transform .12s ease",
+            }}
+            onMouseEnter={(ev) => {
+              ev.currentTarget.style.background = C.gray100;
+              ev.currentTarget.style.transform = "scale(1.15)";
+            }}
+            onMouseLeave={(ev) => {
+              ev.currentTarget.style.background = "transparent";
+              ev.currentTarget.style.transform = "scale(1)";
+            }}
+          >
+            {e}
+          </button>
+        ))}
+      </div>
+
+      {/* 액션 메뉴 */}
+      {actions.length > 0 && (
+        <div
           style={{
-            width: 32,
-            height: 32,
-            borderRadius: 999,
-            background: "transparent",
-            border: 0,
-            cursor: "pointer",
-            fontSize: 18,
-            lineHeight: 1,
-            display: "grid",
-            placeItems: "center",
-            transition: "background .12s ease, transform .12s ease",
-          }}
-          onMouseEnter={(ev) => {
-            ev.currentTarget.style.background = C.gray100;
-            ev.currentTarget.style.transform = "scale(1.15)";
-          }}
-          onMouseLeave={(ev) => {
-            ev.currentTarget.style.background = "transparent";
-            ev.currentTarget.style.transform = "scale(1)";
+            background: "#fff",
+            border: `1px solid ${C.gray200}`,
+            borderRadius: 14,
+            minWidth: 200,
+            padding: 4,
+            boxShadow:
+              "0 10px 28px rgba(25, 31, 40, .16), 0 2px 6px rgba(25, 31, 40, .06)",
+            overflow: "hidden",
           }}
         >
-          {e}
-        </button>
-      ))}
+          {actions.map((a, i) => (
+            <button
+              key={a.key}
+              type="button"
+              onClick={() => {
+                a.onSelect();
+                onDismiss();
+              }}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                padding: "10px 12px",
+                background: "transparent",
+                border: 0,
+                borderTop: i === 0 ? "none" : `1px solid ${C.gray100}`,
+                cursor: "pointer",
+                fontSize: 14,
+                fontWeight: 600,
+                fontFamily: FONT,
+                color: a.danger ? "#F04452" : C.ink,
+                textAlign: "left",
+                transition: "background .12s ease",
+              }}
+              onMouseEnter={(ev) => {
+                ev.currentTarget.style.background = C.gray100;
+              }}
+              onMouseLeave={(ev) => {
+                ev.currentTarget.style.background = "transparent";
+              }}
+            >
+              <span
+                style={{
+                  width: 18,
+                  height: 18,
+                  display: "grid",
+                  placeItems: "center",
+                  color: a.danger ? "#F04452" : C.gray600,
+                }}
+              >
+                {a.icon}
+              </span>
+              <span>{a.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
+
+/* 액션 아이콘 (stroke-current) */
+const ICON_SVG = (d: React.ReactNode) => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    {d}
+  </svg>
+);
+export const ActionIcons = {
+  copy: ICON_SVG(<><rect x="9" y="9" width="12" height="12" rx="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" /></>),
+  download: ICON_SVG(<><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></>),
+  pin: ICON_SVG(<><path d="M12 17v5" /><path d="M5 2h14l-2 7 3 5H4l3-5-2-7z" /></>),
+  unpin: ICON_SVG(<><path d="M3 3l18 18" /><path d="M12 17v5" /><path d="M5 2h14l-2 7 3 5h-5" /></>),
+};
 
 /** 같은 이모지끼리 그룹핑 + 카운트 + 누구 단건지 이름 배열 */
 export function groupReactions(list: Reaction[]) {

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -34,6 +34,8 @@ export type Message = {
   fileType?: string | null;
   fileSize?: number | null;
   deletedAt?: string | null;
+  pinnedAt?: string | null;
+  pinnedById?: string | null;
   createdAt: string;
   sender: { id: string; name: string; avatarColor?: string };
   reactions?: Reaction[];

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -186,6 +186,8 @@ model ChatMessage {
   editedAt    DateTime?
   deletedAt   DateTime?
   scheduledAt DateTime?
+  pinnedAt    DateTime?
+  pinnedById  String?
   createdAt   DateTime  @default(now())
   room        ChatRoom  @relation(fields: [roomId], references: [id], onDelete: Cascade)
   sender      User      @relation("Sender", fields: [senderId], references: [id], onDelete: Cascade)

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -405,6 +405,30 @@ router.patch("/messages/:id", async (req, res) => {
 });
 
 /**
+ * 메시지 고정/해제 토글. 방 멤버 누구나.
+ */
+router.post("/messages/:id/pin", async (req, res) => {
+  const u = (req as any).user;
+  const msg = await prisma.chatMessage.findUnique({ where: { id: req.params.id } });
+  if (!msg) return res.status(404).json({ error: "not found" });
+  const membership = await prisma.roomMember.findUnique({
+    where: { roomId_userId: { roomId: msg.roomId, userId: u.id } },
+  });
+  if (!membership) return res.status(403).json({ error: "방 멤버만 가능" });
+
+  const pin = !msg.pinnedAt;
+  const updated = await prisma.chatMessage.update({
+    where: { id: msg.id },
+    data: {
+      pinnedAt: pin ? new Date() : null,
+      pinnedById: pin ? u.id : null,
+    },
+    include: { sender: { select: { id: true, name: true, avatarColor: true } } },
+  });
+  res.json({ message: updated });
+});
+
+/**
  * 메시지 삭제(소프트). 본인만.
  */
 router.delete("/messages/:id", async (req, res) => {


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- 메시지 꾹 누르면 이모지 바 + 액션 메뉴가 함께 뜨는 텔레그램 스타일 UI
- 액션: 복사(텍스트/파일명), 다운로드(파일 메시지 한정), 고정/해제
- 긴 버블에서도 스크롤 경계 감지 후 자동으로 아래로 뒤집힘
- 서버: `POST /api/chat/messages/:id/pin` 추가 (방 멤버만)
- Prisma: `ChatMessage.pinnedAt`, `pinnedById` 컬럼
- AppLayout: TopBar/사이드바 로고 높이 48px 통일, 드래그 영역 정돈

## Test plan
- [ ] 텍스트 메시지 롱프레스 → 이모지 + 복사 + 고정 3개
- [ ] 파일/이미지 메시지 롱프레스 → 다운로드 포함 4개
- [ ] 고정 누르면 목록 새로고침 시 pinnedAt 유지
- [ ] 긴 메시지에서 메뉴가 스크롤 상단으로 잘리지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #426

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #426
