### PR TITLE
🔀 :: (#475) 코드/이미지 뷰어 portal — 채팅 패널 밖 진짜 풀스크린

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { C, FONT, formatBytes } from "./theme";
 import type { Attachment, Message, Reaction } from "./types";
 import { api } from "../../api";
@@ -538,7 +539,9 @@ function ImageLightbox({
     };
   }, [onClose]);
 
-  return (
+  // 채팅 미니앱 컨테이너에 transform 이 걸려있어 position:fixed 가 viewport 가 아니라
+  // 그 컨테이너 기준으로 잡히는 문제 → document.body 로 portal 해서 진짜 풀 화면.
+  return createPortal(
     <div
       role="dialog"
       onMouseDown={onClose}
@@ -559,8 +562,8 @@ function ImageLightbox({
         alt={alt}
         onMouseDown={(e) => e.stopPropagation()}
         style={{
-          maxWidth: "min(92vw, 1200px)",
-          maxHeight: "90vh",
+          maxWidth: "min(96vw, 1600px)",
+          maxHeight: "94vh",
           width: "auto",
           height: "auto",
           objectFit: "contain",
@@ -619,7 +622,8 @@ function ImageLightbox({
           <path d="M12 15V3" />
         </svg>
       </a>
-    </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -1257,17 +1261,19 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
 function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string; onClose: () => void }) {
   useModalDismiss(true, onClose);
   const lines = code.split("\n");
-  const lineNumWidth = String(lines.length).length * 8 + 12; // 자릿수에 따라 좌측 패딩.
-  return (
+  const lineNumWidth = String(lines.length).length * 9 + 16; // 자릿수에 따라 좌측 패딩.
+  // 채팅 미니앱 컨테이너에 transform 이 걸려있어 자식의 position:fixed 가 viewport 가 아니라
+  // 그 컨테이너 기준으로 잡힘 → portal 로 document.body 에 직접 마운트.
+  return createPortal(
     <div
       style={{
         position: "fixed",
         inset: 0,
-        zIndex: 200,
-        background: "rgba(0,0,0,0.55)",
+        zIndex: 9999,
+        background: "rgba(0,0,0,0.65)",
         display: "grid",
         placeItems: "center",
-        padding: "max(env(safe-area-inset-top), 12px) 12px max(env(safe-area-inset-bottom), 12px)",
+        padding: "max(env(safe-area-inset-top), 16px) 16px max(env(safe-area-inset-bottom), 16px)",
       }}
       onClick={onClose}
     >
@@ -1386,7 +1392,8 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 


### PR DESCRIPTION
## 증상
**코드/이미지 뷰어 portal — 채팅 패널 밖 진짜 풀스크린**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
[증상]
"전체보기" / 이미지 클릭 모달이 채팅 미니앱 우하단 카드 안에 갇혀 작게,
줄번호와 코드가 좁은 폭에서 서로 겹쳐 보였음.

[원인]
채팅 미니앱 컨테이너에 transform/overflow 가 걸려 있어서 자식의
position:fixed 가 viewport 가 아닌 그 컨테이너 기준으로 잡힘.
fixed 는 transform 부모가 있으면 'fixed of viewport' 가 깨짐.

[수정]
- ImageLightbox / CodeViewerModal 둘 다 createPortal(..., document.body) 로 마운트
  → 채팅 패널과 무관하게 진짜 풀 스크린 오버레이.
- 이미지: maxWidth/Height 92vw/90vh → 96vw/94vh 로 확장.
- 코드 모달: dim 0.55→0.65, padding 12→16, z-index 200→9999, 줄번호 칼럼
  여유 폭(자릿수×9+16) 으로 코드와 시각적 분리.

## 수정
**작업 항목 (커밋 단위)**
- fix(chat): 코드/이미지 뷰어를 portal 로 띄워 채팅 패널 밖으로 탈출

**변경 대상 (1개 파일)**
- `client/src/components/chat/MessageBubble.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #53** ↔ **이슈 #475** 로 연결됩니다.

Closes #475
