### PR TITLE
🔀 :: (#481) URL 링크 프리뷰 (OG / Twitter Card unfurl)

### DIFF
--- a/client/src/components/chat/LinkPreview.tsx
+++ b/client/src/components/chat/LinkPreview.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../../api";
+
+/**
+ * 메시지 본문 안 첫 URL 의 OG/Twitter Card 메타를 가져와 카드로 표시.
+ *
+ * - 채팅방을 열 때마다 한 번만 fetch — 동일 URL 은 sessionStorage 에 메모.
+ * - 서버 측에 30분 LRU 가 또 있어 사실상 N+1 한 번이면 끝.
+ * - 메타가 비어있으면(title 없음) 카드 자체 안 그림.
+ */
+
+type Meta = {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  favicon?: string;
+};
+
+const LS_PREFIX = "hinest.unfurl.";
+
+function loadCached(url: string): Meta | null {
+  try {
+    const raw = sessionStorage.getItem(LS_PREFIX + url);
+    if (!raw) return null;
+    return JSON.parse(raw) as Meta;
+  } catch {
+    return null;
+  }
+}
+function saveCached(url: string, m: Meta) {
+  try {
+    sessionStorage.setItem(LS_PREFIX + url, JSON.stringify(m));
+  } catch {
+    // 용량 초과 등 무시
+  }
+}
+
+export function LinkPreview({ url, mine }: { url: string; mine: boolean }) {
+  const [meta, setMeta] = useState<Meta | null>(() => loadCached(url));
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (meta) return;
+    let cancelled = false;
+    api<Meta>("/api/unfurl", { method: "POST", json: { url } })
+      .then((m) => {
+        if (cancelled || !aliveRef.current) return;
+        if (m && (m.title || m.description || m.image)) {
+          setMeta(m);
+          saveCached(url, m);
+        } else {
+          // 메타가 비면 빈 카드 안 그리도록 빈 메타 캐시 — 이후 같은 URL 재요청 안 감.
+          saveCached(url, { url });
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+    // url 단위 fetch — meta 갱신은 알아서.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+
+  if (!meta || (!meta.title && !meta.description && !meta.image)) return null;
+
+  const host = (() => {
+    try { return new URL(meta.url).host; } catch { return ""; }
+  })();
+
+  return (
+    <a
+      href={meta.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => {
+        e.stopPropagation();
+        const bridge = (window as any).hinest;
+        if (bridge?.openExternal) {
+          e.preventDefault();
+          bridge.openExternal(meta.url).catch(() => {});
+        }
+      }}
+      style={{
+        display: "flex",
+        margin: "6px 0 2px",
+        textDecoration: "none",
+        borderRadius: 12,
+        overflow: "hidden",
+        background: mine ? "rgba(0,0,0,0.18)" : "var(--c-surface-2)",
+        border: mine ? "1px solid rgba(255,255,255,0.14)" : "1px solid var(--c-border)",
+        maxWidth: "100%",
+      }}
+    >
+      {meta.image && (
+        <div
+          style={{
+            width: 88,
+            minHeight: 88,
+            flexShrink: 0,
+            backgroundImage: `url(${meta.image})`,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+            backgroundRepeat: "no-repeat",
+          }}
+          aria-hidden
+        />
+      )}
+      <div style={{ flex: 1, minWidth: 0, padding: "8px 10px", display: "flex", flexDirection: "column", gap: 2 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            fontSize: 11,
+            fontWeight: 600,
+            color: mine ? "rgba(255,255,255,0.75)" : "var(--c-text-3)",
+            minWidth: 0,
+          }}
+        >
+          {meta.favicon && (
+            <img
+              src={meta.favicon}
+              alt=""
+              width={12}
+              height={12}
+              loading="lazy"
+              style={{ flexShrink: 0, borderRadius: 2 }}
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).style.display = "none";
+              }}
+            />
+          )}
+          <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {meta.siteName || host}
+          </span>
+        </div>
+        {meta.title && (
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 700,
+              lineHeight: 1.3,
+              color: mine ? "#fff" : "var(--c-text)",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {meta.title}
+          </div>
+        )}
+        {meta.description && (
+          <div
+            style={{
+              fontSize: 12,
+              lineHeight: 1.35,
+              color: mine ? "rgba(255,255,255,0.85)" : "var(--c-text-2)",
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {meta.description}
+          </div>
+        )}
+      </div>
+    </a>
+  );
+}
+
+/** 본문에서 첫 http(s) URL 추출 — 코드 블록 안의 URL 은 펜스 떼낸 뒤 호출하므로 잡히지 않음. */
+export function extractFirstUrl(text: string): string | null {
+  const m = /(https?:\/\/[^\s<>"'`]+)/i.exec(text);
+  if (!m) return null;
+  // 문장 끝 구두점 제거.
+  return m[1].replace(/[).,!?;:]+$/, "");
+}

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -10,6 +10,7 @@ import { useModalDismiss } from "../../lib/useModalDismiss";
 import { highlightCode } from "../../lib/syntaxHighlight";
 import { LangIcon } from "../../lib/langIcon";
 import { splitBlocks, renderInlineMarkdown } from "../../lib/markdown";
+import { LinkPreview, extractFirstUrl } from "./LinkPreview";
 
 /**
  * 파일/이미지/동영상 메시지를 문서함으로 복사 저장.
@@ -1167,6 +1168,16 @@ export function TextBubble({
         if (seg.kind === "inline-code") return <InlineCode key={i} code={seg.code} mine={mine} />;
         return <MarkdownText key={i} text={seg.text} mine={mine} />;
       })}
+      {/* 첫 번째 URL 의 링크 프리뷰 — 코드 segment 의 URL 은 parseCodeSegments 가 떼어낸 뒤라
+          텍스트 segment 안에서만 검색됨. 메시지당 1개만 노출해 UI 부풀림 방지. */}
+      {(() => {
+        for (const s of segments) {
+          if (s.kind !== "text") continue;
+          const u = extractFirstUrl(s.text);
+          if (u) return <LinkPreview key="lp" url={u} mine={mine} />;
+        }
+        return null;
+      })()}
     </div>
   );
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -31,6 +31,7 @@ import projectRouter from "./routes/project.js";
 import webhookRouter from "./routes/webhook.js";
 import meetingRouter from "./routes/meeting.js";
 import pinRouter from "./routes/pin.js";
+import unfurlRouter from "./routes/unfurl.js";
 import { shareLinkAuthedRouter, shareLinkPublicRouter } from "./routes/shareLink.js";
 import { folderShareLinkAuthedRouter } from "./routes/folderShareLink.js";
 import serviceAccountRouter from "./routes/serviceAccount.js";
@@ -183,6 +184,7 @@ app.use("/api/nav", navRouter);
 app.use("/api/project", projectRouter);
 app.use("/api/meeting", meetingRouter);
 app.use("/api/pins", pinRouter);
+app.use("/api/unfurl", unfurlRouter);
 app.use("/api/service-accounts", serviceAccountRouter);
 // 공유 링크 — 생성/관리는 인증 필요, 실제 외부 다운로드는 인증 없이.
 app.use("/api/share-links", shareLinkAuthedRouter);

--- a/server/src/routes/unfurl.ts
+++ b/server/src/routes/unfurl.ts
@@ -1,0 +1,208 @@
+import { Router } from "express";
+import { z } from "zod";
+import { requireAuth } from "../lib/auth.js";
+
+/**
+ * URL 메타데이터(Open Graph / Twitter Card / 기본 <title>) 추출 — 링크 프리뷰용.
+ *
+ * 보안:
+ *  - 인증 필수 — 무한 SSRF 우회 방지.
+ *  - 사설망/메타데이터 IP 차단 (10.*, 172.16-31.*, 192.168.*, 127.*, 169.254.*, ::1).
+ *  - http(s) 만 허용. file://, data:, ftp:// 거부.
+ *  - 응답 본문 1MB 상한, 5초 타임아웃.
+ *  - 내부에서 인메모리 LRU 30분 캐시.
+ *
+ * 응답: { url, title, description?, image?, siteName?, favicon? }
+ */
+
+const router = Router();
+router.use(requireAuth);
+
+const schema = z.object({
+  url: z.string().url().max(2048),
+});
+
+type Meta = {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  favicon?: string;
+};
+
+const cache = new Map<string, { data: Meta; expires: number }>();
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const CACHE_MAX = 500;
+
+function cacheGet(k: string): Meta | null {
+  const e = cache.get(k);
+  if (!e) return null;
+  if (Date.now() > e.expires) {
+    cache.delete(k);
+    return null;
+  }
+  return e.data;
+}
+function cacheSet(k: string, v: Meta) {
+  if (cache.size >= CACHE_MAX) {
+    const first = cache.keys().next().value;
+    if (first) cache.delete(first);
+  }
+  cache.set(k, { data: v, expires: Date.now() + CACHE_TTL_MS });
+}
+
+/** 사설망 / loopback / link-local IP 호스트 차단. DNS resolve 까지 하면 좋지만 일단
+ *  hostname 문자열 기반 차단으로도 흔한 SSRF 시도는 막힘. */
+function isBlockedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h === "metadata.google.internal") return true; // GCP IMDS
+  if (h === "169.254.169.254") return true; // AWS IMDS v1/v2
+  if (/^127\./.test(h)) return true;
+  if (/^10\./.test(h)) return true;
+  if (/^192\.168\./.test(h)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
+  if (h === "::1" || h.startsWith("[::1]")) return true;
+  if (/^fc[0-9a-f]{2}:/.test(h) || /^fd[0-9a-f]{2}:/.test(h)) return true; // ULA
+  return false;
+}
+
+const META_RE = /<meta[^>]+>/gi;
+const TITLE_RE = /<title[^>]*>([^<]+)<\/title>/i;
+const LINK_RE = /<link[^>]+>/gi;
+const ATTR_RE = /(\w+(?::\w+)?)=["']([^"']*)["']/g;
+
+function parseAttrs(tag: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  let m: RegExpExecArray | null;
+  ATTR_RE.lastIndex = 0;
+  while ((m = ATTR_RE.exec(tag)) !== null) {
+    out[m[1].toLowerCase()] = m[2];
+  }
+  return out;
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+function extractMeta(html: string, base: URL): Meta {
+  const meta: Meta = { url: base.toString() };
+  // <meta property="..." content="..."> / <meta name="..." content="...">
+  const tags: { prop: string; content: string }[] = [];
+  let m: RegExpExecArray | null;
+  META_RE.lastIndex = 0;
+  while ((m = META_RE.exec(html)) !== null) {
+    const a = parseAttrs(m[0]);
+    const prop = (a.property || a.name || "").toLowerCase();
+    const content = a.content;
+    if (prop && content) tags.push({ prop, content });
+  }
+  const find = (...keys: string[]) =>
+    tags.find((t) => keys.includes(t.prop))?.content;
+
+  meta.title = find("og:title", "twitter:title");
+  meta.description = find("og:description", "twitter:description", "description");
+  const image = find("og:image", "og:image:url", "twitter:image", "twitter:image:src");
+  if (image) {
+    try {
+      meta.image = new URL(image, base).toString();
+    } catch {}
+  }
+  meta.siteName = find("og:site_name", "application-name");
+
+  // <title> fallback
+  if (!meta.title) {
+    const t = TITLE_RE.exec(html);
+    if (t) meta.title = decodeEntities(t[1].trim());
+  }
+  if (meta.title) meta.title = decodeEntities(meta.title);
+  if (meta.description) meta.description = decodeEntities(meta.description);
+
+  // favicon — <link rel="icon" href="..."> 우선, 없으면 /favicon.ico.
+  let faviconHref: string | undefined;
+  LINK_RE.lastIndex = 0;
+  while ((m = LINK_RE.exec(html)) !== null) {
+    const a = parseAttrs(m[0]);
+    const rel = (a.rel || "").toLowerCase();
+    if (rel.includes("icon") && a.href) {
+      faviconHref = a.href;
+      break;
+    }
+  }
+  try {
+    meta.favicon = new URL(faviconHref || "/favicon.ico", base).toString();
+  } catch {}
+
+  // 너무 긴 값은 잘라서 응답 부풀지 않게.
+  if (meta.title && meta.title.length > 200) meta.title = meta.title.slice(0, 200);
+  if (meta.description && meta.description.length > 400)
+    meta.description = meta.description.slice(0, 400);
+
+  return meta;
+}
+
+router.post("/", async (req, res) => {
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid url" });
+  let url: URL;
+  try {
+    url = new URL(parsed.data.url);
+  } catch {
+    return res.status(400).json({ error: "invalid url" });
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return res.status(400).json({ error: "http(s) only" });
+  }
+  if (isBlockedHost(url.hostname)) {
+    return res.status(400).json({ error: "host not allowed" });
+  }
+
+  const cached = cacheGet(url.toString());
+  if (cached) return res.json(cached);
+
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), 5000);
+  try {
+    const r = await fetch(url.toString(), {
+      signal: ac.signal,
+      redirect: "follow",
+      headers: {
+        // 일부 사이트(GitHub, X)는 user-agent 가 비면 차단/404. 일반 브라우저 처럼 위장.
+        "user-agent": "Mozilla/5.0 (compatible; HiNestBot/1.0; +unfurl)",
+        accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      },
+    });
+    if (!r.ok) {
+      return res.status(200).json({ url: url.toString() });
+    }
+    const ct = (r.headers.get("content-type") || "").toLowerCase();
+    if (!ct.includes("text/html") && !ct.includes("xml")) {
+      // HTML 이 아니면 메타 추출 의미 없음 → URL 만 반환.
+      return res.status(200).json({ url: url.toString() });
+    }
+    // 1MB 까지만 읽기 — 큰 페이지에서 무한 다운로드 방지.
+    const buf = await r.arrayBuffer();
+    const limited = buf.byteLength > 1_000_000 ? buf.slice(0, 1_000_000) : buf;
+    const html = new TextDecoder("utf-8", { fatal: false }).decode(limited);
+    const meta = extractMeta(html, new URL(r.url));
+    cacheSet(url.toString(), meta);
+    res.json(meta);
+  } catch (e: any) {
+    if (e?.name === "AbortError") {
+      return res.status(504).json({ error: "fetch timeout", url: url.toString() });
+    }
+    res.status(200).json({ url: url.toString() });
+  } finally {
+    clearTimeout(t);
+  }
+});
+
+export default router;


