### PR TITLE
🔀 :: (#440) resolve Vercel production build type errors

### DIFF
--- a/client/src/components/EmojiPicker.tsx
+++ b/client/src/components/EmojiPicker.tsx
@@ -81,7 +81,7 @@ export default function EmojiPicker({
     if (!onClose) return;
     function onDoc(e: MouseEvent) {
       if (!ref.current) return;
-      if (!ref.current.contains(e.target as Node)) onClose();
+      if (!ref.current.contains(e.target as Node)) onClose?.();
     }
     // 다음 tick에 등록해서 여는 클릭이 바로 닫지 않게
     const t = setTimeout(() => document.addEventListener("mousedown", onDoc), 50);

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -256,7 +256,9 @@ export default function ChatPage() {
     setMentionIdx(0);
   }
 
-  function pickMention(user: DirectoryUser) {
+  // 호출자는 두 종류 — Directory 의 DirectoryUser, Room 멤버 객체(email 없음).
+  // 실제 사용하는 필드는 id/name 뿐이라 최소 shape 으로 받아 양쪽 다 호환되게.
+  function pickMention(user: { id: string; name: string }) {
     const el = textareaRef.current;
     if (!el) return;
     const cursor = el.selectionStart ?? el.value.length;


### PR DESCRIPTION
## 증상
**resolve Vercel production build type errors**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- EmojiPicker: onClose 가 optional 인데 non-null 로 호출해서 TS2722.
  옵셔널 체이닝(?.())으로 수정.
- ChatPage: pickMention 이 DirectoryUser(email 필수)를 요구했는데
  Room 멤버 객체(email 없음)에서도 호출됨. 실제 쓰는 필드는 id/name 뿐이라
  최소 shape({ id, name })으로 타입 좁혀서 양쪽 호출자 모두 호환.

Vercel 은 production 빌드 시 tsc 를 strict 하게 돌려서 드러난 에러들.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- fix(client): resolve Vercel production build type errors

**변경 대상 (2개 파일)**
- `client/src/components/EmojiPicker.tsx`
- `client/src/pages/ChatPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #20** ↔ **이슈 #440** 로 연결됩니다.

Closes #440
