### PR TITLE
🔀 :: (#483) 코드-only 메시지에서 버블 색/패딩 제거

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1141,13 +1141,18 @@ export function TextBubble({
 }) {
   // 코드(펜스/인라인/휴리스틱) 영역을 떼어내고 일반 텍스트만 URL 링크화.
   const segments = parseCodeSegments(content);
-  // 코드 블록이 하나라도 있으면 둥근모서리 안쪽 패딩이 너무 작으면 보기 안 좋아서
-  // 살짝 늘려준다 (펜스 코드는 자체 padding 갖는 박스라 충돌 없음).
   const hasBlockCode = segments.some((s) => s.kind === "code");
+  // 메시지가 사실상 "코드 블록만" 일 때(텍스트 segment 가 모두 비었음) 채팅 버블의 색·패딩
+  // 전체를 떼어낸다. 종전엔 mine 의 파란 배경이 좌우 8px 띠로 남아 코드 박스 옆에 어색한
+  // 프레임처럼 보였음. 이 경우엔 코드 박스 자체가 메시지의 시각적 컨테이너.
+  const codeOnly =
+    hasBlockCode &&
+    segments.every((s) => s.kind === "code" || (s.kind === "text" && !s.text.trim()));
   return (
     <div
       style={{
-        padding: hasBlockCode ? "8px 8px" : "9px 13px",
+        // codeOnly 면 패딩/배경 제거 → 코드 박스가 끝까지 차지.
+        padding: codeOnly ? 0 : hasBlockCode ? "8px 8px" : "9px 13px",
         fontSize: 14,
         fontWeight: 500,
         lineHeight: 1.4,
@@ -1158,7 +1163,7 @@ export function TextBubble({
         minWidth: 0,
         maxWidth: "100%",
         color: mine ? C.brandFg : C.ink,
-        background: mine ? C.blue : C.bubbleOther,
+        background: codeOnly ? "transparent" : (mine ? C.blue : C.bubbleOther),
         borderRadius: 16,
         fontFamily: FONT,
       }}


### PR DESCRIPTION
## 증상
**코드-only 메시지에서 버블 색/패딩 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
[증상]
import 만 줄줄이 있는 코드 메시지처럼 본문이 코드 블록만으로 구성된 경우,
바깥 채팅 버블(mine 파란색)의 좌우 8px 패딩이 띠로 남아 코드 박스 옆에 어색한
프레임이 그려짐.

[수정]
TextBubble 에서 segments 가 "코드 + 빈 텍스트" 로만 이루어졌으면 codeOnly = true
판정. 그 경우 패딩 0 + 배경 transparent 로 빠짐 → 어두운 코드 박스가 메시지의
시각적 컨테이너 그 자체가 됨. 텍스트가 섞인 경우는 종전대로 색 버블 유지.

## 수정
**작업 항목 (커밋 단위)**
- fix(chat): 코드-only 메시지에서 버블 색/패딩 제거

**변경 대상 (1개 파일)**
- `client/src/components/chat/MessageBubble.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #61** ↔ **이슈 #483** 로 연결됩니다.

Closes #483
