### PR TITLE
🔀 :: (#490) 사이드바 메뉴 가시성 토글 (전사)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -29,6 +29,34 @@ function prefetchRoute(to: string) {
 
 type NavItem = { to: string; label: string; icon: (p: { active?: boolean }) => JSX.Element; end?: boolean };
 
+/** 총관리자가 끈 사이드바 path 들. /api/nav/visibility 응답 + storage 이벤트로 다른 탭 동기화. */
+function useDisabledNav() {
+  const [disabled, setDisabled] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    let cancelled = false;
+    function load() {
+      api<{ disabled: string[] }>("/api/nav/visibility")
+        .then((r) => {
+          if (cancelled) return;
+          setDisabled(new Set(r.disabled ?? []));
+        })
+        .catch(() => {});
+    }
+    load();
+    // 다른 탭/창에서 토글이 바뀌면 즉시 반영.
+    function onChange() { load(); }
+    window.addEventListener("hinest:navVisibilityChange", onChange);
+    // 페이지 포커스 복귀 시에도 한 번 더 — 다른 디바이스의 토글까지.
+    window.addEventListener("focus", onChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("hinest:navVisibilityChange", onChange);
+      window.removeEventListener("focus", onChange);
+    };
+  }, []);
+  return disabled;
+}
+
 const WORK_NAV: NavItem[] = [
   { to: "/", label: "개요", icon: HomeIcon, end: true },
   { to: "/schedule", label: "일정", icon: CalendarIcon },
@@ -66,6 +94,8 @@ function AppLayoutInner() {
   const { user, logout } = useAuth();
   const nav = useNavigate();
   const loc = useLocation();
+  const disabledNav = useDisabledNav();
+  const filterByVisibility = (items: NavItem[]) => items.filter((i) => !disabledNav.has(i.to));
   const isMacDesktop = !!window.hinest?.isDesktop && window.hinest?.platform === "darwin";
   const [isFullscreen, setIsFullscreen] = useState(false);
   // 모바일 사이드바 드로어 — md 미만에서만 의미 있음 (md 이상은 항상 고정 배치)
@@ -127,9 +157,10 @@ function AppLayoutInner() {
         </div>
 
         <nav className="flex-1 overflow-y-auto px-2 py-3 space-y-5">
-          <NavSection label="워크스페이스" items={WORK_NAV} />
-          <NavSection label="커뮤니케이션" items={COMM_NAV} />
-          <NavSection label="자료·재무" items={RESOURCE_NAV} />
+          {/* 총관리자가 끈 항목은 메뉴에서 제외. 섹션 자체가 비면 라벨도 안 보이게. */}
+          {(() => { const items = filterByVisibility(WORK_NAV); return items.length > 0 && <NavSection label="워크스페이스" items={items} />; })()}
+          {(() => { const items = filterByVisibility(COMM_NAV); return items.length > 0 && <NavSection label="커뮤니케이션" items={items} />; })()}
+          {(() => { const items = filterByVisibility(RESOURCE_NAV); return items.length > 0 && <NavSection label="자료·재무" items={items} />; })()}
           <PinsSection />
           <ProjectsSection />
 

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -38,7 +38,7 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat" | "api" | "console" | "server";
+type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav";
 
 type ApiSpecRoute = {
   method: string;
@@ -71,6 +71,7 @@ function SuperAdminContent() {
     : raw === "api" ? "api"
     : raw === "console" ? "console"
     : raw === "server" ? "server"
+    : raw === "nav" ? "nav"
     : "logs";
   const setTab = (t: Tab) => {
     const next = new URLSearchParams(sp);
@@ -86,12 +87,14 @@ function SuperAdminContent() {
         <TabBtn active={tab === "api"} onClick={() => setTab("api")}>API 명세</TabBtn>
         <TabBtn active={tab === "console"} onClick={() => setTab("console")}>콘솔</TabBtn>
         <TabBtn active={tab === "server"} onClick={() => setTab("server")}>서버 로그</TabBtn>
+        <TabBtn active={tab === "nav"} onClick={() => setTab("nav")}>메뉴 관리</TabBtn>
       </div>
       {tab === "logs" && <LogsPanel />}
       {tab === "chat" && <ChatAuditPanel />}
       {tab === "api" && <ApiSpecPanel />}
       {tab === "console" && <ConsolePanel />}
       {tab === "server" && <ServerLogsPanel />}
+      {tab === "nav" && <NavVisibilityPanel />}
     </>
   );
 }
@@ -1141,6 +1144,157 @@ function ServerLogsPanel() {
       <div className="text-[11px] text-ink-500 mt-2">
         프로세스 재기동(배포 등) 시 버퍼 초기화. 디스크/CloudWatch 영속화 없음 — 최근 2,000줄만 메모리에 보관.
       </div>
+    </div>
+  );
+}
+
+/* =============== 메뉴 가시성 — 사이드바 항목 켜고 끄기 =============== */
+// AppLayout 의 NAV 그룹과 동일한 path/label 매핑.
+const NAV_GROUPS: { label: string; items: { to: string; label: string }[] }[] = [
+  {
+    label: "워크스페이스",
+    items: [
+      { to: "/", label: "개요" },
+      { to: "/schedule", label: "일정" },
+      { to: "/attendance", label: "근태·월차" },
+      { to: "/journal", label: "업무일지" },
+      { to: "/meetings", label: "회의록" },
+      { to: "/approvals", label: "전자결재" },
+    ],
+  },
+  {
+    label: "커뮤니케이션",
+    items: [
+      { to: "/notice", label: "공지사항" },
+      { to: "/directory", label: "팀원" },
+      { to: "/org", label: "조직도" },
+    ],
+  },
+  {
+    label: "자료·재무",
+    items: [
+      { to: "/documents", label: "문서함" },
+      { to: "/expense", label: "법인카드" },
+      { to: "/accounts", label: "계정 관리" },
+      { to: "/snippets", label: "스니펫" },
+    ],
+  },
+];
+
+type NavConfigRow = { path: string; enabled: boolean; updatedAt: string; updatedBy?: string | null };
+
+function NavVisibilityPanel() {
+  const [items, setItems] = useState<NavConfigRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => { aliveRef.current = false; };
+  }, []);
+
+  async function load() {
+    try {
+      const r = await api<{ items: NavConfigRow[] }>("/api/admin/nav-visibility");
+      if (!aliveRef.current) return;
+      setItems(r.items);
+      setLoading(false);
+    } catch (e: any) {
+      if (!aliveRef.current) return;
+      setErr(e?.message ?? "불러오기 실패");
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+
+  const disabledMap = useMemo(() => {
+    const m = new Set<string>();
+    for (const r of items) if (!r.enabled) m.add(r.path);
+    return m;
+  }, [items]);
+
+  async function toggle(path: string, nextEnabled: boolean) {
+    setSaving(path);
+    try {
+      await api("/api/admin/nav-visibility", {
+        method: "POST",
+        json: { path, enabled: nextEnabled },
+      });
+      // 낙관적 업데이트.
+      setItems((prev) => {
+        const exist = prev.find((r) => r.path === path);
+        if (exist) {
+          return prev.map((r) => (r.path === path ? { ...r, enabled: nextEnabled } : r));
+        }
+        return [...prev, { path, enabled: nextEnabled, updatedAt: new Date().toISOString() }];
+      });
+      // 같은 탭 / 다른 탭의 AppLayout 사이드바도 즉시 갱신.
+      window.dispatchEvent(new Event("hinest:navVisibilityChange"));
+    } catch (e: any) {
+      alert(e?.message ?? "저장 실패");
+    } finally {
+      if (aliveRef.current) setSaving(null);
+    }
+  }
+
+  if (loading) return <div className="panel p-8 text-center text-ink-500 text-[13px]">불러오는 중…</div>;
+  if (err) return <div className="panel p-6 text-red-600 text-[13px]">{err}</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="text-[12px] text-ink-500">
+        끈 항목은 사이드바에서 즉시 사라져요 (전사 적용). 페이지 자체는 직접 URL 입력으로 들어갈 순 있고, 라우트는 살아있어요.
+      </div>
+      {NAV_GROUPS.map((g) => (
+        <div key={g.label} className="panel p-0 overflow-hidden">
+          <div className="px-4 py-2 bg-ink-25 border-b border-ink-150 text-[12.5px] font-bold text-ink-800">
+            {g.label}
+          </div>
+          <ul className="divide-y divide-ink-100">
+            {g.items.map((it) => {
+              const off = disabledMap.has(it.to);
+              const isSaving = saving === it.to;
+              return (
+                <li key={it.to} className="px-4 py-3 flex items-center gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[13.5px] font-semibold text-ink-900">{it.label}</div>
+                    <code className="text-[11px] text-ink-500 font-mono">{it.to}</code>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => toggle(it.to, off)}
+                    disabled={isSaving}
+                    aria-label={off ? "켜기" : "끄기"}
+                    style={{
+                      width: 46, height: 26, borderRadius: 999,
+                      background: off ? "var(--c-border-strong)" : "var(--c-brand)",
+                      position: "relative",
+                      transition: "background .18s ease",
+                      flexShrink: 0,
+                      border: 0, cursor: "pointer",
+                      opacity: isSaving ? 0.6 : 1,
+                    }}
+                  >
+                    <div
+                      style={{
+                        position: "absolute",
+                        top: 2, left: off ? 2 : 22,
+                        width: 22, height: 22, borderRadius: "50%",
+                        background: "#fff",
+                        boxShadow: "0 1px 3px rgba(0,0,0,.15)",
+                        transition: "left .18s ease",
+                      }}
+                    />
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }

--- a/server/prisma/migrations/20260427100000_nav_config/migration.sql
+++ b/server/prisma/migrations/20260427100000_nav_config/migration.sql
@@ -1,0 +1,8 @@
+-- 사이드바 메뉴 항목 표시 여부 (전사) — 총관리자 토글.
+CREATE TABLE "NavConfig" (
+  "path" TEXT NOT NULL,
+  "enabled" BOOLEAN NOT NULL DEFAULT true,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  "updatedBy" TEXT,
+  CONSTRAINT "NavConfig_pkey" PRIMARY KEY ("path")
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -873,3 +873,12 @@ model Snippet {
   @@index([scope, updatedAt])
   @@index([trigger])
 }
+
+/// 사이드바 메뉴 항목 표시 여부 (전사 단위) — 총관리자 토글로 즉시 숨김/노출.
+/// path 가 키. 행이 없으면 기본 enabled=true 로 간주(누락된 항목까지 굳이 row 안 남김).
+model NavConfig {
+  path      String   @id // 예: "/snippets", "/expense"
+  enabled   Boolean  @default(true)
+  updatedAt DateTime @updatedAt
+  updatedBy String?
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1034,6 +1034,30 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
   res.json(result);
 });
 
+/** 사이드바 메뉴 가시성 관리 (총관리자 전용).
+ *  GET  /api/admin/nav-visibility           전체 NavConfig 행 (disabled 만 의미 있음)
+ *  POST /api/admin/nav-visibility           { path, enabled } upsert.
+ */
+router.get("/nav-visibility", requireSuperAdminStepUp, async (_req, res) => {
+  const rows = await prisma.navConfig.findMany({ orderBy: { path: "asc" } });
+  res.json({ items: rows });
+});
+
+router.post("/nav-visibility", requireSuperAdminStepUp, async (req, res) => {
+  const u = (req as any).user;
+  const schema = z.object({ path: z.string().min(1).max(120), enabled: z.boolean() });
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const { path: p, enabled } = parsed.data;
+  await prisma.navConfig.upsert({
+    where: { path: p },
+    create: { path: p, enabled, updatedBy: u.id },
+    update: { enabled, updatedBy: u.id },
+  });
+  await writeLog(u.id, "NAV_TOGGLE", p, JSON.stringify({ enabled }), req.ip).catch(() => {});
+  res.json({ ok: true });
+});
+
 /** 서버 인메모리 로그 — 콘솔 출력 + HTTP 액세스 라인. 프로세스 재기동 시 초기화. */
 router.get("/server-logs", requireSuperAdminStepUp, async (req, res) => {
   const since = req.query.since ? Number(req.query.since) : undefined;

--- a/server/src/routes/nav.ts
+++ b/server/src/routes/nav.ts
@@ -12,6 +12,16 @@ import { requireAuth } from "../lib/auth.js";
 const router = Router();
 router.use(requireAuth);
 
+/** 사이드바 메뉴 가시성 — 총관리자가 NavConfig 에서 끈 항목 path 목록 반환.
+ *  행이 없는 path 는 기본 노출(true) 로 간주 → 클라는 disabled set 만 알면 됨. */
+router.get("/visibility", async (_req, res) => {
+  const rows = await prisma.navConfig.findMany({
+    where: { enabled: false },
+    select: { path: true },
+  });
+  res.json({ disabled: rows.map((r) => r.path) });
+});
+
 function parseSince(v: unknown): Date | null {
   if (typeof v !== "string" || !v) return null;
   const d = new Date(v);


### PR DESCRIPTION
## 증상
**사이드바 메뉴 가시성 토글 (전사)**

새 기능을 추가합니다.

## 원인
[모델]
- NavConfig { path @id, enabled, updatedAt, updatedBy }
- 행이 없는 path 는 enabled=true 기본 (필요 없는 row 안 만듬)
- migration 20260427100000_nav_config

[서버]
- GET /api/nav/visibility (auth)        끈 path 배열 반환 — 모든 사용자가 사이드바 필터에 사용
- GET /api/admin/nav-visibility (super)  전체 NavConfig 행
- POST /api/admin/nav-visibility (super) { path, enabled } upsert + AuditLog(NAV_TOGGLE)

[클라]
- AppLayout: useDisabledNav() 훅 — fetch + window focus / hinest:navVisibilityChange 로 갱신.
  WORK/COMM/RESOURCE 그룹을 disabled set 으로 필터, 그룹이 비면 라벨도 숨김.
- SuperAdminPage 새 탭 "메뉴 관리":
  · NAV_GROUPS 정적 매핑(AppLayout 과 동기) 으로 13개 항목 토글 노출.
  · 토글 시 낙관적 업데이트 + window 이벤트 디스패치 → AppLayout 즉시 반영.
  · 끈 항목 안내: 사이드바에서만 사라지고 라우트는 살아있음.

## 수정
**작업 항목 (커밋 단위)**
- feat(super-admin): 사이드바 메뉴 가시성 토글 (전사)

**변경 대상 (6개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/prisma/migrations/20260427100000_nav_config/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/routes/admin.ts`
- `server/src/routes/nav.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #68** ↔ **이슈 #490** 로 연결됩니다.

Closes #490
