### PR TITLE
🔀 :: (#480) 메시지 마크다운 — 굵게/기울임/인용/리스트

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -9,6 +9,7 @@ import { copyToClipboard } from "../../lib/clipboard";
 import { useModalDismiss } from "../../lib/useModalDismiss";
 import { highlightCode } from "../../lib/syntaxHighlight";
 import { LangIcon } from "../../lib/langIcon";
+import { splitBlocks, renderInlineMarkdown } from "../../lib/markdown";
 
 /**
  * 파일/이미지/동영상 메시지를 문서함으로 복사 저장.
@@ -1082,6 +1083,54 @@ function renderWithLinks(content: string, mine: boolean): React.ReactNode[] {
   return nodes;
 }
 
+/** 마크다운 블록(>, -, 1.) + 인라인(**, *, ~~, URL) 을 React 노드로. */
+function MarkdownText({ text, mine }: { text: string; mine: boolean }) {
+  const blocks = splitBlocks(text);
+  // 텍스트 안의 URL 링크화는 종전 renderWithLinks 를 그대로 쓰되, 인라인 마크다운 후에 호출.
+  const inline = (s: string, key: string) => <span key={key}>{renderWithLinks(s, mine)}</span>;
+  return (
+    <>
+      {blocks.map((b, i) => {
+        if (b.kind === "blockquote") {
+          return (
+            <blockquote
+              key={i}
+              style={{
+                margin: "4px 0",
+                padding: "2px 10px",
+                borderLeft: `3px solid ${mine ? "rgba(255,255,255,0.45)" : "var(--c-border-strong)"}`,
+                color: mine ? "rgba(255,255,255,0.9)" : "var(--c-text-2)",
+                fontStyle: "normal",
+              }}
+            >
+              {renderInlineMarkdown(b.text, inline)}
+            </blockquote>
+          );
+        }
+        if (b.kind === "ul") {
+          return (
+            <ul key={i} style={{ margin: "4px 0", paddingLeft: 22 }}>
+              {b.items.map((it, j) => (
+                <li key={j}>{renderInlineMarkdown(it, inline)}</li>
+              ))}
+            </ul>
+          );
+        }
+        if (b.kind === "ol") {
+          return (
+            <ol key={i} start={b.start} style={{ margin: "4px 0", paddingLeft: 22 }}>
+              {b.items.map((it, j) => (
+                <li key={j}>{renderInlineMarkdown(it, inline)}</li>
+              ))}
+            </ol>
+          );
+        }
+        return <span key={i}>{renderInlineMarkdown(b.text, inline)}</span>;
+      })}
+    </>
+  );
+}
+
 export function TextBubble({
   content,
   mine,
@@ -1116,7 +1165,7 @@ export function TextBubble({
       {segments.map((seg, i) => {
         if (seg.kind === "code") return <CodeBlockBubble key={i} code={seg.code} lang={seg.lang} mine={mine} />;
         if (seg.kind === "inline-code") return <InlineCode key={i} code={seg.code} mine={mine} />;
-        return <span key={i}>{renderWithLinks(seg.text, mine)}</span>;
+        return <MarkdownText key={i} text={seg.text} mine={mine} />;
       })}
     </div>
   );

--- a/client/src/lib/markdown.tsx
+++ b/client/src/lib/markdown.tsx
@@ -1,0 +1,126 @@
+/**
+ * 채팅 평문에서 마크다운 토큰을 React 노드로.
+ *
+ * 코드 펜스/인라인은 codeDetect 가 이미 떼어내므로 여기서는 "code 가 아닌 평문" 만 처리.
+ * 풀 마크다운 파서(remark/marked) 는 채팅용으론 무거워서 직접 작성. 사내 메신저 톤
+ * (Slack/Jandi) 에 맞춰 다음만 지원:
+ *
+ *  Block
+ *   - "> "          → blockquote
+ *   - "- " / "* "   → 순서 없는 리스트
+ *   - "1. "         → 순서 있는 리스트
+ *
+ *  Inline
+ *   - **bold**
+ *   - *italic* 또는 _italic_  (단, **bold** 는 별도 처리)
+ *   - ~~strike~~
+ *
+ *  URL 자동 링크는 호출 측의 renderWithLinks 가 그대로 처리.
+ */
+
+import type { ReactNode } from "react";
+
+type InlineNode = ReactNode;
+
+// **bold** / __bold__ / *italic* / _italic_ / ~~strike~~ 을 단일 RegExp 로 캡쳐.
+// 우선순위는 ** > __ > ~~ > * > _ — 더 긴 패턴부터 배치해서 ** 가 * 두 개로 잘못 잡히지 않도록.
+const INLINE_RE = /(\*\*([^*\n]+)\*\*|__([^_\n]+)__|~~([^~\n]+)~~|\*([^*\n]+)\*|_([^_\n]+)_)/g;
+
+export function renderInlineMarkdown(
+  text: string,
+  /** URL 등 추가 토큰을 텍스트 조각마다 후처리하기 위한 hook. */
+  textTransform?: (chunk: string, key: string) => InlineNode,
+): InlineNode[] {
+  const out: InlineNode[] = [];
+  let last = 0;
+  let i = 0;
+  let m: RegExpExecArray | null;
+  INLINE_RE.lastIndex = 0;
+  while ((m = INLINE_RE.exec(text)) !== null) {
+    if (m.index > last) {
+      const chunk = text.slice(last, m.index);
+      out.push(textTransform ? textTransform(chunk, `t${i++}`) : chunk);
+    }
+    if (m[2] || m[3]) {
+      out.push(<strong key={`b${i++}`}>{m[2] ?? m[3]}</strong>);
+    } else if (m[4]) {
+      out.push(<s key={`s${i++}`} style={{ opacity: 0.75 }}>{m[4]}</s>);
+    } else if (m[5] || m[6]) {
+      out.push(<em key={`i${i++}`}>{m[5] ?? m[6]}</em>);
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) {
+    const tail = text.slice(last);
+    out.push(textTransform ? textTransform(tail, `t${i++}`) : tail);
+  }
+  return out;
+}
+
+type Block =
+  | { kind: "text"; text: string }
+  | { kind: "blockquote"; text: string }
+  | { kind: "ul"; items: string[] }
+  | { kind: "ol"; items: string[]; start: number };
+
+/** 평문을 줄 기준으로 블록 단위로 묶음. */
+export function splitBlocks(text: string): Block[] {
+  const lines = text.split("\n");
+  const out: Block[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const ln = lines[i];
+    const quote = /^> ?(.*)$/.exec(ln);
+    if (quote) {
+      // 연속된 > 라인 묶기
+      const buf: string[] = [];
+      while (i < lines.length) {
+        const q = /^> ?(.*)$/.exec(lines[i]);
+        if (!q) break;
+        buf.push(q[1]);
+        i++;
+      }
+      out.push({ kind: "blockquote", text: buf.join("\n") });
+      continue;
+    }
+    const ul = /^[-*] (.+)$/.exec(ln);
+    if (ul) {
+      const items: string[] = [];
+      while (i < lines.length) {
+        const m = /^[-*] (.+)$/.exec(lines[i]);
+        if (!m) break;
+        items.push(m[1]);
+        i++;
+      }
+      out.push({ kind: "ul", items });
+      continue;
+    }
+    const ol = /^(\d+)\.\s+(.+)$/.exec(ln);
+    if (ol) {
+      const start = parseInt(ol[1], 10);
+      const items: string[] = [];
+      while (i < lines.length) {
+        const m = /^\d+\.\s+(.+)$/.exec(lines[i]);
+        if (!m) break;
+        items.push(m[1]);
+        i++;
+      }
+      out.push({ kind: "ol", items, start });
+      continue;
+    }
+    // 일반 텍스트는 다음 블록 트리거 줄까지 모음
+    const buf: string[] = [];
+    while (i < lines.length) {
+      const next = lines[i];
+      if (
+        /^> /.test(next) ||
+        /^[-*] /.test(next) ||
+        /^\d+\.\s+/.test(next)
+      ) break;
+      buf.push(next);
+      i++;
+    }
+    out.push({ kind: "text", text: buf.join("\n") });
+  }
+  return out;
+}


### PR DESCRIPTION
## 증상
**메시지 마크다운 — 굵게/기울임/인용/리스트**

새 기능을 추가합니다.

## 원인
[추가]
- client/src/lib/markdown.tsx
  · splitBlocks(text): "> " 인용 / "- *" UL / "1." OL / 일반 텍스트 블록으로 분할.
  · renderInlineMarkdown(text, hook): **bold** / __bold__ / ~~strike~~ / *italic* / _italic_
    인라인 토큰 RegExp 단일 패스로 React 노드 변환. URL 링크는 hook 인자로
    renderWithLinks 를 받아 위임.

[적용]
- MessageBubble TextBubble: 코드 분할 후 남은 평문 segment 를 종전
  renderWithLinks 단순 호출 대신 MarkdownText 로 래핑.
- 코드 펜스 / 인라인 백틱은 그대로(parseCodeSegments 가 먼저 떼어냄). 마크다운은
  코드가 아닌 영역에만 적용 → `**bold**` 같은 토큰이 코드 안에서 깨질 일 없음.

[톤]
- blockquote: 3px 좌측 보더 (mine 일 땐 흰색 0.45, 상대일 땐 border-strong).
- 리스트: 기본 마진 + 좌측 padding 22px.

[비범위]
- 헤딩(#), 표(|...|), 이미지(![]) 는 채팅 스케일에 과한 토큰이라 의도적으로 제외.
- 회의록은 TipTap 가 마크다운 단축 입력 이미 지원하므로 손대지 않음.

## 수정
**작업 항목 (커밋 단위)**
- feat(chat): 메시지 마크다운 — 굵게/기울임/취소선/인용/리스트

**변경 대상 (2개 파일)**
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/lib/markdown.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #58** ↔ **이슈 #480** 로 연결됩니다.

Closes #480
