### PR TITLE
🔀 :: (#430) 역할 체크 denylist → allowlist

### DIFF
--- a/server/src/routes/notice.ts
+++ b/server/src/routes/notice.ts
@@ -7,6 +7,14 @@ import { notifyAllUsers } from "../lib/notify.js";
 const router = Router();
 router.use(requireAuth);
 
+/**
+ * 공지 작성/삭제 권한 allowlist — 새 역할이 추가돼도 기본은 거부되도록 denylist 대신 allowlist.
+ */
+const NOTICE_WRITE_ROLES = new Set(["ADMIN", "MANAGER"]);
+function canWriteNotice(role: unknown): boolean {
+  return typeof role === "string" && NOTICE_WRITE_ROLES.has(role);
+}
+
 router.get("/", async (_req, res) => {
   const list = await prisma.notice.findMany({
     orderBy: [{ pinned: "desc" }, { createdAt: "desc" }],
@@ -23,7 +31,7 @@ const schema = z.object({
 
 router.post("/", async (req, res) => {
   const u = (req as any).user;
-  if (u.role === "MEMBER") return res.status(403).json({ error: "forbidden" });
+  if (!canWriteNotice(u?.role)) return res.status(403).json({ error: "forbidden" });
   const parsed = schema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
   const d = parsed.data;
@@ -44,7 +52,7 @@ router.post("/", async (req, res) => {
 
 router.delete("/:id", async (req, res) => {
   const u = (req as any).user;
-  if (u.role === "MEMBER") return res.status(403).json({ error: "forbidden" });
+  if (!canWriteNotice(u?.role)) return res.status(403).json({ error: "forbidden" });
   await prisma.notice.delete({ where: { id: req.params.id } });
   await writeLog(u.id, "NOTICE_DELETE", req.params.id);
   res.json({ ok: true });


### PR DESCRIPTION
## 증상
**역할 체크 denylist → allowlist**

보안 취약점을 점검하고 보완합니다.

## 원인
기존 "u.role === 'MEMBER' 면 거부" 는 새 역할 문자열이 추가되면 자동 허용되는
위험한 기본값. allowlist 로 바꿔 새 역할은 기본 차단 후 명시적 허용.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- security(notice): 역할 체크 denylist → allowlist (ADMIN/MANAGER 만)

**변경 대상 (1개 파일)**
- `server/src/routes/notice.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #10** ↔ **이슈 #430** 로 연결됩니다.

Closes #430
