### PR TITLE
🔀 :: (#478) 코드 블록 가독성 — 항상 어두운 inset + 다크 hljs

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1150,6 +1150,9 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
   const showExpand = lineCount > 8 || code.length > 400;
   return (
     <div
+      // .code-block 클래스를 박아서 styles.css 가 hljs 다크 팔레트로 강제 — 라이트 테마에서도
+      // 코드 영역만큼은 항상 어두운 inset 으로 통일 (Slack/Discord 패턴).
+      className="code-block"
       style={{
         // display:block + width:100% + min-width:0 콤보 — flex 부모가 0 1 auto 일 때
         // 안에 든 long-content `pre` 가 버블을 부풀려 채팅 영역 밖으로 새는 것 방지.
@@ -1161,8 +1164,10 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
         position: "relative",
         margin: "4px 0",
         borderRadius: 10,
-        background: mine ? "rgba(0,0,0,0.28)" : "var(--c-surface-3)",
-        border: mine ? "1px solid rgba(255,255,255,0.12)" : "1px solid var(--c-border)",
+        // mine(파란 버블) / 상대(회색 버블) 모두 동일한 어두운 코드 surface — 색을 통일해
+        // 사용자가 어떤 버블에서 코드를 봐도 같은 가독성.
+        background: "#1B1F27",
+        border: "1px solid rgba(255,255,255,0.10)",
         overflow: "hidden",
       }}
     >
@@ -1176,8 +1181,9 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
           fontWeight: 700,
           letterSpacing: "0.06em",
           textTransform: "uppercase",
-          color: mine ? "rgba(255,255,255,0.7)" : "var(--c-text-3)",
-          borderBottom: mine ? "1px solid rgba(255,255,255,0.10)" : "1px solid var(--c-border)",
+          // 코드 박스는 어두운 surface 로 통일했으니 헤더도 그에 맞춰 항상 옅은 흰색.
+          color: "rgba(255,255,255,0.7)",
+          borderBottom: "1px solid rgba(255,255,255,0.10)",
         }}
       >
         <span>{lang || "code"}</span>
@@ -1241,8 +1247,8 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
             padding: "6px 10px",
             background: "transparent",
             border: "none",
-            borderTop: mine ? "1px solid rgba(255,255,255,0.10)" : "1px solid var(--c-border)",
-            color: mine ? "rgba(255,255,255,0.85)" : "var(--c-text-3)",
+            borderTop: "1px solid rgba(255,255,255,0.10)",
+            color: "rgba(255,255,255,0.85)",
             fontSize: 11.5,
             fontWeight: 700,
             cursor: "pointer",

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -389,6 +389,39 @@ html.dark .hljs-variable,
 html.dark .hljs-params,
 html.dark .hljs-attr         { color: #e06c75; }
 
+/* 채팅 버블 안의 코드 블록은 라이트 테마라도 항상 어두운 inset 으로 띄움
+   (Slack/Discord 패턴). 그래서 hljs 도 다크 팔레트로 강제. */
+.code-block .hljs              { color: #abb2bf; }
+.code-block .hljs-keyword,
+.code-block .hljs-selector-tag,
+.code-block .hljs-built_in,
+.code-block .hljs-name,
+.code-block .hljs-tag          { color: #c678dd; }
+.code-block .hljs-string,
+.code-block .hljs-title,
+.code-block .hljs-section,
+.code-block .hljs-attribute,
+.code-block .hljs-literal,
+.code-block .hljs-template-tag,
+.code-block .hljs-template-variable,
+.code-block .hljs-type,
+.code-block .hljs-addition     { color: #98c379; }
+.code-block .hljs-comment,
+.code-block .hljs-quote,
+.code-block .hljs-deletion,
+.code-block .hljs-meta         { color: #7f848e; font-style: italic; }
+.code-block .hljs-number,
+.code-block .hljs-symbol,
+.code-block .hljs-bullet,
+.code-block .hljs-link         { color: #d19a66; }
+.code-block .hljs-function .hljs-title,
+.code-block .hljs-class .hljs-title,
+.code-block .hljs-title.function_,
+.code-block .hljs-title.class_  { color: #61afef; }
+.code-block .hljs-variable,
+.code-block .hljs-params,
+.code-block .hljs-attr         { color: #e06c75; }
+
 /* ============================================================ */
 /*                           AVATARS                             */
 /* ============================================================ */


### PR DESCRIPTION
## 증상
**코드 블록 가독성 — 항상 어두운 inset + 다크 hljs**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
[증상]
mine 버블(파랑) 안의 코드 블록이 rgba(0,0,0,0.28) 반투명 어두움 + 위에 hljs
라이트 팔레트(#383a42 등 어두운 텍스트) 가 그려져 어두움 위 어두움 → 잘 안 보임.
다크 테마에선 hljs 다크 팔레트로 그려지지만 mine 의 파란 톤과 충돌.

[수정]
- CodeBlockBubble background: 항상 #1B1F27 단색 어두운 surface (mine/상대 무관).
  Slack/Discord 처럼 코드 영역만큼은 테마와 별개로 통일된 톤.
- 헤더/전체보기 버튼 색도 어두운 surface 에 맞춰 항상 옅은 흰색.
- styles.css 에 `.code-block` 스코프로 hljs 다크 팔레트 강제 — 라이트
  테마에서 코드 블록만큼은 다크 팔레트로 칠해 가독성 확보.
- 키워드(보라) / 문자열(연초록) / 주석(회색) / 숫자(황갈) / 함수명(시안)
  / 변수(코랄) — atom-one-dark 톤 그대로.

[유지]
- 풀 화면 코드 자세히보기 모달은 종전대로 `html.dark` 에 따라 라이트/다크 둘 다 지원.
  거기는 모달 자체가 surface 토큰을 따라가니까 OK.

## 수정
**작업 항목 (커밋 단위)**
- fix(chat): 코드 블록 가독성 — 항상 어두운 inset + 다크 hljs 팔레트 강제

**변경 대상 (2개 파일)**
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #56** ↔ **이슈 #478** 로 연결됩니다.

Closes #478
