### PR TITLE
🔀 :: (#438) assign new team name string in User.team sync

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -291,7 +291,9 @@ router.patch("/teams/:id", async (req, res) => {
   const team = await prisma.team.update({ where: { id: prev.id }, data: { name } });
   // 사용자 team 문자열도 동기화
   if (prev.name !== name) {
-    await prisma.user.updateMany({ where: { team: prev.name }, data: { team } });
+    // `team` 변수는 Team 객체라 문자열 필드에 바로 못 넣음. 새 이름 `name` 을 넣어야
+    // 사용자의 team 문자열이 올바르게 동기화됨.
+    await prisma.user.updateMany({ where: { team: prev.name }, data: { team: name } });
   }
   await writeLog(u.id, "TEAM_UPDATE", team.id, `${prev.name} -> ${name}`);
   res.json({ team });


### PR DESCRIPTION
## 증상
**assign new team name string in User.team sync**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
팀 이름 변경 시 User.team 동기화 로직에서 `data: { team }` 로 Team 객체를
통째로 넣고 있었음. team 필드는 string 이라 TS2322 로 빌드 실패.
새 이름 `name` 을 넣도록 수정. 런타임에도 문자열 필드에 객체가 들어가면서
동기화가 실제로 망가지던 버그.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- fix(admin): assign new team name string instead of Team object

**변경 대상 (1개 파일)**
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #18** ↔ **이슈 #438** 로 연결됩니다.

Closes #438
