### PR TITLE
🔀 :: (#471) 코드 자동감지 토큰 확장 + 언어 추정

### DIFF
--- a/client/src/lib/codeDetect.ts
+++ b/client/src/lib/codeDetect.ts
@@ -1,15 +1,15 @@
 /**
- * 사내톡·회의록의 평문에서 코드 영역을 추출.
+ * 사내톡·회의록 본문에서 코드 영역을 추출 + 언어 추정.
  *
- * 두 가지 신호:
- *  1) 명시적 펜스 — ``` ... ``` (선택적 언어 태그)
- *  2) 휴리스틱 — 같은 들여쓰기·여러 줄에 걸쳐 코드처럼 보이는 토큰이 충분히 모이면 코드로 간주
+ * 신호 3종:
+ *  1) ``` ... ```   — 펜스 블록 (언어 태그 그대로 사용)
+ *  2) `code`        — 인라인 백틱
+ *  3) 휴리스틱      — 멀티라인이 코드 같으면 통째로 코드 처리, 언어는 토큰으로 추정
  *
- * 일반 사용자가 "그냥 코드 붙여넣었는데 어떻게든 보이게" 시나리오를 노린 것.
- * 다국어/한글 평문이 코드로 오인되지 않도록 휴리스틱은 보수적으로:
- *  - 최소 2줄 이상
- *  - 줄 절반 이상이 코드 토큰을 포함
- *  - 한글 비율이 너무 높지 않을 것
+ * 한글 평문이 코드로 오인되지 않도록 휴리스틱은 보수적으로:
+ *  - 비어있지 않은 줄이 3줄 이상
+ *  - 코드 토큰을 포함한 줄이 비어있지 않은 줄의 ⅓ 이상
+ *  - 한글 비율이 절반 이하
  */
 
 export type CodeSegment =
@@ -20,36 +20,150 @@ export type CodeSegment =
 const FENCE = /```([a-zA-Z0-9_+-]*)\n?([\s\S]*?)```/g;
 const INLINE = /`([^`\n]+)`/g;
 
-// 코드 토큰 — 평문에 자연스럽게 잘 안 등장하는 기호/키워드 위주.
-const CODE_TOKEN = /(=>|::|->|;\s*$|\{\s*$|^\s*\}|^\s*function\b|^\s*const\b|^\s*let\b|^\s*var\b|^\s*if\s*\(|^\s*for\s*\(|^\s*while\s*\(|^\s*return\b|^\s*import\b|^\s*from\s+['"]|^\s*export\b|^\s*class\b|^\s*def\s+\w+|^\s*public\s+|^\s*private\s+|^\s*<\?php|^\s*#include|^\s*SELECT\b|^\s*INSERT\b|^\s*UPDATE\b|^\s*DELETE\b)/m;
+// 평문에 자연스럽게 잘 등장하지 않는 코드 신호 — JS/TS/Swift/Kotlin/Python/Java/Go/Rust/SQL/PHP 폭넓게.
+const CODE_TOKEN = new RegExp(
+  [
+    // 기호
+    "=>",
+    "::",
+    "->",
+    ";\\s*$",
+    "\\{\\s*$",
+    "^\\s*\\}",
+    "^\\s*//",
+    "^\\s*/\\*",
+    "^\\s*#\\s*include",
+    "^\\s*@\\w+", // 데코레이터: @Published @Component @Override
+    // 선언/제어 키워드
+    "^\\s*(?:final\\s+|public\\s+|private\\s+|protected\\s+|static\\s+|abstract\\s+|open\\s+|internal\\s+|sealed\\s+)*(?:class|struct|enum|interface|extension|protocol|trait|object)\\b",
+    "^\\s*(?:async\\s+)?(?:function|func|fn|fun|def|sub)\\b",
+    "^\\s*(?:const|let|var|val|mut)\\s",
+    "^\\s*if\\s*[(\\s]",
+    "^\\s*for\\s*[(\\s]",
+    "^\\s*while\\s*[(\\s]",
+    "^\\s*switch\\s*[(\\s]",
+    "^\\s*case\\s+(?:let\\s+)?\\.?\\w",
+    "^\\s*guard\\s+",
+    "^\\s*return\\b",
+    "^\\s*throw\\b",
+    "^\\s*import\\b",
+    "^\\s*from\\s+['\"]",
+    "^\\s*export\\b",
+    "^\\s*package\\b",
+    "^\\s*namespace\\b",
+    "^\\s*use\\s+\\w",
+    "^\\s*public\\s+",
+    "^\\s*private\\s+",
+    // SQL
+    "^\\s*(?:SELECT|INSERT|UPDATE|DELETE|CREATE\\s+TABLE|ALTER\\s+TABLE|DROP\\s+TABLE)\\b",
+    // PHP
+    "^\\s*<\\?php",
+    // HTML/XML
+    "^\\s*</?[a-zA-Z][\\w:-]*[\\s/>]",
+  ].join("|"),
+  "m",
+);
 
-const HANGUL = /[ㄱ-힝]/;
+const HANGUL = /[ㄱ-힣]/;
 
-/** 휴리스틱: 멀티라인 평문이 "코드 같다" 면 true. */
+function isCodeyLine(ln: string): boolean {
+  return CODE_TOKEN.test(ln);
+}
+
 function looksLikeCode(text: string): boolean {
   const lines = text.split("\n");
-  if (lines.length < 2) return false;
-  let codey = 0;
-  let hangulLines = 0;
-  for (const ln of lines) {
-    if (!ln.trim()) continue;
-    if (CODE_TOKEN.test(ln)) codey++;
-    if (HANGUL.test(ln)) hangulLines++;
-  }
-  const nonEmpty = lines.filter((l) => l.trim()).length;
-  if (nonEmpty < 2) return false;
-  // 한글 비율이 절반을 넘으면 코드 아님 (대화 본문일 확률 높음).
-  if (hangulLines / nonEmpty > 0.5) return false;
-  // 코드 토큰이 비어있지 않은 줄의 절반 이상.
-  return codey >= Math.max(2, Math.ceil(nonEmpty / 2));
+  const nonEmpty = lines.filter((l) => l.trim());
+  if (nonEmpty.length < 3) return false;
+  const codey = nonEmpty.filter(isCodeyLine).length;
+  const hangulLines = nonEmpty.filter((l) => HANGUL.test(l)).length;
+  if (hangulLines / nonEmpty.length > 0.5) return false;
+  return codey >= Math.max(2, Math.ceil(nonEmpty.length / 3));
 }
 
 /**
- * 본문을 segment 배열로 쪼갬.
- * 1) 펜스 블록을 먼저 떼어내고
- * 2) 남은 평문에서 인라인 백틱 처리
- * 3) 인라인 백틱조차 없는 평문 통째가 휴리스틱에 걸리면 code 로 변환
+ * 토큰을 보고 언어 추정. 빠른 휴리스틱 — 정확도보단 "Swift / Python / SQL" 정도의 라벨용.
+ * 매치되는 패턴이 가장 많은 언어로 결정. 모두 0이면 undefined.
  */
+const LANG_PATTERNS: { lang: string; patterns: RegExp[] }[] = [
+  {
+    lang: "swift",
+    patterns: [
+      /\b(func|guard\s+let|@Published|@State|ObservableObject|MoyaProvider|UIView|SwiftUI)\b/,
+      /\bcase\s+let\s+\.\w/,
+      /\bfinal\s+class\b/,
+      /\bweak\s+self\b/,
+      /\bprivate\s+let\b/,
+    ],
+  },
+  {
+    lang: "kotlin",
+    patterns: [/\bfun\s+\w+\s*\(/, /\bval\s+\w+/, /\bcompanion\s+object\b/, /\bsuspend\s+fun\b/],
+  },
+  {
+    lang: "typescript",
+    patterns: [/:\s*(string|number|boolean|void|any|unknown|never)\b/, /\binterface\s+\w+\s*\{/, /\btype\s+\w+\s*=/, /\bimport\s+type\b/, /\bas\s+const\b/],
+  },
+  {
+    lang: "javascript",
+    patterns: [/\bconst\s+\w+\s*=/, /=>\s*\{?/, /\brequire\s*\(/, /\bexport\s+default\b/, /\bawait\s+/],
+  },
+  {
+    lang: "tsx",
+    patterns: [/<\/?[A-Z]\w*[\s/>]/, /className=/, /useState\s*</, /useEffect\(/],
+  },
+  {
+    lang: "python",
+    patterns: [/^\s*def\s+\w+\(/m, /^\s*class\s+\w+(?:\(\w+\))?:\s*$/m, /^\s*from\s+\w[\w.]*\s+import\b/m, /\bself\b/, /\bif\s+__name__\s*==\s*['"]__main__['"]/],
+  },
+  {
+    lang: "java",
+    patterns: [/\bpublic\s+(?:static\s+)?(?:void|class|int|String)\b/, /\bSystem\.out\.print/, /\bnew\s+\w+<.+>/],
+  },
+  {
+    lang: "go",
+    patterns: [/^\s*package\s+\w+/m, /\bfunc\s+\w+\(/, /\bfmt\.\w+/, /\bchan\s+\w+/, /\bgo\s+\w+\(/],
+  },
+  {
+    lang: "rust",
+    patterns: [/\bfn\s+\w+\s*\(/, /\blet\s+mut\b/, /::<.+>/, /\bimpl\s+\w+/, /\bSelf\b/],
+  },
+  {
+    lang: "sql",
+    patterns: [/^\s*SELECT\s.+\sFROM\s/im, /^\s*INSERT\s+INTO\s/im, /^\s*CREATE\s+TABLE\s/im, /\bWHERE\s+\w+\s*=/i],
+  },
+  {
+    lang: "html",
+    patterns: [/<!doctype\s+html>/i, /<html[\s>]/i, /<\/?(div|span|p|h\d|ul|li|a|img)\b/i],
+  },
+  {
+    lang: "css",
+    patterns: [/^\s*[.#]?\w[\w-]*\s*\{[^}]*\}/m, /\b(color|background|margin|padding|font-size)\s*:/],
+  },
+  {
+    lang: "json",
+    patterns: [/^\s*\{[\s\S]*"\w+"\s*:\s*/m, /^\s*\[\s*\{/m],
+  },
+  {
+    lang: "bash",
+    patterns: [/^#!\/bin\/(?:bash|sh)/, /^\s*\$\s+\w/m, /\b(?:apt-get|brew|npm|yarn|pnpm|git)\s+\w+/],
+  },
+  {
+    lang: "php",
+    patterns: [/<\?php/, /\$\w+\s*=/, /->\w+\(/],
+  },
+];
+
+export function detectLanguage(code: string): string | undefined {
+  let best: { lang: string; score: number } | null = null;
+  for (const { lang, patterns } of LANG_PATTERNS) {
+    let score = 0;
+    for (const p of patterns) if (p.test(code)) score++;
+    if (score > 0 && (!best || score > best.score)) best = { lang, score };
+  }
+  return best?.lang;
+}
+
+/** 본문을 segment 배열로 쪼갬. 펜스 → 인라인 → 휴리스틱 순. */
 export function parseCodeSegments(content: string): CodeSegment[] {
   const out: CodeSegment[] = [];
   let lastIndex = 0;
@@ -59,29 +173,29 @@ export function parseCodeSegments(content: string): CodeSegment[] {
     if (m.index > lastIndex) {
       out.push(...splitInlineAndHeuristic(content.slice(lastIndex, m.index)));
     }
-    out.push({ kind: "code", lang: m[1] || undefined, code: m[2].replace(/\n$/, "") });
+    const code = m[2].replace(/\n$/, "");
+    // 펜스에 lang 태그가 명시돼 있으면 그 값을 쓰고, 없으면 본문 추정.
+    const lang = m[1] || detectLanguage(code);
+    out.push({ kind: "code", lang, code });
     lastIndex = m.index + m[0].length;
   }
   if (lastIndex < content.length) {
     out.push(...splitInlineAndHeuristic(content.slice(lastIndex)));
   }
-  // 빈 텍스트 제거.
   return out.filter((s) => !(s.kind === "text" && s.text === ""));
 }
 
 function splitInlineAndHeuristic(text: string): CodeSegment[] {
-  // 인라인 백틱이 있으면 거기 우선, 없으면 통째로 휴리스틱 검사.
   if (!text.includes("`")) {
     if (looksLikeCode(text)) {
-      // 앞뒤 공백 줄을 떼서 코드 블록만 남기고 나머지 텍스트를 전후로 분리.
       const trimmed = text.replace(/^\n+|\n+$/g, "");
       const before = text.slice(0, text.indexOf(trimmed));
       const after = text.slice(before.length + trimmed.length);
-      const out: CodeSegment[] = [];
-      if (before) out.push({ kind: "text", text: before });
-      out.push({ kind: "code", code: trimmed });
-      if (after) out.push({ kind: "text", text: after });
-      return out;
+      const segs: CodeSegment[] = [];
+      if (before) segs.push({ kind: "text", text: before });
+      segs.push({ kind: "code", code: trimmed, lang: detectLanguage(trimmed) });
+      if (after) segs.push({ kind: "text", text: after });
+      return segs;
     }
     return [{ kind: "text", text }];
   }


