### PR TITLE
🔀 :: (#470) 사내톡·회의록 코드 자동 감지/렌더

### DIFF
--- a/client/src/components/MeetingEditor.tsx
+++ b/client/src/components/MeetingEditor.tsx
@@ -17,6 +17,21 @@ import { createRoot, type Root } from "react-dom/client";
 import "./MeetingEditor.css";
 import { promptAsync } from "./ConfirmHost";
 import MentionList, { type MentionUser } from "./MentionList";
+import { parseCodeSegments } from "../lib/codeDetect";
+
+/** 페이스트된 평문이 코드처럼 보이는지 — codeDetect 의 휴리스틱 재사용.
+ *  parseCodeSegments 가 반환하는 segment 중 코드(펜스/휴리스틱)가 본문 대부분을 차지하면 true. */
+function looksLikeCodeForEditor(text: string): boolean {
+  if (text.length < 10) return false;
+  const segs = parseCodeSegments(text);
+  // 모든 segment 가 code 거나, 단일 code segment 면 명백히 코드.
+  if (segs.length === 1 && segs[0].kind === "code") return true;
+  const codeChars = segs
+    .filter((s) => s.kind === "code")
+    .reduce((sum, s) => sum + (s.kind === "code" ? s.code.length : 0), 0);
+  // 본문의 60% 이상이 코드 영역이면 통째로 코드 취급.
+  return codeChars >= text.length * 0.6;
+}
 
 /** 노션식 글씨 크기(픽셀) — textStyle 의 `data-font-size` 속성으로 직렬화. */
 const FONT_SIZES = [
@@ -127,6 +142,27 @@ export default function MeetingEditor({ value, onChange, editable = true, placeh
           ]
         : []),
     ],
+    // 평문 붙여넣기를 가로채서 코드처럼 보이면 codeBlock 으로 변환.
+    // - HTML 페이스트(워드/노션 등 서식 있는 출처)는 건드리지 않음
+    // - 휴리스틱은 lib/codeDetect.ts 와 동일 규칙 (한글 비율·코드 토큰 비율)
+    editorProps: {
+      handlePaste: (view, event) => {
+        const html = event.clipboardData?.getData("text/html");
+        if (html) return false; // HTML 페이스트는 기본 동작 유지
+        const text = event.clipboardData?.getData("text/plain");
+        if (!text) return false;
+        if (!looksLikeCodeForEditor(text)) return false;
+        event.preventDefault();
+        // 현재 셀렉션 위치에 codeBlock 노드 삽입.
+        const { schema } = view.state;
+        const codeBlock = schema.nodes.codeBlock;
+        if (!codeBlock) return false;
+        const node = codeBlock.create({}, schema.text(text));
+        const tr = view.state.tr.replaceSelectionWith(node);
+        view.dispatch(tr);
+        return true;
+      },
+    },
     content: value ?? "",
     editable,
     onUpdate: ({ editor }) => {

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -3,6 +3,8 @@ import { C, FONT, formatBytes } from "./theme";
 import type { Attachment, Message, Reaction } from "./types";
 import { api } from "../../api";
 import { alertAsync } from "../ConfirmHost";
+import { parseCodeSegments } from "../../lib/codeDetect";
+import { copyToClipboard } from "../../lib/clipboard";
 
 /**
  * 파일/이미지/동영상 메시지를 문서함으로 복사 저장.
@@ -1079,10 +1081,15 @@ export function TextBubble({
   content: string;
   mine: boolean;
 }) {
+  // 코드(펜스/인라인/휴리스틱) 영역을 떼어내고 일반 텍스트만 URL 링크화.
+  const segments = parseCodeSegments(content);
+  // 코드 블록이 하나라도 있으면 둥근모서리 안쪽 패딩이 너무 작으면 보기 안 좋아서
+  // 살짝 늘려준다 (펜스 코드는 자체 padding 갖는 박스라 충돌 없음).
+  const hasBlockCode = segments.some((s) => s.kind === "code");
   return (
     <div
       style={{
-        padding: "9px 13px",
+        padding: hasBlockCode ? "8px 8px" : "9px 13px",
         fontSize: 14,
         fontWeight: 500,
         lineHeight: 1.4,
@@ -1098,7 +1105,100 @@ export function TextBubble({
         fontFamily: FONT,
       }}
     >
-      {renderWithLinks(content, mine)}
+      {segments.map((seg, i) => {
+        if (seg.kind === "code") return <CodeBlockBubble key={i} code={seg.code} lang={seg.lang} mine={mine} />;
+        if (seg.kind === "inline-code") return <InlineCode key={i} code={seg.code} mine={mine} />;
+        return <span key={i}>{renderWithLinks(seg.text, mine)}</span>;
+      })}
+    </div>
+  );
+}
+
+const CODE_FONT =
+  "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace";
+
+function InlineCode({ code, mine }: { code: string; mine: boolean }) {
+  return (
+    <code
+      style={{
+        fontFamily: CODE_FONT,
+        fontSize: 12.5,
+        padding: "1px 5px",
+        margin: "0 1px",
+        borderRadius: 4,
+        background: mine ? "rgba(255,255,255,0.18)" : "var(--c-surface-3)",
+        color: mine ? "#fff" : "var(--c-fg-strong)",
+        wordBreak: "break-word",
+      }}
+    >
+      {code}
+    </code>
+  );
+}
+
+function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mine: boolean }) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        margin: "4px 0",
+        borderRadius: 10,
+        background: mine ? "rgba(0,0,0,0.28)" : "var(--c-surface-3)",
+        border: mine ? "1px solid rgba(255,255,255,0.12)" : "1px solid var(--c-border)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "4px 8px 4px 10px",
+          fontSize: 10.5,
+          fontWeight: 700,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          color: mine ? "rgba(255,255,255,0.7)" : "var(--c-fg-muted)",
+          borderBottom: mine ? "1px solid rgba(255,255,255,0.10)" : "1px solid var(--c-border)",
+        }}
+      >
+        <span>{lang || "code"}</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            copyToClipboard(code, { title: "복사됨", description: "코드를 클립보드에 복사했어요." });
+          }}
+          style={{
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            color: "inherit",
+            fontSize: 10.5,
+            fontWeight: 700,
+            letterSpacing: "0.06em",
+            padding: "2px 4px",
+          }}
+          title="코드 복사"
+        >
+          복사
+        </button>
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          padding: "8px 10px",
+          fontFamily: CODE_FONT,
+          fontSize: 12.5,
+          lineHeight: 1.5,
+          color: mine ? "#fff" : "var(--c-fg-strong)",
+          whiteSpace: "pre",
+          overflowX: "auto",
+          maxWidth: "100%",
+        }}
+      >
+        <code style={{ fontFamily: "inherit" }}>{code}</code>
+      </pre>
     </div>
   );
 }

--- a/client/src/lib/codeDetect.ts
+++ b/client/src/lib/codeDetect.ts
@@ -1,0 +1,99 @@
+/**
+ * 사내톡·회의록의 평문에서 코드 영역을 추출.
+ *
+ * 두 가지 신호:
+ *  1) 명시적 펜스 — ``` ... ``` (선택적 언어 태그)
+ *  2) 휴리스틱 — 같은 들여쓰기·여러 줄에 걸쳐 코드처럼 보이는 토큰이 충분히 모이면 코드로 간주
+ *
+ * 일반 사용자가 "그냥 코드 붙여넣었는데 어떻게든 보이게" 시나리오를 노린 것.
+ * 다국어/한글 평문이 코드로 오인되지 않도록 휴리스틱은 보수적으로:
+ *  - 최소 2줄 이상
+ *  - 줄 절반 이상이 코드 토큰을 포함
+ *  - 한글 비율이 너무 높지 않을 것
+ */
+
+export type CodeSegment =
+  | { kind: "text"; text: string }
+  | { kind: "code"; code: string; lang?: string }
+  | { kind: "inline-code"; code: string };
+
+const FENCE = /```([a-zA-Z0-9_+-]*)\n?([\s\S]*?)```/g;
+const INLINE = /`([^`\n]+)`/g;
+
+// 코드 토큰 — 평문에 자연스럽게 잘 안 등장하는 기호/키워드 위주.
+const CODE_TOKEN = /(=>|::|->|;\s*$|\{\s*$|^\s*\}|^\s*function\b|^\s*const\b|^\s*let\b|^\s*var\b|^\s*if\s*\(|^\s*for\s*\(|^\s*while\s*\(|^\s*return\b|^\s*import\b|^\s*from\s+['"]|^\s*export\b|^\s*class\b|^\s*def\s+\w+|^\s*public\s+|^\s*private\s+|^\s*<\?php|^\s*#include|^\s*SELECT\b|^\s*INSERT\b|^\s*UPDATE\b|^\s*DELETE\b)/m;
+
+const HANGUL = /[ㄱ-힝]/;
+
+/** 휴리스틱: 멀티라인 평문이 "코드 같다" 면 true. */
+function looksLikeCode(text: string): boolean {
+  const lines = text.split("\n");
+  if (lines.length < 2) return false;
+  let codey = 0;
+  let hangulLines = 0;
+  for (const ln of lines) {
+    if (!ln.trim()) continue;
+    if (CODE_TOKEN.test(ln)) codey++;
+    if (HANGUL.test(ln)) hangulLines++;
+  }
+  const nonEmpty = lines.filter((l) => l.trim()).length;
+  if (nonEmpty < 2) return false;
+  // 한글 비율이 절반을 넘으면 코드 아님 (대화 본문일 확률 높음).
+  if (hangulLines / nonEmpty > 0.5) return false;
+  // 코드 토큰이 비어있지 않은 줄의 절반 이상.
+  return codey >= Math.max(2, Math.ceil(nonEmpty / 2));
+}
+
+/**
+ * 본문을 segment 배열로 쪼갬.
+ * 1) 펜스 블록을 먼저 떼어내고
+ * 2) 남은 평문에서 인라인 백틱 처리
+ * 3) 인라인 백틱조차 없는 평문 통째가 휴리스틱에 걸리면 code 로 변환
+ */
+export function parseCodeSegments(content: string): CodeSegment[] {
+  const out: CodeSegment[] = [];
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  FENCE.lastIndex = 0;
+  while ((m = FENCE.exec(content)) !== null) {
+    if (m.index > lastIndex) {
+      out.push(...splitInlineAndHeuristic(content.slice(lastIndex, m.index)));
+    }
+    out.push({ kind: "code", lang: m[1] || undefined, code: m[2].replace(/\n$/, "") });
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < content.length) {
+    out.push(...splitInlineAndHeuristic(content.slice(lastIndex)));
+  }
+  // 빈 텍스트 제거.
+  return out.filter((s) => !(s.kind === "text" && s.text === ""));
+}
+
+function splitInlineAndHeuristic(text: string): CodeSegment[] {
+  // 인라인 백틱이 있으면 거기 우선, 없으면 통째로 휴리스틱 검사.
+  if (!text.includes("`")) {
+    if (looksLikeCode(text)) {
+      // 앞뒤 공백 줄을 떼서 코드 블록만 남기고 나머지 텍스트를 전후로 분리.
+      const trimmed = text.replace(/^\n+|\n+$/g, "");
+      const before = text.slice(0, text.indexOf(trimmed));
+      const after = text.slice(before.length + trimmed.length);
+      const out: CodeSegment[] = [];
+      if (before) out.push({ kind: "text", text: before });
+      out.push({ kind: "code", code: trimmed });
+      if (after) out.push({ kind: "text", text: after });
+      return out;
+    }
+    return [{ kind: "text", text }];
+  }
+  const out: CodeSegment[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  INLINE.lastIndex = 0;
+  while ((m = INLINE.exec(text)) !== null) {
+    if (m.index > last) out.push({ kind: "text", text: text.slice(last, m.index) });
+    out.push({ kind: "inline-code", code: m[1] });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) out.push({ kind: "text", text: text.slice(last) });
+  return out;
+}


