### PR TITLE
🔀 :: (#487) API 명세 탭 — Express 라우터 자동 introspection

### DIFF
--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -38,7 +38,14 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat";
+type Tab = "logs" | "chat" | "api";
+
+type ApiSpecRoute = {
+  method: string;
+  path: string;
+  auth: "PUBLIC" | "AUTH" | "ADMIN" | "SUPER";
+  middlewares: string[];
+};
 
 export default function SuperAdminPage() {
   return (
@@ -58,7 +65,8 @@ export default function SuperAdminPage() {
 function SuperAdminContent() {
   // 새로고침 유지 — URL 쿼리로 탭 동기화.
   const [sp, setSp] = useSearchParams();
-  const tab = (sp.get("tab") === "chat" ? "chat" : "logs") as Tab;
+  const raw = sp.get("tab");
+  const tab: Tab = raw === "chat" ? "chat" : raw === "api" ? "api" : "logs";
   const setTab = (t: Tab) => {
     const next = new URLSearchParams(sp);
     if (t === "logs") next.delete("tab");
@@ -70,9 +78,11 @@ function SuperAdminContent() {
       <div className="flex items-center gap-1 mb-4 border-b border-ink-150">
         <TabBtn active={tab === "logs"} onClick={() => setTab("logs")}>활동 로그</TabBtn>
         <TabBtn active={tab === "chat"} onClick={() => setTab("chat")}>사내톡 감사</TabBtn>
+        <TabBtn active={tab === "api"} onClick={() => setTab("api")}>API 명세</TabBtn>
       </div>
       {tab === "logs" && <LogsPanel />}
       {tab === "chat" && <ChatAuditPanel />}
+      {tab === "api" && <ApiSpecPanel />}
     </>
   );
 }
@@ -414,4 +424,125 @@ function humanSize(n: number) {
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
   if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
   return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+/* =============== API 명세 =============== */
+function ApiSpecPanel() {
+  const [routes, setRoutes] = useState<ApiSpecRoute[]>([]);
+  const [q, setQ] = useState("");
+  const [authFilter, setAuthFilter] = useState<"" | ApiSpecRoute["auth"]>("");
+  const [methodFilter, setMethodFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => { aliveRef.current = false; };
+  }, []);
+
+  useEffect(() => {
+    api<{ routes: ApiSpecRoute[]; total: number }>("/api/admin/api-spec")
+      .then((r) => {
+        if (!aliveRef.current) return;
+        setRoutes(r.routes);
+      })
+      .catch((e) => { if (aliveRef.current) setErr(e?.message ?? "불러오기 실패"); })
+      .finally(() => { if (aliveRef.current) setLoading(false); });
+  }, []);
+
+  // path 의 첫 segment 로 그룹핑(예: /api/snippet → \"api/snippet\").
+  // 두 번째 segment까지 묶으면 그룹이 너무 잘게 쪼개져서 /api/<리소스> 단위로 통일.
+  const grouped = useMemo(() => {
+    const filtered = routes.filter((r) => {
+      if (authFilter && r.auth !== authFilter) return false;
+      if (methodFilter && r.method !== methodFilter) return false;
+      if (q) {
+        const k = q.toLowerCase();
+        if (!r.path.toLowerCase().includes(k) && !r.method.toLowerCase().includes(k)) return false;
+      }
+      return true;
+    });
+    const map = new Map<string, ApiSpecRoute[]>();
+    for (const r of filtered) {
+      const segs = r.path.split("/").filter(Boolean);
+      const key = segs.length >= 2 ? `/${segs[0]}/${segs[1]}` : `/${segs[0] ?? ""}`;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(r);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [routes, q, authFilter, methodFilter]);
+
+  if (loading) return <div className="panel p-8 text-center text-ink-500 text-[13px]">불러오는 중…</div>;
+  if (err) return <div className="panel p-6 text-red-600 text-[13px]">{err}</div>;
+
+  const totalShown = grouped.reduce((acc, [, list]) => acc + list.length, 0);
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <input
+          className="input flex-1 min-w-[220px]"
+          placeholder="path 또는 method 검색 — 예: /chat, GET"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <select className="input !w-auto" value={methodFilter} onChange={(e) => setMethodFilter(e.target.value)}>
+          <option value="">메소드 전체</option>
+          {["GET", "POST", "PATCH", "PUT", "DELETE"].map((m) => <option key={m} value={m}>{m}</option>)}
+        </select>
+        <select className="input !w-auto" value={authFilter} onChange={(e) => setAuthFilter(e.target.value as any)}>
+          <option value="">권한 전체</option>
+          <option value="PUBLIC">PUBLIC</option>
+          <option value="AUTH">AUTH</option>
+          <option value="ADMIN">ADMIN</option>
+          <option value="SUPER">SUPER</option>
+        </select>
+        <div className="text-[11px] text-ink-500">
+          총 <b className="text-ink-800">{routes.length}</b> 개 · 표시 <b className="text-ink-800">{totalShown}</b>
+        </div>
+      </div>
+
+      {grouped.length === 0 ? (
+        <div className="panel p-10 text-center text-ink-500 text-[13px]">조건에 맞는 라우트가 없어요</div>
+      ) : (
+        <div className="space-y-3">
+          {grouped.map(([groupKey, list]) => (
+            <div key={groupKey} className="panel p-0 overflow-hidden">
+              <div className="px-3 py-2 bg-ink-25 border-b border-ink-150 flex items-center justify-between">
+                <div className="text-[12.5px] font-bold text-ink-800 font-mono">{groupKey}</div>
+                <div className="text-[11px] text-ink-500">{list.length}개</div>
+              </div>
+              <ul className="divide-y divide-ink-100">
+                {list.map((r) => (
+                  <li key={`${r.method} ${r.path}`} className="px-3 py-2 flex items-center gap-3">
+                    <MethodChip method={r.method} />
+                    <code className="flex-1 min-w-0 text-[12.5px] font-mono text-ink-900 truncate">{r.path}</code>
+                    <AuthChip auth={r.auth} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MethodChip({ method }: { method: string }) {
+  const tone =
+    method === "GET" ? "chip-blue"
+    : method === "POST" ? "chip-green"
+    : method === "PATCH" || method === "PUT" ? "chip-amber"
+    : method === "DELETE" ? "chip-red"
+    : "chip-gray";
+  return <span className={`chip ${tone} font-mono`} style={{ minWidth: 56, justifyContent: "center" }}>{method}</span>;
+}
+
+function AuthChip({ auth }: { auth: ApiSpecRoute["auth"] }) {
+  if (auth === "SUPER") return <span className="chip chip-violet">SUPER</span>;
+  if (auth === "ADMIN") return <span className="chip chip-orange">ADMIN</span>;
+  if (auth === "AUTH") return <span className="chip chip-gray">AUTH</span>;
+  return <span className="chip" style={{ background: "transparent", color: "var(--c-text-3)", border: "1px dashed var(--c-border)" }}>PUBLIC</span>;
 }

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -552,6 +552,98 @@ router.delete("/positions/:id", async (req, res) => {
 });
 
 /* ===== 로그 (총관리자 전용 · step-up 필요) ===== */
+/* ===== API 명세 (총관리자) =====
+ * Express 라우터 트리를 깊이우선으로 훑어 등록된 모든 (METHOD, PATH) + 사용된 미들웨어 이름을 수집.
+ * - 인증/권한 미들웨어 이름이 검출되면 auth: \"PUBLIC\" | \"AUTH\" | \"ADMIN\" | \"SUPER\" 로 라벨링.
+ * - 정렬: 첫 path segment 별 그룹 + 그 안에서 path 알파벳 순.
+ */
+router.get("/api-spec", requireSuperAdminStepUp, async (req, res) => {
+  type SpecRoute = {
+    method: string;
+    path: string;
+    auth: "PUBLIC" | "AUTH" | "ADMIN" | "SUPER";
+    middlewares: string[];
+  };
+
+  const AUTH_NAMES = new Set(["requireAuth"]);
+  const ADMIN_NAMES = new Set(["requireAdmin"]);
+  const SUPER_NAMES = new Set(["requireSuperAdmin", "requireSuperAdminStepUp"]);
+
+  function authOf(names: string[]): SpecRoute["auth"] {
+    if (names.some((n) => SUPER_NAMES.has(n))) return "SUPER";
+    if (names.some((n) => ADMIN_NAMES.has(n))) return "ADMIN";
+    if (names.some((n) => AUTH_NAMES.has(n))) return "AUTH";
+    return "PUBLIC";
+  }
+
+  /** Layer.regexp 에서 prefix path 복원. fast_slash 인 경우 빈 prefix.
+   *  복잡한 정규식 라우트(파라미터 포함)는 layer.regexp.fast_slash 가 false 일 때 정규식 toString
+   *  자체에서 \"^\\/api\\/x\\/?\" 패턴을 추출 시도 — 못 찾으면 빈 문자열로 두고 자식 path 만 사용. */
+  function prefixOfRouter(layer: any): string {
+    if (layer.regexp?.fast_slash) return "";
+    const src = layer.regexp?.toString?.() ?? "";
+    // /^\/api\/snippet\/?(?=\/|$)/i  → /api/snippet
+    const m = /^\/\^\\?(\/[^\\\/?]+(?:\\\/[^\\\/?]+)*)\\?\\?\(\?=\\?\/\|\$\)/i.exec(src);
+    if (!m) return "";
+    return m[1].replace(/\\\//g, "/");
+  }
+
+  const routes: SpecRoute[] = [];
+
+  function walk(stack: any[], parentPath: string, parentMw: string[]) {
+    for (const layer of stack) {
+      // 라우터 자체에 박힌 미들웨어 (router.use(requireAuth) 형태)는 layer.handle 에 stack 이 있는 router.
+      // 단순 미들웨어 layer 는 method 가 없고 route 도 없음 → 다음 형제 layer 들에 적용되는 게이트.
+      if (layer.route) {
+        const subPath = layer.route.path;
+        const fullPath = (parentPath + subPath).replace(/\/+/g, "/");
+        // 한 path 에 여러 method 가 등록될 수 있음 (route.methods 객체).
+        const methods = Object.keys(layer.route.methods ?? {}).filter((m) => layer.route.methods[m]);
+        // route 자체에 deps 로 박힌 미들웨어들 (e.g. router.get(path, requireSuperAdminStepUp, handler))
+        const routeMw: string[] = (layer.route.stack ?? [])
+          .map((s: any) => s.name || s.handle?.name || "")
+          .filter(Boolean);
+        const allMw = [...parentMw, ...routeMw];
+        const auth = authOf(allMw);
+        for (const m of methods) {
+          if (m === "_all") continue;
+          routes.push({
+            method: m.toUpperCase(),
+            path: fullPath,
+            auth,
+            middlewares: allMw.filter((n) => n !== "<anonymous>"),
+          });
+        }
+      } else if (layer.name === "router" && layer.handle?.stack) {
+        const prefix = prefixOfRouter(layer);
+        walk(layer.handle.stack, parentPath + prefix, parentMw);
+      } else if (layer.handle?.name && !layer.route) {
+        // 라우터에 직접 박힌 미들웨어(use) — 이름이 있으면 게이트로 누적.
+        // 단, app.use 의 글로벌 미들웨어는 어떤 라우터든 자식이라 부모 컨텍스트로 들어가야 하지만,
+        // 단순화를 위해 이름만 누적. 부모 router.use(requireAuth) 도 여기 걸림.
+        if (!["query", "expressInit", "<anonymous>", "bound dispatch"].includes(layer.handle.name)) {
+          parentMw.push(layer.handle.name);
+        }
+      }
+    }
+  }
+
+  const app = req.app as any;
+  const root = app._router?.stack ?? app.router?.stack ?? [];
+  walk(root, "", []);
+
+  // 중복 제거(같은 path/method 가 여러 layer 매칭될 수 있음) + 정렬.
+  const dedup = new Map<string, SpecRoute>();
+  for (const r of routes) {
+    const k = `${r.method} ${r.path}`;
+    if (!dedup.has(k)) dedup.set(k, r);
+  }
+  const sorted = [...dedup.values()].sort((a, b) =>
+    a.path === b.path ? a.method.localeCompare(b.method) : a.path.localeCompare(b.path),
+  );
+  res.json({ routes: sorted, total: sorted.length });
+});
+
 router.get("/logs", requireSuperAdminStepUp, async (req, res) => {
   const limit = Math.min(Number(req.query.limit ?? 200), 500);
   const logs = await prisma.auditLog.findMany({


### PR DESCRIPTION
## 증상
**API 명세 탭 — Express 라우터 자동 introspection**

새 기능을 추가합니다.

## 원인
[서버]
- GET /api/admin/api-spec (requireSuperAdminStepUp)
- req.app._router.stack 깊이우선 walk 으로 등록된 모든 (METHOD, PATH) 수집.
  · router.use(requireAuth) 등 부모 미들웨어 이름을 누적해 자식 라우트의 "auth" 라벨 결정.
  · 인증 미들웨어 이름 매칭: requireAuth → AUTH, requireAdmin → ADMIN,
    requireSuperAdmin / requireSuperAdminStepUp → SUPER, 그 외 → PUBLIC.
  · 중복 제거 + path 정렬 후 반환.

[클라]
- SuperAdminPage 에 "API 명세" 탭 추가, ?tab=api 동기화.
- ApiSpecPanel:
  · 검색(path/method 부분 매치), 메소드 / 권한 필터.
  · path 의 첫 두 segment 로 그룹핑(/api/<리소스>) — 한 그룹 카드에 라우트들 나열.
  · MethodChip(get/post/patch/delete 색 분기) + AuthChip(PUBLIC/AUTH/ADMIN/SUPER 톤 분기).

## 수정
**작업 항목 (커밋 단위)**
- feat(super-admin): API 명세 탭 — Express 라우터 자동 introspection

**변경 대상 (2개 파일)**
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #65** ↔ **이슈 #487** 로 연결됩니다.

Closes #487
