### PR TITLE
🔀 :: (#465) Security hardening (HSTS, Origin CSRF guard, bcrypt 12)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,10 +50,14 @@ if (IS_PROD) {
 }
 
 // 기본 보안 헤더 — CSP 는 프런트 개발 편의상 기본만.
+// 프로덕션에선 HSTS 2년 + preload 활성화 — HTTPS→HTTP 다운그레이드 공격 차단.
 app.use(
   helmet({
     crossOriginResourcePolicy: { policy: "cross-origin" }, // /uploads 타 origin 로드 허용
     contentSecurityPolicy: false, // API 서버라 HTML 안 서빙. 필요 시 활성화.
+    hsts: IS_PROD
+      ? { maxAge: 63072000, includeSubDomains: true, preload: true }
+      : false,
   })
 );
 
@@ -83,6 +87,27 @@ app.use(
 );
 app.use(express.json({ limit: "2mb" }));
 app.use(cookieParser());
+
+// CSRF 방어 — 쿠키 인증 + SameSite=lax 만으론 크로스 오리진 상태변경 요청에 완전히 안전하지 않음.
+// Origin / Referer 헤더를 허용 오리진 목록과 대조해 안 맞으면 403.
+// GET/HEAD/OPTIONS 는 상태변경이 아니므로 통과. 웹훅(/api/webhook/*)은 자체 토큰 검증이라 예외.
+const STATE_CHANGING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+app.use((req, res, next) => {
+  if (!STATE_CHANGING.has(req.method)) return next();
+  if (req.path.startsWith("/api/webhook/")) return next();
+  if (req.path === "/api/health") return next();
+  const origin = String(req.headers.origin || "");
+  const referer = String(req.headers.referer || "");
+  // Origin 이 있으면 그걸로 검증. 없으면 Referer 의 origin 을 뽑아 검증.
+  // 둘 다 없으면 브라우저 외 클라이언트(스크립트/네이티브 앱)로 간주해 통과 — 쿠키/JWT 체크는 그대로 작동.
+  let sender = origin;
+  if (!sender && referer) {
+    try { sender = new URL(referer).origin; } catch { sender = ""; }
+  }
+  if (!sender) return next();
+  if (CORS_ORIGINS.includes(sender)) return next();
+  return res.status(403).json({ error: "origin not allowed" });
+});
 
 // 레이트 리밋 — 브루트포스/DoS 방어.
 const loginLimiter = rateLimit({

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -97,7 +97,8 @@ router.post("/signup", async (req, res) => {
   const dup = await prisma.user.findUnique({ where: { email } });
   if (dup) return res.status(400).json({ error: "이미 가입된 이메일" });
 
-  const passwordHash = await bcrypt.hash(password, 10);
+  // 2026 기준 bcrypt rounds 12 — 로그인/가입 지연은 체감 없고 GPU 공격 비용은 4x 증가.
+  const passwordHash = await bcrypt.hash(password, 12);
   // 사번은 서버가 자동 부여 — 사용자가 입력하지 않음. 중복 절대 없음 (유니크 체크 반복).
   const employeeNo = await generateUniqueEmployeeNo();
   const user = await prisma.user.create({

--- a/server/src/routes/profile.ts
+++ b/server/src/routes/profile.ts
@@ -64,7 +64,7 @@ router.post("/password", passwordChangeLimiter, async (req, res) => {
     await writeLog(u.id, "PASSWORD_CHANGE_FAIL", undefined, undefined, req.ip);
     return res.status(401).json({ error: "현재 비밀번호가 일치하지 않습니다" });
   }
-  const hash = await bcrypt.hash(parsed.data.next, 10);
+  const hash = await bcrypt.hash(parsed.data.next, 12);
   await prisma.user.update({ where: { id: user.id }, data: { passwordHash: hash } });
   await writeLog(u.id, "PASSWORD_CHANGE", undefined, undefined, req.ip);
   res.json({ ok: true });


### PR DESCRIPTION
## 증상
**Security hardening (HSTS, Origin CSRF guard, bcrypt 12)**

보안 취약점을 점검하고 보완합니다.

## 원인
- helmet HSTS 2y + includeSubDomains + preload (prod only)
- Origin/Referer allowlist check on state-changing methods (POST/PUT/PATCH/DELETE)
  with exceptions for /api/webhook/* (own token) and /api/health
- bcrypt rounds bumped to 12 on signup and password change
  (share link passwords stay at 10 — high-volume, short-lived tokens)

## 수정
**작업 항목 (커밋 단위)**
- sec: HSTS, Origin-based CSRF guard, bcrypt rounds 10→12

**변경 대상 (3개 파일)**
- `server/src/index.ts`
- `server/src/routes/auth.ts`
- `server/src/routes/profile.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #43** ↔ **이슈 #465** 로 연결됩니다.

Closes #465
