### PR TITLE
🔀 :: (#479) 언어 라벨 옆 devicon 미니 로고

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -8,6 +8,7 @@ import { parseCodeSegments } from "../../lib/codeDetect";
 import { copyToClipboard } from "../../lib/clipboard";
 import { useModalDismiss } from "../../lib/useModalDismiss";
 import { highlightCode } from "../../lib/syntaxHighlight";
+import { LangIcon } from "../../lib/langIcon";
 
 /**
  * 파일/이미지/동영상 메시지를 문서함으로 복사 저장.
@@ -1186,7 +1187,10 @@ function CodeBlockBubble({ code, lang, mine }: { code: string; lang?: string; mi
           borderBottom: "1px solid rgba(255,255,255,0.10)",
         }}
       >
-        <span>{lang || "code"}</span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+          <LangIcon lang={lang} size={13} />
+          {lang || "code"}
+        </span>
         <button
           type="button"
           onClick={(e) => {
@@ -1328,8 +1332,12 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
               borderRadius: 6,
               background: "var(--c-surface-3)",
               color: "var(--c-text-3)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
             }}
           >
+            <LangIcon lang={lang} size={14} />
             {lang || "code"}
           </div>
           <div style={{ flex: 1, fontSize: 12, color: "var(--c-text-3)" }}>

--- a/client/src/lib/langIcon.tsx
+++ b/client/src/lib/langIcon.tsx
@@ -1,0 +1,81 @@
+/**
+ * 언어 라벨 옆에 띄울 미니 로고. devicon CDN 의 SVG 를 그대로 <img> 로.
+ *
+ * 언어명 → devicon 슬러그 매핑. (devicon 은 GitHub Actions 같은 일부 명칭이 다름.)
+ * 매핑이 없으면 null 반환 → 아이콘 없이 텍스트만 표시.
+ */
+
+const SLUGS: Record<string, string> = {
+  swift: "swift/swift-original",
+  typescript: "typescript/typescript-original",
+  ts: "typescript/typescript-original",
+  tsx: "typescript/typescript-original",
+  javascript: "javascript/javascript-original",
+  js: "javascript/javascript-original",
+  jsx: "javascript/javascript-original",
+  python: "python/python-original",
+  py: "python/python-original",
+  java: "java/java-original",
+  kotlin: "kotlin/kotlin-original",
+  kt: "kotlin/kotlin-original",
+  go: "go/go-original",
+  golang: "go/go-original",
+  rust: "rust/rust-original",
+  rs: "rust/rust-original",
+  // SQL 은 devicon 에 단독 슬러그 없음 — 일반 DB 로고로 대체.
+  sql: "mysql/mysql-original",
+  mysql: "mysql/mysql-original",
+  postgresql: "postgresql/postgresql-original",
+  postgres: "postgresql/postgresql-original",
+  html: "html5/html5-original",
+  xml: "html5/html5-original",
+  css: "css3/css3-original",
+  scss: "sass/sass-original",
+  sass: "sass/sass-original",
+  bash: "bash/bash-original",
+  sh: "bash/bash-original",
+  shell: "bash/bash-original",
+  php: "php/php-original",
+  ruby: "ruby/ruby-original",
+  rb: "ruby/ruby-original",
+  c: "c/c-original",
+  cpp: "cplusplus/cplusplus-original",
+  "c++": "cplusplus/cplusplus-original",
+  csharp: "csharp/csharp-original",
+  cs: "csharp/csharp-original",
+  dart: "dart/dart-original",
+  // markdown / json / yaml 은 devicon 정식 로고가 없거나 빈약 — 일부러 매핑 안 함.
+};
+
+export function langIconUrl(lang?: string): string | null {
+  if (!lang) return null;
+  const slug = SLUGS[lang.toLowerCase()];
+  if (!slug) return null;
+  // jsdelivr 가 GitHub raw 보다 캐시 / 가용성이 좋음.
+  return `https://cdn.jsdelivr.net/gh/devicons/devicon/icons/${slug}.svg`;
+}
+
+export function LangIcon({ lang, size = 14 }: { lang?: string; size?: number }) {
+  const url = langIconUrl(lang);
+  if (!url) return null;
+  return (
+    <img
+      src={url}
+      alt={lang ?? ""}
+      aria-hidden
+      width={size}
+      height={size}
+      // SVG 라 작은 사이즈에서도 또렷. 로드 실패하면 alt 가 잠깐 보이지만 즉시 숨겨서 깔끔.
+      onError={(e) => {
+        (e.currentTarget as HTMLImageElement).style.display = "none";
+      }}
+      style={{
+        display: "inline-block",
+        width: size,
+        height: size,
+        flexShrink: 0,
+        verticalAlign: "text-bottom",
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## 증상
**언어 라벨 옆 devicon 미니 로고**

새 기능을 추가합니다.

## 원인
[추가]
- client/src/lib/langIcon.tsx — 언어명 → devicon 슬러그 매핑 + LangIcon 컴포넌트.
  · jsdelivr CDN(devicons/devicon) 의 SVG 를 <img> 로 직접 로드.
  · 매핑 없는 언어(json/markdown/yaml 등)는 null 반환 → 텍스트만.
  · onError 시 즉시 hide → 로드 실패 시 alt 깜빡임 방지.
- 매핑 18종: swift / ts / js / tsx / jsx / py / java / kotlin / go / rust /
  sql / html / css / sass / bash / php / ruby / c / cpp / csharp / dart.

[적용]
- CodeBlockBubble 헤더 ("JAVASCRIPT" 라벨 옆): size 13.
- CodeViewerModal 헤더 ("SWIFT" 칩 안): size 14.

번들 영향 없음 — 외부 CDN 이미지 (jsdelivr 캐시).

## 수정
**작업 항목 (커밋 단위)**
- feat(code): 언어 라벨 옆에 devicon 미니 로고 표시

**변경 대상 (2개 파일)**
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/lib/langIcon.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #57** ↔ **이슈 #479** 로 연결됩니다.

Closes #479
