### PR TITLE
🔀 :: (#448) 무음 실패 지점 사용자 피드백 추가

### DIFF
--- a/client/src/components/CreateProjectModal.tsx
+++ b/client/src/components/CreateProjectModal.tsx
@@ -56,7 +56,11 @@ export default function CreateProjectModal({ open, onClose, onCreated }: Props) 
     let alive = true;
     api<{ users: UserLite[] }>("/api/users")
       .then((r) => { if (alive) setUsers(r.users); })
-      .catch(() => {});
+      .catch((e: any) => {
+        if (!alive) return;
+        // 멤버 후보 로드 실패는 프로젝트 생성 자체를 막지 않지만, 사용자에게 왜 목록이 비었는지는 알려야 함
+        setErr(e?.message ?? "멤버 목록을 불러오지 못했어요. 새로고침 후 다시 시도해주세요.");
+      });
     return () => { alive = false; };
   }, [open]);
 

--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "../api";
+import { alertAsync } from "./ConfirmHost";
 
 type Results = {
   people?: any[];
@@ -44,6 +45,7 @@ export default function SearchModal({ open, onClose }: { open: boolean; onClose:
   const [q, setQ] = useState("");
   const [results, setResults] = useState<Results>({});
   const [loading, setLoading] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // 마운트 유지 + visible 플래그로 enter/exit 애니메이션 분리
@@ -80,15 +82,20 @@ export default function SearchModal({ open, onClose }: { open: boolean; onClose:
   const searchTokenRef = useRef(0);
   useEffect(() => {
     if (!open) return;
-    if (!q.trim()) { setResults({}); return; }
+    if (!q.trim()) { setResults({}); setSearchError(null); return; }
     setLoading(true);
+    setSearchError(null);
     const t = setTimeout(async () => {
       const my = ++searchTokenRef.current;
       try {
         const res = await api<{ results: Results }>(`/api/search?q=${encodeURIComponent(q.trim())}`);
         if (my !== searchTokenRef.current) return;
         setResults(res.results);
-      } catch {} finally {
+      } catch (e: any) {
+        if (my !== searchTokenRef.current) return;
+        setResults({});
+        setSearchError(e?.message ?? "검색에 실패했어요. 잠시 후 다시 시도해주세요.");
+      } finally {
         if (my === searchTokenRef.current) setLoading(false);
       }
     }, 180);
@@ -110,9 +117,14 @@ export default function SearchModal({ open, onClose }: { open: boolean; onClose:
       onClose();
       window.dispatchEvent(new CustomEvent("chat:open"));
       window.dispatchEvent(new CustomEvent("chat:open-room", { detail: { roomId: res.room.id } }));
-    } catch {
-      // 실패 시 fallback — 팀원 페이지로 이동
-      go("/directory");
+    } catch (e: any) {
+      // 실패 시 팀원 페이지로 이동하되, 왜 DM 이 안 열렸는지 토스트로 안내
+      onClose();
+      alertAsync({
+        title: "대화방을 열지 못했어요",
+        description: e?.message ?? "잠시 후 팀원 페이지에서 다시 시도해주세요.",
+      });
+      nav("/directory");
     }
   }
 
@@ -179,6 +191,11 @@ export default function SearchModal({ open, onClose }: { open: boolean; onClose:
         <div className="max-h-[60vh] overflow-y-auto">
           {!q.trim() ? (
             <div className="py-12 text-center t-caption">원하는 항목을 검색해보세요.</div>
+          ) : searchError && totalCount === 0 ? (
+            <div className="py-12 text-center">
+              <div className="text-[13px] font-bold text-rose-600">{searchError}</div>
+              <div className="text-[11px] text-ink-500 mt-1">다시 입력하면 자동으로 재시도돼요.</div>
+            </div>
           ) : loading && totalCount === 0 ? (
             <div className="py-12 text-center t-caption">검색 중…</div>
           ) : totalCount === 0 ? (

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -308,7 +308,12 @@ export default function ApprovalsPage() {
                 if (m) setSelected(m);
                 else {
                   // 체인상 다른 스코프의 결재일 수 있음 — 직접 조회해 띄움.
-                  api<{ approval: Approval }>(`/api/approval/${id}`).then((r) => setSelected(r.approval)).catch(() => {});
+                  api<{ approval: Approval }>(`/api/approval/${id}`)
+                    .then((r) => setSelected(r.approval))
+                    .catch((e: any) => alertAsync({
+                      title: "결재를 불러오지 못했어요",
+                      description: e?.message ?? "권한이 없거나 삭제된 결재일 수 있어요.",
+                    }));
                 }
               }}
               onRevise={(origId, prefill) => setRevising({ origId, prefill })}
@@ -340,7 +345,14 @@ export default function ApprovalsPage() {
           onDone={(newId) => {
             setRevising(null);
             load().then(() => {
-              if (newId) api<{ approval: Approval }>(`/api/approval/${newId}`).then((r) => setSelected(r.approval)).catch(() => {});
+              if (newId) {
+                api<{ approval: Approval }>(`/api/approval/${newId}`)
+                  .then((r) => setSelected(r.approval))
+                  .catch((e: any) => alertAsync({
+                    title: "새 결재를 불러오지 못했어요",
+                    description: e?.message ?? "목록에서 다시 선택해주세요.",
+                  }));
+              }
             });
           }}
         />

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -71,6 +71,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   ];
   const [folders, setFolders] = useState<Folder[]>([]);
   const [docs, setDocs] = useState<Doc[]>([]);
+  // 문서/폴더 목록 조회 실패 시 상단에 표시 — empty state 로 오인되는 걸 방지
+  const [loadErr, setLoadErr] = useState<string | null>(null);
   const [q, setQ] = useState("");
   const [creating, setCreating] = useState<null | "folder" | "doc">(null);
   const [uploading, setUploading] = useState(false);
@@ -168,19 +170,26 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       pid
         ? `projectId=${encodeURIComponent(pid)}&${extra}`
         : `scope=${scopeTab}&${extra}`;
-    const [f, d] = await Promise.all([
-      api<{ folders: Folder[] }>(
-        pid
-          ? `/api/document/folders?projectId=${encodeURIComponent(pid)}`
-          : `/api/document/folders?scope=${scopeTab}`,
-      ),
-      api<{ documents: Doc[] }>(
-        `/api/document?${qs(`folderId=${encodeURIComponent(currentFolder)}${q ? `&q=${encodeURIComponent(q)}` : ""}`)}`,
-      ),
-    ]);
-    if (aliveRef && !aliveRef.current) return;
-    setFolders(f.folders);
-    setDocs(d.documents);
+    try {
+      const [f, d] = await Promise.all([
+        api<{ folders: Folder[] }>(
+          pid
+            ? `/api/document/folders?projectId=${encodeURIComponent(pid)}`
+            : `/api/document/folders?scope=${scopeTab}`,
+        ),
+        api<{ documents: Doc[] }>(
+          `/api/document?${qs(`folderId=${encodeURIComponent(currentFolder)}${q ? `&q=${encodeURIComponent(q)}` : ""}`)}`,
+        ),
+      ]);
+      if (aliveRef && !aliveRef.current) return;
+      setFolders(f.folders);
+      setDocs(d.documents);
+      setLoadErr(null);
+    } catch (e: any) {
+      if (aliveRef && !aliveRef.current) return;
+      // 기존에는 uncaught 로 조용히 empty state 처럼 보였음 — 상단에 사유 노출
+      setLoadErr(e?.message ?? "문서 목록을 불러오지 못했어요. 잠시 후 다시 시도해주세요.");
+    }
   }
 
   // 프로젝트 칩 목록 로드 — 임베드 모드 아니고 고정 프로젝트가 없을 때만 필요.
@@ -189,7 +198,11 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     let alive = true;
     api<{ projects: ProjectChip[] }>("/api/document/projects")
       .then((r) => { if (alive) setProjects(r.projects); })
-      .catch(() => {});
+      .catch((e: any) => {
+        if (!alive) return;
+        // 프로젝트 칩은 보조 UI — 실패해도 페이지는 쓸 수 있으니 콘솔에만 남겨서 디버깅 가능하게
+        console.warn("[documents] 프로젝트 칩 로드 실패:", e?.message ?? e);
+      });
     return () => { alive = false; };
   }, [embedded, fixedProjectId]);
 
@@ -218,7 +231,11 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     let alive = true;
     api<{ users: DirUser[] }>("/api/users")
       .then((r) => { if (alive) setAllUsers(r.users); })
-      .catch(() => {});
+      .catch((e: any) => {
+        if (!alive) return;
+        // 모달의 CUSTOM 범위 선택용 — 실패 시 모달 내 에러 영역에 노출
+        setModalErr(e?.message ?? "사용자 목록을 불러오지 못했어요.");
+      });
     return () => { alive = false; };
   }, [creating, allUsers.length]);
 
@@ -1189,6 +1206,17 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
 
       {/* 문서 리스트 */}
       <div className="mb-2 text-[11px] font-extrabold text-ink-500 uppercase tracking-[0.08em]">문서</div>
+      {loadErr && (
+        <div className="mb-2 p-3 rounded-xl bg-rose-50 border border-rose-200 text-[12px] text-rose-700 flex items-center justify-between gap-2">
+          <span>{loadErr}</span>
+          <button
+            className="btn-ghost !px-2 !py-1 text-[11px]"
+            onClick={() => { const ref = { current: true }; load(ref); }}
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
       {docs.length === 0 ? (
         <div className="panel py-14 text-center">
           <div className="mx-auto w-12 h-12 rounded-2xl bg-ink-100 grid place-items-center mb-3">


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- 4개 페이지/컴포넌트의 \`catch {}\` 무음 실패를 사용자 피드백으로 교체
- SearchModal / CreateProjectModal / ApprovalsPage / DocumentsPage

## 변경
- **SearchModal**: 검색 실패 → 에러 상태 표시. DM 열기 실패 → alertAsync 로 이유 안내
- **CreateProjectModal**: 멤버 목록 로드 실패를 폼 에러 영역에 노출
- **ApprovalsPage**: 체인상 다른 스코프 결재 직접 조회 실패를 alertAsync 로 안내
- **DocumentsPage**: 문서/폴더 로드 실패 시 상단 배너 + 재시도 버튼. 프로젝트 칩은 보조 UI 라 console.warn 로 유지

## Test plan
- [ ] 검색 API 를 일부러 실패시켜 에러 메시지가 보이는지 확인
- [ ] 결재 상세 API 401/404 시 alertAsync 동작 확인
- [ ] 문서 목록 API 실패 시 상단 배너 + 재시도 버튼 노출 확인

Closes #448

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #448
