### PR TITLE
🔀 :: (#442) SPA fallback + Render keepalive cron

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,26 @@
+# Render Free 는 15분 무활동 시 sleep → 첫 사용자가 콜드 스타트 30~60초 대기.
+# 10분마다 /api/health 를 치면 항상 warm 상태 유지.
+#
+# 주의: Render Free 는 월 750 인스턴스 시간 제공 — 24/7 항상 깨어있어도 720h 라
+# 단일 인스턴스는 한도 안 넘김.
+# 사용량 절약이 중요하면 cron 을 '*/15 * * * 6,0' 식으로 주말만 돌리는 것도 가능.
+name: Keep Render service warm
+
+on:
+  schedule:
+    # GitHub Actions cron 은 UTC 기준. '*/10 * * * *' = 매 10분.
+    # 실제 실행은 최대 수 분 지연될 수 있음 (무료 러너 큐). 우리 목적엔 충분.
+    - cron: "*/10 * * * *"
+  workflow_dispatch:   # 수동 실행 가능 (Actions 탭에서 "Run workflow")
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Ping /api/health
+        run: |
+          # --max-time 90: 콜드 스타트 시 60초까지 걸릴 수 있으니 여유 있게.
+          # --fail: HTTP 4xx/5xx 면 exit 코드 0 이 아닌 값 반환 → 러너 failed 로 표시.
+          curl --fail --max-time 90 -sS https://hinest-api.onrender.com/api/health
+          echo

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
       "destination": "https://hinest-api.onrender.com/uploads/:path*"
     },
     {
-      "source": "/((?!assets/|.*\\.(?:png|jpg|jpeg|svg|gif|webp|ico|woff|woff2|ttf|eot|js|css|map|txt|xml|webmanifest|json)).*)",
+      "source": "/:path*",
       "destination": "/index.html"
     }
   ],


### PR DESCRIPTION
## 증상
**SPA fallback + Render keepalive cron**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
1) vercel.json rewrite 단순화
   기존 정규식에 negative lookahead(?!...)가 들어있었는데 Vercel 의
   path-to-regexp 파서가 이를 온전히 해석 못 해서 /login 등 하위 경로 새로고침시
   404. 파일시스템 → rewrite 순서라 /:path* → /index.html 로 단순화해도
   실제 파일(/assets/* 등)은 먼저 서빙되므로 안전.

2) GitHub Actions keepalive 추가
   Render Free 가 15분 무활동 시 sleep → 첫 요청 30~60초 대기 체감.
   10분마다 /api/health 핑으로 항상 warm 유지. Free 월 750h 한도 안 넘김.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

## 수정
**작업 항목 (커밋 단위)**
- fix(deploy): SPA fallback + Render keepalive

**변경 대상 (2개 파일)**
- `.github/workflows/keepalive.yml`
- `vercel.json`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #22** ↔ **이슈 #442** 로 연결됩니다.

Closes #442
