### PR TITLE
🔀 :: (#473) 코드 블록 반응형 — 버블 부풀림 + 세로 무한 컷

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1140,6 +1140,13 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
   return (
     <div
       style={{
+        // display:block + width:100% + min-width:0 콤보 — flex 부모가 0 1 auto 일 때
+        // 안에 든 long-content `pre` 가 버블을 부풀려 채팅 영역 밖으로 새는 것 방지.
+        display: "block",
+        width: "100%",
+        minWidth: 0,
+        maxWidth: "100%",
+        boxSizing: "border-box",
         position: "relative",
         margin: "4px 0",
         borderRadius: 10,
@@ -1192,8 +1199,16 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
           fontSize: 12.5,
           lineHeight: 1.5,
           color: mine ? "#fff" : "var(--c-fg-strong)",
-          whiteSpace: "pre",
-          overflowX: "auto",
+          // pre-wrap + break-word: 좁은 화면에서 긴 줄이 자동으로 접힘. 의도된 \n 은 보존.
+          // 종전 whiteSpace:pre + overflowX:auto 는 가로 스크롤이 부모 폭을 밀어 모바일에서 버블이
+          // 화면을 뚫고 나갔음.
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          overflowWrap: "anywhere",
+          // 100줄 넘는 코드 덩어리는 버블 자체를 화면 한 페이지 이상으로 늘리지 않도록
+          // 60vh 안에 가두고 그 안에서만 세로 스크롤.
+          maxHeight: "60vh",
+          overflowY: "auto",
           maxWidth: "100%",
         }}
       >


### PR DESCRIPTION
## 증상
**코드 블록 반응형 — 버블 부풀림 + 세로 무한 컷**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
[증상]
좁은 채팅 패널/모바일에서 코드 블록 메시지가 채팅 영역 밖까지 비어있는 큰
박스로 비치고, 줄 수가 많으면 버블이 화면을 통째로 차지.

[원인]
CodeBlockBubble 의 pre 가 white-space: pre + overflow-x: auto 라
긴 줄이 가로 스크롤로 처리되면서 부모 flex(0 1 auto) 체인을 밀어 버블이
부모 maxWidth(78%) 을 무시하고 부풀었음. 세로엔 제한 없어서 줄 수만큼 무한.

[수정]
- CodeBlockBubble outer: width:100% + minWidth:0 + boxSizing:border-box
  → 부모 폭 안에 갇혀 외부 컨테이너 영향 없음.
- pre: white-space: pre-wrap + word-break: break-word + overflow-wrap: anywhere
  → 좁은 폭에선 자동 줄바꿈, 의도된 \n 은 그대로 보존. 더 이상 가로로 새어나가지 않음.
- pre: maxHeight: 60vh + overflowY: auto
  → 100줄 넘는 덩어리도 한 화면 절반 안쪽에서 자체 세로 스크롤.

## 수정
**작업 항목 (커밋 단위)**
- fix(chat): 코드 블록 모바일에서 버블 부풀림 + 무한 세로 길이

**변경 대상 (1개 파일)**
- `client/src/components/chat/MessageBubble.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #51** ↔ **이슈 #473** 로 연결됩니다.

Closes #473