### PR DESCRIPTION
## 증상
**사내톡·회의록 코드 자동 감지/렌더**

새 기능을 추가합니다.

## 원인
[배경]
``` 펜스나 인라인 백틱 없이 그냥 코드 붙여넣으면 평문으로 흘러서
들여쓰기가 무너지고 가독성도 나쁨. 회의록 에디터엔 코드블록 버튼이 있긴
하지만 누르고 들어가는 동작이라 빠른 공유 흐름에 안 맞음.

[추가]
- client/src/lib/codeDetect.ts (신규)
  · 명시적 ```fence / 인라인 `code` 처리
  · 휴리스틱 — 멀티라인이고 코드 토큰(=>, ;, {, function, const, def, SELECT 등)
    이 비어있지 않은 줄의 절반 이상이며 한글 비율 50% 이하면 코드로 간주.

- chat/MessageBubble TextBubble
  · parseCodeSegments 로 본문 분할, 코드 블록은 모노스페이스 `pre` 박스 +
    "복사" 버튼, 인라인 백틱은 알약 형태로.
  · 내 메시지(파란 배경) / 상대 메시지에서 색·테두리 구분.

- MeetingEditor (TipTap)
  · editorProps.handlePaste 로 평문 페이스트 가로채기.
  · text/html 동반된 페이스트는 기본 동작 유지(워드/노션 서식 보존).
  · 평문이 휴리스틱 통과하면 codeBlock 노드로 감싸서 삽입.

## 수정
**작업 항목 (커밋 단위)**
- feat(code): 사내톡·회의록 코드 자동 감지/렌더

**변경 대상 (3개 파일)**
- `client/src/components/MeetingEditor.tsx`
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/lib/codeDetect.ts`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #48** ↔ **이슈 #470** 로 연결됩니다.

Closes #470
