### PR TITLE
🔀 :: (#466) UX polish: modal Esc + scroll lock, approval comment counter/shortcut

### DIFF
--- a/client/src/lib/useModalDismiss.ts
+++ b/client/src/lib/useModalDismiss.ts
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+
+/**
+ * 모달/오버레이 열려 있는 동안 Esc 로 닫기 + 배경 스크롤 잠금.
+ * 여러 모달이 동시에 열려도 마지막에 등록된 것만 반응하도록 capture 단계에서 한 번만 처리.
+ *
+ * 사용:
+ *   useModalDismiss(open, () => setOpen(false));
+ *
+ * @param open 모달이 열려있으면 true
+ * @param onDismiss Esc 눌렸을 때 호출될 콜백. 저장중 등으로 막아야 하면 함수 안에서 return.
+ * @param opts.lockScroll 기본 true — <body> overflow: hidden 을 켜서 배경 스크롤 방지.
+ */
+export function useModalDismiss(
+  open: boolean,
+  onDismiss: () => void,
+  opts: { lockScroll?: boolean } = {},
+) {
+  const lockScroll = opts.lockScroll !== false;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      // 컴포지션 중(한글 입력 변환) 에는 Esc 가 변환 취소 용도라 여기서 가로채지 않음.
+      if ((e as any).isComposing) return;
+      e.stopPropagation();
+      onDismiss();
+    };
+    // capture 로 등록해서 전역 리스너(⌘K 검색 등) 보다 먼저 잡음.
+    window.addEventListener("keydown", onKey, true);
+
+    let prevOverflow = "";
+    if (lockScroll) {
+      prevOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      window.removeEventListener("keydown", onKey, true);
+      if (lockScroll) document.body.style.overflow = prevOverflow;
+    };
+  }, [open, onDismiss, lockScroll]);
+}

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -599,13 +599,29 @@ function ApprovalDetail({
             <div className="text-[12px] text-ink-400">아직 댓글이 없어요.</div>
           )}
           <div className="mt-2 flex items-start gap-2">
-            <textarea
-              className="input flex-1"
-              rows={2}
-              value={commentBody}
-              onChange={(e) => setCommentBody(e.target.value.slice(0, 2000))}
-              placeholder="반려 사유에 대한 맥락이나 추가 질문을 남겨보세요"
-            />
+            <div className="flex-1 relative">
+              <textarea
+                className="input w-full pb-5"
+                rows={2}
+                value={commentBody}
+                onChange={(e) => setCommentBody(e.target.value.slice(0, 2000))}
+                placeholder="반려 사유에 대한 맥락이나 추가 질문을 남겨보세요  (⌘/Ctrl+Enter 로 등록)"
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter" && commentBody.trim() && !posting) {
+                    e.preventDefault();
+                    postComment();
+                  }
+                }}
+              />
+              {/* 글자 수 표시 — 한도 근처에서만 색상 강조. */}
+              <div
+                className={`absolute right-2 bottom-1 text-[10px] tabular pointer-events-none ${
+                  commentBody.length >= 2000 ? "text-rose-500 font-bold" : commentBody.length >= 1800 ? "text-amber-500" : "text-ink-400"
+                }`}
+              >
+                {commentBody.length}/2000
+              </div>
+            </div>
             <button className="btn-primary" disabled={posting || !commentBody.trim()} onClick={postComment}>
               {posting ? "..." : "등록"}
             </button>

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -6,6 +6,7 @@ import PageHeader from "../components/PageHeader";
 import MonthPicker from "../components/MonthPicker";
 import DateTimePicker from "../components/DateTimePicker";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
+import { useModalDismiss } from "../lib/useModalDismiss";
 
 type Expense = {
   id: string;
@@ -61,6 +62,10 @@ export default function ExpensePage() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  // 모달들: Esc 로 닫기 + 배경 스크롤 잠금.
+  // 저장 중엔 실수로 닫히지 않도록 saving 체크.
+  useModalDismiss(open && !saving, () => setOpen(false));
+  useModalDismiss(preview !== null, () => setPreview(null));
 
   async function load(aliveRef?: { current: boolean }) {
     const q = new URLSearchParams();

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -3,6 +3,7 @@ import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
 import DateTimePicker from "../components/DateTimePicker";
 import { alertAsync } from "../components/ConfirmHost";
+import { useModalDismiss } from "../lib/useModalDismiss";
 
 type Journal = {
   id: string;
@@ -38,6 +39,8 @@ export default function JournalPage() {
   // 삭제 버튼 중복 클릭 방지 + native confirm() 대체용 모달 상태.
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+  // 삭제 확인 모달: 실행 중이 아니면 Esc / 배경 클릭으로 닫기.
+  useModalDismiss(!!confirmRemoveId && !removingId, () => setConfirmRemoveId(null));
 
   // save/remove 후 setState 가 또 돌고, 이때 사용자가 이탈하면 언마운트된 컴포넌트에
   // setState 가 박히며 경고+누수. apiSWR 의 stale→fresh 콜백도 가드 대상.


### PR DESCRIPTION
## 증상
**modal Esc + scroll lock, approval comment counter/shortcut**

유지보수 작업을 진행합니다.

## 원인
…nt polish

- New lib/useModalDismiss hook: Esc closes modal + body scroll lock,
  with IME composition guard and saving-state guard to prevent accidental
  close mid-save. Capture-phase registration so it beats global shortcuts.
- ExpensePage: apply to create-modal (blocked while saving) and receipt preview
- JournalPage: apply to delete-confirm modal
- ApprovalsPage comments: character counter (2000 cap) with color warning
  at 1800/2000, and ⌘/Ctrl+Enter shortcut to submit

## 수정
**작업 항목 (커밋 단위)**
- feat(ux): shared useModalDismiss (Esc + scroll lock) + approval comme…

**변경 대상 (4개 파일)**
- `client/src/lib/useModalDismiss.ts`
- `client/src/pages/ApprovalsPage.tsx`
- `client/src/pages/ExpensePage.tsx`
- `client/src/pages/JournalPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #44** ↔ **이슈 #466** 로 연결됩니다.

Closes #466
