### PR TITLE
🔀 :: (#452) 전사/팀/프로젝트 스코프

### DIFF
--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -11,6 +11,11 @@ import { confirmAsync, alertAsync } from "../components/ConfirmHost";
  * - 비밀번호/토큰/액세스키는 저장하지 않는다. 전용 비밀번호 관리자(1Password 등) 사용 전제.
  * - 이 페이지의 목적은 "어떤 서비스의 계정을 누가 담당하는지" 인덱스.
  *
+ * 공개 범위(scope):
+ * - ALL     — 전사. 로그인 사용자 전원.
+ * - TEAM    — 팀. 동일 팀 사용자(+ ADMIN).
+ * - PROJECT — 프로젝트. 해당 프로젝트 멤버(+ ADMIN).
+ *
  * 편집 권한: 작성자 본인 또는 ADMIN.
  */
 
@@ -31,7 +36,12 @@ const CATEGORY_META: Record<Category, { label: string; color: string; emoji: str
 };
 const CATEGORY_ORDER: Category[] = ["CLOUD", "HOSTING", "VCS", "DB", "PAYMENT", "DOMAIN", "EMAIL", "MONITOR", "AI", "TESTING", "OTHER"];
 
+type Scope = "ALL" | "TEAM" | "PROJECT";
+const SCOPE_LABEL: Record<Scope, string> = { ALL: "전사", TEAM: "팀", PROJECT: "프로젝트" };
+type ScopeTab = "ALL_TAB" | Scope;
+
 type OwnerUser = { id: string; name: string; avatarColor: string; avatarUrl: string | null; email: string; team?: string | null; position?: string | null };
+type ProjectChip = { id: string; name: string; color: string };
 type Account = {
   id: string;
   serviceName: string;
@@ -39,6 +49,10 @@ type Account = {
   loginId: string | null;
   url: string | null;
   notes: string | null;
+  scope: Scope;
+  scopeTeam: string | null;
+  projectId: string | null;
+  project: ProjectChip | null;
   ownerUser: OwnerUser | null;
   ownerName: string | null;
   createdBy: { id: string; name: string };
@@ -54,11 +68,14 @@ type FormState = {
   loginId: string;
   url: string;
   notes: string;
-  ownerUserId: string; // "" = 없음
-  ownerName: string;   // 외부 담당자
+  ownerUserId: string;
+  ownerName: string;
+  scope: Scope;
+  scopeTeam: string;
+  scopeProjectId: string;
 };
 
-const EMPTY_FORM: FormState = {
+const emptyForm = (defaultTeam: string): FormState => ({
   serviceName: "",
   category: "OTHER",
   loginId: "",
@@ -66,20 +83,27 @@ const EMPTY_FORM: FormState = {
   notes: "",
   ownerUserId: "",
   ownerName: "",
-};
+  scope: "ALL",
+  scopeTeam: defaultTeam ?? "",
+  scopeProjectId: "",
+});
 
 export default function ServiceAccountsPage() {
   const { user } = useAuth();
+  const myTeam = (user as any)?.team ?? "";
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [users, setUsers] = useState<DirUser[]>([]);
+  const [projects, setProjects] = useState<ProjectChip[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [q, setQ] = useState("");
   const [filterCat, setFilterCat] = useState<Category | "ALL">("ALL");
+  const [scopeTab, setScopeTab] = useState<ScopeTab>("ALL_TAB");
+  const [filterProjectId, setFilterProjectId] = useState<string>("");
 
   // 모달 상태 — "new" 생성, 문자열은 편집 중 id
   const [editing, setEditing] = useState<"new" | string | null>(null);
-  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [form, setForm] = useState<FormState>(() => emptyForm(myTeam));
   const [saving, setSaving] = useState(false);
   const [formErr, setFormErr] = useState<string | null>(null);
 
@@ -88,7 +112,11 @@ export default function ServiceAccountsPage() {
   async function load() {
     setLoading(true);
     try {
-      const r = await api<{ accounts: Account[] }>("/api/service-accounts");
+      const params = new URLSearchParams();
+      if (scopeTab !== "ALL_TAB") params.set("scope", scopeTab);
+      if (scopeTab === "PROJECT" && filterProjectId) params.set("projectId", filterProjectId);
+      const qs = params.toString();
+      const r = await api<{ accounts: Account[] }>(`/api/service-accounts${qs ? `?${qs}` : ""}`);
       setAccounts(r.accounts);
       setLoadErr(null);
     } catch (e: any) {
@@ -100,10 +128,11 @@ export default function ServiceAccountsPage() {
 
   useEffect(() => {
     load();
-    // 담당자 선택용 — 한 번만 로드
-    api<{ users: DirUser[] }>("/api/users")
-      .then((r) => setUsers(r.users))
-      .catch(() => {});
+  }, [scopeTab, filterProjectId]);
+
+  useEffect(() => {
+    api<{ users: DirUser[] }>("/api/users").then((r) => setUsers(r.users)).catch(() => {});
+    api<{ projects: ProjectChip[] }>("/api/service-accounts/projects").then((r) => setProjects(r.projects)).catch(() => {});
   }, []);
 
   const filtered = useMemo(() => {
@@ -121,7 +150,6 @@ export default function ServiceAccountsPage() {
     });
   }, [accounts, q, filterCat]);
 
-  // 카테고리별 그룹
   const grouped = useMemo(() => {
     const m = new Map<Category, Account[]>();
     for (const a of filtered) {
@@ -133,7 +161,15 @@ export default function ServiceAccountsPage() {
   }, [filtered]);
 
   function openCreate() {
-    setForm(EMPTY_FORM);
+    const init = emptyForm(myTeam);
+    // 프로젝트 탭에서 선택된 프로젝트가 있으면 초기값으로 주입
+    if (scopeTab === "PROJECT" && filterProjectId) {
+      init.scope = "PROJECT";
+      init.scopeProjectId = filterProjectId;
+    } else if (scopeTab === "TEAM") {
+      init.scope = "TEAM";
+    }
+    setForm(init);
     setFormErr(null);
     setEditing("new");
   }
@@ -146,13 +182,16 @@ export default function ServiceAccountsPage() {
       notes: a.notes ?? "",
       ownerUserId: a.ownerUser?.id ?? "",
       ownerName: a.ownerName ?? "",
+      scope: a.scope,
+      scopeTeam: a.scopeTeam ?? myTeam,
+      scopeProjectId: a.projectId ?? "",
     });
     setFormErr(null);
     setEditing(a.id);
   }
   function closeModal() {
     setEditing(null);
-    setForm(EMPTY_FORM);
+    setForm(emptyForm(myTeam));
     setFormErr(null);
   }
 
@@ -161,6 +200,14 @@ export default function ServiceAccountsPage() {
     if (saving) return;
     if (!form.serviceName.trim()) {
       setFormErr("서비스 이름을 입력해주세요.");
+      return;
+    }
+    if (form.scope === "TEAM" && !form.scopeTeam.trim()) {
+      setFormErr("팀 이름을 입력해주세요.");
+      return;
+    }
+    if (form.scope === "PROJECT" && !form.scopeProjectId) {
+      setFormErr("프로젝트를 선택해주세요.");
       return;
     }
     setSaving(true);
@@ -174,6 +221,9 @@ export default function ServiceAccountsPage() {
         notes: form.notes.trim() || null,
         ownerUserId: form.ownerUserId || null,
         ownerName: form.ownerName.trim() || null,
+        scope: form.scope,
+        scopeTeam: form.scope === "TEAM" ? form.scopeTeam.trim() : null,
+        projectId: form.scope === "PROJECT" ? form.scopeProjectId : null,
       };
       if (editing === "new") {
         await api("/api/service-accounts", { method: "POST", json: payload });
@@ -214,6 +264,13 @@ export default function ServiceAccountsPage() {
     }
   }
 
+  const scopeTabs: { key: ScopeTab; label: string }[] = [
+    { key: "ALL_TAB", label: "전체" },
+    { key: "ALL", label: "전사" },
+    { key: "TEAM", label: "팀" },
+    { key: "PROJECT", label: "프로젝트" },
+  ];
+
   return (
     <div className="container-narrow py-6">
       <PageHeader
@@ -233,6 +290,52 @@ export default function ServiceAccountsPage() {
           <div className="mt-0.5 text-amber-700">실제 크레덴셜은 1Password · Bitwarden 같은 전용 비밀번호 관리자에 두고, 여기에는 "어떤 서비스를 누가 쓰는지" 만 기록하세요.</div>
         </div>
       </div>
+
+      {/* 스코프 탭 */}
+      <div className="flex items-center gap-1 mb-3 border-b border-ink-200 overflow-x-auto">
+        {scopeTabs.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => { setScopeTab(t.key); if (t.key !== "PROJECT") setFilterProjectId(""); }}
+            className={`px-3 py-2 text-[12px] font-bold whitespace-nowrap border-b-2 -mb-px transition-colors ${
+              scopeTab === t.key
+                ? "border-brand-600 text-brand-700"
+                : "border-transparent text-ink-500 hover:text-ink-800"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 프로젝트 칩 필터 (PROJECT 탭일 때만) */}
+      {scopeTab === "PROJECT" && (
+        <div className="flex flex-wrap items-center gap-1.5 mb-3">
+          <button
+            onClick={() => setFilterProjectId("")}
+            className={`px-2.5 py-1 rounded-full text-[11px] font-bold border ${
+              filterProjectId === "" ? "bg-brand-600 text-white border-brand-600" : "bg-white text-ink-600 border-ink-200 hover:border-ink-300"
+            }`}
+          >
+            전체 프로젝트
+          </button>
+          {projects.length === 0 ? (
+            <span className="text-[11px] text-ink-400 px-2">참여 중인 프로젝트가 없어요.</span>
+          ) : projects.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => setFilterProjectId(p.id)}
+              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-bold border ${
+                filterProjectId === p.id ? "text-white border-transparent" : "bg-white text-ink-700 border-ink-200 hover:border-ink-300"
+              }`}
+              style={filterProjectId === p.id ? { background: p.color } : undefined}
+            >
+              <span className="w-1.5 h-1.5 rounded-full" style={{ background: filterProjectId === p.id ? "#ffffff" : p.color }} />
+              {p.name}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* 검색 + 카테고리 필터 */}
       <div className="flex flex-col sm:flex-row gap-2 mb-4">
@@ -273,7 +376,7 @@ export default function ServiceAccountsPage() {
       ) : filtered.length === 0 ? (
         <div className="panel py-14 text-center">
           <div className="text-[13px] font-bold text-ink-800">일치하는 계정이 없어요</div>
-          <div className="text-[12px] text-ink-500 mt-1">검색어나 카테고리 필터를 바꿔보세요.</div>
+          <div className="text-[12px] text-ink-500 mt-1">검색어나 필터를 바꿔보세요.</div>
         </div>
       ) : (
         <div className="space-y-6">
@@ -312,6 +415,8 @@ export default function ServiceAccountsPage() {
           form={form}
           setForm={setForm}
           users={users}
+          projects={projects}
+          myTeam={myTeam}
           saving={saving}
           err={formErr}
           onClose={closeModal}
@@ -319,6 +424,22 @@ export default function ServiceAccountsPage() {
         />
       )}
     </div>
+  );
+}
+
+function ScopeBadge({ a }: { a: Account }) {
+  if (a.scope === "ALL") {
+    return <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-ink-100 text-ink-600">전사</span>;
+  }
+  if (a.scope === "TEAM") {
+    return <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-sky-50 text-sky-700 border border-sky-200">팀 · {a.scopeTeam ?? "-"}</span>;
+  }
+  // PROJECT
+  return (
+    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-violet-50 text-violet-700 border border-violet-200">
+      {a.project?.color && <span className="w-1.5 h-1.5 rounded-full" style={{ background: a.project.color }} />}
+      프로젝트 · {a.project?.name ?? "-"}
+    </span>
   );
 }
 
@@ -342,7 +463,10 @@ function AccountCard({
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0">
               <div className="text-[14px] font-extrabold text-ink-900 truncate">{a.serviceName}</div>
-              <div className="text-[11px] text-ink-500">{meta.label}</div>
+              <div className="flex items-center gap-1.5 mt-0.5">
+                <span className="text-[11px] text-ink-500">{meta.label}</span>
+                <ScopeBadge a={a} />
+              </div>
             </div>
             {canEdit && (
               <div className="flex items-center gap-1 flex-shrink-0">
@@ -402,23 +526,30 @@ function AccountCard({
 }
 
 function AccountModal({
-  mode, form, setForm, users, saving, err, onClose, onSubmit,
+  mode, form, setForm, users, projects, myTeam, saving, err, onClose, onSubmit,
 }: {
   mode: "new" | "edit";
   form: FormState;
   setForm: (f: FormState) => void;
   users: DirUser[];
+  projects: ProjectChip[];
+  myTeam: string;
   saving: boolean;
   err: string | null;
   onClose: () => void;
   onSubmit: (e: React.FormEvent) => void;
 }) {
-  // Esc 로 닫기
   useEffect(() => {
     const h = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", h);
     return () => window.removeEventListener("keydown", h);
   }, [onClose]);
+
+  const scopeOptions: { v: Scope; label: string; hint: string }[] = [
+    { v: "ALL", label: "전사", hint: "모든 구성원이 봅니다" },
+    { v: "TEAM", label: "팀", hint: "같은 팀만 봅니다" },
+    { v: "PROJECT", label: "프로젝트", hint: "프로젝트 멤버만 봅니다" },
+  ];
 
   return (
     <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
@@ -455,6 +586,49 @@ function AccountModal({
                 ))}
               </select>
             </label>
+          </div>
+
+          {/* 공개 범위 */}
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] font-bold text-ink-500">공개 범위</span>
+            <div className="grid grid-cols-3 gap-1.5">
+              {scopeOptions.map((o) => (
+                <button
+                  type="button"
+                  key={o.v}
+                  onClick={() => setForm({ ...form, scope: o.v, scopeTeam: o.v === "TEAM" && !form.scopeTeam ? myTeam : form.scopeTeam })}
+                  className={`rounded-xl border px-2.5 py-2 text-left transition-all ${
+                    form.scope === o.v
+                      ? "border-brand-600 bg-brand-50 ring-1 ring-brand-300"
+                      : "border-ink-200 bg-white hover:border-ink-300"
+                  }`}
+                >
+                  <div className="text-[12px] font-extrabold text-ink-900">{o.label}</div>
+                  <div className="text-[10px] text-ink-500 mt-0.5">{o.hint}</div>
+                </button>
+              ))}
+            </div>
+            {form.scope === "TEAM" && (
+              <input
+                className="input mt-1"
+                placeholder={myTeam ? `예: ${myTeam}` : "팀 이름"}
+                value={form.scopeTeam}
+                maxLength={80}
+                onChange={(e) => setForm({ ...form, scopeTeam: e.target.value })}
+              />
+            )}
+            {form.scope === "PROJECT" && (
+              <select
+                className="input mt-1"
+                value={form.scopeProjectId}
+                onChange={(e) => setForm({ ...form, scopeProjectId: e.target.value })}
+              >
+                <option value="">프로젝트 선택…</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+            )}
           </div>
 
           <label className="flex flex-col gap-1">

--- a/server/prisma/migrations/20260424140000_service_account_scope/migration.sql
+++ b/server/prisma/migrations/20260424140000_service_account_scope/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "ServiceAccount"
+  ADD COLUMN "scope" TEXT NOT NULL DEFAULT 'ALL',
+  ADD COLUMN "scopeTeam" TEXT,
+  ADD COLUMN "projectId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ServiceAccount_scope_scopeTeam_idx" ON "ServiceAccount"("scope", "scopeTeam");
+
+-- CreateIndex
+CREATE INDEX "ServiceAccount_projectId_idx" ON "ServiceAccount"("projectId");
+
+-- AddForeignKey
+ALTER TABLE "ServiceAccount" ADD CONSTRAINT "ServiceAccount_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -113,6 +113,7 @@ model Project {
   qaItems        ProjectQaItem[]
   // 전사 캘린더(Event) 중 이 프로젝트 범위로 공유된 일정
   scheduleEvents Event[]
+  serviceAccounts ServiceAccount[] @relation("ProjectServiceAccounts")
 }
 
 /// 프로젝트별 QA(테스트) 체크리스트 — "무엇을 검증했고 결과가 어땠는지" 남기는 용도.
@@ -810,6 +811,11 @@ model ServiceAccount {
   loginId     String? // 로그인 이메일 또는 사용자명
   url         String? // 콘솔/대시보드 URL
   notes       String? // 접근 방법, MFA 사용 여부 등 자유 메모 (비밀번호 금지)
+  // 공개 범위 — ALL(전사) | TEAM(팀) | PROJECT(프로젝트). 문서/회의록과 일관.
+  scope       String   @default("ALL")
+  scopeTeam   String? // scope=TEAM 일 때 팀 이름
+  projectId   String? // scope=PROJECT 일 때 연결된 프로젝트
+  project     Project? @relation("ProjectServiceAccounts", fields: [projectId], references: [id], onDelete: SetNull)
   // 담당자 — 사용자 연결이 있으면 ownerUserId, 외부 담당자는 ownerName 으로 기록.
   ownerUserId String?
   ownerUser   User?    @relation("ServiceAccountOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)
@@ -821,4 +827,6 @@ model ServiceAccount {
 
   @@index([category, serviceName])
   @@index([ownerUserId])
+  @@index([scope, scopeTeam])
+  @@index([projectId])
 }

--- a/server/src/routes/serviceAccount.ts
+++ b/server/src/routes/serviceAccount.ts
@@ -11,27 +11,23 @@ import { requireAuth } from "../lib/auth.js";
  *   누가 담당하는지" 찾기 위한 인덱스. 실제 크레덴셜은 1Password/Bitwarden 같은 전용 도구에 둔다.
  * - `notes` 필드에도 비밀번호는 쓰지 말 것 — 경고 문구는 클라에서 노출.
  *
- * 권한:
- * - 로그인한 사용자는 전체 목록 열람 가능 (팀이 공유 자원으로 쓰는 전제).
- * - 생성/수정/삭제는 작성자(createdById) 본인 또는 ADMIN/SUPER 만.
+ * 공개 범위(scope):
+ * - ALL      — 전사 공개. 로그인 사용자 전원 열람.
+ * - TEAM     — 특정 팀 공개. 동일 team 명을 가진 사용자 + ADMIN/SUPER 만 열람.
+ * - PROJECT  — 프로젝트 공개. 해당 프로젝트의 ProjectMember + ADMIN/SUPER 만 열람.
+ *
+ * 편집 권한: 작성자 본인 또는 ADMIN/SUPER.
  */
 
 const router = Router();
 router.use(requireAuth);
 
 const CATEGORIES = [
-  "CLOUD",      // AWS / GCP / Azure
-  "HOSTING",    // Vercel / Netlify / Render
-  "VCS",        // GitHub / GitLab
-  "PAYMENT",    // Stripe / Toss
-  "DOMAIN",     // 가비아 / Cloudflare
-  "EMAIL",      // Google Workspace / Resend
-  "MONITOR",    // Sentry / Datadog
-  "DB",         // Supabase / Planetscale
-  "AI",         // OpenAI / Anthropic
-  "TESTING",    // BrowserStack / 테스트 계정
-  "OTHER",
+  "CLOUD", "HOSTING", "VCS", "PAYMENT", "DOMAIN", "EMAIL",
+  "MONITOR", "DB", "AI", "TESTING", "OTHER",
 ] as const;
+
+const SCOPES = ["ALL", "TEAM", "PROJECT"] as const;
 
 const baseSchema = z.object({
   serviceName: z.string().trim().min(1).max(80),
@@ -39,6 +35,9 @@ const baseSchema = z.object({
   loginId: z.string().trim().max(200).optional().nullable(),
   url: z.string().trim().url().max(500).optional().nullable().or(z.literal("")),
   notes: z.string().max(2000).optional().nullable(),
+  scope: z.enum(SCOPES).optional().default("ALL"),
+  scopeTeam: z.string().trim().max(80).optional().nullable(),
+  projectId: z.string().optional().nullable(),
   ownerUserId: z.string().optional().nullable(),
   ownerName: z.string().trim().max(80).optional().nullable(),
 });
@@ -46,26 +45,85 @@ const baseSchema = z.object({
 const createSchema = baseSchema;
 const updateSchema = baseSchema.partial();
 
+function isAdmin(user: { role?: string; superAdmin?: boolean }) {
+  return !!user.superAdmin || user.role === "ADMIN";
+}
 function canEdit(user: { id: string; role?: string; superAdmin?: boolean }, row: { createdById: string }) {
-  return user.superAdmin || user.role === "ADMIN" || row.createdById === user.id;
+  return isAdmin(user) || row.createdById === user.id;
 }
 
-/** 목록 — 카테고리 필터와 검색 지원. */
+/**
+ * 현재 유저가 열람 가능한 ServiceAccount 의 where 절을 만든다.
+ * ADMIN/SUPER 는 모든 항목을 본다.
+ */
+async function visibleWhere(user: { id: string; role?: string; superAdmin?: boolean; team?: string | null }) {
+  if (isAdmin(user)) return {};
+
+  // 내가 멤버인 프로젝트 id 목록
+  const memberships = await prisma.projectMember.findMany({
+    where: { userId: user.id },
+    select: { projectId: true },
+  });
+  const projectIds = memberships.map((m) => m.projectId);
+
+  const conditions: any[] = [
+    { scope: "ALL" },
+    // 본인이 만든 항목은 스코프 불문 보이게 (관리 편의)
+    { createdById: user.id },
+  ];
+  if (user.team) {
+    conditions.push({ scope: "TEAM", scopeTeam: user.team });
+  }
+  if (projectIds.length > 0) {
+    conditions.push({ scope: "PROJECT", projectId: { in: projectIds } });
+  }
+  return { OR: conditions };
+}
+
+/** 목록 — 카테고리·검색·스코프 탭·프로젝트 필터 지원. */
 router.get("/", async (req, res) => {
+  const user = (req as any).user as { id: string; role?: string; superAdmin?: boolean; team?: string | null };
+
   const category = typeof req.query.category === "string" ? req.query.category : undefined;
   const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+  const scope = typeof req.query.scope === "string" ? req.query.scope : undefined;
+  const scopeTeam = typeof req.query.scopeTeam === "string" ? req.query.scopeTeam : undefined;
+  const projectId = typeof req.query.projectId === "string" ? req.query.projectId : undefined;
 
-  const where: any = {};
+  const where: any = await visibleWhere(user);
+
   if (category && (CATEGORIES as readonly string[]).includes(category)) {
     where.category = category;
   }
+  if (scope && (SCOPES as readonly string[]).includes(scope)) {
+    // visibleWhere 와 AND 결합 — 열람 가능 집합 안에서 추가 필터
+    where.AND = [{ OR: where.OR }].filter(() => !!where.OR);
+    delete where.OR;
+    where.AND.push({ scope });
+    if (scope === "TEAM" && scopeTeam) where.AND.push({ scopeTeam });
+    if (scope === "PROJECT" && projectId) where.AND.push({ projectId });
+  } else if (projectId) {
+    // scope 필터 없이 projectId 만 — PROJECT 스코프 중 이 프로젝트
+    where.AND = [{ OR: where.OR }].filter(() => !!where.OR);
+    delete where.OR;
+    where.AND.push({ scope: "PROJECT", projectId });
+  }
+
   if (q) {
-    where.OR = [
-      { serviceName: { contains: q, mode: "insensitive" } },
-      { loginId: { contains: q, mode: "insensitive" } },
-      { ownerName: { contains: q, mode: "insensitive" } },
-      { notes: { contains: q, mode: "insensitive" } },
+    const search = [
+      { serviceName: { contains: q, mode: "insensitive" as const } },
+      { loginId: { contains: q, mode: "insensitive" as const } },
+      { ownerName: { contains: q, mode: "insensitive" as const } },
+      { notes: { contains: q, mode: "insensitive" as const } },
     ];
+    if (Array.isArray(where.AND)) {
+      where.AND.push({ OR: search });
+    } else if (where.OR) {
+      where.AND = [{ OR: where.OR }, { OR: search }];
+      delete where.OR;
+    } else {
+      where.OR = search;
+    }
   }
 
   const rows = await prisma.serviceAccount.findMany({
@@ -74,11 +132,55 @@ router.get("/", async (req, res) => {
     include: {
       ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
       createdBy: { select: { id: true, name: true } },
+      project: { select: { id: true, name: true, color: true } },
     },
   });
 
   res.json({ accounts: rows });
 });
+
+/** 프로젝트 칩 — 이 페이지 필터에 노출할, 내가 속한 프로젝트 목록. */
+router.get("/projects", async (req, res) => {
+  const user = (req as any).user as { id: string; role?: string; superAdmin?: boolean };
+  const where = isAdmin(user)
+    ? { status: "ACTIVE" }
+    : { status: "ACTIVE", members: { some: { userId: user.id } } };
+  const projects = await prisma.project.findMany({
+    where,
+    select: { id: true, name: true, color: true },
+    orderBy: { name: "asc" },
+  });
+  res.json({ projects });
+});
+
+async function validateScope(
+  user: { id: string; role?: string; superAdmin?: boolean; team?: string | null },
+  input: { scope?: string; scopeTeam?: string | null; projectId?: string | null },
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const scope = input.scope ?? "ALL";
+  if (scope === "ALL") return { ok: true };
+  if (scope === "TEAM") {
+    if (!input.scopeTeam) return { ok: false, error: "팀 이름을 지정해주세요." };
+    // ADMIN 은 모든 팀 지정 가능. 일반 사용자는 본인 팀만.
+    if (!isAdmin(user) && user.team !== input.scopeTeam) {
+      return { ok: false, error: "본인 팀으로만 공개할 수 있어요." };
+    }
+    return { ok: true };
+  }
+  if (scope === "PROJECT") {
+    if (!input.projectId) return { ok: false, error: "프로젝트를 지정해주세요." };
+    const project = await prisma.project.findUnique({
+      where: { id: input.projectId },
+      select: { id: true, members: { where: { userId: user.id }, select: { id: true } } },
+    });
+    if (!project) return { ok: false, error: "프로젝트를 찾을 수 없어요." };
+    if (!isAdmin(user) && project.members.length === 0) {
+      return { ok: false, error: "해당 프로젝트의 멤버가 아니에요." };
+    }
+    return { ok: true };
+  }
+  return { ok: false, error: "알 수 없는 공개 범위에요." };
+}
 
 router.post("/", async (req, res) => {
   const parsed = createSchema.safeParse(req.body);
@@ -86,18 +188,21 @@ router.post("/", async (req, res) => {
     return res.status(400).json({ error: parsed.error.issues[0]?.message ?? "잘못된 요청" });
   }
   const input = parsed.data;
-  const userId = (req as any).user.id as string;
+  const user = (req as any).user as { id: string; role?: string; superAdmin?: boolean; team?: string | null };
 
-  // URL 빈 문자열은 null 로 정규화 (zod 의 literal("") 을 통과한 경우)
+  const scopeCheck = await validateScope(user, input);
+  if (!scopeCheck.ok) return res.status(400).json({ error: scopeCheck.error });
+
+  // URL 빈 문자열은 null 로 정규화
   const url = input.url === "" ? null : input.url ?? null;
 
-  // ownerUserId 가 실존 유저인지 검증 — 빈 문자열은 null 로
   let ownerUserId = input.ownerUserId || null;
   if (ownerUserId) {
     const exists = await prisma.user.findUnique({ where: { id: ownerUserId }, select: { id: true } });
     if (!exists) return res.status(400).json({ error: "담당자로 지정한 사용자를 찾을 수 없어요." });
   }
 
+  const scope = input.scope ?? "ALL";
   const row = await prisma.serviceAccount.create({
     data: {
       serviceName: input.serviceName,
@@ -105,13 +210,17 @@ router.post("/", async (req, res) => {
       loginId: input.loginId || null,
       url,
       notes: input.notes || null,
+      scope,
+      scopeTeam: scope === "TEAM" ? (input.scopeTeam || null) : null,
+      projectId: scope === "PROJECT" ? (input.projectId || null) : null,
       ownerUserId,
       ownerName: input.ownerName || null,
-      createdById: userId,
+      createdById: user.id,
     },
     include: {
       ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
       createdBy: { select: { id: true, name: true } },
+      project: { select: { id: true, name: true, color: true } },
     },
   });
 
@@ -123,16 +232,29 @@ router.patch("/:id", async (req, res) => {
   if (!parsed.success) {
     return res.status(400).json({ error: parsed.error.issues[0]?.message ?? "잘못된 요청" });
   }
-  const user = (req as any).user as { id: string; role?: string; superAdmin?: boolean };
+  const user = (req as any).user as { id: string; role?: string; superAdmin?: boolean; team?: string | null };
   const id = req.params.id;
 
-  const existing = await prisma.serviceAccount.findUnique({ where: { id }, select: { id: true, createdById: true } });
+  const existing = await prisma.serviceAccount.findUnique({
+    where: { id },
+    select: { id: true, createdById: true, scope: true, scopeTeam: true, projectId: true },
+  });
   if (!existing) return res.status(404).json({ error: "존재하지 않는 계정이에요." });
   if (!canEdit(user, existing)) {
     return res.status(403).json({ error: "이 계정을 수정할 권한이 없어요." });
   }
 
   const input = parsed.data;
+
+  // scope 변경 검증 — 변경 시 (또는 스코프 관련 필드 변경 시) 유효성 체크
+  const nextScope = input.scope ?? existing.scope;
+  const nextScopeTeam = input.scopeTeam !== undefined ? input.scopeTeam : existing.scopeTeam;
+  const nextProjectId = input.projectId !== undefined ? input.projectId : existing.projectId;
+  if (input.scope !== undefined || input.scopeTeam !== undefined || input.projectId !== undefined) {
+    const check = await validateScope(user, { scope: nextScope, scopeTeam: nextScopeTeam, projectId: nextProjectId });
+    if (!check.ok) return res.status(400).json({ error: check.error });
+  }
+
   const data: any = {};
   if (input.serviceName !== undefined) data.serviceName = input.serviceName;
   if (input.category !== undefined) data.category = input.category;
@@ -148,6 +270,11 @@ router.patch("/:id", async (req, res) => {
     }
     data.ownerUserId = next;
   }
+  if (input.scope !== undefined || input.scopeTeam !== undefined || input.projectId !== undefined) {
+    data.scope = nextScope;
+    data.scopeTeam = nextScope === "TEAM" ? (nextScopeTeam || null) : null;
+    data.projectId = nextScope === "PROJECT" ? (nextProjectId || null) : null;
+  }
 
   const row = await prisma.serviceAccount.update({
     where: { id },
@@ -155,6 +282,7 @@ router.patch("/:id", async (req, res) => {
     include: {
       ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
       createdBy: { select: { id: true, name: true } },
+      project: { select: { id: true, name: true, color: true } },
     },
   });
   res.json({ account: row });


### PR DESCRIPTION
## 증상
**전사/팀/프로젝트 스코프**

새 기능을 추가합니다.

## 원인
- ServiceAccount 에 scope/scopeTeam/projectId 추가 (Documents 패턴 동일)
- 열람 권한: ALL 은 전원, TEAM 은 동팀, PROJECT 는 멤버만 (ADMIN 은 전체)
- 페이지에 스코프 탭 + 프로젝트 칩 필터 추가
- 작성 모달에 공개 범위 선택(라디오 + 팀/프로젝트 인풋) 추가
- 카드에 스코프 배지 노출

## 수정
**작업 항목 (커밋 단위)**
- feat(accounts): 전사/팀/프로젝트 스코프 추가

**변경 대상 (4개 파일)**
- `client/src/pages/ServiceAccountsPage.tsx`
- `server/prisma/migrations/20260424140000_service_account_scope/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/routes/serviceAccount.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #30** ↔ **이슈 #452** 로 연결됩니다.

Closes #452
