### PR TITLE
🔀 :: (#468) 공지·회의록 링크 복사 + 공용 clipboard 헬퍼

### DIFF
--- a/client/src/lib/clipboard.ts
+++ b/client/src/lib/clipboard.ts
@@ -1,0 +1,71 @@
+import { alertAsync } from "../components/ConfirmHost";
+
+/**
+ * 텍스트를 클립보드에 복사 + 토스트/알림 피드백.
+ *
+ * navigator.clipboard 는 다음 경우에 실패할 수 있어서 textarea fallback 을 둔다:
+ * - 비-HTTPS 환경(사내 테스트 서버 등)
+ * - 사용자 제스처 컨텍스트가 끊긴 상태 (예: 비동기 await 체인 뒤에서 호출)
+ * - 일부 구형 브라우저 / WebView
+ *
+ * @param text 복사할 문자열
+ * @param opts.title / description 성공 알림 문구. description 을 빈 문자열로 주면 알림 생략.
+ */
+export async function copyToClipboard(
+  text: string,
+  opts: { title?: string; description?: string } = {},
+) {
+  const title = opts.title ?? "복사됨";
+  const description = opts.description ?? "클립보드에 복사했어요.";
+
+  let ok = false;
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      ok = true;
+    }
+  } catch {
+    // fallthrough to fallback
+  }
+  if (!ok) {
+    // execCommand 기반 폴백 — 화면에 안 보이는 textarea 로 복사.
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.setAttribute("readonly", "");
+      ta.style.position = "fixed";
+      ta.style.top = "0";
+      ta.style.left = "0";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      ok = document.execCommand("copy");
+      document.body.removeChild(ta);
+    } catch {
+      ok = false;
+    }
+  }
+
+  if (ok && description) {
+    alertAsync({ title, description });
+  } else if (!ok) {
+    alertAsync({
+      title: "복사 실패",
+      description: "브라우저가 복사를 막았어요. 주소를 직접 선택해 복사해 주세요.",
+    });
+  }
+  return ok;
+}
+
+/**
+ * 현재 origin 기준의 절대 URL 을 만들어 반환. 사내톡에 붙여넣어도 서버/클라 호스트가
+ * 동일하면 그대로 딥링크로 동작.
+ */
+export function absoluteUrl(pathOrQuery: string): string {
+  if (typeof window === "undefined") return pathOrQuery;
+  try {
+    return new URL(pathOrQuery, window.location.origin).toString();
+  } catch {
+    return pathOrQuery;
+  }
+}

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../auth";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
+import { copyToClipboard, absoluteUrl } from "../lib/clipboard";
 // TipTap 에디터는 ~300KB 덩어리 — 회의록 상세 페이지 안에서 다시 한 번 나눠서
 // 제목/메타/공개범위 UI 가 먼저 보이고, 에디터는 뒤따라 로드되도록 함.
 const MeetingEditor = lazy(() => import("../components/MeetingEditor"));
@@ -230,6 +231,23 @@ export default function MeetingDetailPage() {
           ← 회의록 목록
         </Link>
         <div className="flex items-center gap-2 flex-wrap justify-end">
+          <button
+            type="button"
+            className="btn-ghost inline-flex items-center gap-1"
+            title="이 회의록 링크 복사"
+            onClick={() =>
+              copyToClipboard(absoluteUrl(`/meetings/${meeting.id}`), {
+                title: "링크 복사됨",
+                description: "사내톡에 붙여넣으면 이 회의록으로 바로 이동돼요.",
+              })
+            }
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72" />
+              <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72" />
+            </svg>
+            링크 복사
+          </button>
           <PinButton type="MEETING" id={meeting.id} label={meeting.title} />
           <button className="btn-ghost" onClick={() => setHistoryOpen(true)} title="버전 히스토리">히스토리</button>
           {canEdit && !edit && (

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -6,6 +6,7 @@ import { useNotifications } from "../notifications";
 import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
+import { copyToClipboard, absoluteUrl } from "../lib/clipboard";
 
 type ReactionAgg = { emoji: string; count: number; reactedByMe: boolean };
 type Notice = {
@@ -240,6 +241,23 @@ export default function NoticePage() {
                   <h2 className="text-xl font-bold mt-2">{selected.title}</h2>
                 </div>
                 <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    className="btn-ghost inline-flex items-center gap-1"
+                    title="이 공지로 연결되는 링크를 복사"
+                    onClick={() =>
+                      copyToClipboard(absoluteUrl(`/notice?id=${selected.id}`), {
+                        title: "링크 복사됨",
+                        description: "사내톡에 붙여넣으면 이 공지로 바로 이동돼요.",
+                      })
+                    }
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72" />
+                      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72" />
+                    </svg>
+                    링크 복사
+                  </button>
                   <PinButton type="NOTICE" id={selected.id} label={selected.title} />
                   {canPost && (
                     <button


### PR DESCRIPTION
## 증상
**공지·회의록 링크 복사 + 공용 clipboard 헬퍼**

새 기능을 추가합니다.

## 원인
사내톡·DM 에 공지/회의록 링크를 바로 붙여넣어 공유하는 플로우를 일급 UX 로.

- client/src/lib/clipboard.ts: navigator.clipboard + execCommand 폴백 + 토스트.
  HTTPS 아닌 사내 테스트 서버 / 구형 WebView 에서도 복사 동작하도록 안전망.
- NoticePage: 상세 헤더에 "링크 복사" → /notice?id=<id> 절대 URL 을 클립보드에.
- MeetingDetailPage: 상단 액션 바에 동일 버튼 → /meetings/<id>.

서버 변경 없음. 기존 ShareLinkModal/ServiceAccountsPage 복사 로직은 후속에서
동일 헬퍼로 교체 가능 (이번 PR 에선 영향 범위 최소화).

## 수정
**작업 항목 (커밋 단위)**
- feat(collab): 공지·회의록 "링크 복사" 버튼 + 공용 clipboard 헬퍼

**변경 대상 (3개 파일)**
- `client/src/lib/clipboard.ts`
- `client/src/pages/MeetingDetailPage.tsx`
- `client/src/pages/NoticePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #46** ↔ **이슈 #468** 로 연결됩니다.

Closes #468
