### PR TITLE
🔀 :: (#434) SQLite → Postgres (Supabase) provider 전환

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ server/uploads/
 .env
 .env.local
 
-# prisma / sqlite
+# prisma / sqlite (레거시 — 개발 편의상 아직 로컬 dev.db 는 커밋 안 함)
 server/prisma/*.db
 server/prisma/*.db-journal
-server/prisma/migrations/
+# 주의: migrations/ 는 Postgres 전환 후부터 반드시 커밋함.
+# 예전 SQLite 시절 migration 디렉토리는 이미 제외된 상태 — 첫 Postgres
+# 마이그레이션을 새로 생성해서 그 이후의 히스토리를 추적.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,48 @@
+# =============================================================================
+# HiNest 서버 환경 변수 샘플
+# 실제 배포 시에는 이 파일을 `.env` 로 복사하고 값 채워넣기.
+# .env 는 gitignore 됨 — 절대 커밋하지 말 것.
+# =============================================================================
+
+# 기본 실행 환경
+NODE_ENV=development
+PORT=4000
+
+# 클라이언트(Vite) origin — CORS 화이트리스트
+# 프로덕션에선 실제 Vercel 도메인으로 교체 (예: https://hinest.vercel.app)
+CLIENT_ORIGIN=http://localhost:1000
+
+# -----------------------------------------------------------------------------
+# Supabase Postgres
+# -----------------------------------------------------------------------------
+# Supabase Dashboard → Settings → Database → Connection string
+# 두 URL 이 필요:
+#   - DATABASE_URL : 런타임용 (pgBouncer transaction mode, 포트 6543)
+#                    → Prisma 가 짧게 connection 맺고 끊음
+#   - DIRECT_URL   : 마이그레이션용 (direct, 포트 5432)
+#                    → prisma migrate 가 세션 유지 필요
+#
+# 예시 (Supabase 가 제공하는 포맷):
+# DATABASE_URL="postgresql://postgres.<project-ref>:<password>@aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres?pgbouncer=true"
+# DIRECT_URL="postgresql://postgres.<project-ref>:<password>@aws-0-ap-northeast-2.pooler.supabase.com:5432/postgres"
+DATABASE_URL=
+DIRECT_URL=
+
+# -----------------------------------------------------------------------------
+# JWT — 16자 이상 필수. 프로덕션은 반드시 랜덤하게.
+# 생성 예:  node -e "console.log(require('crypto').randomBytes(48).toString('base64url'))"
+# -----------------------------------------------------------------------------
+JWT_SECRET=
+
+# 개발 중에만, 위 JWT_SECRET 이 비어도 기동 허용하려면 1 로.
+# 프로덕션 배포엔 절대 설정하지 말 것.
+# ALLOW_DEV_JWT_SECRET=1
+
+# -----------------------------------------------------------------------------
+# Supabase Storage — 파일 업로드 저장소
+# -----------------------------------------------------------------------------
+# Supabase Dashboard → Settings → API
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+# 버킷 이름 — 미리 Dashboard → Storage 에서 만들어두기 (Private 권장)
+SUPABASE_STORAGE_BUCKET=hinest-uploads

--- a/server/package.json
+++ b/server/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "prisma generate && tsc -p tsconfig.json",
     "start": "node dist/index.js",
+    "postinstall": "prisma generate",
     "db:setup": "prisma migrate dev --name init && tsx prisma/seed.ts",
+    "db:migrate:deploy": "prisma migrate deploy",
     "db:seed": "tsx prisma/seed.ts",
     "db:studio": "prisma studio"
   },

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -4,8 +4,12 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
+  provider = "postgresql"
   url      = env("DATABASE_URL")
+  // Supabase 는 connection pooling(pgBouncer) 과 direct connection 을 분리 제공.
+  // - DATABASE_URL   : 앱 런타임용 (pgBouncer, port 6543)
+  // - DIRECT_URL     : 마이그레이션용 (direct, port 5432)
+  directUrl = env("DIRECT_URL")
 }
 
 model User {


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- Prisma datasource provider `sqlite` → `postgresql`.
- `DIRECT_URL` 분리 — Supabase pgBouncer (런타임) / direct (마이그레이션).
- `.env.example` 추가 — Supabase / JWT / Storage 값 전부 문서화.
- `postinstall: prisma generate` — Koyeb/Docker 빌드 시 자동 client 생성.
- `.gitignore` — Postgres 마이그레이션부터는 추적.

## 사용자 후속 조치
Supabase 프로젝트 생성 후:
1. `server/.env` 에 `DATABASE_URL` / `DIRECT_URL` / `JWT_SECRET` 채우기
2. 기존 SQLite 마이그레이션 정리: `rm -rf server/prisma/migrations`
3. `cd server && npx prisma migrate dev --name postgres_init` → 새 PG 마이그레이션 생성
4. 새 마이그레이션 커밋

## Test plan
- [ ] `.env` 채운 뒤 `npm run dev:server` 정상 기동
- [ ] 로그인/주요 API 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #434

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #434
