### PR TITLE
🔀 :: (#427) JWT_SECRET fail-closed + 전역 apiLimiter 마운트

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -86,6 +86,10 @@ app.use((req, res, next) => {
 
 app.get("/api/health", (_req, res) => res.json({ ok: true }));
 
+// 전역 API 레이트 리밋 — 라우트별 특수 limiter 는 그 뒤에 추가로 씌운다.
+// (login/upload 는 더 엄격한 limiter 가 먼저 적용됨)
+app.use("/api", apiLimiter);
+
 app.use("/api/auth", loginLimiter, authRouter);
 app.use("/api/me", meRouter);
 app.use("/api/admin", adminRouter);

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -2,12 +2,22 @@ import jwt from "jsonwebtoken";
 import type { Request, Response, NextFunction } from "express";
 import { prisma } from "./db.js";
 
-// 프로덕션에서 JWT_SECRET 이 비어 있으면 즉시 기동 실패 — 기본값 토큰 위조 방지
+// JWT_SECRET 은 언제나 필수. NODE_ENV 누락/오탈자로 프로덕션에서 하드코딩 fallback 이 쓰이는
+// 사고를 막기 위해, 개발 모드에서도 명시적으로 .env 에 지정하도록 강제한다.
+// 다만 개발 편의를 위해 ALLOW_DEV_JWT_SECRET=1 이면 임의 개발 시크릿을 허용.
 const IS_PROD = process.env.NODE_ENV === "production";
 const RAW_SECRET = process.env.JWT_SECRET;
-if (IS_PROD && (!RAW_SECRET || RAW_SECRET.length < 16)) {
-  throw new Error(
-    "JWT_SECRET 환경변수가 없거나 너무 짧습니다. 16자 이상의 강한 시크릿을 지정하세요."
+const ALLOW_DEV_FALLBACK = !IS_PROD && process.env.ALLOW_DEV_JWT_SECRET === "1";
+if (!RAW_SECRET || RAW_SECRET.length < 16) {
+  if (!ALLOW_DEV_FALLBACK) {
+    throw new Error(
+      "JWT_SECRET 환경변수가 없거나 너무 짧습니다. 16자 이상의 강한 시크릿을 .env 에 지정하세요. " +
+      "(개발 편의상 임시로 허용하려면 ALLOW_DEV_JWT_SECRET=1)"
+    );
+  }
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[auth] WARNING: JWT_SECRET 이 없어 개발용 임시 시크릿을 사용합니다. 프로덕션 기동 전에 반드시 .env 에 JWT_SECRET 을 설정하세요."
   );
 }
 const SECRET = RAW_SECRET ?? "hinest-dev-secret-change-me";


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- **JWT_SECRET 항상 필수**: 기존엔 `IS_PROD` 일 때만 검증. `NODE_ENV` 가 빠지거나 오탈자가 나면 프로덕션에서 `"hinest-dev-secret-change-me"` 하드코딩 fallback 이 쓰여 토큰이 위조될 수 있었음. 이제는 항상 필수이며, 개발 편의를 위해 `ALLOW_DEV_JWT_SECRET=1` 로 명시적 opt-in 해야만 fallback 이 허용됨 (경고 로그 포함).
- **apiLimiter 전역 마운트**: `apiLimiter` 가 정의만 돼 있고 어디에도 `app.use` 되지 않아 분당 리밋이 실질적으로 없던 상태. `/api` 전체에 선적용하고, login/upload 는 기존대로 더 엄격한 limiter 가 그 뒤에 추가 적용.

## Test plan
- [ ] `JWT_SECRET` 없는 상태로 `npm run dev:server` → 기동 실패 메시지 확인
- [ ] `ALLOW_DEV_JWT_SECRET=1` + `JWT_SECRET` 없음 → 경고 후 정상 기동
- [ ] `.env` 에 16자 이상 `JWT_SECRET` 지정 → 정상 기동 + 로그인 동작
- [ ] `/api/health` 를 분당 600회 초과 호출 시 429 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #427

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #427