### PR DESCRIPTION
## 증상
**코드 자동감지 토큰 확장 + 언어 추정**

새 기능을 추가합니다.

## 원인
[강화]
- 휴리스틱 토큰 폭 확대: Swift(func, guard let, @Published, case let .),
  Kotlin(fun, val, suspend), Java(public class), Go(package), Rust(fn, mut),
  데코레이터(@\w+), 주석 시작(//, /*), HTML 태그 등 — 종전엔 JS/TS 위주라
  Swift 큰 덩어리도 평문으로 흘렀음.
- 한글 비율 기준 유지(50%) + 비어있지 않은 줄 3 이상 + 코드성 줄이 1/3 이상.

[추가]
- detectLanguage(code): swift/kotlin/ts/js/tsx/python/java/go/rust/sql/html/css/
  json/bash/php 14종을 시그니처 토큰 매치 점수로 1순위 결정.
- 펜스에 lang 태그가 있으면 그대로, 없거나 휴리스틱 결과면 detectLanguage 로 보강.
  CodeBlockBubble 헤더에 "SWIFT" 같은 라벨이 자동으로 뜸.

## 수정
**작업 항목 (커밋 단위)**
- feat(code): 자동감지 + 언어 라벨 추정 강화

**변경 대상 (1개 파일)**
- `client/src/lib/codeDetect.ts`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #49** ↔ **이슈 #471** 로 연결됩니다.

Closes #471
