### PR TITLE
🔀 :: (#482) 스니펫 라이브러리 + 채팅 슬래시 자동완성

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ import {
   MeetingsPage,
   MeetingDetailPage,
   ServiceAccountsPage,
+  SnippetsPage,
   AdminPage,
   SuperAdminPage,
 } from "./routes";
@@ -97,6 +98,7 @@ export default function App() {
           <Route path="meetings" element={<MeetingsPage />} />
           <Route path="meetings/:id" element={<MeetingDetailPage />} />
           <Route path="accounts" element={<ServiceAccountsPage />} />
+          <Route path="snippets" element={<SnippetsPage />} />
           <Route
             path="admin"
             element={

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -49,6 +49,7 @@ const RESOURCE_NAV: NavItem[] = [
   { to: "/documents", label: "문서함", icon: DocsIcon },
   { to: "/expense", label: "법인카드", icon: CardIcon },
   { to: "/accounts", label: "계정 관리", icon: KeyIcon },
+  { to: "/snippets", label: "스니펫", icon: SnippetIcon },
 ];
 
 export default function AppLayout() {
@@ -496,6 +497,7 @@ const BREADCRUMB: Record<string, string> = {
   "/org": "조직도",
   "/documents": "문서함",
   "/accounts": "계정 관리",
+  "/snippets": "스니펫",
   "/approvals": "전자결재",
   "/expense": "법인카드",
   "/admin": "관리자",
@@ -601,6 +603,7 @@ function DocsIcon({ active }: I) { return svgBase(!!active, <><path d="M14 2H6a2
 function ApprovalIcon({ active }: I) { return svgBase(!!active, <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /><path d="m9 14 2 2 4-4" /></>); }
 function CardIcon({ active }: I) { return svgBase(!!active, <><rect x="3" y="6" width="18" height="13" rx="2" /><path d="M3 11h18M7 16h4" /></>); }
 function KeyIcon({ active }: I) { return svgBase(!!active, <><circle cx="7.5" cy="15.5" r="4.5" /><path d="m10.5 12.5 10-10M17 7l3 3M15.5 8.5l3 3" /></>); }
+function SnippetIcon({ active }: I) { return svgBase(!!active, <><path d="m8 3-4 4 4 4M16 3l4 4-4 4" /><path d="M14 4 10 20" /></>); }
 function ShieldIcon({ active }: I) { return svgBase(!!active, <><path d="M12 3 4 6v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V6z" /><path d="m9 12 2 2 4-4" /></>); }
 function CrownIcon({ active }: I) { return svgBase(!!active, <><path d="M3 18h18" /><path d="M3 8l4 5 5-8 5 8 4-5v10H3z" /></>); }
 const _unused_swInv = swInv;

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth";
 import { useNotifications } from "../notifications";
 import { resolvePresence } from "../lib/presence";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
+import { SnippetSlashMenu, type SnippetSlashHandle } from "./chat/SnippetSlashMenu";
 import {
   C,
   FONT,
@@ -1460,6 +1461,7 @@ function RoomView({
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const slashRef = useRef<SnippetSlashHandle | null>(null);
   const [reactingId, setReactingId] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const prevCountRef = useRef(0);
@@ -1896,8 +1898,28 @@ function RoomView({
               padding: "10px 14px 14px",
               background: C.surface,
               display: "flex", alignItems: "flex-end", gap: 8,
+              position: "relative",
             }}
           >
+            <SnippetSlashMenu
+              textareaRef={textareaRef}
+              value={input}
+              onReplace={(start, end, replacement) => {
+                const next = input.slice(0, start) + replacement + input.slice(end);
+                setInput(next);
+                // 치환 후 커서를 삽입 끝으로 이동 + 높이 자동 조정.
+                requestAnimationFrame(() => {
+                  const ta = textareaRef.current;
+                  if (!ta) return;
+                  const pos = start + replacement.length;
+                  ta.focus();
+                  ta.setSelectionRange(pos, pos);
+                  ta.style.height = "auto";
+                  ta.style.height = Math.min(ta.scrollHeight, 92) + "px";
+                });
+              }}
+              innerRef={slashRef}
+            />
             <div
               style={{
                 flex: 1, minWidth: 0,
@@ -1919,6 +1941,8 @@ function RoomView({
                   el.style.height = Math.min(el.scrollHeight, 92) + "px";
                 }}
                 onKeyDown={(e) => {
+                  // 슬래시 자동완성 메뉴가 열려있으면 ↑↓/Enter/Esc/Tab 을 그쪽이 먼저 소비.
+                  if (slashRef.current?.handleKey(e)) return;
                   if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
                     e.preventDefault();
                     onSend();

--- a/client/src/components/chat/SnippetSlashMenu.tsx
+++ b/client/src/components/chat/SnippetSlashMenu.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../../api";
+import { LangIcon } from "../../lib/langIcon";
+
+/**
+ * 채팅 입력창의 슬래시 자동완성.
+ *
+ * 사용법: 부모 컴포넌트가 textareaRef·value·setValue 를 넘기면 이 컴포넌트가
+ *   - 커서 직전 토큰이 /\w* 패턴이면 메뉴 노출
+ *   - 화살표/Enter/Esc 처리(onKeyDown 가드 함수 노출)
+ *   - 선택 시 /토큰 을 스니펫 body 로 치환 + 사용 +1
+ *
+ * 부모는 textarea 의 onKeyDown 첫 줄에서 menuRef.current?.handleKey(e) 호출.
+ *   handleKey 가 true 를 반환하면 부모는 Enter→send 로 진행하지 않음.
+ */
+
+type Item = {
+  id: string;
+  trigger: string;
+  title: string;
+  body: string;
+  lang: string;
+  scope: "PRIVATE" | "ALL";
+  uses: number;
+};
+
+export type SnippetSlashHandle = {
+  /** textarea onKeyDown 에서 호출. 메뉴가 키를 소비했으면 true 반환 → 부모는 send 등 후속 처리 중단. */
+  handleKey: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean;
+};
+
+/** 커서 직전이 / 로 시작하는 토큰인지 검사. ` /tail` 또는 줄 시작의 `/` 만 인정. */
+function detectSlashToken(value: string, cursor: number): { start: number; end: number; query: string } | null {
+  // 커서 위치에서 뒤로 올라가며 공백/줄바꿈을 만날 때까지 토큰 수집.
+  let s = cursor;
+  while (s > 0 && !/\s/.test(value[s - 1])) s--;
+  const token = value.slice(s, cursor);
+  if (!token.startsWith("/")) return null;
+  // / 만 있거나 / 뒤에 영문/숫자/한글/하이픈만 있을 때 매치 (공백 등 다른 문자 들어가면 즉시 종료).
+  if (!/^\/[\w\-가-힣]*$/.test(token)) return null;
+  return { start: s, end: cursor, query: token.slice(1) };
+}
+
+export function SnippetSlashMenu({
+  textareaRef,
+  value,
+  onReplace,
+  innerRef,
+}: {
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  value: string;
+  /** start..end 구간을 replacement 로 치환. */
+  onReplace: (start: number, end: number, replacement: string) => void;
+  innerRef: React.MutableRefObject<SnippetSlashHandle | null>;
+}) {
+  const [items, setItems] = useState<Item[]>([]);
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(0);
+  const [token, setToken] = useState<{ start: number; end: number; query: string } | null>(null);
+  const fetchSeq = useRef(0);
+
+  // 커서 변경/value 변경 시 토큰 재계산.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    function update() {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      const detected = detectSlashToken(value, ta.selectionStart ?? 0);
+      setToken(detected);
+      if (!detected) {
+        setOpen(false);
+        setItems([]);
+      }
+    }
+    update();
+    ta.addEventListener("keyup", update);
+    ta.addEventListener("click", update);
+    return () => {
+      ta.removeEventListener("keyup", update);
+      ta.removeEventListener("click", update);
+    };
+  }, [textareaRef, value]);
+
+  // 토큰 변경 시 fetch.
+  useEffect(() => {
+    if (!token) return;
+    const seq = ++fetchSeq.current;
+    api<{ items: Item[] }>(`/api/snippet/search?q=${encodeURIComponent(token.query)}&limit=8`)
+      .then((r) => {
+        if (seq !== fetchSeq.current) return; // 결과 도착 전 다른 쿼리로 바뀌었으면 무시
+        setItems(r.items ?? []);
+        setOpen((r.items ?? []).length > 0);
+        setActive(0);
+      })
+      .catch(() => {});
+  }, [token?.query]);
+
+  // 키 가드 — 메뉴가 열려있을 때 위/아래/Enter/Tab/Esc 가로채기.
+  innerRef.current = {
+    handleKey: (e) => {
+      if (!open || items.length === 0 || !token) return false;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActive((a) => (a + 1) % items.length);
+        return true;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActive((a) => (a - 1 + items.length) % items.length);
+        return true;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        return true;
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        select(items[active]);
+        return true;
+      }
+      return false;
+    },
+  };
+
+  function select(it: Item) {
+    if (!token) return;
+    onReplace(token.start, token.end, it.body);
+    setOpen(false);
+    setItems([]);
+    // 사용 +1 — 실패해도 무음 (인기 정렬 가중치일 뿐).
+    api(`/api/snippet/${it.id}/use`, { method: "POST" }).catch(() => {});
+  }
+
+  if (!open || items.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 12,
+        right: 12,
+        bottom: "100%",
+        marginBottom: 6,
+        background: "var(--c-surface)",
+        border: "1px solid var(--c-border)",
+        borderRadius: 12,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+        maxHeight: 240,
+        overflowY: "auto",
+        zIndex: 10,
+      }}
+      onMouseDown={(e) => e.preventDefault()} // 클릭 시 textarea 포커스 유지
+    >
+      <div
+        style={{
+          padding: "6px 10px",
+          fontSize: 10.5,
+          fontWeight: 700,
+          letterSpacing: "0.06em",
+          textTransform: "uppercase",
+          color: "var(--c-text-3)",
+          borderBottom: "1px solid var(--c-border)",
+        }}
+      >
+        스니펫{token?.query ? ` · /${token.query}` : ""}
+      </div>
+      {items.map((it, i) => (
+        <button
+          key={it.id}
+          type="button"
+          onClick={() => select(it)}
+          onMouseEnter={() => setActive(i)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            width: "100%",
+            padding: "8px 10px",
+            background: i === active ? "var(--c-surface-2)" : "transparent",
+            border: "none",
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+              fontSize: 11.5,
+              fontWeight: 700,
+              padding: "2px 6px",
+              borderRadius: 4,
+              background: "var(--c-surface-3)",
+              color: "var(--c-text)",
+              flexShrink: 0,
+            }}
+          >
+            /{it.trigger}
+          </span>
+          <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontSize: 13, fontWeight: 600, color: "var(--c-text)" }}>
+            {it.title}
+          </span>
+          {it.lang && (
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 3, fontSize: 10.5, color: "var(--c-text-3)", flexShrink: 0 }}>
+              <LangIcon lang={it.lang} size={11} />
+              {it.lang}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/SnippetsPage.tsx
+++ b/client/src/pages/SnippetsPage.tsx
@@ -1,0 +1,382 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { api } from "../api";
+import { useAuth } from "../auth";
+import PageHeader from "../components/PageHeader";
+import { confirmAsync, alertAsync } from "../components/ConfirmHost";
+import { useModalDismiss } from "../lib/useModalDismiss";
+import { copyToClipboard } from "../lib/clipboard";
+import { highlightCode } from "../lib/syntaxHighlight";
+import { LangIcon } from "../lib/langIcon";
+
+/**
+ * 스니펫 라이브러리 — 자주 쓰는 명령/쿼리/코드 조각을 저장 + 채팅 입력창의 슬래시
+ * 자동완성으로 호출.
+ *
+ * 정렬: 최근 수정 순. 검색은 trigger / title / body 부분 매치.
+ * scope: PRIVATE(나만) / ALL(전사). 수정·삭제는 본인만.
+ */
+
+type Snippet = {
+  id: string;
+  ownerId: string;
+  trigger: string;
+  title: string;
+  body: string;
+  lang: string;
+  scope: "PRIVATE" | "ALL";
+  uses: number;
+  createdAt: string;
+  updatedAt: string;
+  owner?: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
+};
+
+type FormState = {
+  trigger: string;
+  title: string;
+  body: string;
+  lang: string;
+  scope: "PRIVATE" | "ALL";
+};
+
+const EMPTY_FORM: FormState = { trigger: "", title: "", body: "", lang: "", scope: "PRIVATE" };
+
+export default function SnippetsPage() {
+  const { user } = useAuth();
+  const [list, setList] = useState<Snippet[]>([]);
+  const [q, setQ] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [editing, setEditing] = useState<Snippet | null>(null);
+  const [creating, setCreating] = useState(false);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => { aliveRef.current = false; };
+  }, []);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const r = await api<{ snippets: Snippet[] }>(`/api/snippet?q=${encodeURIComponent(q)}`);
+      if (!aliveRef.current) return;
+      setList(r.snippets);
+    } catch {
+      // 무음
+    } finally {
+      if (aliveRef.current) setLoading(false);
+    }
+  }
+
+  // 검색어 디바운스 — 빠르게 타이핑할 때 매 키마다 GET 안 치도록.
+  useEffect(() => {
+    const t = setTimeout(load, q ? 200 : 0);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [q]);
+
+  const mineCount = useMemo(() => list.filter((s) => s.ownerId === user?.id).length, [list, user?.id]);
+  const sharedCount = list.length - mineCount;
+
+  return (
+    <div>
+      <PageHeader
+        eyebrow="라이브러리"
+        title="스니펫"
+        description="자주 쓰는 명령·쿼리·코드 조각을 저장하고 채팅에서 / 로 호출하세요."
+        right={
+          <button className="btn-primary" onClick={() => setCreating(true)}>
+            + 새 스니펫
+          </button>
+        }
+      />
+
+      <div className="flex items-center gap-3 mb-3 flex-wrap">
+        <input
+          className="input flex-1 min-w-[200px]"
+          placeholder="trigger / 제목 / 본문 검색"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <div className="text-[12px] text-ink-500">
+          내 것 <b className="text-ink-800">{mineCount}</b> · 전사 공유 <b className="text-ink-800">{sharedCount}</b>
+        </div>
+      </div>
+
+      {loading && list.length === 0 ? (
+        <div className="panel p-8 text-center text-ink-500 text-[13px]">불러오는 중…</div>
+      ) : list.length === 0 ? (
+        <div className="panel p-12 text-center text-ink-500">
+          <div className="text-[14px] font-semibold">{q ? "검색 결과가 없어요" : "아직 스니펫이 없어요"}</div>
+          <div className="text-[12px] mt-1">"+ 새 스니펫" 으로 자주 쓰는 조각을 등록해 보세요.</div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {list.map((s) => (
+            <SnippetCard
+              key={s.id}
+              s={s}
+              isMine={s.ownerId === user?.id}
+              onEdit={() => setEditing(s)}
+              onDelete={async () => {
+                const ok = await confirmAsync({
+                  title: "스니펫 삭제",
+                  description: `"${s.title}" 을 삭제할까요? 되돌릴 수 없어요.`,
+                  tone: "danger",
+                });
+                if (!ok) return;
+                try {
+                  await api(`/api/snippet/${s.id}`, { method: "DELETE" });
+                  if (aliveRef.current) setList((arr) => arr.filter((x) => x.id !== s.id));
+                } catch (e: any) {
+                  alertAsync({ title: "삭제 실패", description: e?.message ?? "다시 시도해 주세요" });
+                }
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {(creating || editing) && (
+        <SnippetEditor
+          initial={editing ?? EMPTY_FORM}
+          onClose={() => { setCreating(false); setEditing(null); }}
+          onSaved={(saved) => {
+            if (!aliveRef.current) return;
+            if (editing) {
+              setList((arr) => arr.map((x) => (x.id === saved.id ? saved : x)));
+            } else {
+              setList((arr) => [saved, ...arr]);
+            }
+            setCreating(false);
+            setEditing(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function SnippetCard({ s, isMine, onEdit, onDelete }: { s: Snippet; isMine: boolean; onEdit: () => void; onDelete: () => void }) {
+  const [expanded, setExpanded] = useState(false);
+  const isLong = s.body.length > 200 || s.body.split("\n").length > 6;
+  const html = highlightCode(s.body, s.lang || undefined);
+  return (
+    <div className="panel p-4 flex flex-col gap-2.5">
+      <div className="flex items-start gap-2 min-w-0">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className="font-mono text-[11.5px] font-bold px-2 py-0.5 rounded-md"
+              style={{ background: "var(--c-surface-3)", color: "var(--c-text)" }}
+            >
+              /{s.trigger}
+            </span>
+            {s.lang && (
+              <span className="inline-flex items-center gap-1 text-[10.5px] font-bold uppercase tracking-[0.06em] text-ink-500">
+                <LangIcon lang={s.lang} size={11} />
+                {s.lang}
+              </span>
+            )}
+            {s.scope === "ALL" ? (
+              <span className="chip chip-blue">전사</span>
+            ) : (
+              <span className="chip chip-gray">개인</span>
+            )}
+            <span className="text-[10.5px] text-ink-400 ml-auto">사용 {s.uses}회</span>
+          </div>
+          <div className="font-bold text-[14px] text-ink-900 mt-1.5 break-words">{s.title}</div>
+        </div>
+      </div>
+      <div
+        className="code-block"
+        style={{
+          borderRadius: 8,
+          background: "#1B1F27",
+          border: "1px solid rgba(255,255,255,0.10)",
+          overflow: "hidden",
+        }}
+      >
+        <pre
+          style={{
+            margin: 0,
+            padding: "8px 10px",
+            fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+            fontSize: 12,
+            lineHeight: 1.5,
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            maxHeight: expanded ? "60vh" : 140,
+            overflowY: "auto",
+          }}
+        >
+          <code className="hljs" dangerouslySetInnerHTML={{ __html: html }} />
+        </pre>
+        {isLong && (
+          <button
+            type="button"
+            onClick={() => setExpanded((x) => !x)}
+            style={{
+              width: "100%",
+              padding: "5px 8px",
+              fontSize: 11,
+              fontWeight: 700,
+              color: "rgba(255,255,255,0.85)",
+              background: "transparent",
+              border: "none",
+              borderTop: "1px solid rgba(255,255,255,0.10)",
+              cursor: "pointer",
+            }}
+          >
+            {expanded ? "접기" : "펼치기"}
+          </button>
+        )}
+      </div>
+      <div className="flex items-center gap-1.5">
+        <button
+          className="btn-ghost btn-xs"
+          onClick={() =>
+            copyToClipboard(s.body, { title: "복사됨", description: "본문을 클립보드에 복사했어요." })
+          }
+        >
+          복사
+        </button>
+        {isMine && (
+          <>
+            <button className="btn-ghost btn-xs" onClick={onEdit}>수정</button>
+            <button className="btn-ghost btn-xs text-red-600" onClick={onDelete}>삭제</button>
+          </>
+        )}
+        <span className="ml-auto text-[10.5px] text-ink-400">
+          {s.owner?.name ?? "—"} · {new Date(s.updatedAt).toLocaleDateString("ko-KR")}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SnippetEditor({
+  initial,
+  onClose,
+  onSaved,
+}: {
+  initial: Snippet | FormState;
+  onClose: () => void;
+  onSaved: (s: Snippet) => void;
+}) {
+  const isEdit = "id" in initial;
+  const [form, setForm] = useState<FormState>({
+    trigger: initial.trigger,
+    title: initial.title,
+    body: initial.body,
+    lang: initial.lang,
+    scope: initial.scope,
+  });
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState("");
+  useModalDismiss(true, () => { if (!saving) onClose(); });
+
+  async function save() {
+    if (saving) return;
+    setSaving(true);
+    setErr("");
+    try {
+      const url = isEdit ? `/api/snippet/${(initial as Snippet).id}` : "/api/snippet";
+      const r = await api<{ snippet: Snippet }>(url, {
+        method: isEdit ? "PATCH" : "POST",
+        json: form,
+      });
+      onSaved(r.snippet);
+    } catch (e: any) {
+      setErr(e?.message ?? "저장에 실패했어요");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center p-4"
+      style={{ background: "rgba(0,0,0,0.5)" }}
+      onClick={() => { if (!saving) onClose(); }}
+    >
+      <div
+        className="panel p-5 w-full max-w-[640px] max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-lg font-bold mb-3">{isEdit ? "스니펫 수정" : "새 스니펫"}</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-3">
+          <div>
+            <label className="field-label">trigger (단축 호출 키)</label>
+            <input
+              className="input"
+              value={form.trigger}
+              onChange={(e) => setForm({ ...form, trigger: e.target.value })}
+              placeholder="예: tail-log"
+              maxLength={40}
+              required
+            />
+            <div className="text-[11px] text-ink-500 mt-1">채팅에서 / + 이 값 으로 자동완성에서 호출</div>
+          </div>
+          <div>
+            <label className="field-label">언어 (선택)</label>
+            <input
+              className="input"
+              value={form.lang}
+              onChange={(e) => setForm({ ...form, lang: e.target.value })}
+              placeholder="예: bash, sql, swift"
+              maxLength={40}
+            />
+          </div>
+        </div>
+        <div className="mb-3">
+          <label className="field-label">제목</label>
+          <input
+            className="input"
+            value={form.title}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            maxLength={200}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="field-label">본문</label>
+          <textarea
+            className="input font-mono"
+            value={form.body}
+            onChange={(e) => setForm({ ...form, body: e.target.value })}
+            rows={10}
+            maxLength={20_000}
+            placeholder="자주 쓰는 명령/쿼리/코드 조각을 입력"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="field-label">공개 범위</label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className={`btn-ghost ${form.scope === "PRIVATE" ? "!bg-brand-50 !text-brand-700" : ""}`}
+              onClick={() => setForm({ ...form, scope: "PRIVATE" })}
+            >
+              개인
+            </button>
+            <button
+              type="button"
+              className={`btn-ghost ${form.scope === "ALL" ? "!bg-brand-50 !text-brand-700" : ""}`}
+              onClick={() => setForm({ ...form, scope: "ALL" })}
+            >
+              전사 공유
+            </button>
+          </div>
+        </div>
+        {err && <div className="text-[12px] font-semibold text-red-600 mb-2">{err}</div>}
+        <div className="flex justify-end gap-2">
+          <button className="btn-ghost" onClick={onClose} disabled={saving}>취소</button>
+          <button className="btn-primary" onClick={save} disabled={saving}>
+            {saving ? "저장 중…" : "저장"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -22,6 +22,7 @@ export const loadProject = () => import("./pages/ProjectPage");
 export const loadMeetings = () => import("./pages/MeetingsPage");
 export const loadMeetingDetail = () => import("./pages/MeetingDetailPage");
 export const loadAccounts = () => import("./pages/ServiceAccountsPage");
+export const loadSnippets = () => import("./pages/SnippetsPage");
 export const loadAdmin = () => import("./pages/AdminPage");
 export const loadSuperAdmin = () => import("./pages/SuperAdminPage");
 
@@ -39,6 +40,7 @@ export const ProjectPage = lazy(loadProject);
 export const MeetingsPage = lazy(loadMeetings);
 export const MeetingDetailPage = lazy(loadMeetingDetail);
 export const ServiceAccountsPage = lazy(loadAccounts);
+export const SnippetsPage = lazy(loadSnippets);
 export const AdminPage = lazy(loadAdmin);
 export const SuperAdminPage = lazy(loadSuperAdmin);
 
@@ -58,4 +60,5 @@ export const ROUTE_PREFETCH: Record<string, () => Promise<unknown>> = {
   "/super-admin": loadSuperAdmin,
   "/meetings": loadMeetings,
   "/accounts": loadAccounts,
+  "/snippets": loadSnippets,
 };

--- a/server/prisma/migrations/20260427000000_snippets/migration.sql
+++ b/server/prisma/migrations/20260427000000_snippets/migration.sql
@@ -1,0 +1,21 @@
+-- 스니펫 라이브러리 — 자주 쓰는 텍스트/코드 조각.
+CREATE TABLE "Snippet" (
+  "id" TEXT NOT NULL,
+  "ownerId" TEXT NOT NULL,
+  "trigger" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "body" TEXT NOT NULL,
+  "lang" TEXT NOT NULL DEFAULT '',
+  "scope" TEXT NOT NULL DEFAULT 'PRIVATE',
+  "uses" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "Snippet_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Snippet_ownerId_updatedAt_idx" ON "Snippet"("ownerId", "updatedAt");
+CREATE INDEX "Snippet_scope_updatedAt_idx" ON "Snippet"("scope", "updatedAt");
+CREATE INDEX "Snippet_trigger_idx" ON "Snippet"("trigger");
+
+ALTER TABLE "Snippet" ADD CONSTRAINT "Snippet_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -90,6 +90,7 @@ model User {
   folderShareLinksCreated FolderShareLink[]      @relation("FolderShareLinkCreator")
   serviceAccountsOwned    ServiceAccount[]       @relation("ServiceAccountOwner")
   serviceAccountsCreated  ServiceAccount[]       @relation("ServiceAccountCreator")
+  snippets                Snippet[]              @relation("SnippetOwner")
 }
 
 /// 팀/프로젝트 — 사이드바 "팀" 카테고리 아래에 자신이 참여중인 프로젝트가 표시됨.
@@ -845,4 +846,30 @@ model ServiceAccount {
   @@index([ownerUserId])
   @@index([scope, scopeTeam])
   @@index([projectId])
+}
+
+/// 스니펫 라이브러리 — 자주 쓰는 명령/쿼리/regex 등을 저장. 채팅 입력창의 슬래시 자동완성으로 호출.
+/// scope 는 다른 리소스와 동일 패턴: PRIVATE(나만) | ALL(전사). 팀/프로젝트 범위는 후속에서 확장 가능.
+model Snippet {
+  id        String   @id @default(cuid())
+  ownerId   String
+  owner     User     @relation("SnippetOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  /// 호출용 짧은 키워드 — 예: "tail-log", "rebase-main". 영문/한글/숫자/하이픈 허용.
+  trigger   String
+  /// 사람이 보는 제목 — 검색·리스트 정렬에 사용.
+  title     String
+  /// 본문 — 채팅 입력창에 그대로 삽입될 텍스트. 코드 펜스 직접 포함 가능.
+  body      String
+  /// 코드 언어 태그(syntaxHighlight 매핑용). 빈 문자열이면 텍스트로 취급.
+  lang      String   @default("")
+  /// 공유 범위 — 우선 PRIVATE / ALL 두 단계만. (TEAM/PROJECT 는 후속.)
+  scope     String   @default("PRIVATE")
+  /// 사용 횟수 — 정렬·인기 표시에 사용. 사용 시 +1.
+  uses      Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([ownerId, updatedAt])
+  @@index([scope, updatedAt])
+  @@index([trigger])
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import webhookRouter from "./routes/webhook.js";
 import meetingRouter from "./routes/meeting.js";
 import pinRouter from "./routes/pin.js";
 import unfurlRouter from "./routes/unfurl.js";
+import snippetRouter from "./routes/snippet.js";
 import { shareLinkAuthedRouter, shareLinkPublicRouter } from "./routes/shareLink.js";
 import { folderShareLinkAuthedRouter } from "./routes/folderShareLink.js";
 import serviceAccountRouter from "./routes/serviceAccount.js";
@@ -185,6 +186,7 @@ app.use("/api/project", projectRouter);
 app.use("/api/meeting", meetingRouter);
 app.use("/api/pins", pinRouter);
 app.use("/api/unfurl", unfurlRouter);
+app.use("/api/snippet", snippetRouter);
 app.use("/api/service-accounts", serviceAccountRouter);
 // 공유 링크 — 생성/관리는 인증 필요, 실제 외부 다운로드는 인증 없이.
 app.use("/api/share-links", shareLinkAuthedRouter);

--- a/server/src/routes/snippet.ts
+++ b/server/src/routes/snippet.ts
@@ -1,0 +1,134 @@
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../lib/db.js";
+import { requireAuth } from "../lib/auth.js";
+
+/**
+ * 스니펫 라이브러리 CRUD.
+ *
+ * scope 모델:
+ *  - PRIVATE: 본인만 조회/수정
+ *  - ALL    : 전사 조회 가능, 수정/삭제는 본인만
+ */
+
+const router = Router();
+router.use(requireAuth);
+
+const upsertSchema = z.object({
+  trigger: z.string().min(1).max(40).regex(/^[\w\-가-힣]+$/, "영문/숫자/하이픈/한글만"),
+  title: z.string().min(1).max(200),
+  body: z.string().min(1).max(20_000),
+  lang: z.string().max(40).optional().default(""),
+  scope: z.enum(["PRIVATE", "ALL"]).optional().default("PRIVATE"),
+});
+
+/** 본인 + 전사 공개 모두 — 검색·정렬 옵션. */
+router.get("/", async (req, res) => {
+  const u = (req as any).user;
+  const q = String(req.query.q ?? "").trim().toLowerCase();
+  const where: any = {
+    OR: [{ ownerId: u.id }, { scope: "ALL" }],
+  };
+  if (q) {
+    where.AND = [
+      {
+        OR: [
+          { title: { contains: q, mode: "insensitive" } },
+          { trigger: { contains: q, mode: "insensitive" } },
+          { body: { contains: q, mode: "insensitive" } },
+        ],
+      },
+    ];
+  }
+  const snippets = await prisma.snippet.findMany({
+    where,
+    orderBy: [{ updatedAt: "desc" }],
+    take: 200,
+    include: { owner: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+  });
+  res.json({ snippets });
+});
+
+/** 슬래시 자동완성용 — 매우 가벼운 응답. trigger prefix 우선 매치, 그 다음 title. */
+router.get("/search", async (req, res) => {
+  const u = (req as any).user;
+  const q = String(req.query.q ?? "").trim().toLowerCase();
+  const limit = Math.min(20, Math.max(1, parseInt(String(req.query.limit ?? 10), 10) || 10));
+  if (!q) {
+    // 빈 쿼리면 가장 최근/사용 빈도 순.
+    const items = await prisma.snippet.findMany({
+      where: { OR: [{ ownerId: u.id }, { scope: "ALL" }] },
+      orderBy: [{ uses: "desc" }, { updatedAt: "desc" }],
+      take: limit,
+      select: { id: true, trigger: true, title: true, body: true, lang: true, scope: true, uses: true },
+    });
+    return res.json({ items });
+  }
+  const items = await prisma.snippet.findMany({
+    where: {
+      AND: [
+        { OR: [{ ownerId: u.id }, { scope: "ALL" }] },
+        {
+          OR: [
+            { trigger: { contains: q, mode: "insensitive" } },
+            { title: { contains: q, mode: "insensitive" } },
+          ],
+        },
+      ],
+    },
+    orderBy: [{ uses: "desc" }, { updatedAt: "desc" }],
+    take: limit,
+    select: { id: true, trigger: true, title: true, body: true, lang: true, scope: true, uses: true },
+  });
+  res.json({ items });
+});
+
+router.post("/", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = upsertSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const snippet = await prisma.snippet.create({
+    data: { ...parsed.data, ownerId: u.id },
+  });
+  res.json({ snippet });
+});
+
+router.patch("/:id", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = upsertSchema.partial().safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const exist = await prisma.snippet.findUnique({ where: { id: req.params.id } });
+  if (!exist) return res.status(404).json({ error: "not found" });
+  if (exist.ownerId !== u.id) return res.status(403).json({ error: "forbidden" });
+  const snippet = await prisma.snippet.update({
+    where: { id: req.params.id },
+    data: parsed.data,
+  });
+  res.json({ snippet });
+});
+
+router.delete("/:id", async (req, res) => {
+  const u = (req as any).user;
+  const exist = await prisma.snippet.findUnique({ where: { id: req.params.id } });
+  if (!exist) return res.status(404).json({ error: "not found" });
+  if (exist.ownerId !== u.id) return res.status(403).json({ error: "forbidden" });
+  await prisma.snippet.delete({ where: { id: req.params.id } });
+  res.json({ ok: true });
+});
+
+/** 사용 횟수 + 1 — 자동완성에서 삽입할 때 호출. 인기 정렬 가중치. */
+router.post("/:id/use", async (req, res) => {
+  const u = (req as any).user;
+  const exist = await prisma.snippet.findUnique({ where: { id: req.params.id } });
+  if (!exist) return res.status(404).json({ error: "not found" });
+  if (exist.ownerId !== u.id && exist.scope !== "ALL") {
+    return res.status(403).json({ error: "forbidden" });
+  }
+  await prisma.snippet.update({
+    where: { id: req.params.id },
+    data: { uses: { increment: 1 } },
+  });
+  res.json({ ok: true });
+});
+
+export default router;


### PR DESCRIPTION
## 증상
**스니펫 라이브러리 + 채팅 슬래시 자동완성**

새 기능을 추가합니다.

## 원인
[목적]
자주 쓰는 명령/쿼리/regex/메시지 템플릿을 한 번 저장해두고 채팅 입력창에서
"/<trigger>" 로 즉시 호출. 채팅 외에 결재 댓글·일지·회의록에서도 본문 복사로
재사용 가능.

[서버]
- prisma Snippet 모델 + 마이그레이션 20260427000000_snippets:
  ownerId / trigger / title / body / lang / scope(PRIVATE|ALL) / uses /
  createdAt / updatedAt + 인덱스 3종.
- routes/snippet.ts:
  · GET /api/snippet?q=...           목록(본인 + 전사 공유) updatedAt desc
  · GET /api/snippet/search?q=...    슬래시 자동완성용 — uses desc 우선
  · POST /api/snippet                 생성
  · PATCH /api/snippet/:id            본인만 수정
  · DELETE /api/snippet/:id           본인만 삭제
  · POST /api/snippet/:id/use         사용 +1 (인기 가중치)

[클라]
- pages/SnippetsPage.tsx + 라우트 /snippets
  · 검색(디바운스 200ms), 카드 그리드, hljs 신택스로 본문 미리보기
  · 본인은 수정/삭제, 모두 복사 가능
  · 편집 모달에 trigger 검증(영문/숫자/하이픈/한글), 공개 범위 토글
- components/chat/SnippetSlashMenu.tsx + ChatMiniApp 입력바
  · 커서 직전 토큰이 "/\w*" 면 메뉴 노출(공백 뒤/줄 시작 한정)
  · ↑↓ 이동 / Enter·Tab 삽입 / Esc 닫기, onMouseDown preventDefault 로

## 수정
**작업 항목 (커밋 단위)**
- feat(snippets): 스니펫 라이브러리 + 채팅 슬래시 자동완성

**변경 대상 (10개 파일)**
- `client/src/App.tsx`
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatMiniApp.tsx`
- `client/src/components/chat/SnippetSlashMenu.tsx`
- `client/src/pages/SnippetsPage.tsx`
- `client/src/routes.ts`
- `server/prisma/migrations/20260427000000_snippets/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/index.ts`
- `server/src/routes/snippet.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #60** ↔ **이슈 #482** 로 연결됩니다.

Closes #482
