### PR TITLE
🔀 :: (#451) 서비스 계정 레지스트리 페이지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,6 +24,7 @@ import {
   ProjectPage,
   MeetingsPage,
   MeetingDetailPage,
+  ServiceAccountsPage,
   AdminPage,
   SuperAdminPage,
 } from "./routes";
@@ -95,6 +96,7 @@ export default function App() {
           <Route path="projects/:id" element={<ProjectPage />} />
           <Route path="meetings" element={<MeetingsPage />} />
           <Route path="meetings/:id" element={<MeetingDetailPage />} />
+          <Route path="accounts" element={<ServiceAccountsPage />} />
           <Route
             path="admin"
             element={

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -48,6 +48,7 @@ const COMM_NAV: NavItem[] = [
 const RESOURCE_NAV: NavItem[] = [
   { to: "/documents", label: "문서함", icon: DocsIcon },
   { to: "/expense", label: "법인카드", icon: CardIcon },
+  { to: "/accounts", label: "계정 관리", icon: KeyIcon },
 ];
 
 export default function AppLayout() {
@@ -494,6 +495,7 @@ const BREADCRUMB: Record<string, string> = {
   "/directory": "팀원",
   "/org": "조직도",
   "/documents": "문서함",
+  "/accounts": "계정 관리",
   "/approvals": "전자결재",
   "/expense": "법인카드",
   "/admin": "관리자",
@@ -598,6 +600,7 @@ function OrgIcon({ active }: I) { return svgBase(!!active, <><rect x="8" y="3" w
 function DocsIcon({ active }: I) { return svgBase(!!active, <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M8 13h8M8 17h5" /></>); }
 function ApprovalIcon({ active }: I) { return svgBase(!!active, <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /><path d="m9 14 2 2 4-4" /></>); }
 function CardIcon({ active }: I) { return svgBase(!!active, <><rect x="3" y="6" width="18" height="13" rx="2" /><path d="M3 11h18M7 16h4" /></>); }
+function KeyIcon({ active }: I) { return svgBase(!!active, <><circle cx="7.5" cy="15.5" r="4.5" /><path d="m10.5 12.5 10-10M17 7l3 3M15.5 8.5l3 3" /></>); }
 function ShieldIcon({ active }: I) { return svgBase(!!active, <><path d="M12 3 4 6v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V6z" /><path d="m9 12 2 2 4-4" /></>); }
 function CrownIcon({ active }: I) { return svgBase(!!active, <><path d="M3 18h18" /><path d="M3 8l4 5 5-8 5 8 4-5v10H3z" /></>); }
 const _unused_swInv = swInv;

--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -25,6 +25,7 @@ const PAGES: PageEntry[] = [
   { label: "팀원", desc: "구성원 디렉토리", path: "/directory", aliases: ["directory", "member", "people", "팀원", "디렉토리"], emoji: "👥" },
   { label: "조직도", desc: "조직 트리", path: "/org", aliases: ["org", "organization", "조직도", "조직"], emoji: "🏢" },
   { label: "문서함", desc: "회사 문서", path: "/documents", aliases: ["document", "file", "문서", "파일"], emoji: "📄" },
+  { label: "계정 관리", desc: "서비스 계정 레지스트리", path: "/accounts", aliases: ["account", "credential", "aws", "vercel", "계정", "크레덴셜"], emoji: "🔑" },
   { label: "법인카드", desc: "카드 사용내역", path: "/expense", aliases: ["expense", "card", "카드", "지출", "법카"], emoji: "💳" },
   { label: "내 프로필", desc: "내 정보 수정", path: "/profile", aliases: ["profile", "me", "프로필", "내정보"], emoji: "🙂" },
 ];

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -1,0 +1,537 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api";
+import { useAuth } from "../auth";
+import PageHeader from "../components/PageHeader";
+import { confirmAsync, alertAsync } from "../components/ConfirmHost";
+
+/**
+ * 서비스 계정 레지스트리 — 회사에서 쓰는 AWS/Vercel/GitHub/테스트 계정을 한 곳에 모으는 페이지.
+ *
+ * 보안 원칙:
+ * - 비밀번호/토큰/액세스키는 저장하지 않는다. 전용 비밀번호 관리자(1Password 등) 사용 전제.
+ * - 이 페이지의 목적은 "어떤 서비스의 계정을 누가 담당하는지" 인덱스.
+ *
+ * 편집 권한: 작성자 본인 또는 ADMIN.
+ */
+
+type Category = "CLOUD" | "HOSTING" | "VCS" | "PAYMENT" | "DOMAIN" | "EMAIL" | "MONITOR" | "DB" | "AI" | "TESTING" | "OTHER";
+
+const CATEGORY_META: Record<Category, { label: string; color: string; emoji: string }> = {
+  CLOUD:    { label: "클라우드", color: "#F59E0B", emoji: "☁️" },
+  HOSTING:  { label: "호스팅",   color: "#000000", emoji: "▲" },
+  VCS:      { label: "저장소",   color: "#24292F", emoji: "🐙" },
+  PAYMENT:  { label: "결제",     color: "#635BFF", emoji: "💳" },
+  DOMAIN:   { label: "도메인",   color: "#F38020", emoji: "🌐" },
+  EMAIL:    { label: "이메일",   color: "#EA4335", emoji: "✉️" },
+  MONITOR:  { label: "모니터링", color: "#7B3FE4", emoji: "📡" },
+  DB:       { label: "데이터베이스", color: "#336791", emoji: "🗄️" },
+  AI:       { label: "AI",       color: "#10A37F", emoji: "🤖" },
+  TESTING:  { label: "테스트",   color: "#16A34A", emoji: "🧪" },
+  OTHER:    { label: "기타",     color: "#6B7280", emoji: "📦" },
+};
+const CATEGORY_ORDER: Category[] = ["CLOUD", "HOSTING", "VCS", "DB", "PAYMENT", "DOMAIN", "EMAIL", "MONITOR", "AI", "TESTING", "OTHER"];
+
+type OwnerUser = { id: string; name: string; avatarColor: string; avatarUrl: string | null; email: string; team?: string | null; position?: string | null };
+type Account = {
+  id: string;
+  serviceName: string;
+  category: Category;
+  loginId: string | null;
+  url: string | null;
+  notes: string | null;
+  ownerUser: OwnerUser | null;
+  ownerName: string | null;
+  createdBy: { id: string; name: string };
+  createdAt: string;
+  updatedAt: string;
+};
+
+type DirUser = { id: string; name: string; email: string; team?: string | null; position?: string | null; avatarColor?: string; avatarUrl?: string | null };
+
+type FormState = {
+  serviceName: string;
+  category: Category;
+  loginId: string;
+  url: string;
+  notes: string;
+  ownerUserId: string; // "" = 없음
+  ownerName: string;   // 외부 담당자
+};
+
+const EMPTY_FORM: FormState = {
+  serviceName: "",
+  category: "OTHER",
+  loginId: "",
+  url: "",
+  notes: "",
+  ownerUserId: "",
+  ownerName: "",
+};
+
+export default function ServiceAccountsPage() {
+  const { user } = useAuth();
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [users, setUsers] = useState<DirUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
+  const [q, setQ] = useState("");
+  const [filterCat, setFilterCat] = useState<Category | "ALL">("ALL");
+
+  // 모달 상태 — "new" 생성, 문자열은 편집 중 id
+  const [editing, setEditing] = useState<"new" | string | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [formErr, setFormErr] = useState<string | null>(null);
+
+  const canEdit = (a: Account) => user?.role === "ADMIN" || (user as any)?.superAdmin || a.createdBy.id === user?.id;
+
+  async function load() {
+    setLoading(true);
+    try {
+      const r = await api<{ accounts: Account[] }>("/api/service-accounts");
+      setAccounts(r.accounts);
+      setLoadErr(null);
+    } catch (e: any) {
+      setLoadErr(e?.message ?? "계정 목록을 불러오지 못했어요.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+    // 담당자 선택용 — 한 번만 로드
+    api<{ users: DirUser[] }>("/api/users")
+      .then((r) => setUsers(r.users))
+      .catch(() => {});
+  }, []);
+
+  const filtered = useMemo(() => {
+    const k = q.trim().toLowerCase();
+    return accounts.filter((a) => {
+      if (filterCat !== "ALL" && a.category !== filterCat) return false;
+      if (!k) return true;
+      return (
+        a.serviceName.toLowerCase().includes(k) ||
+        (a.loginId ?? "").toLowerCase().includes(k) ||
+        (a.ownerUser?.name ?? "").toLowerCase().includes(k) ||
+        (a.ownerName ?? "").toLowerCase().includes(k) ||
+        (a.notes ?? "").toLowerCase().includes(k)
+      );
+    });
+  }, [accounts, q, filterCat]);
+
+  // 카테고리별 그룹
+  const grouped = useMemo(() => {
+    const m = new Map<Category, Account[]>();
+    for (const a of filtered) {
+      const list = m.get(a.category) ?? [];
+      list.push(a);
+      m.set(a.category, list);
+    }
+    return CATEGORY_ORDER.filter((c) => m.has(c)).map((c) => ({ category: c, items: m.get(c)! }));
+  }, [filtered]);
+
+  function openCreate() {
+    setForm(EMPTY_FORM);
+    setFormErr(null);
+    setEditing("new");
+  }
+  function openEdit(a: Account) {
+    setForm({
+      serviceName: a.serviceName,
+      category: a.category,
+      loginId: a.loginId ?? "",
+      url: a.url ?? "",
+      notes: a.notes ?? "",
+      ownerUserId: a.ownerUser?.id ?? "",
+      ownerName: a.ownerName ?? "",
+    });
+    setFormErr(null);
+    setEditing(a.id);
+  }
+  function closeModal() {
+    setEditing(null);
+    setForm(EMPTY_FORM);
+    setFormErr(null);
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (saving) return;
+    if (!form.serviceName.trim()) {
+      setFormErr("서비스 이름을 입력해주세요.");
+      return;
+    }
+    setSaving(true);
+    setFormErr(null);
+    try {
+      const payload: any = {
+        serviceName: form.serviceName.trim(),
+        category: form.category,
+        loginId: form.loginId.trim() || null,
+        url: form.url.trim() || null,
+        notes: form.notes.trim() || null,
+        ownerUserId: form.ownerUserId || null,
+        ownerName: form.ownerName.trim() || null,
+      };
+      if (editing === "new") {
+        await api("/api/service-accounts", { method: "POST", json: payload });
+      } else if (typeof editing === "string") {
+        await api(`/api/service-accounts/${editing}`, { method: "PATCH", json: payload });
+      }
+      closeModal();
+      await load();
+    } catch (err: any) {
+      setFormErr(err?.message ?? "저장에 실패했어요.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove(a: Account) {
+    const ok = await confirmAsync({
+      title: "이 계정 항목을 삭제할까요?",
+      description: `"${a.serviceName}" 에 대한 기록이 사라집니다. (실제 서비스 계정은 영향받지 않아요)`,
+      confirmLabel: "삭제",
+      tone: "danger",
+    });
+    if (!ok) return;
+    try {
+      await api(`/api/service-accounts/${a.id}`, { method: "DELETE" });
+      await load();
+    } catch (e: any) {
+      alertAsync({ title: "삭제 실패", description: e?.message ?? "다시 시도해주세요" });
+    }
+  }
+
+  async function copyId(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      alertAsync({ title: "복사됨", description: "로그인 ID 를 클립보드에 복사했어요." });
+    } catch {
+      window.prompt("복사하세요", text);
+    }
+  }
+
+  return (
+    <div className="container-narrow py-6">
+      <PageHeader
+        eyebrow="팀 리소스"
+        title="계정 관리"
+        description="AWS · Vercel · 테스트 계정 등 팀이 쓰는 서비스 계정을 한 곳에서 관리해요. ⚠️ 비밀번호는 저장하지 마세요."
+        right={
+          <button className="btn-primary" onClick={openCreate}>+ 계정 추가</button>
+        }
+      />
+
+      {/* 경고 배너 */}
+      <div className="panel p-3 mb-4 bg-amber-50 border border-amber-200 text-[12px] text-amber-800 flex items-start gap-2">
+        <span className="text-base leading-none">🔐</span>
+        <div>
+          <div className="font-bold">비밀번호·토큰·액세스키는 여기에 저장하지 않아요.</div>
+          <div className="mt-0.5 text-amber-700">실제 크레덴셜은 1Password · Bitwarden 같은 전용 비밀번호 관리자에 두고, 여기에는 "어떤 서비스를 누가 쓰는지" 만 기록하세요.</div>
+        </div>
+      </div>
+
+      {/* 검색 + 카테고리 필터 */}
+      <div className="flex flex-col sm:flex-row gap-2 mb-4">
+        <input
+          className="input flex-1"
+          placeholder="서비스 이름·로그인 ID·담당자·메모 검색"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          maxLength={80}
+        />
+        <select
+          className="input sm:w-40"
+          value={filterCat}
+          onChange={(e) => setFilterCat(e.target.value as Category | "ALL")}
+        >
+          <option value="ALL">전체 카테고리</option>
+          {CATEGORY_ORDER.map((c) => (
+            <option key={c} value={c}>{CATEGORY_META[c].emoji} {CATEGORY_META[c].label}</option>
+          ))}
+        </select>
+      </div>
+
+      {loadErr && (
+        <div className="mb-3 p-3 rounded-xl bg-rose-50 border border-rose-200 text-[12px] text-rose-700 flex items-center justify-between gap-2">
+          <span>{loadErr}</span>
+          <button className="btn-ghost !px-2 !py-1 text-[11px]" onClick={load}>다시 시도</button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="panel py-14 text-center t-caption">불러오는 중…</div>
+      ) : accounts.length === 0 ? (
+        <div className="panel py-14 text-center">
+          <div className="mx-auto w-12 h-12 rounded-2xl bg-ink-100 grid place-items-center mb-3 text-xl">🔑</div>
+          <div className="text-[13px] font-bold text-ink-800">아직 등록된 계정이 없어요</div>
+          <div className="text-[12px] text-ink-500 mt-1">우측 상단 <b>+ 계정 추가</b> 버튼으로 첫 계정을 등록해보세요.</div>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="panel py-14 text-center">
+          <div className="text-[13px] font-bold text-ink-800">일치하는 계정이 없어요</div>
+          <div className="text-[12px] text-ink-500 mt-1">검색어나 카테고리 필터를 바꿔보세요.</div>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {grouped.map(({ category, items }) => {
+            const meta = CATEGORY_META[category];
+            return (
+              <section key={category}>
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="inline-flex items-center gap-1.5 text-[11px] font-extrabold text-ink-500 uppercase tracking-[0.08em]">
+                    <span>{meta.emoji}</span>
+                    <span>{meta.label}</span>
+                    <span className="text-ink-400 tabular">· {items.length}</span>
+                  </span>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {items.map((a) => (
+                    <AccountCard
+                      key={a.id}
+                      a={a}
+                      canEdit={canEdit(a)}
+                      onEdit={() => openEdit(a)}
+                      onDelete={() => remove(a)}
+                      onCopy={() => a.loginId && copyId(a.loginId)}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      {editing && (
+        <AccountModal
+          mode={editing === "new" ? "new" : "edit"}
+          form={form}
+          setForm={setForm}
+          users={users}
+          saving={saving}
+          err={formErr}
+          onClose={closeModal}
+          onSubmit={submit}
+        />
+      )}
+    </div>
+  );
+}
+
+function AccountCard({
+  a, canEdit, onEdit, onDelete, onCopy,
+}: {
+  a: Account;
+  canEdit: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+  onCopy: () => void;
+}) {
+  const meta = CATEGORY_META[a.category];
+  return (
+    <div className="panel p-4">
+      <div className="flex items-start gap-3">
+        <div className="w-9 h-9 rounded-xl grid place-items-center text-white flex-shrink-0" style={{ background: meta.color }}>
+          <span className="text-base leading-none">{meta.emoji}</span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <div className="text-[14px] font-extrabold text-ink-900 truncate">{a.serviceName}</div>
+              <div className="text-[11px] text-ink-500">{meta.label}</div>
+            </div>
+            {canEdit && (
+              <div className="flex items-center gap-1 flex-shrink-0">
+                <button className="btn-ghost !px-2 !py-1 text-[11px]" onClick={onEdit} title="편집">편집</button>
+                <button className="btn-ghost !px-2 !py-1 text-[11px] text-danger" onClick={onDelete} title="삭제">삭제</button>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-2.5 space-y-1.5 text-[12px]">
+            {a.loginId && (
+              <div className="flex items-center gap-1.5 text-ink-700">
+                <span className="text-ink-400 w-14 flex-shrink-0">로그인</span>
+                <span className="tabular truncate font-medium">{a.loginId}</span>
+                <button className="btn-ghost !px-1.5 !py-0.5 text-[10px]" onClick={onCopy} title="복사">복사</button>
+              </div>
+            )}
+            {a.url && (
+              <div className="flex items-center gap-1.5 text-ink-700">
+                <span className="text-ink-400 w-14 flex-shrink-0">URL</span>
+                <a href={a.url} target="_blank" rel="noopener noreferrer" className="text-brand-600 hover:underline truncate">
+                  {a.url}
+                </a>
+              </div>
+            )}
+            <div className="flex items-center gap-1.5 text-ink-700">
+              <span className="text-ink-400 w-14 flex-shrink-0">담당자</span>
+              {a.ownerUser ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <span
+                    className="w-5 h-5 rounded-full grid place-items-center text-white text-[10px] font-bold overflow-hidden"
+                    style={{ background: a.ownerUser.avatarUrl ? "transparent" : a.ownerUser.avatarColor }}
+                  >
+                    {a.ownerUser.avatarUrl ? (
+                      <img src={a.ownerUser.avatarUrl} alt={a.ownerUser.name} className="w-full h-full object-cover" />
+                    ) : (
+                      a.ownerUser.name[0]
+                    )}
+                  </span>
+                  <span className="font-medium">{a.ownerUser.name}</span>
+                  {a.ownerUser.team && <span className="text-ink-400 text-[11px]">· {a.ownerUser.team}</span>}
+                </span>
+              ) : a.ownerName ? (
+                <span className="font-medium">{a.ownerName} <span className="text-ink-400 text-[11px]">· 외부</span></span>
+              ) : (
+                <span className="text-ink-400">미지정</span>
+              )}
+            </div>
+            {a.notes && (
+              <div className="mt-1.5 pt-1.5 border-t border-ink-100 text-ink-600 whitespace-pre-wrap break-words text-[11.5px]">{a.notes}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AccountModal({
+  mode, form, setForm, users, saving, err, onClose, onSubmit,
+}: {
+  mode: "new" | "edit";
+  form: FormState;
+  setForm: (f: FormState) => void;
+  users: DirUser[];
+  saving: boolean;
+  err: string | null;
+  onClose: () => void;
+  onSubmit: (e: React.FormEvent) => void;
+}) {
+  // Esc 로 닫기
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+      <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="계정 편집">
+        <div className="section-head">
+          <div className="title">{mode === "new" ? "새 계정 추가" : "계정 편집"}</div>
+          <button className="btn-icon" onClick={onClose} aria-label="닫기">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+          </button>
+        </div>
+        <form className="p-5 space-y-3 max-h-[75vh] overflow-auto" onSubmit={onSubmit}>
+          <div className="grid grid-cols-1 sm:grid-cols-[1fr_140px] gap-2">
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] font-bold text-ink-500">서비스 이름 *</span>
+              <input
+                className="input"
+                placeholder='예: "AWS 프로덕션", "Vercel - hinest"'
+                value={form.serviceName}
+                maxLength={80}
+                required
+                autoFocus
+                onChange={(e) => setForm({ ...form, serviceName: e.target.value })}
+              />
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] font-bold text-ink-500">카테고리</span>
+              <select
+                className="input"
+                value={form.category}
+                onChange={(e) => setForm({ ...form, category: e.target.value as Category })}
+              >
+                {CATEGORY_ORDER.map((c) => (
+                  <option key={c} value={c}>{CATEGORY_META[c].emoji} {CATEGORY_META[c].label}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] font-bold text-ink-500">로그인 ID / 이메일</span>
+            <input
+              className="input"
+              placeholder="예: ops@hinest.com"
+              value={form.loginId}
+              maxLength={200}
+              onChange={(e) => setForm({ ...form, loginId: e.target.value })}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] font-bold text-ink-500">콘솔 URL</span>
+            <input
+              className="input"
+              type="url"
+              placeholder="https://console.aws.amazon.com"
+              value={form.url}
+              maxLength={500}
+              onChange={(e) => setForm({ ...form, url: e.target.value })}
+            />
+          </label>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] font-bold text-ink-500">담당자 (사내)</span>
+              <select
+                className="input"
+                value={form.ownerUserId}
+                onChange={(e) => setForm({ ...form, ownerUserId: e.target.value, ownerName: e.target.value ? "" : form.ownerName })}
+              >
+                <option value="">선택 안 함</option>
+                {users.map((u) => (
+                  <option key={u.id} value={u.id}>
+                    {u.name}{u.team ? ` · ${u.team}` : ""}{u.position ? ` · ${u.position}` : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[11px] font-bold text-ink-500">담당자 (외부)</span>
+              <input
+                className="input"
+                placeholder="사내 유저가 아닐 때 수기 입력"
+                value={form.ownerName}
+                maxLength={80}
+                disabled={!!form.ownerUserId}
+                onChange={(e) => setForm({ ...form, ownerName: e.target.value })}
+              />
+            </label>
+          </div>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] font-bold text-ink-500">메모 <span className="text-rose-600 font-normal">(비밀번호 금지)</span></span>
+            <textarea
+              className="input"
+              rows={3}
+              placeholder="접근 방법, MFA 장치, 요금제 등 자유 메모"
+              value={form.notes}
+              maxLength={2000}
+              onChange={(e) => setForm({ ...form, notes: e.target.value })}
+            />
+            <span className="text-[10px] text-ink-400">⚠️ 비밀번호·액세스키·API 토큰은 여기에 쓰지 마세요. 전용 비밀번호 관리자에 두세요.</span>
+          </label>
+
+          {err && <div className="text-[12px] text-rose-600 p-2 rounded-lg bg-rose-50 border border-rose-200">{err}</div>}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <button type="button" className="btn-ghost" onClick={onClose} disabled={saving}>취소</button>
+            <button className="btn-primary" disabled={saving}>
+              {saving ? "저장 중…" : (mode === "new" ? "추가" : "저장")}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -21,6 +21,7 @@ export const loadExpense = () => import("./pages/ExpensePage");
 export const loadProject = () => import("./pages/ProjectPage");
 export const loadMeetings = () => import("./pages/MeetingsPage");
 export const loadMeetingDetail = () => import("./pages/MeetingDetailPage");
+export const loadAccounts = () => import("./pages/ServiceAccountsPage");
 export const loadAdmin = () => import("./pages/AdminPage");
 export const loadSuperAdmin = () => import("./pages/SuperAdminPage");
 
@@ -37,6 +38,7 @@ export const ExpensePage = lazy(loadExpense);
 export const ProjectPage = lazy(loadProject);
 export const MeetingsPage = lazy(loadMeetings);
 export const MeetingDetailPage = lazy(loadMeetingDetail);
+export const ServiceAccountsPage = lazy(loadAccounts);
 export const AdminPage = lazy(loadAdmin);
 export const SuperAdminPage = lazy(loadSuperAdmin);
 
@@ -55,4 +57,5 @@ export const ROUTE_PREFETCH: Record<string, () => Promise<unknown>> = {
   "/admin": loadAdmin,
   "/super-admin": loadSuperAdmin,
   "/meetings": loadMeetings,
+  "/accounts": loadAccounts,
 };

--- a/server/prisma/migrations/20260424130000_add_service_account/migration.sql
+++ b/server/prisma/migrations/20260424130000_add_service_account/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "ServiceAccount" (
+    "id" TEXT NOT NULL,
+    "serviceName" TEXT NOT NULL,
+    "category" TEXT NOT NULL DEFAULT 'OTHER',
+    "loginId" TEXT,
+    "url" TEXT,
+    "notes" TEXT,
+    "ownerUserId" TEXT,
+    "ownerName" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ServiceAccount_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ServiceAccount_category_serviceName_idx" ON "ServiceAccount"("category", "serviceName");
+
+-- CreateIndex
+CREATE INDEX "ServiceAccount_ownerUserId_idx" ON "ServiceAccount"("ownerUserId");
+
+-- AddForeignKey
+ALTER TABLE "ServiceAccount" ADD CONSTRAINT "ServiceAccount_ownerUserId_fkey" FOREIGN KEY ("ownerUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ServiceAccount" ADD CONSTRAINT "ServiceAccount_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -58,36 +58,38 @@ model User {
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
 
-  inviteKey             InviteKey?             @relation("UsedKey")
-  events                Event[]
-  leaves                Leave[]
-  attendances           Attendance[]
-  journals              Journal[]
-  notices               Notice[]
-  messagesSent          ChatMessage[]          @relation("Sender")
-  memberships           RoomMember[]
-  logs                  AuditLog[]
-  cardExpenses          CardExpense[]
-  notifications         Notification[]
-  documents             Document[]             @relation("DocumentAuthor")
-  approvalsRequested    Approval[]             @relation("ApprovalRequester")
-  approvalReviews       ApprovalStep[]         @relation("ApprovalReviewer")
-  passkeys              Passkey[]
-  desktopBios           DesktopBiometric[]
-  reactions             MessageReaction[]
-  projects              ProjectMember[]
-  projectsCreated       Project[]              @relation("ProjectCreator")
-  meetings              Meeting[]              @relation("MeetingAuthor")
-  meetingViews          MeetingViewer[]
-  noticeReactions       NoticeReaction[]
-  pins                  Pin[]
-  notifPref             NotificationPref?
-  approvalLineFavorites ApprovalLineFavorite[]
-  approvalComments      ApprovalComment[]
-  meetingRevisions      MeetingRevision[]
-  documentRevisions     DocumentRevision[]
-  shareLinksCreated     DocumentShareLink[]    @relation("ShareLinkCreator")
-  folderShareLinksCreated FolderShareLink[]    @relation("FolderShareLinkCreator")
+  inviteKey               InviteKey?             @relation("UsedKey")
+  events                  Event[]
+  leaves                  Leave[]
+  attendances             Attendance[]
+  journals                Journal[]
+  notices                 Notice[]
+  messagesSent            ChatMessage[]          @relation("Sender")
+  memberships             RoomMember[]
+  logs                    AuditLog[]
+  cardExpenses            CardExpense[]
+  notifications           Notification[]
+  documents               Document[]             @relation("DocumentAuthor")
+  approvalsRequested      Approval[]             @relation("ApprovalRequester")
+  approvalReviews         ApprovalStep[]         @relation("ApprovalReviewer")
+  passkeys                Passkey[]
+  desktopBios             DesktopBiometric[]
+  reactions               MessageReaction[]
+  projects                ProjectMember[]
+  projectsCreated         Project[]              @relation("ProjectCreator")
+  meetings                Meeting[]              @relation("MeetingAuthor")
+  meetingViews            MeetingViewer[]
+  noticeReactions         NoticeReaction[]
+  pins                    Pin[]
+  notifPref               NotificationPref?
+  approvalLineFavorites   ApprovalLineFavorite[]
+  approvalComments        ApprovalComment[]
+  meetingRevisions        MeetingRevision[]
+  documentRevisions       DocumentRevision[]
+  shareLinksCreated       DocumentShareLink[]    @relation("ShareLinkCreator")
+  folderShareLinksCreated FolderShareLink[]      @relation("FolderShareLinkCreator")
+  serviceAccountsOwned    ServiceAccount[]       @relation("ServiceAccountOwner")
+  serviceAccountsCreated  ServiceAccount[]       @relation("ServiceAccountCreator")
 }
 
 /// 팀/프로젝트 — 사이드바 "팀" 카테고리 아래에 자신이 참여중인 프로젝트가 표시됨.
@@ -675,7 +677,7 @@ model Folder {
   project      Project?   @relation(fields: [projectId], references: [id], onDelete: Cascade)
   createdAt    DateTime   @default(now())
 
-  shareLinks   FolderShareLink[]
+  shareLinks FolderShareLink[]
 
   @@index([projectId])
 }
@@ -796,4 +798,27 @@ model MeetingViewer {
 
   @@unique([meetingId, userId])
   @@index([userId])
+}
+
+/// 서비스 계정 레지스트리 — AWS/Vercel/GitHub/외부 SaaS 등의 "누가 어떤 계정을 쓰는지" 기록.
+/// 보안상 비밀번호는 저장하지 않음(1Password 등 전용 도구 사용 전제).
+/// 로그인 ID(이메일/사용자명)·콘솔 URL·담당자·분류·메모만 보관.
+model ServiceAccount {
+  id          String   @id @default(cuid())
+  serviceName String // "AWS 프로덕션", "Vercel - hinest", "GitHub Org" 등 식별용 이름
+  category    String   @default("OTHER") // CLOUD | HOSTING | VCS | PAYMENT | DOMAIN | EMAIL | MONITOR | DB | AI | TESTING | OTHER
+  loginId     String? // 로그인 이메일 또는 사용자명
+  url         String? // 콘솔/대시보드 URL
+  notes       String? // 접근 방법, MFA 사용 여부 등 자유 메모 (비밀번호 금지)
+  // 담당자 — 사용자 연결이 있으면 ownerUserId, 외부 담당자는 ownerName 으로 기록.
+  ownerUserId String?
+  ownerUser   User?    @relation("ServiceAccountOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
+  ownerName   String? // ownerUserId 가 없을 때 수기 이름 (예: 외주 개발자)
+  createdById String
+  createdBy   User     @relation("ServiceAccountCreator", fields: [createdById], references: [id], onDelete: Cascade)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([category, serviceName])
+  @@index([ownerUserId])
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,6 +33,7 @@ import meetingRouter from "./routes/meeting.js";
 import pinRouter from "./routes/pin.js";
 import { shareLinkAuthedRouter, shareLinkPublicRouter } from "./routes/shareLink.js";
 import { folderShareLinkAuthedRouter } from "./routes/folderShareLink.js";
+import serviceAccountRouter from "./routes/serviceAccount.js";
 import path from "node:path";
 import mime from "mime-types";
 
@@ -157,6 +158,7 @@ app.use("/api/nav", navRouter);
 app.use("/api/project", projectRouter);
 app.use("/api/meeting", meetingRouter);
 app.use("/api/pins", pinRouter);
+app.use("/api/service-accounts", serviceAccountRouter);
 // 공유 링크 — 생성/관리는 인증 필요, 실제 외부 다운로드는 인증 없이.
 app.use("/api/share-links", shareLinkAuthedRouter);
 app.use("/api/folder-share-links", folderShareLinkAuthedRouter);

--- a/server/src/routes/serviceAccount.ts
+++ b/server/src/routes/serviceAccount.ts
@@ -1,0 +1,174 @@
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../lib/db.js";
+import { requireAuth } from "../lib/auth.js";
+
+/**
+ * 서비스 계정 레지스트리 — AWS/Vercel/GitHub 등 외부 서비스의 "누가 어떤 계정을 쓰는지" 기록.
+ *
+ * 보안 원칙:
+ * - 비밀번호/액세스키/토큰은 저장하지 않는다. 어디까지나 "어떤 서비스에 어떤 로그인 ID 로,
+ *   누가 담당하는지" 찾기 위한 인덱스. 실제 크레덴셜은 1Password/Bitwarden 같은 전용 도구에 둔다.
+ * - `notes` 필드에도 비밀번호는 쓰지 말 것 — 경고 문구는 클라에서 노출.
+ *
+ * 권한:
+ * - 로그인한 사용자는 전체 목록 열람 가능 (팀이 공유 자원으로 쓰는 전제).
+ * - 생성/수정/삭제는 작성자(createdById) 본인 또는 ADMIN/SUPER 만.
+ */
+
+const router = Router();
+router.use(requireAuth);
+
+const CATEGORIES = [
+  "CLOUD",      // AWS / GCP / Azure
+  "HOSTING",    // Vercel / Netlify / Render
+  "VCS",        // GitHub / GitLab
+  "PAYMENT",    // Stripe / Toss
+  "DOMAIN",     // 가비아 / Cloudflare
+  "EMAIL",      // Google Workspace / Resend
+  "MONITOR",    // Sentry / Datadog
+  "DB",         // Supabase / Planetscale
+  "AI",         // OpenAI / Anthropic
+  "TESTING",    // BrowserStack / 테스트 계정
+  "OTHER",
+] as const;
+
+const baseSchema = z.object({
+  serviceName: z.string().trim().min(1).max(80),
+  category: z.enum(CATEGORIES).optional().default("OTHER"),
+  loginId: z.string().trim().max(200).optional().nullable(),
+  url: z.string().trim().url().max(500).optional().nullable().or(z.literal("")),
+  notes: z.string().max(2000).optional().nullable(),
+  ownerUserId: z.string().optional().nullable(),
+  ownerName: z.string().trim().max(80).optional().nullable(),
+});
+
+const createSchema = baseSchema;
+const updateSchema = baseSchema.partial();
+
+function canEdit(user: { id: string; role?: string; superAdmin?: boolean }, row: { createdById: string }) {
+  return user.superAdmin || user.role === "ADMIN" || row.createdById === user.id;
+}
+
+/** 목록 — 카테고리 필터와 검색 지원. */
+router.get("/", async (req, res) => {
+  const category = typeof req.query.category === "string" ? req.query.category : undefined;
+  const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+
+  const where: any = {};
+  if (category && (CATEGORIES as readonly string[]).includes(category)) {
+    where.category = category;
+  }
+  if (q) {
+    where.OR = [
+      { serviceName: { contains: q, mode: "insensitive" } },
+      { loginId: { contains: q, mode: "insensitive" } },
+      { ownerName: { contains: q, mode: "insensitive" } },
+      { notes: { contains: q, mode: "insensitive" } },
+    ];
+  }
+
+  const rows = await prisma.serviceAccount.findMany({
+    where,
+    orderBy: [{ category: "asc" }, { serviceName: "asc" }],
+    include: {
+      ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
+      createdBy: { select: { id: true, name: true } },
+    },
+  });
+
+  res.json({ accounts: rows });
+});
+
+router.post("/", async (req, res) => {
+  const parsed = createSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.issues[0]?.message ?? "잘못된 요청" });
+  }
+  const input = parsed.data;
+  const userId = (req as any).user.id as string;
+
+  // URL 빈 문자열은 null 로 정규화 (zod 의 literal("") 을 통과한 경우)
+  const url = input.url === "" ? null : input.url ?? null;
+
+  // ownerUserId 가 실존 유저인지 검증 — 빈 문자열은 null 로
+  let ownerUserId = input.ownerUserId || null;
+  if (ownerUserId) {
+    const exists = await prisma.user.findUnique({ where: { id: ownerUserId }, select: { id: true } });
+    if (!exists) return res.status(400).json({ error: "담당자로 지정한 사용자를 찾을 수 없어요." });
+  }
+
+  const row = await prisma.serviceAccount.create({
+    data: {
+      serviceName: input.serviceName,
+      category: input.category ?? "OTHER",
+      loginId: input.loginId || null,
+      url,
+      notes: input.notes || null,
+      ownerUserId,
+      ownerName: input.ownerName || null,
+      createdById: userId,
+    },
+    include: {
+      ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
+      createdBy: { select: { id: true, name: true } },
+    },
+  });
+
+  res.json({ account: row });
+});
+
+router.patch("/:id", async (req, res) => {
+  const parsed = updateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.issues[0]?.message ?? "잘못된 요청" });
+  }
+  const user = (req as any).user as { id: string; role?: string; superAdmin?: boolean };
+  const id = req.params.id;
+
+  const existing = await prisma.serviceAccount.findUnique({ where: { id }, select: { id: true, createdById: true } });
+  if (!existing) return res.status(404).json({ error: "존재하지 않는 계정이에요." });
+  if (!canEdit(user, existing)) {
+    return res.status(403).json({ error: "이 계정을 수정할 권한이 없어요." });
+  }
+
+  const input = parsed.data;
+  const data: any = {};
+  if (input.serviceName !== undefined) data.serviceName = input.serviceName;
+  if (input.category !== undefined) data.category = input.category;
+  if (input.loginId !== undefined) data.loginId = input.loginId || null;
+  if (input.url !== undefined) data.url = input.url === "" ? null : input.url;
+  if (input.notes !== undefined) data.notes = input.notes || null;
+  if (input.ownerName !== undefined) data.ownerName = input.ownerName || null;
+  if (input.ownerUserId !== undefined) {
+    const next = input.ownerUserId || null;
+    if (next) {
+      const exists = await prisma.user.findUnique({ where: { id: next }, select: { id: true } });
+      if (!exists) return res.status(400).json({ error: "담당자로 지정한 사용자를 찾을 수 없어요." });
+    }
+    data.ownerUserId = next;
+  }
+
+  const row = await prisma.serviceAccount.update({
+    where: { id },
+    data,
+    include: {
+      ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
+      createdBy: { select: { id: true, name: true } },
+    },
+  });
+  res.json({ account: row });
+});
+
+router.delete("/:id", async (req, res) => {
+  const user = (req as any).user as { id: string; role?: string; superAdmin?: boolean };
+  const existing = await prisma.serviceAccount.findUnique({ where: { id: req.params.id }, select: { id: true, createdById: true } });
+  if (!existing) return res.status(404).json({ error: "존재하지 않는 계정이에요." });
+  if (!canEdit(user, existing)) {
+    return res.status(403).json({ error: "이 계정을 삭제할 권한이 없어요." });
+  }
+  await prisma.serviceAccount.delete({ where: { id: req.params.id } });
+  res.json({ ok: true });
+});
+
+export default router;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
팀이 쓰는 AWS · Vercel · GitHub · 테스트 계정 등을 한 곳에 모으고 **담당자를 지정**할 수 있는 페이지. 사이드바 \`팀 리소스\` → \`계정 관리\` 또는 \`/accounts\`.

## 보안 원칙 🔐
- **비밀번호·토큰·액세스키는 저장하지 않습니다.** 실제 크레덴셜은 1Password · Bitwarden 같은 전용 도구에 두세요.
- notes 필드에도 비밀번호 금지 — 경고 배너·라벨로 명시
- 열람은 로그인 사용자 전원, 편집/삭제는 작성자 본인 또는 ADMIN 만

## 필드
- 서비스 이름 / 카테고리(11종) / 로그인 ID / 콘솔 URL / 메모
- 담당자: 사내 유저(ownerUserId) 또는 외부 담당자(ownerName)

## UI
- 카테고리별 그룹핑, 검색 + 필터
- 로그인 ID 원클릭 복사, URL 새 탭 열기
- ⌘K 전역 검색에서도 페이지 진입 가능
- 모달 Esc 닫기, aria-modal 등 접근성 속성

## Migration
- \`20260424130000_add_service_account\` — ServiceAccount 테이블 + 인덱스 2개

## Test plan
- [ ] \`/accounts\` 접근 후 + 계정 추가 → 목록 반영 확인
- [ ] 카테고리별 그룹핑 정상 표시
- [ ] 검색 · 필터 동작
- [ ] 담당자 사내 유저 지정 시 아바타 노출, 외부 입력 시 "· 외부" 뱃지
- [ ] 작성자/ADMIN 외엔 편집·삭제 버튼 미노출
- [ ] DB 마이그레이션: \`npx prisma migrate deploy\`

Closes #451

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #451
