### PR TITLE
🔀 :: (#460) 활성 토글 + 팀/프로젝트 다중 공유 + 앱 아이콘 스타일

### DIFF
--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -125,11 +125,14 @@ type Account = {
   notes: string | null;
   scope: Scope;
   scopeTeam: string | null;
+  scopeTeams: string[];
   projectId: string | null;
+  projectIds: string[];
   project: ProjectChip | null;
   ownerUser: OwnerUser | null;
   ownerName: string | null;
   iconUrl: string | null;
+  active: boolean;
   hasPassword: boolean;
   createdBy: { id: string; name: string };
   createdAt: string;
@@ -147,8 +150,9 @@ type FormState = {
   ownerUserId: string;
   ownerName: string;
   scope: Scope;
-  scopeTeam: string;
-  scopeProjectId: string;
+  // 다중 팀/프로젝트 공유 — scopeTeams[0] 이 레거시 대표값(scopeTeam) 과 동기화됨.
+  scopeTeams: string[];
+  scopeProjectIds: string[];
   // 비밀번호 입력 — 편집 시 빈 값은 "변경 없음", "CLEAR" sentinel 은 제거, 문자열은 새 값.
   password: string;
   clearPassword: boolean;
@@ -165,8 +169,8 @@ const emptyForm = (defaultTeam: string): FormState => ({
   ownerUserId: "",
   ownerName: "",
   scope: "ALL",
-  scopeTeam: defaultTeam ?? "",
-  scopeProjectId: "",
+  scopeTeams: defaultTeam ? [defaultTeam] : [],
+  scopeProjectIds: [],
   password: "",
   clearPassword: false,
   iconUrl: "",
@@ -249,7 +253,7 @@ export default function ServiceAccountsPage() {
     // 프로젝트 탭에서 선택된 프로젝트가 있으면 초기값으로 주입
     if (scopeTab === "PROJECT" && filterProjectId) {
       init.scope = "PROJECT";
-      init.scopeProjectId = filterProjectId;
+      init.scopeProjectIds = [filterProjectId];
     } else if (scopeTab === "TEAM") {
       init.scope = "TEAM";
     }
@@ -267,8 +271,16 @@ export default function ServiceAccountsPage() {
       ownerUserId: a.ownerUser?.id ?? "",
       ownerName: a.ownerName ?? "",
       scope: a.scope,
-      scopeTeam: a.scopeTeam ?? myTeam,
-      scopeProjectId: a.projectId ?? "",
+      scopeTeams: a.scopeTeams?.length
+        ? a.scopeTeams
+        : a.scopeTeam
+          ? [a.scopeTeam]
+          : myTeam ? [myTeam] : [],
+      scopeProjectIds: a.projectIds?.length
+        ? a.projectIds
+        : a.projectId
+          ? [a.projectId]
+          : [],
       password: "",
       clearPassword: false,
       iconUrl: a.iconUrl ?? "",
@@ -289,12 +301,12 @@ export default function ServiceAccountsPage() {
       setFormErr("서비스 이름을 입력해주세요.");
       return;
     }
-    if (form.scope === "TEAM" && !form.scopeTeam.trim()) {
-      setFormErr("팀 이름을 입력해주세요.");
+    if (form.scope === "TEAM" && form.scopeTeams.filter((t) => t.trim()).length === 0) {
+      setFormErr("팀을 하나 이상 입력해주세요.");
       return;
     }
-    if (form.scope === "PROJECT" && !form.scopeProjectId) {
-      setFormErr("프로젝트를 선택해주세요.");
+    if (form.scope === "PROJECT" && form.scopeProjectIds.length === 0) {
+      setFormErr("프로젝트를 하나 이상 선택해주세요.");
       return;
     }
     setSaving(true);
@@ -309,8 +321,11 @@ export default function ServiceAccountsPage() {
         ownerUserId: form.ownerUserId || null,
         ownerName: form.ownerName.trim() || null,
         scope: form.scope,
-        scopeTeam: form.scope === "TEAM" ? form.scopeTeam.trim() : null,
-        projectId: form.scope === "PROJECT" ? form.scopeProjectId : null,
+        scopeTeams: form.scope === "TEAM" ? form.scopeTeams.map((t) => t.trim()).filter(Boolean) : [],
+        // 서버가 scopeTeam(레거시 대표값)도 배열 첫 요소로 채우지만, 명시적으로 같이 보내 호환 보장.
+        scopeTeam: form.scope === "TEAM" ? (form.scopeTeams[0]?.trim() || null) : null,
+        projectIds: form.scope === "PROJECT" ? form.scopeProjectIds : [],
+        projectId: form.scope === "PROJECT" ? (form.scopeProjectIds[0] || null) : null,
         iconUrl: form.iconUrl.trim() || null,
       };
       // 비밀번호: 명시적으로 지우기 선택 시 null, 새 값 있으면 보냄, 빈 값이면 변경 없음(PATCH).
@@ -496,6 +511,17 @@ export default function ServiceAccountsPage() {
                       onEdit={() => openEdit(a)}
                       onDelete={() => remove(a)}
                       onCopy={() => a.loginId && copyId(a.loginId)}
+                      onToggleActive={async () => {
+                        // 낙관적 업데이트 — 실패 시 load() 로 서버값으로 복구.
+                        const next = !a.active;
+                        setAccounts((prev) => prev.map((x) => (x.id === a.id ? { ...x, active: next } : x)));
+                        try {
+                          await api(`/api/service-accounts/${a.id}`, { method: "PATCH", json: { active: next } });
+                        } catch (e: any) {
+                          await alertAsync({ title: "변경 실패", description: e?.message ?? "활성 상태를 바꾸지 못했어요." });
+                          load();
+                        }
+                      }}
                       onCopyPassword={async () => {
                         // 본인 로그인 비번 재확인 — promptAsync 의 password 타입으로 화면에 안 보이게 입력받음.
                         const myPw = await promptAsync({
@@ -557,19 +583,23 @@ function ScopeBadge({ a }: { a: Account }) {
     return <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-ink-100 text-ink-600">전사</span>;
   }
   if (a.scope === "TEAM") {
-    return <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-sky-50 text-sky-700 border border-sky-200">팀 · {a.scopeTeam ?? "-"}</span>;
+    // 배열 우선, 없으면 레거시 단일값.
+    const teams = (a.scopeTeams?.length ? a.scopeTeams : a.scopeTeam ? [a.scopeTeam] : []);
+    const label = teams.length <= 2 ? teams.join(", ") : `${teams[0]} 외 ${teams.length - 1}개`;
+    return <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-sky-50 text-sky-700 border border-sky-200">팀 · {label || "-"}</span>;
   }
   // PROJECT
+  const extraCount = Math.max(0, (a.projectIds?.length ?? 0) - 1);
   return (
     <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-bold bg-violet-50 text-violet-700 border border-violet-200">
       {a.project?.color && <span className="w-1.5 h-1.5 rounded-full" style={{ background: a.project.color }} />}
-      프로젝트 · {a.project?.name ?? "-"}
+      프로젝트 · {a.project?.name ?? "-"}{extraCount > 0 ? ` 외 ${extraCount}개` : ""}
     </span>
   );
 }
 
 function AccountCard({
-  a, canEdit, onEdit, onDelete, onCopy, onCopyPassword,
+  a, canEdit, onEdit, onDelete, onCopy, onCopyPassword, onToggleActive,
 }: {
   a: Account;
   canEdit: boolean;
@@ -577,6 +607,7 @@ function AccountCard({
   onDelete: () => void;
   onCopy: () => void;
   onCopyPassword: () => void;
+  onToggleActive: () => void;
 }) {
   const meta = CATEGORY_META[a.category];
   // 아이콘 해상 순서:
@@ -591,38 +622,65 @@ function AccountCard({
     ? a.iconUrl || (host ? `https://www.google.com/s2/favicons?domain=${host}&sz=64` : null)
     : null;
   return (
-    <div className="panel p-4">
+    <div className={`panel p-4 relative transition-opacity ${a.active ? "" : "opacity-60"}`}>
       <div className="flex items-start gap-3">
+        {/* 앱 아이콘 스타일 — iOS 스퀘어클 느낌의 둥근 모서리 + 미묘한 그라데이션/섀도우.
+             이미지는 컨테이너를 꽉 채워 앱 로고처럼 바로 눈에 띄게 한다. */}
         <div
-          className="w-9 h-9 rounded-xl grid place-items-center flex-shrink-0 overflow-hidden"
-          style={{ background: iconSrc ? "#F8F8FA" : meta.color, color: "#fff" }}
+          className="w-10 h-10 grid place-items-center flex-shrink-0 overflow-hidden ring-1 ring-black/5 shadow-sm"
+          style={{
+            borderRadius: "22%",
+            background: iconSrc
+              ? "linear-gradient(180deg, #FFFFFF 0%, #F3F4F7 100%)"
+              : `linear-gradient(180deg, ${meta.color} 0%, ${meta.color}dd 100%)`,
+            color: "#fff",
+          }}
         >
           {iconSrc ? (
             <img
               src={iconSrc}
               alt=""
-              width={28}
-              height={28}
-              className="w-7 h-7 object-contain"
+              className="w-full h-full object-cover"
               loading="lazy"
               referrerPolicy="no-referrer"
               onError={() => setIconErr(true)}
             />
           ) : (
-            <span className="text-base leading-none">{meta.emoji}</span>
+            <span className="text-lg leading-none">{meta.emoji}</span>
           )}
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0">
               <div className="text-[14px] font-extrabold text-ink-900 truncate">{a.serviceName}</div>
-              <div className="flex items-center gap-1.5 mt-0.5">
+              <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
                 <span className="text-[11px] text-ink-500">{meta.label}</span>
                 <ScopeBadge a={a} />
+                {!a.active && (
+                  <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-md bg-ink-100 text-ink-500 border border-ink-200">
+                    비활성
+                  </span>
+                )}
               </div>
             </div>
             {canEdit && (
               <div className="flex items-center gap-1 flex-shrink-0">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={a.active}
+                  onClick={onToggleActive}
+                  title={a.active ? "비활성화" : "활성화"}
+                  className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                    a.active ? "bg-brand-600" : "bg-ink-300"
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                      a.active ? "translate-x-[18px]" : "translate-x-0.5"
+                    }`}
+                  />
+                </button>
                 <button className="btn-ghost !px-2 !py-1 text-[11px]" onClick={onEdit} title="편집">편집</button>
                 <button className="btn-ghost !px-2 !py-1 text-[11px] text-danger" onClick={onDelete} title="삭제">삭제</button>
               </div>
@@ -687,6 +745,108 @@ function AccountCard({
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+/** 팀 공유 다중 편집기 — 칩 + 입력창 + "+" 버튼. Enter/쉼표로도 추가. */
+function MultiTeamEditor({
+  teams, myTeam, onChange,
+}: {
+  teams: string[];
+  myTeam: string;
+  onChange: (next: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  function add(raw: string) {
+    const t = raw.trim();
+    if (!t) return;
+    if (teams.includes(t)) return;
+    onChange([...teams, t]);
+    setDraft("");
+  }
+  function remove(t: string) {
+    onChange(teams.filter((x) => x !== t));
+  }
+  return (
+    <div className="mt-1 flex flex-col gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {teams.map((t) => (
+          <span key={t} className="inline-flex items-center gap-1 rounded-full bg-brand-50 border border-brand-200 text-brand-800 text-[11px] font-semibold px-2 py-0.5">
+            {t}
+            <button type="button" onClick={() => remove(t)} className="text-brand-600 hover:text-brand-900" aria-label={`${t} 제거`}>×</button>
+          </span>
+        ))}
+        {teams.length === 0 && <span className="text-[11px] text-ink-400">아직 추가된 팀이 없어요.</span>}
+      </div>
+      <div className="flex items-center gap-1.5">
+        <input
+          className="input flex-1"
+          placeholder={myTeam ? `예: ${myTeam}` : "팀 이름"}
+          value={draft}
+          maxLength={80}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === ",") {
+              e.preventDefault();
+              add(draft);
+            } else if (e.key === "Backspace" && !draft && teams.length > 0) {
+              // 입력란이 비어있을 때 백스페이스로 마지막 칩 제거.
+              onChange(teams.slice(0, -1));
+            }
+          }}
+        />
+        <button type="button" className="btn-ghost !px-2.5 !py-1.5 text-[11px] font-bold" onClick={() => add(draft)}>
+          + 추가
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** 프로젝트 공유 다중 편집기 — 선택된 프로젝트는 칩, 나머지는 드롭다운으로 추가. */
+function MultiProjectEditor({
+  selected, projects, onChange,
+}: {
+  selected: string[];
+  projects: ProjectChip[];
+  onChange: (next: string[]) => void;
+}) {
+  const available = projects.filter((p) => !selected.includes(p.id));
+  function add(id: string) {
+    if (!id || selected.includes(id)) return;
+    onChange([...selected, id]);
+  }
+  function remove(id: string) {
+    onChange(selected.filter((x) => x !== id));
+  }
+  const selectedChips = selected
+    .map((id) => projects.find((p) => p.id === id))
+    .filter(Boolean) as ProjectChip[];
+  return (
+    <div className="mt-1 flex flex-col gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {selectedChips.map((p) => (
+          <span key={p.id} className="inline-flex items-center gap-1 rounded-full border text-[11px] font-semibold px-2 py-0.5" style={{ background: `${p.color}18`, borderColor: `${p.color}55`, color: p.color }}>
+            <span className="w-1.5 h-1.5 rounded-full" style={{ background: p.color }} />
+            {p.name}
+            <button type="button" onClick={() => remove(p.id)} className="hover:opacity-70" aria-label={`${p.name} 제거`}>×</button>
+          </span>
+        ))}
+        {selectedChips.length === 0 && <span className="text-[11px] text-ink-400">아직 선택된 프로젝트가 없어요.</span>}
+      </div>
+      {available.length > 0 && (
+        <select
+          className="input"
+          value=""
+          onChange={(e) => { add(e.target.value); e.currentTarget.value = ""; }}
+        >
+          <option value="">+ 프로젝트 추가…</option>
+          {available.map((p) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      )}
     </div>
   );
 }
@@ -799,7 +959,14 @@ function AccountModal({
                 <button
                   type="button"
                   key={o.v}
-                  onClick={() => setForm({ ...form, scope: o.v, scopeTeam: o.v === "TEAM" && !form.scopeTeam ? myTeam : form.scopeTeam })}
+                  onClick={() => setForm({
+                    ...form,
+                    scope: o.v,
+                    // TEAM 처음 선택 시 내 팀을 기본값으로 세팅. 이미 채워져 있으면 유지.
+                    scopeTeams: o.v === "TEAM" && form.scopeTeams.length === 0 && myTeam
+                      ? [myTeam]
+                      : form.scopeTeams,
+                  })}
                   className={`rounded-xl border px-2.5 py-2 text-left transition-all ${
                     form.scope === o.v
                       ? "border-brand-600 bg-brand-50 ring-1 ring-brand-300"
@@ -812,25 +979,18 @@ function AccountModal({
               ))}
             </div>
             {form.scope === "TEAM" && (
-              <input
-                className="input mt-1"
-                placeholder={myTeam ? `예: ${myTeam}` : "팀 이름"}
-                value={form.scopeTeam}
-                maxLength={80}
-                onChange={(e) => setForm({ ...form, scopeTeam: e.target.value })}
+              <MultiTeamEditor
+                teams={form.scopeTeams}
+                myTeam={myTeam}
+                onChange={(next) => setForm({ ...form, scopeTeams: next })}
               />
             )}
             {form.scope === "PROJECT" && (
-              <select
-                className="input mt-1"
-                value={form.scopeProjectId}
-                onChange={(e) => setForm({ ...form, scopeProjectId: e.target.value })}
-              >
-                <option value="">프로젝트 선택…</option>
-                {projects.map((p) => (
-                  <option key={p.id} value={p.id}>{p.name}</option>
-                ))}
-              </select>
+              <MultiProjectEditor
+                selected={form.scopeProjectIds}
+                projects={projects}
+                onChange={(next) => setForm({ ...form, scopeProjectIds: next })}
+              />
             )}
           </div>
 
@@ -902,13 +1062,19 @@ function AccountModal({
             <span className="text-[11px] font-bold text-ink-500">로고</span>
             <div className="flex items-center gap-2">
               <div
-                className="w-11 h-11 rounded-xl grid place-items-center flex-shrink-0 overflow-hidden border border-ink-150"
-                style={{ background: previewSrc ? "#F8F8FA" : CATEGORY_META[form.category].color, color: "#fff" }}
+                className="w-12 h-12 grid place-items-center flex-shrink-0 overflow-hidden ring-1 ring-black/5 shadow-sm"
+                style={{
+                  borderRadius: "22%",
+                  background: previewSrc
+                    ? "linear-gradient(180deg, #FFFFFF 0%, #F3F4F7 100%)"
+                    : `linear-gradient(180deg, ${CATEGORY_META[form.category].color} 0%, ${CATEGORY_META[form.category].color}dd 100%)`,
+                  color: "#fff",
+                }}
               >
                 {previewSrc ? (
-                  <img src={previewSrc} alt="" className="w-9 h-9 object-contain" referrerPolicy="no-referrer" />
+                  <img src={previewSrc} alt="" className="w-full h-full object-cover" referrerPolicy="no-referrer" />
                 ) : (
-                  <span className="text-lg leading-none">{CATEGORY_META[form.category].emoji}</span>
+                  <span className="text-xl leading-none">{CATEGORY_META[form.category].emoji}</span>
                 )}
               </div>
               <div className="flex-1 min-w-0">

--- a/server/prisma/migrations/20260424180000_service_account_active/migration.sql
+++ b/server/prisma/migrations/20260424180000_service_account_active/migration.sql
@@ -1,0 +1,2 @@
+-- 서비스 계정 활성 상태. false 면 "비활성"(해지/만료/중단). 기본 true.
+ALTER TABLE "ServiceAccount" ADD COLUMN "active" BOOLEAN NOT NULL DEFAULT true;

--- a/server/prisma/migrations/20260424190000_service_account_multi_scope/migration.sql
+++ b/server/prisma/migrations/20260424190000_service_account_multi_scope/migration.sql
@@ -1,0 +1,9 @@
+-- 서비스 계정 공유 범위 다중화.
+-- 기존 단일 scopeTeam / projectId 는 그대로 두고, 여러 값을 담는 text[] 를 추가한다.
+-- 가시성 쿼리에선 (scopeTeam = ? OR ? = ANY(scopeTeams)) 같은 형태로 둘 다 조사.
+ALTER TABLE "ServiceAccount" ADD COLUMN "scopeTeams" TEXT[] NOT NULL DEFAULT '{}'::text[];
+ALTER TABLE "ServiceAccount" ADD COLUMN "projectIds" TEXT[] NOT NULL DEFAULT '{}'::text[];
+
+-- 기존 단일 값 백필 — 이미 저장된 공유 범위를 배열에도 반영.
+UPDATE "ServiceAccount" SET "scopeTeams" = ARRAY["scopeTeam"]::text[] WHERE "scopeTeam" IS NOT NULL AND "scope" = 'TEAM';
+UPDATE "ServiceAccount" SET "projectIds" = ARRAY["projectId"]::text[] WHERE "projectId" IS NOT NULL AND "scope" = 'PROJECT';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -813,14 +813,20 @@ model ServiceAccount {
   notes       String? // 접근 방법, MFA 사용 여부 등 자유 메모
   // 커스텀 로고 URL — 사용자가 업로드한 이미지(/uploads/xxx). null 이면 URL/이름 기반 favicon 자동 추측.
   iconUrl     String?
+  // 활성 상태 — false 면 목록에서 비활성 배지로 표기. 해지/만료/중단된 계정을 "삭제 없이" 기록에 남길 때 사용.
+  active      Boolean  @default(true)
   // 비밀번호 — AES-256-GCM 로 암호화된 blob (포맷 v1:iv:tag:ct, base64).
   // 서버의 ACCOUNT_ENC_KEY 로만 복호화. 목록 GET 에선 반환하지 않음 — 상세 reveal 시에만 복호화.
   passwordEnc String?
   // 공개 범위 — ALL(전사) | TEAM(팀) | PROJECT(프로젝트). 문서/회의록과 일관.
   scope       String   @default("ALL")
-  scopeTeam   String? // scope=TEAM 일 때 팀 이름
-  projectId   String? // scope=PROJECT 일 때 연결된 프로젝트
+  // scope=TEAM 일 때 공유 대상 팀들 (여러 팀 가능). 레거시 단일 값은 scopeTeam 에 유지.
+  scopeTeam   String?
+  scopeTeams  String[] @default([])
+  // scope=PROJECT 일 때 연결된 프로젝트들. 레거시 단일 값은 projectId 에 유지.
+  projectId   String?
   project     Project? @relation("ProjectServiceAccounts", fields: [projectId], references: [id], onDelete: SetNull)
+  projectIds  String[] @default([])
   // 담당자 — 사용자 연결이 있으면 ownerUserId, 외부 담당자는 ownerName 으로 기록.
   ownerUserId String?
   ownerUser   User?    @relation("ServiceAccountOwner", fields: [ownerUserId], references: [id], onDelete: SetNull)

--- a/server/src/routes/serviceAccount.ts
+++ b/server/src/routes/serviceAccount.ts
@@ -41,9 +41,15 @@ const baseSchema = z.object({
   notes: z.string().max(2000).optional().nullable(),
   scope: z.enum(SCOPES).optional().default("ALL"),
   scopeTeam: z.string().trim().max(80).optional().nullable(),
+  // 다중 팀 공유 — "내 팀 + 다른 팀들" 형태. scopeTeam 은 레거시/대표값으로 배열의 첫 요소와 동기화한다.
+  scopeTeams: z.array(z.string().trim().min(1).max(80)).optional(),
   projectId: z.string().optional().nullable(),
+  // 다중 프로젝트 공유 — 대표값(projectId) 외에 추가 공유 프로젝트 id 목록.
+  projectIds: z.array(z.string().min(1)).optional(),
   ownerUserId: z.string().optional().nullable(),
   ownerName: z.string().trim().max(80).optional().nullable(),
+  // 활성 여부 — 기본 true. 해지/만료된 계정을 삭제 없이 비활성으로 남겨 기록 보존.
+  active: z.boolean().optional(),
   // 평문 비밀번호 — 서버에서 즉시 암호화해 passwordEnc 에만 저장.
   // null 로 보내면 기존 저장된 값 삭제, undefined 면 변경 없음(PATCH).
   password: z.string().max(512).nullable().optional(),
@@ -79,10 +85,17 @@ async function visibleWhere(user: { id: string; role?: string; superAdmin?: bool
     { createdById: user.id },
   ];
   if (user.team) {
-    conditions.push({ scope: "TEAM", scopeTeam: user.team });
+    // scope=TEAM 중 단일값(scopeTeam) 일치 OR 배열(scopeTeams) 포함
+    conditions.push({ scope: "TEAM", OR: [{ scopeTeam: user.team }, { scopeTeams: { has: user.team } }] });
   }
   if (projectIds.length > 0) {
-    conditions.push({ scope: "PROJECT", projectId: { in: projectIds } });
+    conditions.push({
+      scope: "PROJECT",
+      OR: [
+        { projectId: { in: projectIds } },
+        { projectIds: { hasSome: projectIds } },
+      ],
+    });
   }
   return { OR: conditions };
 }
@@ -107,13 +120,12 @@ router.get("/", async (req, res) => {
     where.AND = [{ OR: where.OR }].filter(() => !!where.OR);
     delete where.OR;
     where.AND.push({ scope });
-    if (scope === "TEAM" && scopeTeam) where.AND.push({ scopeTeam });
-    if (scope === "PROJECT" && projectId) where.AND.push({ projectId });
+    if (scope === "TEAM" && scopeTeam) where.AND.push({ OR: [{ scopeTeam }, { scopeTeams: { has: scopeTeam } }] });
+    if (scope === "PROJECT" && projectId) where.AND.push({ OR: [{ projectId }, { projectIds: { has: projectId } }] });
   } else if (projectId) {
-    // scope 필터 없이 projectId 만 — PROJECT 스코프 중 이 프로젝트
     where.AND = [{ OR: where.OR }].filter(() => !!where.OR);
     delete where.OR;
-    where.AND.push({ scope: "PROJECT", projectId });
+    where.AND.push({ scope: "PROJECT", OR: [{ projectId }, { projectIds: { has: projectId } }] });
   }
 
   if (q) {
@@ -203,29 +215,28 @@ router.get("/projects", async (req, res) => {
 });
 
 async function validateScope(
-  user: { id: string; role?: string; superAdmin?: boolean; team?: string | null },
-  input: { scope?: string; scopeTeam?: string | null; projectId?: string | null },
+  _user: { id: string; role?: string; superAdmin?: boolean; team?: string | null },
+  input: { scope?: string; scopeTeam?: string | null; scopeTeams?: string[]; projectId?: string | null; projectIds?: string[] },
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const scope = input.scope ?? "ALL";
   if (scope === "ALL") return { ok: true };
   if (scope === "TEAM") {
-    if (!input.scopeTeam) return { ok: false, error: "팀 이름을 지정해주세요." };
-    // ADMIN 은 모든 팀 지정 가능. 일반 사용자는 본인 팀만.
-    if (!isAdmin(user) && user.team !== input.scopeTeam) {
-      return { ok: false, error: "본인 팀으로만 공개할 수 있어요." };
-    }
+    const teams = [
+      ...(input.scopeTeam ? [input.scopeTeam] : []),
+      ...((input.scopeTeams ?? []).filter(Boolean)),
+    ];
+    if (teams.length === 0) return { ok: false, error: "팀을 하나 이상 지정해주세요." };
+    // "페이지를 볼 수 있는 사람 = 공유 대상 지정 가능" 원칙 — 팀 이름 자유 입력 허용.
     return { ok: true };
   }
   if (scope === "PROJECT") {
-    if (!input.projectId) return { ok: false, error: "프로젝트를 지정해주세요." };
-    const project = await prisma.project.findUnique({
-      where: { id: input.projectId },
-      select: { id: true, members: { where: { userId: user.id }, select: { id: true } } },
-    });
-    if (!project) return { ok: false, error: "프로젝트를 찾을 수 없어요." };
-    if (!isAdmin(user) && project.members.length === 0) {
-      return { ok: false, error: "해당 프로젝트의 멤버가 아니에요." };
-    }
+    const ids = [
+      ...(input.projectId ? [input.projectId] : []),
+      ...((input.projectIds ?? []).filter(Boolean)),
+    ];
+    if (ids.length === 0) return { ok: false, error: "프로젝트를 하나 이상 지정해주세요." };
+    const found = await prisma.project.findMany({ where: { id: { in: ids } }, select: { id: true } });
+    if (found.length !== ids.length) return { ok: false, error: "선택한 프로젝트 중 일부를 찾을 수 없어요." };
     return { ok: true };
   }
   return { ok: false, error: "알 수 없는 공개 범위에요." };
@@ -262,6 +273,17 @@ router.post("/", async (req, res) => {
   }
 
   const scope = input.scope ?? "ALL";
+  // 다중 범위 정규화:
+  //  - scopeTeam 단일값 + scopeTeams 배열을 합쳐 중복 제거, 공백 제거.
+  //  - 대표값(scopeTeam / projectId)은 배열의 첫 요소로 세팅 — 레거시 UI/쿼리 호환.
+  const teamsAll = Array.from(new Set(
+    [input.scopeTeam, ...(input.scopeTeams ?? [])].map((s) => (s ?? "").trim()).filter(Boolean)
+  ));
+  const projAll = Array.from(new Set(
+    [input.projectId, ...(input.projectIds ?? [])].map((s) => s ?? "").filter(Boolean)
+  ));
+  const primaryTeam = scope === "TEAM" ? (teamsAll[0] ?? null) : null;
+  const primaryProject = scope === "PROJECT" ? (projAll[0] ?? null) : null;
   const row = await prisma.serviceAccount.create({
     data: {
       serviceName: input.serviceName,
@@ -269,10 +291,13 @@ router.post("/", async (req, res) => {
       loginId: input.loginId || null,
       url,
       iconUrl: input.iconUrl === "" ? null : input.iconUrl ?? null,
+      active: input.active ?? true,
       notes: input.notes || null,
       scope,
-      scopeTeam: scope === "TEAM" ? (input.scopeTeam || null) : null,
-      projectId: scope === "PROJECT" ? (input.projectId || null) : null,
+      scopeTeam: primaryTeam,
+      scopeTeams: scope === "TEAM" ? teamsAll : [],
+      projectId: primaryProject,
+      projectIds: scope === "PROJECT" ? projAll : [],
       ownerUserId,
       ownerName: input.ownerName || null,
       passwordEnc,
@@ -299,7 +324,7 @@ router.patch("/:id", async (req, res) => {
 
   const existing = await prisma.serviceAccount.findUnique({
     where: { id },
-    select: { id: true, createdById: true, scope: true, scopeTeam: true, projectId: true },
+    select: { id: true, createdById: true, scope: true, scopeTeam: true, scopeTeams: true, projectId: true, projectIds: true },
   });
   if (!existing) return res.status(404).json({ error: "존재하지 않는 계정이에요." });
   if (!canEdit(user, existing)) {
@@ -310,10 +335,27 @@ router.patch("/:id", async (req, res) => {
 
   // scope 변경 검증 — 변경 시 (또는 스코프 관련 필드 변경 시) 유효성 체크
   const nextScope = input.scope ?? existing.scope;
-  const nextScopeTeam = input.scopeTeam !== undefined ? input.scopeTeam : existing.scopeTeam;
+  const nextScopeTeams = input.scopeTeams !== undefined
+    ? input.scopeTeams
+    : existing.scopeTeams ?? [];
+  const nextScopeTeam = input.scopeTeam !== undefined
+    ? input.scopeTeam
+    : existing.scopeTeam;
+  const nextProjectIds = input.projectIds !== undefined
+    ? input.projectIds
+    : existing.projectIds ?? [];
   const nextProjectId = input.projectId !== undefined ? input.projectId : existing.projectId;
-  if (input.scope !== undefined || input.scopeTeam !== undefined || input.projectId !== undefined) {
-    const check = await validateScope(user, { scope: nextScope, scopeTeam: nextScopeTeam, projectId: nextProjectId });
+  const scopeRelatedChanged =
+    input.scope !== undefined || input.scopeTeam !== undefined || input.scopeTeams !== undefined ||
+    input.projectId !== undefined || input.projectIds !== undefined;
+  if (scopeRelatedChanged) {
+    const check = await validateScope(user, {
+      scope: nextScope,
+      scopeTeam: nextScopeTeam,
+      scopeTeams: nextScopeTeams,
+      projectId: nextProjectId,
+      projectIds: nextProjectIds,
+    });
     if (!check.ok) return res.status(400).json({ error: check.error });
   }
 
@@ -323,6 +365,7 @@ router.patch("/:id", async (req, res) => {
   if (input.loginId !== undefined) data.loginId = input.loginId || null;
   if (input.url !== undefined) data.url = input.url === "" ? null : input.url;
   if (input.iconUrl !== undefined) data.iconUrl = input.iconUrl === "" ? null : input.iconUrl;
+  if (input.active !== undefined) data.active = input.active;
   if (input.notes !== undefined) data.notes = input.notes || null;
   if (input.ownerName !== undefined) data.ownerName = input.ownerName || null;
   if (input.ownerUserId !== undefined) {
@@ -333,10 +376,18 @@ router.patch("/:id", async (req, res) => {
     }
     data.ownerUserId = next;
   }
-  if (input.scope !== undefined || input.scopeTeam !== undefined || input.projectId !== undefined) {
+  if (scopeRelatedChanged) {
+    const teamsAll = Array.from(new Set(
+      [nextScopeTeam, ...(nextScopeTeams ?? [])].map((s) => (s ?? "").trim()).filter(Boolean)
+    ));
+    const projAll = Array.from(new Set(
+      [nextProjectId, ...(nextProjectIds ?? [])].map((s) => s ?? "").filter(Boolean)
+    ));
     data.scope = nextScope;
-    data.scopeTeam = nextScope === "TEAM" ? (nextScopeTeam || null) : null;
-    data.projectId = nextScope === "PROJECT" ? (nextProjectId || null) : null;
+    data.scopeTeam = nextScope === "TEAM" ? (teamsAll[0] ?? null) : null;
+    data.scopeTeams = nextScope === "TEAM" ? teamsAll : [];
+    data.projectId = nextScope === "PROJECT" ? (projAll[0] ?? null) : null;
+    data.projectIds = nextScope === "PROJECT" ? projAll : [];
   }
   // 비밀번호 — undefined 면 변경 없음, null/빈 문자열은 제거, 값이 있으면 암호화.
   if (input.password !== undefined) {


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- 카드에 활성/비활성 토글 스위치 추가 (옵티미스틱, 실패 시 복구)
- 공유 범위 TEAM/PROJECT 를 다중 선택 가능 — 칩 + 추가 입력
  - TEAM: 내 팀 외 다른 팀도 자유롭게 추가
  - PROJECT: 여러 프로젝트 동시 공유
  - 레거시 단일 필드(scopeTeam/projectId)는 배열 첫 요소와 동기화해 호환 유지
- 로고 프레임을 iOS 스퀘어클 스타일로 — 22% 반경·그라데이션·링·섀도우, 이미지가 컨테이너 꽉 채움

## Test plan
- [ ] 활성 토글 클릭 → 카드 디밍 + 비활성 배지 표시, 새로고침 후 유지
- [ ] 팀 공유에 \"+ 추가\" 로 다른 팀 이름 붙여 저장 → 해당 팀 사용자에게도 보임
- [ ] 프로젝트 공유에 여러 프로젝트 선택 저장 → 모든 멤버에게 보임
- [ ] 로고가 둥근 앱 아이콘처럼 렌더되는지 (favicon / 업로드 / 이모지 모두)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #460

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #460
