### PR TITLE
🔀 :: (#439) proxy /api and /uploads to Render

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "//": [
+    "Vercel 에 배포되는 건 client/ 뿐임. server 는 Render 에서 돌고, desktop 은 로컬 빌드.",
+    "빌드/출력/설치 명령은 모두 client/ 서브디렉토리 기준으로 실행.",
+    "rewrites 순서 주의 — /api/*, /uploads/* 를 Render 로 프록시하는 규칙이",
+    "SPA fallback 보다 먼저 와야 함 (Vercel 은 첫 매치 규칙만 적용).",
+    "프록시 방식을 택한 이유: 브라우저가 같은 origin 으로 호출하게 되므로",
+    "cross-site 쿠키(SameSite=None; Secure) 와 CORS preflight 부담이 사라짐."
+  ],
+  "buildCommand": "cd client && npm install && npm run build",
+  "outputDirectory": "client/dist",
+  "installCommand": "echo skipping root install",
+  "framework": null,
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://hinest-api.onrender.com/api/:path*"
+    },
+    {
+      "source": "/uploads/:path*",
+      "destination": "https://hinest-api.onrender.com/uploads/:path*"
+    },
+    {
+      "source": "/((?!assets/|.*\\.(?:png|jpg|jpeg|svg|gif|webp|ico|woff|woff2|ttf|eot|js|css|map|txt|xml|webmanifest|json)).*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 증상
**proxy /api and /uploads to Render**

유지보수 작업을 진행합니다.

## 원인
Vercel 에 client/ 빌드 배포하면서, 백엔드 호출을 Render 로 프록시.
same-origin 유지 → 쿠키(JWT) / CORS preflight 고민 제거.

- buildCommand / outputDirectory 를 client/ 모노레포 기준으로 지정
- /api/*, /uploads/* 는 hinest-api.onrender.com 으로 rewrite (SPA fallback 보다 먼저)
- 나머지 경로는 index.html 로 fallback (SPA 라우팅)
- 정적 자산 캐싱 + 기본 보안 헤더

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- deploy(vercel): proxy /api and /uploads to Render backend

**변경 대상 (1개 파일)**
- `vercel.json`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #19** ↔ **이슈 #439** 로 연결됩니다.

Closes #439
