### PR TITLE
🔀 :: (#445) 다크모드 테마 미리보기 스와치 색상 오류 수정

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1273,7 +1273,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                   </td>
                   <td>
                     <div className="flex items-center gap-2">
-                      <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: d.author.avatarUrl ? "transparent" : d.author.avatarColor }}>
+                      <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: d.author.avatarUrl ? "transparent" : (d.author.avatarColor ?? "#6B7280") }}>
                         {d.author.avatarUrl ? (
                           <img src={d.author.avatarUrl} alt={d.author.name} className="w-full h-full object-cover" />
                         ) : (

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -529,26 +529,37 @@ function ThemePanel() {
   );
 }
 
+// 테마 미리보기 스와치는 현재 활성 테마에 관계없이
+// 항상 해당 테마의 고정 색상을 보여야 함 → inline style 로 Tailwind/다크모드 오버라이드 차단
+const LIGHT = {
+  bg: "#F5F6F8", surface: "#FFFFFF", border: "#E6E8EC",
+  ink200: "#DDE0E4", ink150: "#E6E8EC",
+};
+const DARK = {
+  bg: "#0E1014", surface: "#171A20", border: "#2A2F38",
+  ink200: "#363B45", ink150: "#2A2F38",
+};
+
 function SwatchLight() {
   return (
-    <div className="w-full h-full p-3 bg-ink-25 flex gap-2">
-      <div className="w-10 rounded-md bg-white border border-ink-150" />
+    <div className="w-full h-full p-3 flex gap-2" style={{ background: LIGHT.bg }}>
+      <div className="w-10 rounded-md" style={{ background: LIGHT.surface, border: `1px solid ${LIGHT.border}` }} />
       <div className="flex-1 space-y-1.5">
-        <div className="h-2 rounded bg-ink-200" />
-        <div className="h-2 rounded bg-ink-150 w-3/4" />
-        <div className="h-6 rounded bg-white border border-ink-150" />
+        <div className="h-2 rounded" style={{ background: LIGHT.ink200 }} />
+        <div className="h-2 rounded w-3/4" style={{ background: LIGHT.ink150 }} />
+        <div className="h-6 rounded" style={{ background: LIGHT.surface, border: `1px solid ${LIGHT.border}` }} />
       </div>
     </div>
   );
 }
 function SwatchDark() {
   return (
-    <div className="w-full h-full p-3 flex gap-2" style={{ background: "#0F1115" }}>
-      <div className="w-10 rounded-md" style={{ background: "#17191F", border: "1px solid #2A2E37" }} />
+    <div className="w-full h-full p-3 flex gap-2" style={{ background: DARK.bg }}>
+      <div className="w-10 rounded-md" style={{ background: DARK.surface, border: `1px solid ${DARK.border}` }} />
       <div className="flex-1 space-y-1.5">
-        <div className="h-2 rounded" style={{ background: "#343942" }} />
-        <div className="h-2 rounded w-3/4" style={{ background: "#2A2E37" }} />
-        <div className="h-6 rounded" style={{ background: "#17191F", border: "1px solid #2A2E37" }} />
+        <div className="h-2 rounded" style={{ background: DARK.ink200 }} />
+        <div className="h-2 rounded w-3/4" style={{ background: DARK.ink150 }} />
+        <div className="h-6 rounded" style={{ background: DARK.surface, border: `1px solid ${DARK.border}` }} />
       </div>
     </div>
   );
@@ -556,18 +567,18 @@ function SwatchDark() {
 function SwatchSystem() {
   return (
     <div className="w-full h-full flex">
-      <div className="w-1/2 p-3 bg-ink-25 flex gap-1.5">
-        <div className="w-6 rounded bg-white border border-ink-150" />
+      <div className="w-1/2 p-3 flex gap-1.5" style={{ background: LIGHT.bg }}>
+        <div className="w-6 rounded" style={{ background: LIGHT.surface, border: `1px solid ${LIGHT.border}` }} />
         <div className="flex-1 space-y-1">
-          <div className="h-1.5 rounded bg-ink-200" />
-          <div className="h-1.5 rounded bg-ink-150 w-2/3" />
+          <div className="h-1.5 rounded" style={{ background: LIGHT.ink200 }} />
+          <div className="h-1.5 rounded w-2/3" style={{ background: LIGHT.ink150 }} />
         </div>
       </div>
-      <div className="w-1/2 p-3 flex gap-1.5" style={{ background: "#0F1115" }}>
-        <div className="w-6 rounded" style={{ background: "#17191F", border: "1px solid #2A2E37" }} />
+      <div className="w-1/2 p-3 flex gap-1.5" style={{ background: DARK.bg }}>
+        <div className="w-6 rounded" style={{ background: DARK.surface, border: `1px solid ${DARK.border}` }} />
         <div className="flex-1 space-y-1">
-          <div className="h-1.5 rounded" style={{ background: "#343942" }} />
-          <div className="h-1.5 rounded w-2/3" style={{ background: "#2A2E37" }} />
+          <div className="h-1.5 rounded" style={{ background: DARK.ink200 }} />
+          <div className="h-1.5 rounded w-2/3" style={{ background: DARK.ink150 }} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- 프로필 페이지의 테마 선택 UI에서 `SwatchLight`/`SwatchSystem` 컴포넌트가 Tailwind 유틸 클래스를 사용해 다크모드 CSS 오버라이드 영향을 받던 버그 수정
- 다크모드에서 "라이트 모드" 선택 버튼의 미리보기가 다크 색상으로 보이는 문제

## 변경 내용
- `SwatchLight` / `SwatchDark` / `SwatchSystem`: 모두 inline style로 교체 → 현재 활성 테마와 무관하게 항상 올바른 색상 표시
- `DocumentsPage` 아바타 `avatarColor` 에 fallback 색상(`#6B7280`) 추가 → undefined 시 빈 배경 방지

## 재현 방법
1. 다크모드 활성화
2. 프로필 → 테마 설정 진입
3. "라이트 모드" 선택 버튼의 미리보기가 다크 색상으로 보임 (버그)
4. PR 적용 후: 라이트 미리보기는 항상 밝은 색상으로 올바르게 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #445

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #445
