### PR TITLE
🔀 :: (#484) 라이트박스/코드뷰어 닫으면 롱프레스 메뉴 자동 오픈되는 버그

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -545,10 +545,17 @@ function ImageLightbox({
 
   // 채팅 미니앱 컨테이너에 transform 이 걸려있어 position:fixed 가 viewport 가 아니라
   // 그 컨테이너 기준으로 잡히는 문제 → document.body 로 portal 해서 진짜 풀 화면.
+  // [중요] React portal 은 React 트리 따라 이벤트가 버블링되므로, 여기서 mousedown 을
+  // stopPropagation 안 하면 닫기 직후 사라진 모달 위치의 React 부모(LongPress)가
+  // mousedown 만 받고 mouseup 은 못 받아 롱프레스 타이머가 발동되는 버그가 생김.
   return createPortal(
     <div
       role="dialog"
-      onMouseDown={onClose}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        onClose();
+      }}
+      onClick={(e) => e.stopPropagation()}
       style={{
         position: "fixed",
         inset: 0,
@@ -1356,7 +1363,13 @@ function CodeViewerModal({ code, lang, onClose }: { code: string; lang?: string;
         placeItems: "center",
         padding: "max(env(safe-area-inset-top), 16px) 16px max(env(safe-area-inset-bottom), 16px)",
       }}
-      onClick={onClose}
+      // 같은 portal 버블링 방지 — 닫기 후 React 부모 LongPress 가 mousedown 만 받고
+      // mouseup 못 받아 롱프레스 메뉴가 자동으로 뜨는 사고 차단.
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        onClose();
+      }}
+      onClick={(e) => e.stopPropagation()}
     >
       <div
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## 증상
이미지 라이트박스 / 코드 자세히보기 모달을 배경 클릭으로 닫으면 그 자리의 메시지에 롱프레스 메뉴(이모지 + 복사/다운로드/고정/삭제)가 자동으로 떴음.

## 원인
React portal 은 **DOM 트리가 아니라 React 트리** 를 따라 이벤트가 버블링.
1. 사용자가 모달 배경에 mousedown
2. 모달 `onMouseDown={onClose}` → 즉시 언마운트
3. 같은 mousedown 이 React 트리 따라 `LongPress.onMouseDown` 까지 → 420ms 타이머 시작
4. 모달이 사라졌으니 후속 mouseup 은 LongPress 영역 밖 / 빈 공간에서 발생 → 타이머 취소 안 됨
5. 420ms 후 `onLongPress` 발동 → 리액션 메뉴 오픈

## 수정
`ImageLightbox` / `CodeViewerModal` 의 `onMouseDown` 에 `stopPropagation` 추가. `onClick` 도 막아 `onClickCapture` 경로도 차단.

Closes #484
