### PR TITLE
🔀 :: (#476) highlight.js 신택스 하이라이팅 + 모달 배경 불투명

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
         "@tiptap/react": "^3.22.4",
         "@tiptap/starter-kit": "^3.22.4",
         "@tiptap/suggestion": "^3.22.4",
+        "highlight.js": "^11.11.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0",
@@ -2408,6 +2409,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/is-binary-path": {

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@tiptap/react": "^3.22.4",
     "@tiptap/starter-kit": "^3.22.4",
     "@tiptap/suggestion": "^3.22.4",
+    "highlight.js": "^11.11.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -7,6 +7,7 @@ import { alertAsync } from "../ConfirmHost";
 import { parseCodeSegments } from "../../lib/codeDetect";
 import { copyToClipboard } from "../../lib/clipboard";
 import { useModalDismiss } from "../../lib/useModalDismiss";
+import { highlightCode } from "../../lib/syntaxHighlight";
 
 /**
  * 파일/이미지/동영상 메시지를 문서함으로 복사 저장.
@@ -1133,7 +1134,7 @@ function InlineCode({ code, mine }: { code: string; mine: boolean }) {
         margin: "0 1px",
         borderRadius: 4,
         background: mine ? "rgba(255,255,255,0.18)" : "var(--c-surface-3)",
-        color: mine ? "#fff" : "var(--c-fg-strong)",
+        color: mine ? "#fff" : "var(--c-text)",
         wordBreak: "break-word",
       }}
     >
@@ -1175,7 +1176,7 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
           fontWeight: 700,
           letterSpacing: "0.06em",
           textTransform: "uppercase",
-          color: mine ? "rgba(255,255,255,0.7)" : "var(--c-fg-muted)",
+          color: mine ? "rgba(255,255,255,0.7)" : "var(--c-text-3)",
           borderBottom: mine ? "1px solid rgba(255,255,255,0.10)" : "1px solid var(--c-border)",
         }}
       >
@@ -1208,21 +1209,22 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
           fontFamily: CODE_FONT,
           fontSize: 12.5,
           lineHeight: 1.5,
-          color: mine ? "#fff" : "var(--c-fg-strong)",
           // pre-wrap + break-word: 좁은 화면에서 긴 줄이 자동으로 접힘. 의도된 \n 은 보존.
-          // 종전 whiteSpace:pre + overflowX:auto 는 가로 스크롤이 부모 폭을 밀어 모바일에서 버블이
-          // 화면을 뚫고 나갔음.
           whiteSpace: "pre-wrap",
           wordBreak: "break-word",
           overflowWrap: "anywhere",
-          // 100줄 넘는 코드 덩어리는 버블 자체를 화면 한 페이지 이상으로 늘리지 않도록
-          // 60vh 안에 가두고 그 안에서만 세로 스크롤.
           maxHeight: "60vh",
           overflowY: "auto",
           maxWidth: "100%",
         }}
       >
-        <code style={{ fontFamily: "inherit" }}>{code}</code>
+        <code
+          className="hljs"
+          // highlight.js 가 토큰별 span 으로 감싼 HTML 을 그대로 주입.
+          // hljs.highlight 출력은 안전(이스케이프 처리됨) — 자체 sanitization 추가 불필요.
+          dangerouslySetInnerHTML={{ __html: highlightCode(code, lang) }}
+          style={{ fontFamily: "inherit" }}
+        />
       </pre>
       {showExpand && (
         <button
@@ -1240,7 +1242,7 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
             background: "transparent",
             border: "none",
             borderTop: mine ? "1px solid rgba(255,255,255,0.10)" : "1px solid var(--c-border)",
-            color: mine ? "rgba(255,255,255,0.85)" : "var(--c-fg-muted)",
+            color: mine ? "rgba(255,255,255,0.85)" : "var(--c-text-3)",
             fontSize: 11.5,
             fontWeight: 700,
             cursor: "pointer",
@@ -1270,7 +1272,10 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
         position: "fixed",
         inset: 0,
         zIndex: 9999,
-        background: "rgba(0,0,0,0.65)",
+        // 종전 0.65 는 배경 캘린더가 비쳐 어수선했음. 0.85 로 올려 거의 가림 + backdropFilter 로 블러.
+        background: "rgba(0,0,0,0.85)",
+        backdropFilter: "blur(4px)",
+        WebkitBackdropFilter: "blur(4px)",
         display: "grid",
         placeItems: "center",
         padding: "max(env(safe-area-inset-top), 16px) 16px max(env(safe-area-inset-bottom), 16px)",
@@ -1283,14 +1288,15 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
           width: "min(1100px, 100%)",
           height: "100%",
           maxHeight: "100%",
-          background: "var(--c-surface-1)",
-          color: "var(--c-fg-strong)",
+          // 패널은 불투명한 surface — 종전엔 토큰 var 가 일부 환경에서 투명하게 잡혀 배경이 비쳤음.
+          background: "var(--c-surface)",
+          color: "var(--c-text)",
           borderRadius: 14,
           border: "1px solid var(--c-border)",
           display: "flex",
           flexDirection: "column",
           overflow: "hidden",
-          boxShadow: "0 20px 60px rgba(0,0,0,0.35)",
+          boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
         }}
       >
         {/* 헤더 */}