### PR DESCRIPTION
## 증상
**URL 링크 프리뷰 (OG / Twitter Card unfurl)**

새 기능을 추가합니다.

## 원인
[서버]
- server/src/routes/unfurl.ts (신규) — POST /api/unfurl { url }
  · 인증 필수 (requireAuth) — SSRF 우회 방지.
  · http(s) 만 허용 + 사설망/loopback/link-local IP/AWS·GCP 메타데이터 호스트 차단.
  · 5초 타임아웃, 응답 1MB 상한, redirect follow.
  · <meta property|name=og:* twitter:* description> + <title> + <link rel=icon>
    파싱해 { url, title, description, image, siteName, favicon } 반환.
  · 인메모리 LRU 30분 캐시 (max 500).

[클라]
- client/src/components/chat/LinkPreview.tsx (신규)
  · 메시지 본문 첫 URL 만 카드로 노출.
  · sessionStorage 메모 + 서버 LRU → 같은 URL 재요청 0회.
  · siteName + favicon / title (2줄 클램프) / description (2줄 클램프) /
    image (88px 정사각 썸네일).
  · mine(파란 버블) / 상대 버블에 맞춰 보더·배경 톤 분기.
- MessageBubble TextBubble: 코드 segment 떼고 남은 텍스트 첫 URL 한 개만 LinkPreview 로.

## 수정
**작업 항목 (커밋 단위)**
- feat(chat): URL 링크 프리뷰 (OG/Twitter Card unfurl)

**변경 대상 (4개 파일)**
- `client/src/components/chat/LinkPreview.tsx`
- `client/src/components/chat/MessageBubble.tsx`
- `server/src/index.ts`
- `server/src/routes/unfurl.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #59** ↔ **이슈 #481** 로 연결됩니다.

Closes #481
