### PR TITLE
🔀 :: (#469) 카테고리별 OS 알림 + 음소거 채팅방 OS 알림 차단(버그)

### DIFF
--- a/client/src/lib/notifPrefs.ts
+++ b/client/src/lib/notifPrefs.ts
@@ -1,0 +1,111 @@
+/**
+ * 카테고리별 데스크톱 알림 ON/OFF + 채팅방 음소거 존중.
+ *
+ * 기존 구조:
+ *  - lib/desktopNotify.ts 가 OS 알림 발송 + 마스터 ON/OFF (LS_ENABLED)
+ *  - notifications.tsx 가 SSE/poll 로 받은 알림을 deliverPendingNotifications 로 위임
+ *  - components/chat/theme.tsx 가 방별 muted 플래그를 hinest.chat.roomSettings.v1 에 저장
+ *
+ * 이번 변경의 목적:
+ *  1) 카테고리별(공지/DM/멘션/결재/시스템) 토글 — 마이페이지에서 세분화 설정 가능.
+ *  2) 채팅방 알림 끔 토글이 OS 알림에도 반영되도록 — 종전엔 미읽음 뱃지만 가렸음.
+ */
+
+import type { NotifType } from "../notifications";
+
+const LS_PREFS = "hinest.notif.prefs.v1";
+const ROOM_SETTINGS_KEY = "hinest.chat.roomSettings.v1"; // chat/theme.tsx 와 동일 키
+
+/** 사용자에게 노출할 카테고리. NotifType 보다 묶음 단위 — APPROVAL_* 두 개를 한 토글로. */
+export type NotifCategory = "NOTICE" | "CHAT" | "MENTION" | "APPROVAL" | "SYSTEM";
+
+export const NOTIF_CATEGORIES: { key: NotifCategory; label: string; desc: string }[] = [
+  { key: "NOTICE", label: "공지사항", desc: "사내 공지 / 일정 / 회의록 알림" },
+  { key: "CHAT", label: "사내톡 메시지", desc: "DM 및 그룹 대화의 새 메시지" },
+  { key: "MENTION", label: "@멘션", desc: "사내톡·문서에서 나를 호출했을 때" },
+  { key: "APPROVAL", label: "결재", desc: "결재 요청/검토 알림" },
+  { key: "SYSTEM", label: "시스템", desc: "관리자·시스템에서 보내는 알림" },
+];
+
+export type NotifPrefs = Record<NotifCategory, boolean>;
+
+const DEFAULT_PREFS: NotifPrefs = {
+  NOTICE: true,
+  CHAT: true,
+  MENTION: true,
+  APPROVAL: true,
+  SYSTEM: true,
+};
+
+/** NotifType → 사용자 카테고리 매핑. */
+function categoryOf(type: NotifType): NotifCategory {
+  if (type === "DM") return "CHAT";
+  if (type === "MENTION") return "MENTION";
+  if (type === "APPROVAL_REQUEST" || type === "APPROVAL_REVIEW") return "APPROVAL";
+  if (type === "NOTICE") return "NOTICE";
+  return "SYSTEM";
+}
+
+export function loadPrefs(): NotifPrefs {
+  if (typeof window === "undefined") return { ...DEFAULT_PREFS };
+  try {
+    const raw = localStorage.getItem(LS_PREFS);
+    if (!raw) return { ...DEFAULT_PREFS };
+    const parsed = JSON.parse(raw) as Partial<NotifPrefs>;
+    // DEFAULT 와 머지 — 새 카테고리 추가 시 기본값 ON 으로 보강.
+    return { ...DEFAULT_PREFS, ...parsed };
+  } catch {
+    return { ...DEFAULT_PREFS };
+  }
+}
+
+export function savePrefs(p: NotifPrefs) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(LS_PREFS, JSON.stringify(p));
+    // 다른 탭/컴포넌트가 즉시 반영하도록 이벤트.
+    window.dispatchEvent(new CustomEvent("hinest:notifPrefsChange"));
+  } catch {}
+}
+
+export function setCategoryEnabled(cat: NotifCategory, on: boolean) {
+  const cur = loadPrefs();
+  cur[cat] = on;
+  savePrefs(cur);
+}
+
+/** linkUrl 에서 ?room=<id> 파싱 — DM/MENTION 알림은 항상 이 패턴. */
+function roomIdFromLinkUrl(linkUrl?: string | null): string | null {
+  if (!linkUrl) return null;
+  const m = /[?&#]room=([^&]+)/.exec(linkUrl);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+function isRoomMuted(roomId: string): boolean {
+  try {
+    const raw = localStorage.getItem(ROOM_SETTINGS_KEY);
+    if (!raw) return false;
+    const map = JSON.parse(raw) as Record<string, { muted?: boolean }>;
+    return !!map?.[roomId]?.muted;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 알림 1건이 데스크톱 OS 알림으로 떠야 하는지 판정.
+ * - 카테고리 토글이 꺼져있으면 false
+ * - 채팅 카테고리(CHAT/MENTION)면서 해당 방이 음소거면 false
+ *
+ * 마스터 토글(isDesktopEnabled)·권한 체크는 desktopNotify.showDesktopNotification 안에서 수행.
+ */
+export function shouldDeliverNotif(n: { type: NotifType; linkUrl?: string | null }): boolean {
+  const prefs = loadPrefs();
+  const cat = categoryOf(n.type);
+  if (!prefs[cat]) return false;
+  if (cat === "CHAT" || cat === "MENTION") {
+    const roomId = roomIdFromLinkUrl(n.linkUrl);
+    if (roomId && isRoomMuted(roomId)) return false;
+  }
+  return true;
+}

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "./api";
 import { deliverPendingNotifications, markSeen } from "./lib/desktopNotify";
+import { shouldDeliverNotif } from "./lib/notifPrefs";
 
 export type NotifType = "NOTICE" | "DM" | "APPROVAL_REQUEST" | "APPROVAL_REVIEW" | "MENTION" | "SYSTEM";
 
@@ -68,8 +69,11 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         initialRef.current = false;
         markSeen(unreadItems.map((n) => n.id));
       } else {
+        // 카테고리 토글 / 방별 음소거를 통과한 것만 OS 알림으로.
+        // 가로막힌 항목은 벨/채팅 UI 에는 그대로 들어가지만 OS 토스트는 안 뜸.
+        const allowed = unreadItems.filter((n) => shouldDeliverNotif(n));
         deliverPendingNotifications(
-          unreadItems.map((n) => ({ id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl }))
+          allowed.map((n) => ({ id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl }))
         );
       }
     } catch {}
@@ -138,9 +142,15 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
             //  같은 유저 세션이 동시에 여러 번 GET /api/notification 치는 문제 → 서버 부하 증가.
             //  30초 주기 poll + visibilitychange poll 으로 서버 기준 재싱크는 이미 커버됨.)
             setItems((prev) => (prev.some((x) => x.id === n.id) ? prev : [n, ...prev]));
-            deliverPendingNotifications([
-              { id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl },
-            ]);
+            // 동일 가드 — 음소거된 방의 SSE 푸시는 OS 알림 띄우지 않음.
+            if (shouldDeliverNotif(n)) {
+              deliverPendingNotifications([
+                { id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl },
+              ]);
+            } else {
+              // 가드에 걸린 알림도 "이미 본 것" 으로 마킹해서 reload() 시 재발송 방지.
+              markSeen([n.id]);
+            }
           } catch {}
         });
         // 채팅 실시간 푸시 — ChatMiniApp 이 window 리스너로 수신.

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -12,6 +12,13 @@ import {
   showDesktopNotification,
   type DesktopNotifPermission,
 } from "../lib/desktopNotify";
