### PR TITLE
🔀 :: (#472) 새 배포 자동 적용 (한가할 때 무리 없이 reload)

### DIFF
--- a/client/src/components/UpdateBanner.tsx
+++ b/client/src/components/UpdateBanner.tsx
@@ -25,6 +25,23 @@ function dismissFor(ms: number) {
   localStorage.setItem(DISMISS_KEY, String(Date.now() + ms));
 }
 
+/** 사용자가 지금 뭔가 작성 중인지 휴리스틱.
+ *  - 입력창에 포커스가 있거나
+ *  - 마지막 키 입력이 5초 이내거나
+ *  → 자동 적용을 미루고 배너만 띄움(사용자가 직접 누르도록).
+ *  내부 도구라 거의 항상 누군가 무언가 치고 있음 → 너무 길게 잡으면 영영 자동 적용 안 됨. */
+const TYPING_QUIET_MS = 5_000;
+
+function isTypingNow(lastKey: number): boolean {
+  if (Date.now() - lastKey < TYPING_QUIET_MS) return true;
+  const a = document.activeElement;
+  if (!a) return false;
+  const tag = a.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if ((a as HTMLElement).isContentEditable) return true;
+  return false;
+}
+
 export default function UpdateBanner() {
   const [reg, setReg] = useState<ServiceWorkerRegistration | null>(null);
   const [applying, setApplying] = useState(false);
@@ -33,16 +50,49 @@ export default function UpdateBanner() {
   useEffect(() => {
     if (isDesktop) return;
 
+    let lastKey = 0;
+    const onKey = () => { lastKey = Date.now(); };
+    window.addEventListener("keydown", onKey, true);
+
+    let pendingReg: ServiceWorkerRegistration | null = null;
+    let autoTimer: number | null = null;
+
+    /** 자동 적용 시도. 입력 중이면 다음 기회로 미루고 배너만 띄움. */
+    function tryAutoApply() {
+      if (!pendingReg) return;
+      if (isTypingNow(lastKey)) {
+        setReg(pendingReg); // 배너 표시 → 사용자 직접 클릭하면 적용
+        return;
+      }
+      // 한가함 → 즉시 적용. SKIP_WAITING + controllerchange 가 main.tsx 에서 reload.
+      const w = pendingReg.waiting;
+      if (w) {
+        w.postMessage("SKIP_WAITING");
+        // 안전망 — controllerchange 이벤트가 안 오는 환경 대응.
+        window.setTimeout(() => window.location.reload(), 1500);
+      } else {
+        window.location.reload();
+      }
+    }
+
     function onReady(e: Event) {
       const detail = (e as CustomEvent<{ reg?: ServiceWorkerRegistration }>).detail;
       const r = detail?.reg ?? null;
       if (!r) return;
       if (isDismissed()) return;
+      pendingReg = r;
+      // 배너를 일단 노출 + 6초 뒤 자동 적용 시도. 그 사이 사용자가 닫으면 취소.
       setReg(r);
+      if (autoTimer) window.clearTimeout(autoTimer);
+      autoTimer = window.setTimeout(tryAutoApply, 6_000);
     }
 
     window.addEventListener("hinest:update-ready", onReady as EventListener);
-    return () => window.removeEventListener("hinest:update-ready", onReady as EventListener);
+    return () => {
+      window.removeEventListener("hinest:update-ready", onReady as EventListener);
+      window.removeEventListener("keydown", onKey, true);
+      if (autoTimer) window.clearTimeout(autoTimer);
+    };
   }, [isDesktop]);
 
   if (isDesktop || !reg) return null;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -61,6 +61,13 @@ if (typeof window !== "undefined") {
           });
           // 30분마다 업데이트 체크 (앱을 켜놓고 방치하는 경우 대비)
           setInterval(() => { reg.update().catch(() => {}); }, 30 * 60 * 1000);
+          // 탭이 포그라운드로 돌아올 때 즉시 한번 확인 — 다른 일 보고 돌아왔을 때
+          // 30분을 기다리지 않고 바로 새 버전을 끌어오게.
+          document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState === "visible") {
+              reg.update().catch(() => {});
+            }
+          });
         })
         .catch(() => { /* 서비스 워커 등록 실패는 무시 */ });
 


### PR DESCRIPTION
## 증상
**새 배포 자동 적용 (한가할 때 무리 없이 reload)**

새 기능을 추가합니다.

## 원인
[배경]
배포 직후 사용자가 "왜 자동감지 안 되지?" 하는 경우 거의 SW 캐시 문제.
종전엔 배너의 "새로고침" 버튼을 눌러야만 적용됐고, 업데이트 체크도 30분 주기뿐.

[추가]
- main.tsx
  · visibilitychange → reg.update() 즉시 호출. 다른 탭/앱 봤다 돌아오면
    30분 안 기다리고 곧장 새 SW 끌어옴.
- UpdateBanner.tsx
  · update-ready 시 배너 노출 + 6초 후 자동 적용 시도.
  · 자동 적용 가드 (isTypingNow):
      - INPUT/TEXTAREA/SELECT/contentEditable 에 포커스 있으면 미룸
      - 마지막 키 입력 5초 이내면 미룸
    → 작성 중 글이 reload 로 날아가는 사고 방지.
  · 가드에 걸리면 배너만 띄워서 사용자가 직접 클릭하도록 유도.

## 수정
**작업 항목 (커밋 단위)**
- feat(pwa): 새 배포 자동 적용 — 한가하면 6초 뒤 무리 없이 reload

**변경 대상 (2개 파일)**
- `client/src/components/UpdateBanner.tsx`
- `client/src/main.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #50** ↔ **이슈 #472** 로 연결됩니다.

Closes #472
