### PR TITLE
🔀 :: (#464) Responsive polish: sidebar / org-chart / directory mobile

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -162,7 +162,7 @@ function AppLayoutInner() {
           <div className="border-t border-ink-150 px-2 pt-2">
             <NavLink
               to="/download"
-              className="flex items-center gap-2.5 h-[32px] px-3 rounded-full text-[12.5px] font-semibold text-ink-500 hover:bg-ink-100 hover:text-ink-900 transition"
+              className="flex items-center gap-2.5 h-[40px] md:h-[32px] px-3 rounded-full text-[13px] md:text-[12.5px] font-semibold text-ink-500 hover:bg-ink-100 hover:text-ink-900 transition"
               title="데스크톱 · 모바일 앱 다운로드"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -263,6 +263,7 @@ function MyProfileHero({
           </div>
           <div className="text-[11px] text-ink-500 tabular mt-0.5">{me.email}</div>
         </div>
+        {/* 통계 — 모바일에선 콤팩트 인라인 뱃지, md+ 부터는 큰 숫자 카드 */}
         <div className="hidden md:flex items-center gap-6 pr-2">
           <div className="text-center">
             <div className="text-[11px] font-bold text-ink-500 uppercase tracking-wider">동료</div>
@@ -273,6 +274,11 @@ function MyProfileHero({
             <div className="text-[11px] font-bold text-ink-500 uppercase tracking-wider">팀</div>
             <div className="text-[22px] font-extrabold text-ink-900 tabular" style={{ letterSpacing: "-0.02em" }}>{teamCount}</div>
           </div>
+        </div>
+        <div className="md:hidden w-full mt-2 flex items-center gap-3 text-[12px] text-ink-500">
+          <span>동료 <b className="text-ink-900 tabular">{totalCount - 1}</b></span>
+          <span className="text-ink-300">·</span>
+          <span>팀 <b className="text-ink-900 tabular">{teamCount}</b></span>
         </div>
       </div>
     </div>
@@ -401,7 +407,7 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
       <div className="hidden md:block flex-1 min-w-0">
         {u.team && <span className="chip-blue">{u.team}</span>}
       </div>
-      <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition">
+      <div className="flex items-center gap-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition">
         <a href={`mailto:${u.email}`} className="btn-icon" title="이메일">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="3" y="5" width="18" height="14" rx="2" />

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -457,7 +457,7 @@ function PersonNode({
   const isMe = u.id === meId;
   // width 를 "고정" 해서 '나' 칩 유무와 관계없이 모든 카드 크기가 동일하도록 함.
   return (
-    <div className="group flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-ink-150 bg-white dark:bg-ink-50 hover:border-brand-300 hover:shadow-pop transition w-[180px]">
+    <div className="group flex items-center gap-2 px-2.5 py-1.5 rounded-lg border border-ink-150 bg-white dark:bg-ink-50 hover:border-brand-300 hover:shadow-pop transition w-[150px] sm:w-[180px]">
       <UserAvatar u={u} size={28} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1 min-w-0">


### PR DESCRIPTION
## 증상
**sidebar / org-chart / directory mobile**

유지보수 작업을 진행합니다.

## 원인
- AppLayout 앱 다운로드 링크: 모바일 40px 터치 타겟 + 13px 폰트 (md 이하)
- OrgChart 노드 카드: <375px 에서 180px 고정이 넘쳐서 w-[150px] sm:w-[180px] 로
- DirectoryPage hero 통계: 모바일에선 완전히 숨겨져 있던 것을 콤팩트 인라인으로 보이게
- DirectoryPage 행 액션 (이메일/DM): hover-only 가 모바일에선 터치가 없어 사용 불가 → 항상 표시, md+ 만 hover 에 의존

## 수정
**작업 항목 (커밋 단위)**
- fix(responsive): sidebar/org-chart/directory mobile improvements

**변경 대상 (3개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/pages/DirectoryPage.tsx`
- `client/src/pages/OrgChartPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #42** ↔ **이슈 #464** 로 연결됩니다.

Closes #464