+import {
+  NOTIF_CATEGORIES,
+  loadPrefs,
+  setCategoryEnabled,
+  type NotifCategory,
+  type NotifPrefs,
+} from "../lib/notifPrefs";
 
 // 아바타 색상 팔레트.
 // 다크 모드 surface (#17191F 부근) 와 거의 같은 `#17191F` 를 빼고
@@ -438,11 +445,64 @@ function DesktopNotifyPanel() {
               onChange={(e) => onToggle(e.target.checked)}
             />
           </label>
+
+          <NotifCategoryToggles disabled={!enabled} />
+
           <button type="button" className="btn-ghost" onClick={onTest}>
             테스트 알림 보내기
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+/* ===== 카테고리별 알림 토글 — 마스터 ON 일 때만 의미 있음 ===== */
+function NotifCategoryToggles({ disabled }: { disabled: boolean }) {
+  const [prefs, setPrefs] = useState<NotifPrefs>(() => loadPrefs());
+
+  // 다른 탭/창에서 토글이 바뀌면 이 패널도 즉시 따라가게.
+  useEffect(() => {
+    const onChange = () => setPrefs(loadPrefs());
+    window.addEventListener("hinest:notifPrefsChange", onChange);
+    window.addEventListener("storage", onChange); // 다른 탭 동기화
+    return () => {
+      window.removeEventListener("hinest:notifPrefsChange", onChange);
+      window.removeEventListener("storage", onChange);
+    };
+  }, []);
+
+  function toggle(cat: NotifCategory, on: boolean) {
+    setCategoryEnabled(cat, on);
+    setPrefs((p) => ({ ...p, [cat]: on }));
+  }
+
+  return (
+    <div className={`rounded-lg border border-ink-150 overflow-hidden ${disabled ? "opacity-60 pointer-events-none" : ""}`}>
+      <div className="px-3 py-2 bg-ink-25 border-b border-ink-150 flex items-center justify-between">
+        <div className="text-[12px] font-bold text-ink-700">카테고리별 알림</div>
+        <div className="text-[11px] text-ink-500">사내톡 메시지·@멘션은 채팅방에서 끈 방은 자동 제외</div>
+      </div>
+      <ul className="divide-y divide-ink-100">
+        {NOTIF_CATEGORIES.map((c) => {
+          const checked = !!prefs[c.key];
+          return (
+            <li key={c.key} className="px-3 py-2.5 flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="text-[13px] font-semibold text-ink-900 truncate">{c.label}</div>
+                <div className="text-[11px] text-ink-500 mt-0.5">{c.desc}</div>
+              </div>
+              <input
+                type="checkbox"
+                className="accent-brand-500 w-5 h-5 flex-shrink-0"
+                checked={checked}
+                onChange={(e) => toggle(c.key, e.target.checked)}
+                aria-label={`${c.label} 알림`}
+              />
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## 증상
**카테고리별 OS 알림 + 음소거 채팅방 OS 알림 차단(버그)**

새 기능을 추가합니다.

## 원인
[버그]
사내톡 채팅방에서 알림 끄기 토글을 켜도, 그 방의 새 메시지가 OS 토스트로
계속 떴다. 종전엔 ChatMiniApp 안에서 미읽음 뱃지만 가렸을 뿐 실제
deliverPendingNotifications 경로는 통과시키고 있었음.

[수정 / 추가]
- client/src/lib/notifPrefs.ts (신규)
  · NotifCategory: NOTICE / CHAT / MENTION / APPROVAL / SYSTEM
  · loadPrefs / savePrefs / setCategoryEnabled — localStorage hinest.notif.prefs.v1
  · shouldDeliverNotif(n): 카테고리 토글 + 채팅방 음소거(roomSettings.v1) 통합 판정.
    음소거 방은 linkUrl 의 ?room=<id> 에서 ID 추출해 매칭.
- notifications.tsx
  · reload() / SSE notification 두 경로 모두 shouldDeliverNotif 게이트 통과 후에만
    OS 알림 발송. 차단된 항목은 markSeen 으로 "본 것" 처리해서 다음 reload 때
    재발송되지 않도록.
- ProfilePage DesktopNotifyPanel
  · 마스터 토글 아래에 카테고리별 체크박스 5개 노출.
  · hinest:notifPrefsChange 커스텀 이벤트 + storage 이벤트 동시 구독해
    여러 탭/창에서 토글이 바뀌어도 즉시 동기화.

## 수정
**작업 항목 (커밋 단위)**
- feat(notif): 카테고리별 OS 알림 토글 + 음소거 채팅방 OS 알림 차단

**변경 대상 (3개 파일)**
- `client/src/lib/notifPrefs.ts`
- `client/src/notifications.tsx`
- `client/src/pages/ProfilePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #47** ↔ **이슈 #469** 로 연결됩니다.

Closes #469
