### PR TITLE
🔀 :: (#489) 콘솔 자동완성(Tab + @) + 서버 로그 탭

### DIFF
--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -38,7 +38,7 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat" | "api" | "console";
+type Tab = "logs" | "chat" | "api" | "console" | "server";
 
 type ApiSpecRoute = {
   method: string;
@@ -67,7 +67,11 @@ function SuperAdminContent() {
   const [sp, setSp] = useSearchParams();
   const raw = sp.get("tab");
   const tab: Tab =
-    raw === "chat" ? "chat" : raw === "api" ? "api" : raw === "console" ? "console" : "logs";
+    raw === "chat" ? "chat"
+    : raw === "api" ? "api"
+    : raw === "console" ? "console"
+    : raw === "server" ? "server"
+    : "logs";
   const setTab = (t: Tab) => {
     const next = new URLSearchParams(sp);
     if (t === "logs") next.delete("tab");
@@ -81,11 +85,13 @@ function SuperAdminContent() {
         <TabBtn active={tab === "chat"} onClick={() => setTab("chat")}>사내톡 감사</TabBtn>
         <TabBtn active={tab === "api"} onClick={() => setTab("api")}>API 명세</TabBtn>
         <TabBtn active={tab === "console"} onClick={() => setTab("console")}>콘솔</TabBtn>
+        <TabBtn active={tab === "server"} onClick={() => setTab("server")}>서버 로그</TabBtn>
       </div>
       {tab === "logs" && <LogsPanel />}
       {tab === "chat" && <ChatAuditPanel />}
       {tab === "api" && <ApiSpecPanel />}
       {tab === "console" && <ConsolePanel />}
+      {tab === "server" && <ServerLogsPanel />}
     </>
   );
 }
@@ -548,6 +554,117 @@ type ConsoleEntry =
   | { kind: "input"; text: string; ts: number }
   | { kind: "output"; text: string; ok: boolean; ts: number };
 
+/** 명령어 트리 — 토큰 위치별로 다음에 올 수 있는 후보. 'arg:user' 같이 prefix 가
+ *  arg: 인 항목은 정적 후보가 아니라 동적 fetch 컨텍스트 (서버 자동완성). */
+const CMD_TREE: Record<string, any> = {
+  help: {},
+  "?": {},
+  whoami: {},
+  clear: {},
+  cls: {},
+  users: { list: { "arg:limit": {} }, find: { "arg:query": {} } },
+  user: {
+    info: { "arg:user": {} },
+    role: { "arg:user": { MEMBER: {}, MANAGER: {}, ADMIN: {} } },
+    grant: { admin: { "arg:user": {} }, super: { "arg:user": {} } },
+    revoke: { admin: { "arg:user": {} }, super: { "arg:user": {} } },
+    lock: { "arg:user": {} },
+    unlock: { "arg:user": {} },
+    resign: { "arg:user": { "arg:date": {} } },
+    "reset-pw": { "arg:user": {} },
+    team: { "arg:user": { "arg:team": {} } },
+    position: { "arg:user": { "arg:position": {} } },
+  },
+  rooms: { list: { "arg:limit": {} } },
+  room: { info: { "arg:roomId": {} } },
+  notice: { broadcast: { "arg:text": {} } },
+  system: { stats: {} },
+  audit: { recent: { "arg:limit": {} } },
+  cache: { evict: { user: { "arg:user": {} } } },
+};
+
+type Suggestion = {
+  /** 화면에 보일 라벨 */
+  label: string;
+  /** 입력에 삽입될 토큰 */
+  insert: string;
+  /** 보조 정보 우측 노출 */
+  hint?: string;
+};
+
+type CompCtx =
+  | { kind: "static"; tokens: string[] } // 트리에 박힌 정적 토큰 후보
+  | { kind: "user" }
+  | { kind: "team" }
+  | { kind: "position" };
+
+/** input + 커서 위치를 보고 현재 토큰 + 다음 후보 컨텍스트를 결정. */
+function resolveCompletion(
+  input: string,
+  cursor: number,
+): { ctx: CompCtx; tokenStart: number; tokenEnd: number; query: string } | null {
+  // 토큰 = 공백으로 잘랐을 때의 단어 단위.
+  const before = input.slice(0, cursor);
+  // 커서 직전 토큰 위치.
+  let s = cursor;
+  while (s > 0 && !/\s/.test(input[s - 1])) s--;
+  const currentToken = input.slice(s, cursor);
+  const completed = before.slice(0, s).trim();
+  const completedTokens = completed ? completed.split(/\s+/) : [];
+
+  // 트리를 따라 들어감.
+  let node: any = CMD_TREE;
+  for (const t of completedTokens) {
+    // 동적 arg: 자식이면 그 자식 노드의 자식 단계로 진입 (값은 무시하고 트리만 한 칸 깊게).
+    const argKey = Object.keys(node).find((k) => k.startsWith("arg:"));
+    if (node[t] !== undefined) {
+      node = node[t];
+    } else if (argKey) {
+      node = node[argKey];
+    } else {
+      // 알 수 없는 토큰 — 자유 입력 단계. 후보 없음.
+      return null;
+    }
+    if (!node || typeof node !== "object") return null;
+  }
+
+  // 현재 토큰이 @ 로 시작하면 동적 컨텍스트(user/team/position) 강제.
+  const atMatch = currentToken.startsWith("@");
+  if (atMatch) {
+    // 트리에서 arg:user|arg:team|arg:position 자식이 있는지 보고 그 컨텍스트 사용.
+    const argKey = Object.keys(node).find((k) => k.startsWith("arg:"));
+    let kind: CompCtx["kind"] = "user";
+    if (argKey === "arg:team") kind = "team";
+    else if (argKey === "arg:position") kind = "position";
+    else if (argKey === "arg:user") kind = "user";
+    else if (!argKey) kind = "user"; // 기본은 user (가장 자주 쓰이는 시나리오)
+    return {
+      ctx: { kind },
+      tokenStart: s,
+      tokenEnd: cursor,
+      query: currentToken.slice(1),
+    };
+  }
+
+  // 정적 후보 (Tab 완성).
+  const keys = Object.keys(node);
+  const staticKeys = keys.filter((k) => !k.startsWith("arg:"));
+  // 동적 자식이 있으면 — 컨텍스트도 같이 후보로 노출.
+  const argKey = keys.find((k) => k.startsWith("arg:"));
+  if (staticKeys.length > 0) {
+    return {
+      ctx: { kind: "static", tokens: staticKeys },
+      tokenStart: s,
+      tokenEnd: cursor,
+      query: currentToken,
+    };
+  }
+  if (argKey === "arg:user") return { ctx: { kind: "user" }, tokenStart: s, tokenEnd: cursor, query: currentToken };
+  if (argKey === "arg:team") return { ctx: { kind: "team" }, tokenStart: s, tokenEnd: cursor, query: currentToken };
+  if (argKey === "arg:position") return { ctx: { kind: "position" }, tokenStart: s, tokenEnd: cursor, query: currentToken };
+  return null;
+}
+
 function ConsolePanel() {
   const [history, setHistory] = useState<ConsoleEntry[]>(() => [
     {
@@ -555,13 +672,19 @@ function ConsolePanel() {
       ok: true,
       ts: Date.now(),
       text:
-        "총관리자 콘솔. `help` 입력으로 명령 목록.\n" +
-        "예: users find 김 / user grant admin <id|email|사번>",
+        "총관리자 콘솔. `help` 로 사용법.\n" +
+        "Tab — 명령어 자동완성, @ — 유저/팀/직급 자동완성.",
     },
   ]);
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
-  // 위/아래 화살표로 이전 명령 재호출.
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [active, setActive] = useState(0);
+  const [open, setOpen] = useState(false);
+  const compRef = useRef<{ tokenStart: number; tokenEnd: number } | null>(null);
+  const fetchSeq = useRef(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // 위/아래 화살표로 이전 명령 재호출 (자동완성 닫혀있을 때만).
   const cmdHistRef = useRef<string[]>([]);
   const cmdHistIdxRef = useRef(-1);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -577,6 +700,64 @@ function ConsolePanel() {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [history]);
+
+  /** input 또는 cursor 가 바뀔 때 동적 컨텍스트(@) 면 자동으로 fetch. */
+  async function recomputeOpen() {
+    const el = inputRef.current;
+    if (!el) return;
+    const cursor = el.selectionStart ?? el.value.length;
+    const r = resolveCompletion(input, cursor);
+    if (!r) {
+      setOpen(false);
+      setSuggestions([]);
+      compRef.current = null;
+      return;
+    }
+    compRef.current = { tokenStart: r.tokenStart, tokenEnd: r.tokenEnd };
+    if (r.ctx.kind === "static") {
+      // @ 가 아닌 경우엔 Tab 누를 때만 메뉴 노출. 자동 표시는 안 함.
+      if (input.slice(r.tokenStart, r.tokenEnd).startsWith("@")) {
+        // 도달 안 함, 안전망
+      }
+      // 자동 노출 X
+      setOpen(false);
+      return;
+    }
+    // 동적 컨텍스트 — @ 토큰일 때만 자동 fetch + 표시.
+    const isAt = input.slice(r.tokenStart, r.tokenEnd).startsWith("@");
+    if (!isAt) {
+      setOpen(false);
+      return;
+    }
+    const seq = ++fetchSeq.current;
+    try {
+      const res = await api<{ items: any[] }>(
+        `/api/admin/console/complete?ctx=${r.ctx.kind}&q=${encodeURIComponent(r.query)}&limit=10`,
+      );
+      if (seq !== fetchSeq.current) return;
+      const items: Suggestion[] = (res.items ?? []).map((it) => {
+        if (r.ctx.kind === "user") {
+          return {
+            label: `${it.name} · ${it.email}${it.team ? ` · ${it.team}` : ""}`,
+            insert: it.id,
+            hint: it.role + (it.active ? "" : " (비활성)"),
+          };
+        }
+        return { label: it.value, insert: /\s/.test(it.value) ? `"${it.value}"` : it.value };
+      });
+      setSuggestions(items);
+      setActive(0);
+      setOpen(items.length > 0);
+    } catch {
+      setOpen(false);
+    }
+  }
+
+  // 입력 변할 때마다 컨텍스트 재계산. @ 면 자동으로 fetch+open.
+  useEffect(() => {
+    void recomputeOpen();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [input]);
 
   async function execute(raw: string) {
     const cmd = raw.trim();
@@ -604,7 +785,79 @@ function ConsolePanel() {
     }
   }
 
+  function applySuggestion(s: Suggestion) {
+    const range = compRef.current;
+    if (!range) return;
+    const next = input.slice(0, range.tokenStart) + s.insert + " " + input.slice(range.tokenEnd);
+    setInput(next);
+    setOpen(false);
+    setSuggestions([]);
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      const pos = range.tokenStart + s.insert.length + 1;
+      el.focus();
+      el.setSelectionRange(pos, pos);
+    });
+  }
+
+  /** Tab 핸들러 — 정적/동적 후보를 즉석에서 만들어 노출. 후보 1개면 곧장 삽입. */
+  async function handleTab() {
+    const el = inputRef.current;
+    if (!el) return;
+    const cursor = el.selectionStart ?? el.value.length;
+    const r = resolveCompletion(input, cursor);
+    if (!r) return;
+    compRef.current = { tokenStart: r.tokenStart, tokenEnd: r.tokenEnd };
+    let items: Suggestion[] = [];
+    if (r.ctx.kind === "static") {
+      const q = r.query.toLowerCase();
+      items = r.ctx.tokens
+        .filter((t) => !q || t.toLowerCase().startsWith(q))
+        .map((t) => ({ label: t, insert: t }));
+    } else {
+      try {
+        const res = await api<{ items: any[] }>(
+          `/api/admin/console/complete?ctx=${r.ctx.kind}&q=${encodeURIComponent(r.query)}&limit=10`,
+        );
+        items = (res.items ?? []).map((it) => {
+          if (r.ctx.kind === "user") {
+            return {
+              label: `${it.name} · ${it.email}${it.team ? ` · ${it.team}` : ""}`,
+              insert: it.id,
+              hint: it.role + (it.active ? "" : " (비활성)"),
+            };
+          }
+          return { label: it.value, insert: /\s/.test(it.value) ? `"${it.value}"` : it.value };
+        });
+      } catch {
+        items = [];
+      }
+    }
+    if (items.length === 0) return;
+    if (items.length === 1) {
+      applySuggestion(items[0]);
+      return;
+    }
+    setSuggestions(items);
+    setActive(0);
+    setOpen(true);
+  }
+
   function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    // Tab — 자동완성 트리거.
+    if (e.key === "Tab") {
+      e.preventDefault();
+      void handleTab();
+      return;
+    }
+    // 메뉴 열려있을 때 ↑↓/Enter/Esc 가 메뉴를 우선.
+    if (open && suggestions.length > 0) {
+      if (e.key === "ArrowDown") { e.preventDefault(); setActive((a) => (a + 1) % suggestions.length); return; }
+      if (e.key === "ArrowUp") { e.preventDefault(); setActive((a) => (a - 1 + suggestions.length) % suggestions.length); return; }
+      if (e.key === "Enter" && !e.nativeEvent.isComposing) { e.preventDefault(); applySuggestion(suggestions[active]); return; }
+      if (e.key === "Escape") { e.preventDefault(); setOpen(false); return; }
+    }
     if (e.key === "Enter" && !e.nativeEvent.isComposing) {
       e.preventDefault();
       const v = input;
@@ -681,10 +934,57 @@ function ConsolePanel() {
           padding: "8px 12px",
           borderTop: "1px solid rgba(255,255,255,0.08)",
           background: "#171A20",
+          position: "relative",
         }}
       >
+        {open && suggestions.length > 0 && (
+          <div
+            style={{
+              position: "absolute",
+              left: 12,
+              right: 12,
+              bottom: "100%",
+              marginBottom: 6,
+              background: "#171A20",
+              border: "1px solid rgba(255,255,255,0.12)",
+              borderRadius: 10,
+              boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
+              maxHeight: 240,
+              overflowY: "auto",
+              zIndex: 10,
+            }}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {suggestions.map((s, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => applySuggestion(s)}
+                onMouseEnter={() => setActive(i)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  width: "100%",
+                  padding: "7px 10px",
+                  background: i === active ? "rgba(120,150,255,0.12)" : "transparent",
+                  border: 0,
+                  cursor: "pointer",
+                  textAlign: "left",
+                  fontFamily: "inherit",
+                }}
+              >
+                <span style={{ color: "#E5E9F0", fontSize: 12.5, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {s.label}
+                </span>
+                {s.hint && <span style={{ color: "#7F8792", fontSize: 11 }}>{s.hint}</span>}
+              </button>
+            ))}
+          </div>
+        )}
         <span style={{ color: "#9CA3AF", fontSize: 13, fontWeight: 700 }}>{">"}</span>
         <input
+          ref={inputRef}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={onKeyDown}
@@ -693,7 +993,7 @@ function ConsolePanel() {
           spellCheck={false}
           autoCapitalize="off"
           autoCorrect="off"
-          placeholder='help (사용법) · 예: user grant admin user@hi.com'
+          placeholder="Tab 자동완성 / @ 유저·팀·직급 선택 / help"
           style={{
             flex: 1,
             border: 0,
@@ -705,6 +1005,141 @@ function ConsolePanel() {
             padding: "4px 0",
           }}
         />
+      </div>
+    </div>
+  );
+}
+
+/* =============== 서버 로그 — 인메모리 버퍼 폴링 =============== */
+type LogLevel = "info" | "warn" | "error" | "http";
+type ServerLog = { ts: number; level: LogLevel; msg: string };
+
+function ServerLogsPanel() {
+  const [logs, setLogs] = useState<ServerLog[]>([]);
+  const [level, setLevel] = useState<"" | LogLevel>("");
+  const [q, setQ] = useState("");
+  const [follow, setFollow] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const aliveRef = useRef(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => { aliveRef.current = false; };
+  }, []);
+
+  async function load() {
+    try {
+      const params = new URLSearchParams();
+      if (level) params.set("level", level);
+      if (q) params.set("q", q);
+      params.set("limit", "1000");
+      const r = await api<{ logs: ServerLog[] }>(`/api/admin/server-logs?${params}`);
+      if (!aliveRef.current) return;
+      setLogs(r.logs);
+      setLoading(false);
+    } catch (e: any) {
+      if (!aliveRef.current) return;
+      setErr(e?.message ?? "불러오기 실패");
+      setLoading(false);
+    }
+  }
+
+  // 검색·레벨 변경 시 즉시 reload, 그리고 follow 켜져 있으면 3초마다 자동 갱신.
+  useEffect(() => {
+    void load();
+    if (!follow) return;
+    const id = window.setInterval(load, 3000);
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [level, q, follow]);
+
+  // follow 켜져 있고 새 로그가 들어오면 자동으로 최하단 스크롤.
+  useEffect(() => {
+    if (!follow) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [logs, follow]);
+
+  if (loading) return <div className="panel p-8 text-center text-ink-500 text-[13px]">불러오는 중…</div>;
+  if (err) return <div className="panel p-6 text-red-600 text-[13px]">{err}</div>;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <input
+          className="input flex-1 min-w-[220px]"
+          placeholder="로그 본문 검색 — 예: error, /api/chat"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <select className="input !w-auto" value={level} onChange={(e) => setLevel(e.target.value as any)}>
+          <option value="">레벨 전체</option>
+          <option value="http">HTTP</option>
+          <option value="info">INFO</option>
+          <option value="warn">WARN</option>
+          <option value="error">ERROR</option>
+        </select>
+        <label className="flex items-center gap-1.5 text-[12px] text-ink-700 cursor-pointer">
+          <input
+            type="checkbox"
+            className="accent-brand-500"
+            checked={follow}
+            onChange={(e) => setFollow(e.target.checked)}
+          />
+          자동 갱신 (3초)
+        </label>
+        <button className="btn-ghost btn-xs" onClick={() => load()}>새로고침</button>
+        <div className="text-[11px] text-ink-500">{logs.length}건</div>
+      </div>
+
+      <div
+        ref={scrollRef}
+        style={{
+          background: "#0E1014",
+          color: "#D4D8DE",
+          borderRadius: 12,
+          border: "1px solid var(--c-border)",
+          padding: "10px 12px",
+          height: "min(64vh, 580px)",
+          overflowY: "auto",
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+          fontSize: 12,
+          lineHeight: 1.55,
+        }}
+      >
+        {logs.length === 0 ? (
+          <div style={{ color: "#7F8792", textAlign: "center", padding: 32 }}>
+            아직 로그가 없어요. 프로세스 재기동 후 새로 쌓인 줄만 보여요.
+          </div>
+        ) : (
+          logs.map((l, i) => (
+            <div key={i} style={{ display: "flex", gap: 8, alignItems: "flex-start", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+              <span style={{ color: "#7F8792", flexShrink: 0 }}>
+                {new Date(l.ts).toISOString().slice(11, 23)}
+              </span>
+              <span
+                style={{
+                  flexShrink: 0,
+                  fontWeight: 700,
+                  width: 50,
+                  color:
+                    l.level === "error" ? "#FCA5A5"
+                    : l.level === "warn" ? "#FCD34D"
+                    : l.level === "http" ? "#7896FF"
+                    : "#86EFAC",
+                }}
+              >
+                {l.level.toUpperCase()}
+              </span>
+              <span style={{ flex: 1, minWidth: 0 }}>{l.msg}</span>
+            </div>
+          ))
+        )}
+      </div>
+      <div className="text-[11px] text-ink-500 mt-2">
+        프로세스 재기동(배포 등) 시 버퍼 초기화. 디스크/CloudWatch 영속화 없음 — 최근 2,000줄만 메모리에 보관.
       </div>
     </div>
   );

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,6 +38,11 @@ import { folderShareLinkAuthedRouter } from "./routes/folderShareLink.js";
 import serviceAccountRouter from "./routes/serviceAccount.js";
 import path from "node:path";
 import mime from "mime-types";
+import { installConsoleHook, pushHttpLog } from "./lib/logBuffer.js";
+
+// 콘솔 로그를 인메모리 버퍼에도 적재 — 총관리자 \"서버 로그\" 탭에서 조회.
+// 반드시 다른 import 가 끝난 뒤(이 시점), 첫 console.log 이전에 호출.
+installConsoleHook();
 
 const app = express();
 const PORT = Number(process.env.PORT ?? 4000);
@@ -89,6 +94,16 @@ app.use(
 );
 app.use(express.json({ limit: "2mb" }));
 app.use(cookieParser());
+
+// HTTP 액세스 라인을 인메모리 버퍼에 적재 — \"GET /api/x 200 12ms\" 형식.
+app.use((req, res, next) => {
+  const start = Date.now();
+  res.on("finish", () => {
+    const dur = Date.now() - start;
+    pushHttpLog(`${req.method} ${req.originalUrl || req.url} ${res.statusCode} ${dur}ms`);
+  });
+  next();
+});
 
 // CSRF 방어 — 쿠키 인증 + SameSite=lax 만으론 크로스 오리진 상태변경 요청에 완전히 안전하지 않음.
 // Origin / Referer 헤더를 허용 오리진 목록과 대조해 안 맞으면 403.

--- a/server/src/lib/logBuffer.ts
+++ b/server/src/lib/logBuffer.ts
@@ -1,0 +1,97 @@
+/**
+ * 인메모리 서버 로그 링버퍼 — 총관리자 콘솔에서 보기 위한 용도.
+ *
+ * 처리:
+ *  - console.log/info/warn/error 를 monkey-patch 해서 들어오는 라인을 동시에 버퍼에 적재.
+ *  - HTTP 액세스 로그도 미들웨어에서 push.
+ *  - 메모리 절약을 위해 최대 2000줄 유지(가장 오래된 것부터 버림).
+ *  - 프로세스 재기동 시 초기화 — 디스크 영속화 없음.
+ */
+
+export type LogLevel = "info" | "warn" | "error" | "http";
+
+export type LogEntry = {
+  ts: number; // epoch ms
+  level: LogLevel;
+  msg: string;
+};
+
+const MAX = 2000;
+const buf: LogEntry[] = [];
+
+function pushEntry(level: LogLevel, msg: string) {
+  buf.push({ ts: Date.now(), level, msg: msg.length > 4000 ? msg.slice(0, 4000) + "…" : msg });
+  if (buf.length > MAX) buf.splice(0, buf.length - MAX);
+}
+
+export function getLogs(opts: { since?: number; level?: LogLevel; q?: string; limit?: number } = {}): LogEntry[] {
+  const limit = Math.min(2000, Math.max(1, opts.limit ?? 500));
+  let arr = buf;
+  if (opts.since) arr = arr.filter((e) => e.ts > opts.since!);
+  if (opts.level) arr = arr.filter((e) => e.level === opts.level);
+  if (opts.q) {
+    const k = opts.q.toLowerCase();
+    arr = arr.filter((e) => e.msg.toLowerCase().includes(k));
+  }
+  // 최근 N 만 반환.
+  return arr.slice(-limit);
+}
+
+export function pushHttpLog(line: string) {
+  pushEntry("http", line);
+}
+
+let installed = false;
+
+/** 한 번만 호출 — console 메서드를 가로채 버퍼에 동기화 적재.
+ *  원래 stdout 동작은 유지(서버 콘솔/Cloudwatch 도 그대로 쓰임). */
+export function installConsoleHook() {
+  if (installed) return;
+  installed = true;
+  const origLog = console.log.bind(console);
+  const origInfo = console.info.bind(console);
+  const origWarn = console.warn.bind(console);
+  const origError = console.error.bind(console);
+
+  function fmt(args: any[]): string {
+    return args
+      .map((a) => {
+        if (typeof a === "string") return a;
+        try {
+          return JSON.stringify(a, replaceCircular(), 2);
+        } catch {
+          return String(a);
+        }
+      })
+      .join(" ");
+  }
+
+  console.log = (...args: any[]) => {
+    pushEntry("info", fmt(args));
+    origLog(...args);
+  };
+  console.info = (...args: any[]) => {
+    pushEntry("info", fmt(args));
+    origInfo(...args);
+  };
+  console.warn = (...args: any[]) => {
+    pushEntry("warn", fmt(args));
+    origWarn(...args);
+  };
+  console.error = (...args: any[]) => {
+    pushEntry("error", fmt(args));
+    origError(...args);
+  };
+}
+
+/** JSON.stringify 순환 참조 안전망. */
+function replaceCircular() {
+  const seen = new WeakSet();
+  return (_key: string, value: any) => {
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) return "[Circular]";
+      seen.add(value);
+    }
+    return value;
+  };
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -5,6 +5,7 @@ import bcrypt from "bcryptjs";
 import { prisma } from "../lib/db.js";
 import { requireAdmin, requireAuth, requireSuperAdminStepUp, verifySuperToken, writeLog, evictUserCache } from "../lib/auth.js";
 import { todayStr } from "../lib/dates.js";
+import { getLogs, type LogLevel } from "../lib/logBuffer.js";
 
 const router = Router();
 router.use(requireAuth, requireAdmin);
@@ -655,13 +656,78 @@ router.get("/api-spec", requireSuperAdminStepUp, async (req, res) => {
  */
 const consoleSchema = z.object({ cmd: z.string().min(1).max(200) });
 
+/** 콘솔 입력창의 @ 자동완성용 — ctx 에 따라 유저/팀/직급 후보 반환. */
+router.get("/console/complete", requireSuperAdminStepUp, async (req, res) => {
+  const ctx = String(req.query.ctx ?? "user").toLowerCase();
+  const q = String(req.query.q ?? "").trim();
+  const limit = Math.min(20, Math.max(1, parseInt(String(req.query.limit ?? 10), 10) || 10));
+
+  if (ctx === "user") {
+    // 빈 q 면 최근 가입 순. 검색은 이름/이메일/사번/HR코드 부분 매치.
+    const where = q
+      ? {
+          OR: [
+            { name: { contains: q, mode: "insensitive" as const } },
+            { email: { contains: q, mode: "insensitive" as const } },
+            { employeeNo: { contains: q, mode: "insensitive" as const } },
+            { hrCode: { contains: q, mode: "insensitive" as const } },
+          ],
+        }
+      : {};
+    const users = await prisma.user.findMany({
+      where,
+      take: limit,
+      orderBy: q ? { name: "asc" } : { createdAt: "desc" },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        employeeNo: true,
+        team: true,
+        position: true,
+        role: true,
+        active: true,
+      },
+    });
+    return res.json({ items: users });
+  }
+
+  if (ctx === "team" || ctx === "position") {
+    // distinct — 유저 테이블에 들어있는 고유 팀/직급 값 모음.
+    const rows = await prisma.user.findMany({
+      where: ctx === "team" ? { team: { not: null } } : { position: { not: null } },
+      select: ctx === "team" ? { team: true } : { position: true },
+      distinct: ctx === "team" ? ["team"] : ["position"],
+      take: 200,
+    });
+    let values = rows
+      .map((r: any) => (ctx === "team" ? r.team : r.position))
+      .filter((v: any): v is string => !!v && typeof v === "string");
+    if (q) {
+      const k = q.toLowerCase();
+      values = values.filter((v) => v.toLowerCase().includes(k));
+    }
+    values.sort((a, b) => a.localeCompare(b, "ko"));
+    return res.json({ items: values.slice(0, limit).map((v) => ({ value: v })) });
+  }
+
+  return res.status(400).json({ error: "unknown ctx" });
+});
+
 router.post("/console", requireSuperAdminStepUp, async (req, res) => {
   const u = (req as any).user;
   const parsed = consoleSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
   const raw = parsed.data.cmd.trim();
-  // 간이 토크나이저 — quoted 인자는 미지원, 공백 분리. 사번/이메일/cuid 류는 공백 없음 가정.
-  const tokens = raw.split(/\s+/);
+  // 토크나이저 — \"공백 포함 값\" / '공백 포함 값' 지원. 그 외엔 공백 분리.
+  const tokens: string[] = [];
+  {
+    const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(raw)) !== null) {
+      tokens.push(m[1] ?? m[2] ?? m[3] ?? "");
+    }
+  }
   const head = (tokens[0] || "").toLowerCase();
   const sub = (tokens[1] || "").toLowerCase();
   const arg1 = tokens[2] || "";
@@ -864,7 +930,11 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
       const target = await findUser(arg1);
       if (!target) { result = err(`유저를 찾을 수 없음: ${arg1}`); }
       else {
-        const value = arg2 === "-" ? null : tokens.slice(3).join(" ").trim() || null;
+        // 토크나이저가 quoted 처리하므로 arg2 가 그대로 \"디자인팀\" 같은 값 한 덩어리로 들어옴.
+        // 빈값(\"-\") → null. 추가 토큰이 더 있으면 공백 결합(quote 없이 입력한 케이스 대비).
+        const tail = tokens.slice(3).join(" ").trim();
+        const combined = tail ? `${arg2} ${tail}` : arg2;
+        const value = combined === "-" || !combined ? null : combined;
         await prisma.user.update({
           where: { id: target.id },
           data: sub === "team" ? { team: value } : { position: value },
@@ -905,6 +975,7 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
         ]);
       }
     } else if (head === "notice" && sub === "broadcast") {
+      // 따옴표로 감싸 보내거나 그냥 공백 단어들로 보내거나 둘 다 허용.
       const body = tokens.slice(2).join(" ").trim();
       if (!body) { result = err("본문이 비었어요. 예: notice broadcast 내일 점검 있어요"); }
       else {
@@ -961,6 +1032,19 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
   // 모든 명령(성공/실패 무관) 감사 로그.
   await writeLog(u.id, "SUPER_CONSOLE", undefined, raw, req.ip).catch(() => {});
   res.json(result);
+});
+
+/** 서버 인메모리 로그 — 콘솔 출력 + HTTP 액세스 라인. 프로세스 재기동 시 초기화. */
+router.get("/server-logs", requireSuperAdminStepUp, async (req, res) => {
+  const since = req.query.since ? Number(req.query.since) : undefined;
+  const levelRaw = String(req.query.level ?? "");
+  const level = (["info", "warn", "error", "http"] as const).includes(levelRaw as any)
+    ? (levelRaw as LogLevel)
+    : undefined;
+  const q = typeof req.query.q === "string" ? req.query.q : undefined;
+  const limit = req.query.limit ? Math.min(2000, Math.max(1, Number(req.query.limit))) : 500;
+  const logs = getLogs({ since, level, q, limit });
+  res.json({ logs, now: Date.now() });
 });
 
 router.get("/logs", requireSuperAdminStepUp, async (req, res) => {


### PR DESCRIPTION
## 증상
**콘솔 자동완성(Tab + @) + 서버 로그 탭**

새 기능을 추가합니다.

## 원인
[콘솔 자동완성]
서버:
- GET /api/admin/console/complete?ctx=user|team|position&q=...
  · user: 이름/이메일/사번/HR코드 부분 매치 → id 반환
  · team / position: User 테이블 distinct 값 정렬 반환
- 토크나이저 quoted 인자 지원: "디자인팀" 처럼 공백 포함 값 한 덩어리.

클라:
- ConsolePanel 에 명령어 트리 + resolveCompletion(input, cursor) 도입.
- Tab: 현재 토큰 컨텍스트 분석 → 정적(트리 토큰) 또는 동적(서버 fetch).
  단일 매치면 즉시 삽입, 다수면 드롭다운.
- @: 토큰이 @ 로 시작하면 자동으로 컨텍스트 fetch + 노출.
  ↑↓ / Enter / Esc 로 메뉴 조작.
- 선택 시 토큰 영역을 id 또는 값으로 치환 + 공백 한 칸 추가.

[서버 로그]
서버:
- lib/logBuffer.ts: 최대 2000줄 인메모리 링버퍼.
  · installConsoleHook() 으로 console.log/info/warn/error 가로채기 — 원래 출력 유지하며 동시에 적재.
  · pushHttpLog 미들웨어로 "GET /api/x 200 12ms" 라인 push.
- GET /api/admin/server-logs (super stepUp): since/level/q/limit 필터.

클라:
- SuperAdminPage "서버 로그" 탭, ?tab=server.
- ServerLogsPanel: 검색 + 레벨 필터(전체/HTTP/INFO/WARN/ERROR) + 자동갱신(3s)

## 수정
**작업 항목 (커밋 단위)**
- feat(super-admin): 콘솔 자동완성(Tab + @) + 서버 로그 탭

**변경 대상 (4개 파일)**
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/index.ts`
- `server/src/lib/logBuffer.ts`
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #67** ↔ **이슈 #489** 로 연결됩니다.

Closes #489
