### PR TITLE
🔀 :: (#491) 끈 메뉴 라우트 차단 + 서지완 HiNest 개발자 딱지 + 콘솔 포커스 fix

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -10,6 +10,7 @@ import CreateProjectModal from "./CreateProjectModal";
 import { NotificationProvider, useNotifications } from "../notifications";
 import { PinsProvider, usePins, pinLinkUrl } from "../pins";
 import { ROUTE_PREFETCH, loadProject } from "../routes";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 /**
  * 사이드바 hover/focus prefetch — 사용자가 클릭하기 전에 해당 페이지 청크를
@@ -28,6 +29,42 @@ function prefetchRoute(to: string) {
 }
 
 type NavItem = { to: string; label: string; icon: (p: { active?: boolean }) => JSX.Element; end?: boolean };
+
+/** 토글 path → 영향받는 자식 path prefix 매핑.
+ *  /meetings 끄면 /meetings/123 도 막아야 하니까 startsWith 비교. */
+function isPathBlocked(pathname: string, disabled: Set<string>): string | null {
+  if (disabled.size === 0) return null;
+  // 정확히 일치하거나(/journal), 자식 경로(/meetings/abc) 도 차단.
+  for (const p of disabled) {
+    // "/" 자체를 끈 경우는 정확 매치만 (다른 모든 경로의 prefix 라 너무 광범위).
+    if (p === "/") {
+      if (pathname === "/") return p;
+      continue;
+    }
+    if (pathname === p || pathname.startsWith(p + "/")) return p;
+  }
+  return null;
+}
+
+/** 끈 메뉴는 라우트 진입도 차단 — Outlet 자리에 안내 화면. */
+function RouteVisibilityGate({ disabled, children }: { disabled: Set<string>; children: React.ReactNode }) {
+  const loc = useLocation();
+  const blocked = isPathBlocked(loc.pathname, disabled);
+  if (!blocked) return <>{children}</>;
+  return (
+    <div className="panel p-10 text-center">
+      <div className="text-[18px] font-extrabold text-ink-900 mb-2">사용할 수 없는 메뉴</div>
+      <div className="text-[13px] text-ink-600 leading-relaxed">
+        이 메뉴는 총관리자가 비활성화 했어요.
+        <br />
+        다시 사용하려면 총관리자에게 요청해 주세요.
+      </div>
+      <NavLink to="/" className="btn-primary inline-flex mt-5">
+        개요로 돌아가기
+      </NavLink>
+    </div>
+  );
+}
 
 /** 총관리자가 끈 사이드바 path 들. /api/nav/visibility 응답 + storage 이벤트로 다른 탭 동기화. */
 function useDisabledNav() {
@@ -225,7 +262,10 @@ function AppLayoutInner() {
                 </div>
               )}
               <div className="min-w-0 flex-1">
-                <div className="text-[13px] font-semibold text-ink-900 truncate">{user?.name}</div>
+                <div className="text-[13px] font-semibold text-ink-900 truncate flex items-center gap-1">
+                  <span className="truncate">{user?.name}</span>
+                  {isDevAccount({ name: user?.name }) && <DevBadge />}
+                </div>
                 <div className="text-[11px] text-ink-500 truncate">{user?.email}</div>
               </div>
             </NavLink>
@@ -262,7 +302,9 @@ function AppLayoutInner() {
         <TopBar draggable={showTitlebarSpace} onOpenNav={() => setMobileNavOpen(true)} />
         <main className="flex-1 overflow-y-auto">
           <div className="max-w-[1400px] mx-auto px-4 md:px-8 py-4 md:py-6">
-            <Outlet />
+            <RouteVisibilityGate disabled={disabledNav}>
+              <Outlet />
+            </RouteVisibilityGate>
           </div>
         </main>
       </div>

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -42,6 +42,7 @@ import { parseCodeSegments } from "../lib/codeDetect";
 import { copyToClipboard } from "../lib/clipboard";
 import { highlightCode } from "../lib/syntaxHighlight";
 import { LangIcon } from "../lib/langIcon";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 /**
  * 팝업 내부 사내톡 — 토스(Toss) 스타일 코디네이터.
@@ -2131,8 +2132,9 @@ function RoomView({
                   ) : null}
                   <div style={{ minWidth: 0, flex: "0 1 auto", position: "relative" }}>
                     {!mine && m.showMeta && (
-                      <div style={{ fontSize: 11.5, fontWeight: 600, color: C.gray600, marginLeft: 4, marginBottom: 3 }}>
+                      <div style={{ fontSize: 11.5, fontWeight: 600, color: C.gray600, marginLeft: 4, marginBottom: 3, display: "inline-flex", alignItems: "center", gap: 4 }}>
                         {m.sender.name}
+                        {isDevAccount(m.sender) && <DevBadge />}
                       </div>
                     )}
                     <div

--- a/client/src/lib/devBadge.tsx
+++ b/client/src/lib/devBadge.tsx
@@ -1,0 +1,49 @@
+/**
+ * \"HiNest 개발자\" 딱지 — 서지완(이 앱 만든 사람) 계정에만 노출.
+ *
+ * 식별 기준은 이름. 동일 회사에 동명 이인이 생기면 그 때 DB 컬럼으로 승격.
+ * (지금은 한 명이라 어디든 import 해서 isDevAccount(user) 만 체크하면 됨.)
+ */
+
+export function isDevAccount(u: { name?: string | null } | null | undefined): boolean {
+  if (!u) return false;
+  return u.name === "서지완";
+}
+
+export function DevBadge({
+  size = "sm",
+  inline = true,
+}: {
+  size?: "sm" | "md";
+  inline?: boolean;
+}) {
+  const fs = size === "md" ? 11.5 : 10;
+  const pad = size === "md" ? "2px 7px" : "1.5px 6px";
+  return (
+    <span
+      title="HiNest 를 만든 개발자"
+      style={{
+        display: inline ? "inline-flex" : "flex",
+        alignItems: "center",
+        gap: 3,
+        padding: pad,
+        borderRadius: 999,
+        fontSize: fs,
+        fontWeight: 800,
+        letterSpacing: "0.02em",
+        // 브랜드 그라데이션 — 시각적으로 확 띄게.
+        background: "linear-gradient(135deg, #3B5CF0 0%, #7C3AED 100%)",
+        color: "#fff",
+        whiteSpace: "nowrap",
+        flexShrink: 0,
+        boxShadow: "0 1px 2px rgba(60,75,200,0.25)",
+      }}
+    >
+      <svg width={fs - 1} height={fs - 1} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+      HiNest 개발자
+    </span>
+  );
+}

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
 import { alertAsync } from "../components/ConfirmHost";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 type DirectoryUser = {
   id: string;
@@ -318,7 +319,10 @@ function GridCard({
             <PresenceDot u={u} size={12} ring={2} />
           </div>
           <div className="min-w-0 flex-1">
-            <div className="text-[15px] font-extrabold text-ink-900 tracking-tight truncate">{u.name}</div>
+            <div className="text-[15px] font-extrabold text-ink-900 tracking-tight truncate inline-flex items-center gap-1.5">
+              {u.name}
+              {isDevAccount(u) && <DevBadge />}
+            </div>
             <div className="text-[12px] text-ink-600 truncate mt-0.5">
               {u.position ?? "—"}
             </div>
@@ -396,7 +400,10 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
       </div>
       <div className="min-w-0 flex-1 md:w-[28%] md:flex-initial">
         <div className="flex items-center gap-1.5">
-          <div className="text-[14px] font-extrabold text-ink-900 truncate tracking-tight">{u.name}</div>
+          <div className="text-[14px] font-extrabold text-ink-900 truncate tracking-tight inline-flex items-center gap-1.5">
+            {u.name}
+            {isDevAccount(u) && <DevBadge />}
+          </div>
           <PresenceBadge u={u} />
         </div>
         <div className="text-[11px] text-ink-500 tabular truncate">{u.email}</div>

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -19,6 +19,7 @@ import {
   type NotifCategory,
   type NotifPrefs,
 } from "../lib/notifPrefs";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 // 아바타 색상 팔레트.
 // 다크 모드 surface (#17191F 부근) 와 거의 같은 `#17191F` 를 빼고
@@ -178,7 +179,10 @@ export default function ProfilePage() {
                 </div>
               )}
               <div className="min-w-0">
-                <div className="text-[18px] font-extrabold text-ink-900 tracking-tight truncate">{name}</div>
+                <div className="text-[18px] font-extrabold text-ink-900 tracking-tight truncate flex items-center gap-1.5 min-w-0">
+                  <span className="truncate min-w-0">{name}</span>
+                  {isDevAccount({ name }) && <DevBadge size="md" />}
+                </div>
                 <div className="text-[12px] text-ink-500 truncate">{user.email}</div>
               </div>
             </div>

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -784,7 +784,12 @@ function ConsolePanel() {
       if (!aliveRef.current) return;
       setHistory((h) => [...h, { kind: "output", ok: false, text: `요청 실패: ${e?.message ?? "unknown"}`, ts: Date.now() }]);
     } finally {
-      if (aliveRef.current) setBusy(false);
+      if (aliveRef.current) {
+        setBusy(false);
+        // disabled 가 풀린 직후 포커스 복구 — busy 동안 input 이 disabled 라 포커스가 빠지므로
+        // 다음 페인트 사이클에서 다시 잡아줘야 사용자가 곧장 다음 명령을 칠 수 있음.
+        requestAnimationFrame(() => inputRef.current?.focus());
+      }
     }
   }
 


### PR DESCRIPTION
## 증상
**끈 메뉴 라우트 차단 + 서지완 HiNest 개발자 딱지 + 콘솔 포커스 fix**

새 기능을 추가합니다.

## 원인
[라우트 차단]
종전엔 사이드바에서만 숨기고 직접 URL 진입은 가능했음.
- AppLayout 의 <Outlet /> 을 RouteVisibilityGate 로 감쌈.
- 현재 pathname 이 끈 path 와 정확 일치하거나 그 자식("/meetings/123")이면
  본문 자리에 "사용할 수 없는 메뉴" 안내 + 개요로 돌아가기 버튼.
- "/" 는 prefix 매칭에서 제외 (모든 경로의 prefix 라 너무 광범위 → 정확 매치만).

["HiNest 개발자" 딱지]
- client/src/lib/devBadge.tsx (신규)
  · isDevAccount(u) — 이름이 "서지완" 인 계정만 true.
  · DevBadge — brand→violet 그라데이션 칩, 코드 아이콘 + 라벨.
- 적용 위치:
  · ChatMiniApp 메시지 발신자 이름 옆
  · DirectoryPage 카드뷰 + 행뷰 둘 다
  · ProfilePage 미리보기 카드 (size=md)
  · AppLayout 사이드바 하단 본인 정보

[버그 수정]
콘솔 명령 실행 후 입력창 포커스 빠지던 문제 — disabled={busy} 때문에 포커스
박탈 → busy 해제 후에도 자동 복구 안 됨. finally 의 setBusy(false) 직후
requestAnimationFrame 으로 input 재포커스.

## 수정
**작업 항목 (커밋 단위)**
- feat(super-admin/dev): 끈 메뉴 라우트 차단 + 서지완 "HiNest 개발자" 딱지

**변경 대상 (6개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatMiniApp.tsx`
- `client/src/lib/devBadge.tsx`
- `client/src/pages/DirectoryPage.tsx`
- `client/src/pages/ProfilePage.tsx`
- `client/src/pages/SuperAdminPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #69** ↔ **이슈 #491** 로 연결됩니다.

Closes #491
