### PR TITLE
🔀 :: (#494) HiNest 개발자 딱지 노출 확대 + 서지완 superAdmin + API 명세서 라벨

### DIFF
--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import DateTimePicker from "../components/DateTimePicker";
 import { alertAsync } from "../components/ConfirmHost";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 type ApprovalType = "TRIP" | "OFFSITE" | "EXPENSE" | "PURCHASE" | "GENERAL" | "OTHER";
 type Step = {
@@ -598,8 +599,9 @@ function ApprovalDetail({
                     {c.author.avatarUrl ? <img src={c.author.avatarUrl} alt={c.author.name} className="w-full h-full object-cover" /> : c.author.name[0]}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-baseline gap-1.5">
+                    <div className="flex items-baseline gap-1.5 flex-wrap">
                       <div className="text-[12px] font-bold text-ink-900">{c.author.name}</div>
+                      {isDevAccount(c.author) && <DevBadge />}
                       <div className="text-[10px] text-ink-400 tabular">{new Date(c.createdAt).toLocaleString("ko-KR")}</div>
                     </div>
                     <div className="text-[13px] text-ink-800 whitespace-pre-wrap leading-[1.55] mt-0.5">{c.content}</div>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import InstallAppBanner from "../components/InstallAppBanner";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 type Notice = { id: string; title: string; content: string; createdAt: string; author: { name: string }; pinned: boolean };
 type Event = { id: string; title: string; startAt: string; endAt: string; scope: string; color: string };
@@ -264,8 +265,9 @@ export default function DashboardPage() {
                     {n.pinned && <span className="chip-red">PIN</span>}
                     <div className="text-[13px] font-semibold text-ink-900 truncate">{n.title}</div>
                   </div>
-                  <div className="text-[11px] text-ink-500 mt-0.5 flex items-center gap-1.5">
+                  <div className="text-[11px] text-ink-500 mt-0.5 flex items-center gap-1.5 flex-wrap">
                     <span>{n.author?.name}</span>
+                    {isDevAccount(n.author) && <DevBadge />}
                     <span className="text-ink-300">·</span>
                     <span className="tabular">{new Date(n.createdAt).toLocaleDateString("ko-KR")}</span>
                   </div>

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -6,6 +6,7 @@ import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
 import { copyToClipboard, absoluteUrl } from "../lib/clipboard";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 // TipTap 에디터는 ~300KB 덩어리 — 회의록 상세 페이지 안에서 다시 한 번 나눠서
 // 제목/메타/공개범위 UI 가 먼저 보이고, 에디터는 뒤따라 로드되도록 함.
 const MeetingEditor = lazy(() => import("../components/MeetingEditor"));
@@ -295,6 +296,7 @@ export default function MeetingDetailPage() {
             )}
           </span>
           {meeting.author.name}
+          {isDevAccount(meeting.author) && <DevBadge />}
         </span>
         <span>·</span>
         <span>{new Date(meeting.createdAt).toLocaleString("ko-KR", { year: "numeric", month: "short", day: "numeric" })}</span>
@@ -455,6 +457,7 @@ function ViewerPicker({
                 )}
               </span>
               <span>{u.name}</span>
+              {isDevAccount(u) && <DevBadge />}
               <span className="text-[10px] text-slate-400">{u.team ?? ""}</span>
             </button>
           );

--- a/client/src/pages/MeetingsPage.tsx
+++ b/client/src/pages/MeetingsPage.tsx
@@ -4,6 +4,7 @@ import { api, apiSWR, invalidateCache } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { alertAsync } from "../components/ConfirmHost";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 type MeetingRow = {
   id: string;
@@ -139,6 +140,7 @@ export default function MeetingsPage() {
                 <div className="text-[14px] font-bold truncate">{m.title || "제목 없음"}</div>
                 <div className="flex items-center gap-2 mt-0.5 text-[11.5px] text-slate-500">
                   <span>{m.author.name}</span>
+                  {isDevAccount(m.author) && <DevBadge />}
                   <span>·</span>
                   <span>{new Date(m.updatedAt).toLocaleString("ko-KR", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
                   {m.project && (

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -7,6 +7,7 @@ import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
 import { copyToClipboard, absoluteUrl } from "../lib/clipboard";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 type ReactionAgg = { emoji: string; count: number; reactedByMe: boolean };
 type Notice = {
@@ -211,8 +212,10 @@ export default function NoticePage() {
                   )}
                   <div className="font-semibold text-ink-900 truncate">{n.title}</div>
                 </div>
-                <div className="text-xs text-slate-500 mt-0.5">
-                  {n.author?.name} · {new Date(n.createdAt).toLocaleDateString("ko-KR")}
+                <div className="text-xs text-slate-500 mt-0.5 inline-flex items-center gap-1.5">
+                  <span>{n.author?.name}</span>
+                  {isDevAccount(n.author) && <DevBadge />}
+                  <span>· {new Date(n.createdAt).toLocaleDateString("ko-KR")}</span>
                 </div>
               </button>
             ))}
@@ -235,6 +238,7 @@ export default function NoticePage() {
                       </span>
                     )}
                     <span>{selected.author?.name}</span>
+                    {isDevAccount(selected.author) && <DevBadge />}
                     <span>·</span>
                     <span>{new Date(selected.createdAt).toLocaleString("ko-KR")}</span>
                   </div>

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -4,6 +4,7 @@ import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { alertAsync } from "../components/ConfirmHost";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
 
 type DirUser = {
   id: string;
@@ -265,9 +266,10 @@ function MemberRow({
     <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-ink-25">
       <UserAvatar u={u} size={36} />
       <div className="flex-1 min-w-0">
-        <div className="text-[13px] font-bold text-ink-900 truncate">
-          {u.name}
-          {u.id === meId && <span className="chip-gray ml-1.5">나</span>}
+        <div className="text-[13px] font-bold text-ink-900 truncate inline-flex items-center gap-1.5">
+          <span className="truncate min-w-0">{u.name}</span>
+          {isDevAccount(u) && <DevBadge />}
+          {u.id === meId && <span className="chip-gray">나</span>}
         </div>
         <div className="text-[11px] text-ink-500 truncate">{u.position ?? "—"}</div>
       </div>
@@ -462,6 +464,7 @@ function PersonNode({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1 min-w-0">
           <span className="text-[12px] font-bold text-ink-900 truncate">{u.name}</span>
+          {isDevAccount(u) && <DevBadge />}
           {isMe && <span className="chip-gray !text-[9px] flex-shrink-0">나</span>}
         </div>
         <div className="text-[10px] text-ink-500 truncate">

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -159,7 +159,7 @@ function SuperAdminContent() {
             </button>
           </div>
         )}
-        <TabBtn active={tab === "api"} onClick={() => setTab("api")}>API 명세</TabBtn>
+        <TabBtn active={tab === "api"} onClick={() => setTab("api")}>API 명세서</TabBtn>
         <TabBtn active={tab === "console"} onClick={() => setTab("console")}>콘솔</TabBtn>
         <TabBtn active={tab === "server"} onClick={() => setTab("server")}>서버 로그</TabBtn>
         <TabBtn active={tab === "nav"} onClick={() => setTab("nav")}>메뉴 관리</TabBtn>

--- a/server/prisma/migrations/20260427110000_grant_super_seojiwan/migration.sql
+++ b/server/prisma/migrations/20260427110000_grant_super_seojiwan/migration.sql
@@ -1,0 +1,7 @@
+-- 서지완 계정에 총관리자 + ADMIN role 부여 (멱등 — 이미 super 면 no-op).
+-- 동명이인이 생기면 이 migration 으로는 부족. 그 때 별도 처리.
+UPDATE "User"
+SET "superAdmin" = true,
+    "role" = 'ADMIN'
+WHERE name = '서지완'
+  AND ("superAdmin" = false OR role <> 'ADMIN');


### PR DESCRIPTION
## 증상
**HiNest 개발자 딱지 노출 확대 + 서지완 superAdmin + API 명세서 라벨**

새 기능을 추가합니다.

## 원인
[딱지 추가 노출 위치]
- OrgChartPage 트리/검색 결과 둘 다
- NoticePage 목록 + 상세 작성자
- MeetingsPage 목록 작성자
- MeetingDetailPage 작성자 + 뷰어 목록
- ApprovalsPage 댓글 작성자
- DashboardPage 공지 미리보기 작성자

이로써 다른 사용자가 서지완 이름을 보는 거의 모든 자리에 "HiNest 개발자" 칩이
함께 노출됨. (이미 들어간 곳: 채팅 메시지 발신자, 디렉토리 카드/행, 본인 프로필,
사이드바 본인 정보.)

[서지완 superAdmin 권한]
- 마이그레이션 20260427110000_grant_super_seojiwan
  UPDATE "User" SET superAdmin=true, role='ADMIN' WHERE name='서지완' AND
  (현재 super=false OR role<>'ADMIN'). 멱등.

[라벨]
- 총관리자 탭 "API 명세" → "API 명세서"

## 수정
**작업 항목 (커밋 단위)**
- feat(dev): HiNest 개발자 딱지 노출 확대 + 서지완 superAdmin 부여 + API 명세서 라벨

**변경 대상 (8개 파일)**
- `client/src/pages/ApprovalsPage.tsx`
- `client/src/pages/DashboardPage.tsx`
- `client/src/pages/MeetingDetailPage.tsx`
- `client/src/pages/MeetingsPage.tsx`
- `client/src/pages/NoticePage.tsx`
- `client/src/pages/OrgChartPage.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/prisma/migrations/20260427110000_grant_super_seojiwan/migration.sql`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #72** ↔ **이슈 #494** 로 연결됩니다.

Closes #494
