### PR TITLE
🔀 :: (#437) install devDependencies during build

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -17,7 +17,10 @@ services:
     rootDir: server         # 모노레포 — server/ 하위에서 빌드
     # postinstall 에 prisma generate 가 이미 걸려 있으므로 install 만 해도 client 생성됨.
     # 빌드 후 prisma migrate deploy 로 프로덕션 스키마 반영.
-    buildCommand: npm install && npm run build && npx prisma migrate deploy
+    # NODE_ENV=production 때문에 npm install 이 devDependencies 를 스킵 →
+    # @types/node, @types/express, typescript, prisma CLI 가 설치 안 돼 tsc 빌드가 터짐.
+    # --include=dev 로 명시적으로 devDeps 도 포함시켜야 빌드 가능.
+    buildCommand: npm install --include=dev && npm run build && npx prisma migrate deploy
     startCommand: npm run start
     healthCheckPath: /api/health
     autoDeploy: true        # main 브랜치 push 시 자동 재배포


### PR DESCRIPTION
## 증상
**install devDependencies during build**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
Render injects NODE_ENV=production, which makes `npm install` skip
devDependencies by default. tsc, @types/node, @types/express 등이
빌드 타임에 필요한데 설치가 안 돼서 TS2307/TS7016/TS2580 으로 빌드 실패함.

--include=dev 로 명시해서 빌드 타임에만 devDeps 도 끌어오게 수정.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- fix(render): install devDependencies during build

**변경 대상 (1개 파일)**
- `render.yaml`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #17** ↔ **이슈 #437** 로 연결됩니다.

Closes #437
