### PR TITLE
🔀 :: (#435) API 서버 Blueprint 정의

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,46 @@
+# Render Blueprint — HiNest API 서버 자동 배포 정의.
+#
+# 사용 방법:
+#   1) Render Dashboard → New → Blueprint → 이 리포 선택
+#   2) `sync: false` 로 표시된 env 값은 Dashboard 에서 직접 채워야 함
+#      (Supabase 대시보드에서 복사한 값들)
+#
+# Render Free 주의사항:
+#   - 15분 무활동 시 자동 sleep → 다음 요청 시 ~30초 콜드스타트
+#   - 월 750시간 제공 (24/7 하나까지 가능)
+services:
+  - type: web
+    name: hinest-api
+    runtime: node
+    plan: free
+    region: singapore       # 한국에서 가장 가까운 Render 리전
+    rootDir: server         # 모노레포 — server/ 하위에서 빌드
+    # postinstall 에 prisma generate 가 이미 걸려 있으므로 install 만 해도 client 생성됨.
+    # 빌드 후 prisma migrate deploy 로 프로덕션 스키마 반영.
+    buildCommand: npm install && npm run build && npx prisma migrate deploy
+    startCommand: npm run start
+    healthCheckPath: /api/health
+    autoDeploy: true        # main 브랜치 push 시 자동 재배포
+    envVars:
+      - key: NODE_ENV
+        value: production
+      # Render 는 PORT 를 주입. 서버 코드가 process.env.PORT 를 이미 쓰고 있어 그대로 둠.
+      - key: PORT
+        value: 10000
+      # Supabase 에서 복사 — Dashboard 에서 수동 입력
+      - key: DATABASE_URL
+        sync: false
+      - key: DIRECT_URL
+        sync: false
+      - key: SUPABASE_URL
+        sync: false
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        sync: false
+      - key: SUPABASE_STORAGE_BUCKET
+        value: hinest-uploads
+      # JWT — Render 가 자동으로 강한 랜덤 값 생성해 세팅.
+      - key: JWT_SECRET
+        generateValue: true
+      # Vercel 배포 후 실제 클라이언트 도메인으로 교체 (예: https://hinest.vercel.app)
+      - key: CLIENT_ORIGIN
+        sync: false


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
`render.yaml` 추가 — Render Free 플랜에 API 서버를 Blueprint 로 자동 배포.

- Node runtime, `rootDir: server`, Singapore 리전
- `npm install` → `npm run build` → `prisma migrate deploy` → `npm start`
- `/api/health` 헬스체크
- Supabase 관련 env 는 Render Dashboard 에서 수동 입력
- JWT_SECRET 은 Render 가 자동 생성

## Test plan
- [ ] Render → New → Blueprint → 리포 선택 후 `render.yaml` 자동 감지
- [ ] 필요 env 값 채운 뒤 배포 → `/api/health` 응답 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #435

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #435
