### PR TITLE
🔀 :: (#444) 모바일 터치 타겟 및 스크롤 개선

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -445,7 +445,7 @@ function PinsSection() {
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); toggle(p.targetType, p.targetId); }}
-                className="md:opacity-0 md:group-hover:opacity-100 w-4 h-4 grid place-items-center rounded text-ink-400 hover:text-ink-900"
+                className="md:opacity-0 md:group-hover:opacity-100 w-7 h-7 md:w-4 md:h-4 grid place-items-center rounded text-ink-400 hover:text-ink-900"
                 title="핀 해제"
               >
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -815,9 +815,10 @@ function CreateModal({
                     </button>
                     <button
                       type="button"
-                      className="w-4 h-4 rounded-full text-ink-400 hover:text-ink-700 text-[14px] leading-none"
+                      className="w-6 h-6 rounded-full text-ink-400 hover:text-ink-700 text-[14px] leading-none grid place-items-center"
                       onClick={() => removeTemplate(t.id)}
                       title="삭제"
+                      aria-label="템플릿 삭제"
                     >×</button>
                   </span>
                 ))}
@@ -926,9 +927,10 @@ function CreateModal({
                     </button>
                     <button
                       type="button"
-                      className="w-4 h-4 rounded-full text-ink-400 hover:text-ink-700 text-[14px] leading-none"
+                      className="w-6 h-6 rounded-full text-ink-400 hover:text-ink-700 text-[14px] leading-none grid place-items-center"
                       onClick={() => removeLine(l.id)}
                       title="삭제"
+                      aria-label="결재선 삭제"
                     >×</button>
                   </span>
                 ))}

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -156,7 +156,7 @@ export default function AttendancePage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2 card">
           <h2 className="text-lg font-bold mb-4">{month} 출퇴근 기록</h2>
-          <div className="overflow-hidden rounded-xl border border-slate-100 overflow-x-auto">
+          <div className="overflow-hidden rounded-xl border border-slate-100 overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
             <table className="w-full text-sm min-w-[480px]">
               <thead className="bg-slate-50 text-slate-500 text-xs">
                 <tr>
@@ -214,7 +214,7 @@ export default function AttendancePage() {
       {(user?.role === "ADMIN" || user?.role === "MANAGER") && (
         <div className="card mt-6">
           <h2 className="text-lg font-bold mb-4">전체 휴가 승인 대기</h2>
-          <div className="overflow-hidden rounded-xl border border-slate-100 overflow-x-auto">
+          <div className="overflow-hidden rounded-xl border border-slate-100 overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
             <table className="w-full text-sm min-w-[720px]">
               <thead className="bg-slate-50 text-slate-500 text-xs">
                 <tr>

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -381,7 +381,7 @@ export default function ExpensePage() {
                       alt="receipt"
                       loading="lazy"
                       decoding="async"
-                      className="max-h-36 rounded-xl border border-ink-150 shadow-sm"
+                      className="max-h-[50vh] sm:max-h-36 rounded-xl border border-ink-150 shadow-sm"
                     />
                     <button
                       type="button"


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- WCAG 2.5.5 기준(44×44px) 이하인 소형 버튼 크기 개선
- iOS Safari 모멘텀 스크롤 누락된 테이블에 `-webkit-overflow-scrolling: touch` 추가
- 모바일에서 영수증 미리보기 이미지 잘림 방지

## 변경 내용
| 파일 | 변경 내용 |
|------|-----------|
| ApprovalsPage | 삭제 버튼 `w-4→w-6`, `aria-label` 추가 |
| AppLayout | 핀 해제 버튼 모바일 `w-7 h-7`, 데스크톱 `w-4 h-4` |
| ExpensePage | 영수증 미리보기 `max-h-[50vh] sm:max-h-36` |
| AttendancePage | 테이블 2개에 iOS 터치 스크롤 추가 |

## Test plan
- [ ] 모바일(375px)에서 결재 템플릿/결재선 삭제 버튼 탭 테스트
- [ ] iOS Safari에서 근태 테이블 스와이프 스크롤 확인
- [ ] 모바일에서 영수증 이미지 세로로 긴 것 잘리지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #444

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #444
