### PR TITLE
🔀 :: (#429) Excel 업로드 행 수 상한 5000

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -170,10 +170,18 @@ const importRowSchema = z.object({
   note: z.string().optional(),
   team: z.string().optional(),
 });
+/** 1회 import 최대 행 수 — DoS 방지용 상한. 실무상 넉넉한 5000. */
+const IMPORT_MAX_ROWS = 5000;
+
 router.post("/users/import", async (req, res) => {
   const u = (req as any).user;
   const rows = Array.isArray(req.body?.rows) ? req.body.rows : null;
   if (!rows) return res.status(400).json({ error: "rows 배열이 필요합니다." });
+  if (rows.length > IMPORT_MAX_ROWS) {
+    return res.status(413).json({
+      error: `한 번에 업로드 가능한 최대 행 수(${IMPORT_MAX_ROWS})를 초과했습니다. 나눠서 업로드해 주세요.`,
+    });
+  }
 
   let updated = 0;
   let skipped = 0;


### PR DESCRIPTION
## 증상
**Excel 업로드 행 수 상한 5000**

보안 취약점을 점검하고 보완합니다.

## 원인
기존엔 rows 배열 길이 무제한이라 각 행당 1~3 회 DB 쿼리가 발생.
극단적으로 큰 엑셀 업로드 시 서버가 장시간 점유될 수 있었음.
상한 초과 시 413 + 안내 메시지로 조기 거절.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- security(admin/import): Excel 일괄 업로드 행 수 상한 5000 — DoS 방지

**변경 대상 (1개 파일)**
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #9** ↔ **이슈 #429** 로 연결됩니다.

Closes #429
