### PR TITLE
🔀 :: (#446) 접근성 개선 — aria-label, aria-modal, alt 텍스트

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -203,6 +203,7 @@ function AppLayoutInner() {
               }}
               className="btn-icon"
               title="로그아웃"
+              aria-label="로그아웃"
             >
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4" />

--- a/client/src/components/ProjectCalendar.tsx
+++ b/client/src/components/ProjectCalendar.tsx
@@ -345,7 +345,7 @@ export default function ProjectCalendar({
                 style={{ background: meUrl ? "transparent" : (me?.avatarColor ?? "#64748B") }}
               >
                 {meUrl ? (
-                  <img src={meUrl} alt="" className="w-full h-full object-cover" />
+                  <img src={meUrl} alt={me?.name ?? "내 프로필"} className="w-full h-full object-cover" />
                 ) : (
                   (me?.name ?? user.name ?? "나")[0]
                 )}

--- a/client/src/components/RevisionHistoryModal.tsx
+++ b/client/src/components/RevisionHistoryModal.tsx
@@ -73,7 +73,7 @@ export default function RevisionHistoryModal({
       <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()}>
         <div className="section-head">
           <div className="title">버전 히스토리 · {title}</div>
-          <button className="btn-icon" onClick={onClose}>
+          <button className="btn-icon" onClick={onClose} aria-label="닫기">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
           </button>
         </div>

--- a/client/src/components/ShareLinkModal.tsx
+++ b/client/src/components/ShareLinkModal.tsx
@@ -92,12 +92,12 @@ export default function ShareLinkModal({ documentId, folderId, documentTitle, on
 
   return (
     <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
-      <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()}>
+      <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="공유 링크 관리">
         <div className="section-head">
           <div className="title">
             {isFolder ? "📁 폴더 공유 링크" : "외부 공유 링크"} · {documentTitle}
           </div>
-          <button className="btn-icon" onClick={onClose}>
+          <button className="btn-icon" onClick={onClose} aria-label="닫기">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
           </button>
         </div>

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -794,7 +794,7 @@ function CreateModal({
       <div className="panel w-full max-w-[560px] shadow-pop overflow-hidden" onClick={(e) => e.stopPropagation()}>
         <div className="section-head">
           <div className="title">{reviseFromId ? "수정해서 재상신" : "새 결재 올리기"}</div>
-          <button className="btn-icon" onClick={onClose}>
+          <button className="btn-icon" onClick={onClose} aria-label="닫기">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
           </button>
         </div>

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1318,7 +1318,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
           <div className="panel w-full max-w-md" onClick={(e) => e.stopPropagation()}>
             <div className="section-head">
               <div className="title">새 폴더</div>
-              <button className="btn-icon" onClick={() => setCreating(null)}>
+              <button className="btn-icon" onClick={() => setCreating(null)} aria-label="닫기">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
               </button>
             </div>
@@ -1428,7 +1428,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
           <div className="panel w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
             <div className="section-head">
               <div className="title">문서 업로드</div>
-              <button className="btn-icon" onClick={() => setCreating(null)}>
+              <button className="btn-icon" onClick={() => setCreating(null)} aria-label="닫기">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
               </button>
             </div>


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
스크린 리더 및 키보드 네비게이션 사용자를 위한 접근성 속성 추가

## 변경 내용
| 파일 | 변경 내용 |
|------|-----------|
| ShareLinkModal | 닫기 버튼 `aria-label="닫기"`, 패널 `role="dialog" aria-modal="true"` |
| RevisionHistoryModal | 닫기 버튼 `aria-label="닫기"` |
| ApprovalsPage | 닫기 버튼 `aria-label="닫기"` |
| DocumentsPage | 폴더/문서 생성 모달 닫기 버튼 `aria-label="닫기"` (2개) |
| AppLayout | 로그아웃 버튼에 `aria-label` 추가 (title만 있었음) |
| ProjectCalendar | 아바타 `alt=""` → `alt={이름}` |

## Test plan
- [ ] VoiceOver(macOS) 또는 TalkBack(Android)으로 각 모달 닫기 버튼 포커스 시 "닫기" 읽히는지 확인
- [ ] Tab키로 모달 내 포커스 순환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #446

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #446
