### PR TITLE
🔀 :: (#432) 프로덕션 CORS 화이트리스트 + /uploads CSP

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -30,6 +30,7 @@ import mime from "mime-types";
 
 const app = express();
 const PORT = Number(process.env.PORT ?? 4000);
+const IS_PROD = process.env.NODE_ENV === "production";
 const ORIGIN = process.env.CLIENT_ORIGIN ?? "http://localhost:1000";
 
 // 기본 보안 헤더 — CSP 는 프런트 개발 편의상 기본만.
@@ -39,9 +40,14 @@ app.use(
     contentSecurityPolicy: false, // API 서버라 HTML 안 서빙. 필요 시 활성화.
   })
 );
+
+// CORS — 프로덕션은 CLIENT_ORIGIN 만 허용. 개발에선 로컬호스트 편의 허용.
+const CORS_ORIGINS = IS_PROD
+  ? [ORIGIN]
+  : [ORIGIN, "http://localhost:1000", "http://127.0.0.1:1000"];
 app.use(
   cors({
-    origin: [ORIGIN, "http://localhost:1000", "http://127.0.0.1:1000"],
+    origin: CORS_ORIGINS,
     credentials: true,
   })
 );
@@ -124,6 +130,8 @@ app.use("/uploads", requireAuth, (req, res, next) => {
   }
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
+  // defense-in-depth — /uploads 에서 내려가는 HTML 이 실수로라도 실행되지 않도록 tight CSP
+  res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'");
   // 이미지/영상/오디오가 아니면 인라인 실행 방지 + 강제 다운로드
   const mt = mime.lookup(name) || "application/octet-stream";
   const inline = INLINE_MIME_PREFIXES.some((p) => String(mt).startsWith(p));


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- `IS_PROD` 에서는 CORS 를 `CLIENT_ORIGIN` 단독 허용. 로컬호스트 허용은 개발 전용.
- `/uploads` 응답에 `default-src 'none'; sandbox; frame-ancestors 'none'` CSP 헤더 추가 — 업로드 파일이 브라우저에서 스크립트/iframe 으로 실행되지 않도록 추가 방어.

## Test plan
- [ ] `NODE_ENV=production` + `CLIENT_ORIGIN=https://app.example` → 타 origin preflight 차단
- [ ] 개발 모드 → 로컬호스트 origin 계속 허용
- [ ] `/uploads/<file>` 응답 헤더에 CSP 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #432

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #432
