### PR TITLE
🔀 :: (#495) 조직도에선 아이콘 only

### DIFF
--- a/client/src/lib/devBadge.tsx
+++ b/client/src/lib/devBadge.tsx
@@ -13,20 +13,27 @@ export function isDevAccount(u: { name?: string | null } | null | undefined): bo
 export function DevBadge({
   size = "sm",
   inline = true,
+  iconOnly = false,
 }: {
   size?: "sm" | "md";
   inline?: boolean;
+  /** 좁은 자리(조직도 카드 등) 에선 라벨 빼고 그라데이션 원 + 코드 아이콘만. */
+  iconOnly?: boolean;
 }) {
   const fs = size === "md" ? 11.5 : 10;
-  const pad = size === "md" ? "2px 7px" : "1.5px 6px";
+  const pad = iconOnly ? 0 : size === "md" ? "2px 7px" : "1.5px 6px";
+  const dim = iconOnly ? (size === "md" ? 18 : 14) : undefined;
   return (
     <span
-      title="HiNest 를 만든 개발자"
+      title="HiNest 개발자"
       style={{
         display: inline ? "inline-flex" : "flex",
         alignItems: "center",
+        justifyContent: "center",
         gap: 3,
         padding: pad,
+        width: dim,
+        height: dim,
         borderRadius: 999,
         fontSize: fs,
         fontWeight: 800,
@@ -39,11 +46,11 @@ export function DevBadge({
         boxShadow: "0 1px 2px rgba(60,75,200,0.25)",
       }}
     >
-      <svg width={fs - 1} height={fs - 1} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+      <svg width={iconOnly ? (size === "md" ? 11 : 9) : fs - 1} height={iconOnly ? (size === "md" ? 11 : 9) : fs - 1} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
         <polyline points="16 18 22 12 16 6" />
         <polyline points="8 6 2 12 8 18" />
       </svg>
-      HiNest 개발자
+      {!iconOnly && "HiNest 개발자"}
     </span>
   );
 }

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -268,7 +268,7 @@ function MemberRow({
       <div className="flex-1 min-w-0">
         <div className="text-[13px] font-bold text-ink-900 truncate inline-flex items-center gap-1.5">
           <span className="truncate min-w-0">{u.name}</span>
-          {isDevAccount(u) && <DevBadge />}
+          {isDevAccount(u) && <DevBadge iconOnly />}
           {u.id === meId && <span className="chip-gray">나</span>}
         </div>
         <div className="text-[11px] text-ink-500 truncate">{u.position ?? "—"}</div>
@@ -464,7 +464,7 @@ function PersonNode({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1 min-w-0">
           <span className="text-[12px] font-bold text-ink-900 truncate">{u.name}</span>
-          {isDevAccount(u) && <DevBadge />}
+          {isDevAccount(u) && <DevBadge iconOnly />}
           {isMe && <span className="chip-gray !text-[9px] flex-shrink-0">나</span>}
         </div>
         <div className="text-[10px] text-ink-500 truncate">


### PR DESCRIPTION
## 증상
**조직도에선 아이콘 only**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
OrgChartPage 의 카드 폭이 좁아 "HiNest 개발자" 라벨이 줄바꿈되거나 다른 정보를 밀어냄.
- DevBadge 에 iconOnly prop 추가 (size 별 14/18px 원형, 코드 아이콘만).
- OrgChartPage 두 사용 지점(트리/검색) 둘 다 iconOnly 로 교체.

다른 노출 위치(채팅/디렉토리/공지/회의록/결재/대시보드/사이드바)는 종전대로 라벨 포함.

## 수정
**작업 항목 (커밋 단위)**
- fix(devbadge): 조직도에선 아이콘 only 로 — 라벨 빼고 작은 그라데이션 칩

**변경 대상 (2개 파일)**
- `client/src/lib/devBadge.tsx`
- `client/src/pages/OrgChartPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #73** ↔ **이슈 #495** 로 연결됩니다.

Closes #495