@@ -1314,12 +1320,12 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
               padding: "3px 8px",
               borderRadius: 6,
               background: "var(--c-surface-3)",
-              color: "var(--c-fg-muted)",
+              color: "var(--c-text-3)",
             }}
           >
             {lang || "code"}
           </div>
-          <div style={{ flex: 1, fontSize: 12, color: "var(--c-fg-muted)" }}>
+          <div style={{ flex: 1, fontSize: 12, color: "var(--c-text-3)" }}>
             {lines.length}줄 · {code.length.toLocaleString()}자
           </div>
           <button
@@ -1341,13 +1347,13 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
             ✕
           </button>
         </div>
-        {/* 본문 — 줄번호 + 코드 */}
+        {/* 본문 — 줄번호 + 코드. 둘 다 불투명한 surface 위에 그려야 배경 비치지 않음. */}
         <div
           style={{
             flex: 1,
             minHeight: 0,
             overflow: "auto",
-            background: "var(--c-surface-1)",
+            background: "var(--c-surface)",
           }}
         >
           <div style={{ display: "flex", alignItems: "stretch", minHeight: "100%" }}>
@@ -1361,7 +1367,7 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
                 fontFamily: CODE_FONT,
                 fontSize: 13,
                 lineHeight: 1.6,
-                color: "var(--c-fg-muted)",
+                color: "var(--c-text-3)",
                 background: "var(--c-surface-2)",
                 borderRight: "1px solid var(--c-border)",
                 userSelect: "none",
@@ -1380,14 +1386,18 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
                 fontFamily: CODE_FONT,
                 fontSize: 13,
                 lineHeight: 1.6,
-                color: "var(--c-fg-strong)",
                 whiteSpace: "pre",
                 overflowX: "auto",
                 flex: 1,
                 minWidth: 0,
+                background: "var(--c-surface)",
               }}
             >
-              <code style={{ fontFamily: "inherit" }}>{code}</code>
+              <code
+                className="hljs"
+                dangerouslySetInnerHTML={{ __html: highlightCode(code, lang) }}
+                style={{ fontFamily: "inherit" }}
+              />
             </pre>
           </div>
         </div>

