### PR TITLE
🔀 :: (#443) 공유링크 다운로드 카운트 레이스 컨디션 수정

### DIFF
--- a/server/src/routes/shareLink.ts
+++ b/server/src/routes/shareLink.ts
@@ -178,7 +178,16 @@ pub.post("/:token/download", async (req, res) => {
       const ok = await bcrypt.compare(password, fl.passwordHash);
       if (!ok) return res.status(401).json({ error: "비밀번호가 올바르지 않아요" });
     }
-    await prisma.folderShareLink.update({ where: { id: fl.id }, data: { downloads: { increment: 1 } } });
+    // 원자적 카운트 증가 — 동시 요청이 maxDownloads 를 초과하는 것을 DB 레벨에서 차단
+    const folderWhere: any = { id: fl.id, revokedAt: null };
+    if (fl.maxDownloads !== null) folderWhere.downloads = { lt: fl.maxDownloads };
+    const folderUpdated = await prisma.folderShareLink.updateMany({
+      where: folderWhere,
+      data: { downloads: { increment: 1 } },
+    });
+    if (folderUpdated.count === 0) {
+      return res.status(429).json({ error: statusMsg(429) });
+    }
     return streamFolderZip(fl.folder.id, fl.folder.name, res);
   }
   if (folderResult.err && folderResult.err !== 404) {
@@ -203,8 +212,18 @@ pub.post("/:token/download", async (req, res) => {
   const buf = await readFile(key);
   if (!buf) return res.status(404).json({ error: "파일을 찾을 수 없어요" });
 
-  // 다운로드 카운트 증가 + 감사 로그 — 동시 요청으로 maxDownloads 초과 방지는 낙관적.
-  await prisma.documentShareLink.update({ where: { id: link.id }, data: { downloads: { increment: 1 } } });
+  // 원자적 카운트 증가 — updateMany + WHERE 조건으로 동시 요청이 maxDownloads 를 초과하는 것을 방지.
+  // count === 0 이면 다른 요청이 먼저 한도를 채웠음을 의미.
+  const docWhere: any = { id: link.id, revokedAt: null };
+  if (link.maxDownloads !== null) docWhere.downloads = { lt: link.maxDownloads };
+  const docUpdated = await prisma.documentShareLink.updateMany({
+    where: docWhere,
+    data: { downloads: { increment: 1 } },
+  });
+  if (docUpdated.count === 0) {
+    return res.status(429).json({ error: statusMsg(429) });
+  }
+
   await prisma.shareLinkAccess.create({
     data: { linkId: link.id, action: "DOWNLOAD", ip: req.ip, userAgent: req.get("user-agent")?.slice(0, 200) },
   });


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- 기존 낙관적 카운트 증가(`update + increment`) 방식은 동시 다운로드 요청이 몰릴 때 maxDownloads 한도를 초과할 수 있는 TOCTOU(Time-of-check to Time-of-use) 취약점이 있었음
- `updateMany` + `WHERE downloads < maxDownloads` 조건으로 DB 레벨에서 원자적으로 처리
- `count === 0` 이면 한도 초과로 판단해 즉시 429 반환
- 문서 공유 링크(`DocumentShareLink`) + 폴더 공유 링크(`FolderShareLink`) 양쪽 모두 수정

## Test plan
- [ ] maxDownloads=1 링크에 동시 요청 2개 → 1개만 성공, 나머지 429 반환 확인
- [ ] maxDownloads=null (무제한) 링크 정상 다운로드 확인
- [ ] 폴더 공유 링크도 동일하게 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #443

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #443
