### PR TITLE
🔀 :: (#477) 그룹·1:1 시각 구분 + 코드 모달 dim 완화

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -734,6 +734,10 @@ function ListView({
               presenceTitle = p?.presenceMessage ? `${info.label} · ${p.presenceMessage}` : info.label;
             }
           }
+          // 그룹/팀방: 아바타에 people 뱃지 + 제목 옆에 인원수 칩.
+          // 1:1 은 종전과 동일 (presence 점만).
+          const isGroup = r.type !== "DIRECT";
+          const memberCount = isGroup ? r.members.length : undefined;
           return (
             <ListRow
               key={r.id}
@@ -748,6 +752,8 @@ function ListView({
               muted={muted}
               presenceColor={presenceColor}
               presenceTitle={presenceTitle}
+              isGroup={isGroup}
+              memberCount={memberCount}
             />
           );
         })}
@@ -808,7 +814,7 @@ function EmptyRow({ children }: { children: React.ReactNode }) {
 
 /* ===== 범용 리스트 행 ===== */
 function ListRow({
-  onClick, avatar, title, titleHighlight, subtitle, subtitleHighlight, subtitlePrefix, rightTop, unread, muted, presenceColor, presenceTitle,
+  onClick, avatar, title, titleHighlight, subtitle, subtitleHighlight, subtitlePrefix, rightTop, unread, muted, presenceColor, presenceTitle, isGroup, memberCount,
 }: {
   onClick: () => void;
   avatar: { name: string; color: string; imageUrl?: string | null };
@@ -822,6 +828,8 @@ function ListRow({
   muted?: boolean;
   presenceColor?: string;
   presenceTitle?: string;
+  isGroup?: boolean;
+  memberCount?: number;
 }) {
   return (
     <button
@@ -839,7 +847,35 @@ function ListRow({
       onMouseEnter={(e) => (e.currentTarget.style.background = C.gray100)}
       onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
     >
-      <Avatar name={avatar.name} color={avatar.color} imageUrl={avatar.imageUrl ?? null} size={46} presenceColor={presenceColor} presenceTitle={presenceTitle} />
+      <div style={{ position: "relative", flexShrink: 0 }}>
+        <Avatar name={avatar.name} color={avatar.color} imageUrl={avatar.imageUrl ?? null} size={46} presenceColor={isGroup ? undefined : presenceColor} presenceTitle={isGroup ? undefined : presenceTitle} />
+        {isGroup && (
+          // 그룹/팀방 표시 — 아바타 우하단에 사람 두 명 아이콘. presence 점 자리.
+          <div
+            title={memberCount ? `그룹 · ${memberCount}명` : "그룹"}
+            style={{
+              position: "absolute",
+              bottom: -2,
+              right: -2,
+              width: 18,
+              height: 18,
+              borderRadius: 999,
+              background: C.blue,
+              color: "#fff",
+              border: `2px solid var(--c-surface)`,
+              display: "grid",
+              placeItems: "center",
+            }}
+          >
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+          </div>
+        )}
+      </div>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <div
@@ -853,6 +889,23 @@ function ListRow({
             <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
               {highlight(title, titleHighlight)}
             </span>
+            {isGroup && memberCount !== undefined && (
+              // 인원수 칩 — 글자 톤 낮춰서 제목보다 부차적으로.
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: "1px 6px",
+                  borderRadius: 999,
+                  background: C.gray100,
+                  color: C.gray600,
+                  flexShrink: 0,
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {memberCount}
+              </span>
+            )}
             {muted && (
               <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={C.gray500} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-label="알림 꺼짐" style={{ flexShrink: 0 }}>
                 <path d="M15 9v3M3 21l18-18" />

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1272,10 +1272,11 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
         position: "fixed",
         inset: 0,
         zIndex: 9999,
-        // 종전 0.65 는 배경 캘린더가 비쳐 어수선했음. 0.85 로 올려 거의 가림 + backdropFilter 로 블러.
-        background: "rgba(0,0,0,0.85)",
-        backdropFilter: "blur(4px)",
-        WebkitBackdropFilter: "blur(4px)",
+        // dim 은 약하게(0.45) 두고 backdrop-filter 로 강하게 흐림(blur 12px) — 배경이 보이긴 하되
+        // 어떤 콘텐츠인지 식별 안 될 정도로 부드럽게. 모달은 100% 불투명 패널이라 가독성 영향 없음.
+        background: "rgba(0,0,0,0.45)",
+        backdropFilter: "blur(12px) saturate(1.2)",
+        WebkitBackdropFilter: "blur(12px) saturate(1.2)",
         display: "grid",
         placeItems: "center",
         padding: "max(env(safe-area-inset-top), 16px) 16px max(env(safe-area-inset-bottom), 16px)",


### PR DESCRIPTION
## 증상
**그룹·1:1 시각 구분 + 코드 모달 dim 완화**

새 기능을 추가합니다.

## 원인
[그룹 vs 1:1 구분]
종전 채팅 리스트는 1:1 든 그룹/팀방이든 동일한 단일 아바타라 한눈에 구분이 안 됨.
- ListRow 에 isGroup / memberCount prop 추가.
- type !== "DIRECT" 인 방에 한해:
  · 아바타 우하단(presence 점 자리) 에 사람 둘 아이콘 — 파란 원, surface 색 테두리.
  · 제목 옆에 인원수 칩(N) — gray100/gray600 톤으로 제목보다 부차적.
- 1:1 방은 종전과 동일하게 상대방 presence 점만.

[코드 자세히보기 모달 — 너무 단색이라는 피드백]
dim 0.85 / blur 4px → dim 0.45 / blur 12px + saturate 1.2.
배경이 비치긴 하지만 강한 블러로 식별 안 되는 부드러운 흐림. 모달 패널 자체는
100% 불투명이라 가독성 손실 없음.

## 수정
**작업 항목 (커밋 단위)**
- feat(chat): 그룹/팀방을 1:1 와 시각적으로 구분 + 코드 모달 dim 완화

**변경 대상 (2개 파일)**
- `client/src/components/ChatMiniApp.tsx`
- `client/src/components/chat/MessageBubble.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #55** ↔ **이슈 #477** 로 연결됩니다.

Closes #477