--- a/client/src/lib/syntaxHighlight.ts
+++ b/client/src/lib/syntaxHighlight.ts
@@ -1,0 +1,90 @@
+/**
+ * 코드 신택스 하이라이팅 — highlight.js 코어 + 자주 쓰는 언어 16종만 등록.
+ *
+ * 풀 패키지(common)는 ~80KB 정도지만 코어+필요 언어만 골라서 등록하면 ~30KB.
+ * 채팅/회의록 모두 동일 결과를 캐시해 재사용하기 위해 결과 메모도.
+ */
+
+import hljs from "highlight.js/lib/core";
+
+// 등록 — 사내 개발팀이 자주 쓰는 언어 위주.
+import swift from "highlight.js/lib/languages/swift";
+import typescript from "highlight.js/lib/languages/typescript";
+import javascript from "highlight.js/lib/languages/javascript";
+import python from "highlight.js/lib/languages/python";
+import java from "highlight.js/lib/languages/java";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import go from "highlight.js/lib/languages/go";
+import rust from "highlight.js/lib/languages/rust";
+import sql from "highlight.js/lib/languages/sql";
+import xml from "highlight.js/lib/languages/xml"; // html/xml 공용
+import css from "highlight.js/lib/languages/css";
+import json from "highlight.js/lib/languages/json";
+import bash from "highlight.js/lib/languages/bash";
+import php from "highlight.js/lib/languages/php";
+import markdown from "highlight.js/lib/languages/markdown";
+import yaml from "highlight.js/lib/languages/yaml";
+
+hljs.registerLanguage("swift", swift);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("ts", typescript);
+hljs.registerLanguage("tsx", typescript);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("js", javascript);
+hljs.registerLanguage("jsx", javascript);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("py", python);
+hljs.registerLanguage("java", java);
+hljs.registerLanguage("kotlin", kotlin);
+hljs.registerLanguage("kt", kotlin);
+hljs.registerLanguage("go", go);
+hljs.registerLanguage("rust", rust);
+hljs.registerLanguage("rs", rust);
+hljs.registerLanguage("sql", sql);
+hljs.registerLanguage("html", xml);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("sh", bash);
+hljs.registerLanguage("shell", bash);
+hljs.registerLanguage("php", php);
+hljs.registerLanguage("markdown", markdown);
+hljs.registerLanguage("md", markdown);
+hljs.registerLanguage("yaml", yaml);
+hljs.registerLanguage("yml", yaml);
+
+const cache = new Map<string, string>();
+
+/** code → 하이라이트된 HTML 문자열. lang 미지정 시 자동 감지. 동일 입력은 메모. */
+export function highlightCode(code: string, lang?: string): string {
+  const key = `${lang ?? ""}:${code}`;
+  const cached = cache.get(key);
+  if (cached) return cached;
+  let html: string;
+  try {
+    if (lang && hljs.getLanguage(lang)) {
+      html = hljs.highlight(code, { language: lang, ignoreIllegals: true }).value;
+    } else {
+      html = hljs.highlightAuto(code).value;
+    }
+  } catch {
+    html = escapeHtml(code);
+  }
+  // 캐시 너무 부풀지 않게 200개 제한.
+  if (cache.size > 200) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey) cache.delete(firstKey);
+  }
+  cache.set(key, html);
+  return html;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -323,6 +323,73 @@ html.dark .chip-orange{ background: rgba(251,146,60,.18); color: #FDBA74; }
 html.dark .chip-violet{ background: rgba(167,139,250,.2); color: #C4B5FD; }
 
 /* ============================================================ */
+/*                       SYNTAX HIGHLIGHT                         */
+/* highlight.js 클래스에 라이트/다크 둘 다 자연스러운 색을 입힘.
+   atom-one 계열의 요약본. 사내 도구라 한 가지 톤만 유지.            */
+/* ============================================================ */
+.hljs              { color: #383a42; background: transparent; }
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-built_in,
+.hljs-name,
+.hljs-tag          { color: #a626a4; }
+.hljs-string,
+.hljs-title,
+.hljs-section,
+.hljs-attribute,
+.hljs-literal,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-addition     { color: #50a14f; }
+.hljs-comment,
+.hljs-quote,
+.hljs-deletion,
+.hljs-meta         { color: #a0a1a7; font-style: italic; }
+.hljs-number,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link         { color: #986801; }
+.hljs-function .hljs-title,
+.hljs-class .hljs-title,
+.hljs-title.function_,
+.hljs-title.class_  { color: #4078f2; }
+.hljs-variable,
+.hljs-params,
+.hljs-attr         { color: #e45649; }
+
+html.dark .hljs              { color: #abb2bf; }
+html.dark .hljs-keyword,
+html.dark .hljs-selector-tag,
+html.dark .hljs-built_in,
+html.dark .hljs-name,
+html.dark .hljs-tag          { color: #c678dd; }
+html.dark .hljs-string,
+html.dark .hljs-title,
+html.dark .hljs-section,
+html.dark .hljs-attribute,
+html.dark .hljs-literal,
+html.dark .hljs-template-tag,
+html.dark .hljs-template-variable,
+html.dark .hljs-type,
+html.dark .hljs-addition     { color: #98c379; }
+html.dark .hljs-comment,
+html.dark .hljs-quote,
+html.dark .hljs-deletion,
+html.dark .hljs-meta         { color: #7f848e; font-style: italic; }
+html.dark .hljs-number,
+html.dark .hljs-symbol,
+html.dark .hljs-bullet,
+html.dark .hljs-link         { color: #d19a66; }
+html.dark .hljs-function .hljs-title,
+html.dark .hljs-class .hljs-title,
+html.dark .hljs-title.function_,
+html.dark .hljs-title.class_  { color: #61afef; }
+html.dark .hljs-variable,
+html.dark .hljs-params,
+html.dark .hljs-attr         { color: #e06c75; }
+
+/* ============================================================ */
 /*                           AVATARS                             */
 /* ============================================================ */
 .avatar {


### PR DESCRIPTION
## 증상
**highlight.js 신택스 하이라이팅 + 모달 배경 불투명**

새 기능을 추가합니다.

## 원인
[증상]
1) 코드 전체보기 모달 뒤로 캘린더/사내톡이 비쳐 보였음 — dim 65% 라
   배경이 투과됨. 패널 배경 토큰도 var(--c-fg-strong) 같이 정의되지 않은
   값을 써서 일부 요소는 색이 빠짐.
2) 모든 글자가 흰색 한 톤이라 코드처럼 보이지 않음 (예약어/문자열/주석 구분 X).

[추가]
- highlight.js 코어 + 16개 언어(swift/ts/js/py/java/kotlin/go/rust/sql/html/css/
  json/bash/php/markdown/yaml) 모듈식 등록 → 풀번들 대비 ~30KB.
- client/src/lib/syntaxHighlight.ts: highlightCode(code, lang)
  - lang 지정시 그 언어로, 미지정시 highlightAuto.
  - 200건 LRU 메모로 같은 코드 재렌더 시 즉시 반환.
- styles.css: atom-one 계열의 라이트/다크 양쪽 hljs 토큰 컬러.
  html.dark 셀렉터로 자동 전환.
- MessageBubble: CodeBlockBubble / CodeViewerModal 둘 다 highlight.js HTML 을
  dangerouslySetInnerHTML 로 주입. (hljs 출력은 자체 escape 처리된 안전한 HTML.)

[수정]
- CodeViewerModal dim 0.65 → 0.85 + backdrop-filter blur(4px) → 배경 비침 제거.
- 패널 surface: 정의 안 된 var(--c-surface-1) → 정의된 var(--c-surface)
- 텍스트: 정의 안 된 var(--c-fg-strong)/var(--c-fg-muted) → var(--c-text)/var(--c-text-3)

## 수정
**작업 항목 (커밋 단위)**
- feat(code): highlight.js 신택스 하이라이팅 + 모달 배경 불투명

**변경 대상 (5개 파일)**
- `client/package-lock.json`
- `client/package.json`
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/lib/syntaxHighlight.ts`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #54** ↔ **이슈 #476** 로 연결됩니다.

Closes #476
