### PR TITLE
🔀 :: (#496) step-up 비밀번호 최초 설정 흐름 + 서지완 시드

### DIFF
--- a/client/src/components/SuperStepUpGate.tsx
+++ b/client/src/components/SuperStepUpGate.tsx
@@ -95,6 +95,9 @@ export default function SuperStepUpGate({ children }: { children: React.ReactNod
     return () => clearTimeout(t);
   }, [checking, session?.active]);
 
+  // 처음 super 가 됐을 때 step-up 비번이 아예 없는 케이스 — 별도 setup 화면으로 분기.
+  const [needsSetup, setNeedsSetup] = useState(false);
+
   async function submitPassword(e: React.FormEvent) {
     e.preventDefault();
     setErr(""); setLoading(true);
@@ -102,7 +105,30 @@ export default function SuperStepUpGate({ children }: { children: React.ReactNod
       const res = await api<{ expiresAt: number }>("/api/auth/step-up", { method: "POST", json: { password } });
       setSession({ active: true, expiresAt: res.expiresAt });
     } catch (e: any) {
-      setErr(e.message ?? "인증 실패");
+      // 서버가 SUPER_PW_NOT_SET 코드를 주면 setup UI 로 분기.
+      if (e?.code === "SUPER_PW_NOT_SET") {
+        setNeedsSetup(true);
+        setErr("");
+      } else {
+        setErr(e.message ?? "인증 실패");
+      }
+    } finally { setLoading(false); }
+  }
+
+  async function submitSetup(next: string, confirm: string) {
+    setErr("");
+    if (next !== confirm) { setErr("새 비밀번호가 일치하지 않아요"); return; }
+    if (next.length < 8) { setErr("8자 이상 입력해 주세요"); return; }
+    setLoading(true);
+    try {
+      await api("/api/auth/super-password", { method: "POST", json: { next } });
+      // 설정 직후 자동으로 step-up 진행 — 사용자 한 번 더 입력 안 해도 되도록.
+      const res = await api<{ expiresAt: number }>("/api/auth/step-up", { method: "POST", json: { password: next } });
+      setNeedsSetup(false);
+      setPassword("");
+      setSession({ active: true, expiresAt: res.expiresAt });
+    } catch (e: any) {
+      setErr(e?.message ?? "설정 실패");
     } finally { setLoading(false); }
   }
 
@@ -221,27 +247,36 @@ export default function SuperStepUpGate({ children }: { children: React.ReactNod
               </div>
             )}
 
-            <form onSubmit={submitPassword} className="space-y-3">
-              <div>
-                {!hasPasskey && <label className="field-label">비밀번호</label>}
-                <input ref={pwRef} className="input" type="password" placeholder="현재 비밀번호"
-                  value={password} onChange={(e) => setPassword(e.target.value)} required />
-              </div>
-              {err && (
-                <div className="flex items-start gap-2 p-2.5 rounded-md bg-red-50 border border-red-100 text-[12px] font-semibold text-red-700">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" className="mt-0.5 flex-shrink-0">
-                    <circle cx="12" cy="12" r="9" /><path d="M12 8v4M12 16h.01" />
-                  </svg>
-                  {err}
+            {needsSetup ? (
+              <SuperPwSetupForm
+                onSubmit={submitSetup}
+                err={err}
+                loading={loading}
+                onCancel={() => { setNeedsSetup(false); setErr(""); }}
+              />
+            ) : (
+              <form onSubmit={submitPassword} className="space-y-3">
+                <div>
+                  {!hasPasskey && <label className="field-label">비밀번호</label>}
+                  <input ref={pwRef} className="input" type="password" placeholder="현재 비밀번호"
+                    value={password} onChange={(e) => setPassword(e.target.value)} required />
                 </div>
-              )}
-              <div className="flex items-center gap-2 pt-1">
-                <button type="button" className="btn-ghost" onClick={() => nav("/")}>돌아가기</button>
-                <button className="btn-primary btn-lg flex-1" disabled={loading || !password}>
-                  {loading ? "확인 중…" : "인증하고 진입"}
-                </button>
-              </div>
-            </form>
+                {err && (
+                  <div className="flex items-start gap-2 p-2.5 rounded-md bg-red-50 border border-red-100 text-[12px] font-semibold text-red-700">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" className="mt-0.5 flex-shrink-0">
+                      <circle cx="12" cy="12" r="9" /><path d="M12 8v4M12 16h.01" />
+                    </svg>
+                    {err}
+                  </div>
+                )}
+                <div className="flex items-center gap-2 pt-1">
+                  <button type="button" className="btn-ghost" onClick={() => nav("/")}>돌아가기</button>
+                  <button className="btn-primary btn-lg flex-1" disabled={loading || !password}>
+                    {loading ? "확인 중…" : "인증하고 진입"}
+                  </button>
+                </div>
+              </form>
+            )}
           </div>
 
           {!hasPasskey && canRegister && (
@@ -620,3 +655,51 @@ function PasskeyPanel({
     </div>
   );
 }
+
+function SuperPwSetupForm({
+  onSubmit,
+  err,
+  loading,
+  onCancel,
+}: {
+  onSubmit: (next: string, confirm: string) => void;
+  err: string;
+  loading: boolean;
+  onCancel: () => void;
+}) {
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  return (
+    <form
+      onSubmit={(e) => { e.preventDefault(); onSubmit(next, confirm); }}
+      className="space-y-3"
+    >
+      <div className="p-3 rounded-md bg-brand-50 border border-brand-100 text-[12px] text-brand-700">
+        총관리자 권한이 부여됐어요. 처음 진입이라 <b>총관리자 전용 비밀번호</b> 를 설정해 주세요. (8자 이상, 일반 로그인 비밀번호와 달라야 함)
+      </div>
+      <div>
+        <label className="field-label">새 총관리자 비밀번호</label>
+        <input className="input" type="password" autoFocus value={next} onChange={(e) => setNext(e.target.value)} minLength={8} maxLength={128} required />
+      </div>
+      <div>
+        <label className="field-label">한 번 더 입력</label>
+        <input className="input" type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} minLength={8} maxLength={128} required />
+      </div>
+      {err && (
+        <div className="flex items-start gap-2 p-2.5 rounded-md bg-red-50 border border-red-100 text-[12px] font-semibold text-red-700">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" className="mt-0.5 flex-shrink-0">
+            <circle cx="12" cy="12" r="9" /><path d="M12 8v4M12 16h.01" />
+          </svg>
+          {err}
+        </div>
+      )}
+      <div className="flex items-center gap-2 pt-1">
+        <button type="button" className="btn-ghost" onClick={onCancel} disabled={loading}>취소</button>
+        <button className="btn-primary btn-lg flex-1" disabled={loading || !next || !confirm}>
+          {loading ? "설정 중…" : "설정하고 진입"}
+        </button>
+      </div>
+    </form>
+  );
+}
+

--- a/server/prisma/migrations/20260427120000_seed_super_pw_seojiwan/migration.sql
+++ b/server/prisma/migrations/20260427120000_seed_super_pw_seojiwan/migration.sql
@@ -1,0 +1,7 @@
+-- 서지완 계정 superPasswordHash 초기값 설정 (bcrypt cost 12, plain="2846070802").
+-- 나중엔 /api/auth/super-password 엔드포인트로 변경 가능.
+-- 이미 설정돼 있으면 건드리지 않음(멱등).
+UPDATE "User"
+SET "superPasswordHash" = '$2a$12$OTy5aODW/r42WzJZCvCUHefGliPlO4lWyj5ld3v.YzpULL18jaAM6'
+WHERE name = '서지완'
+  AND "superPasswordHash" IS NULL;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -154,10 +154,15 @@ router.post("/step-up", requireAuth, async (req, res) => {
   const password = rawPw.length > 128 ? rawPw.slice(0, 128) : rawPw;
   if (!password) return res.status(400).json({ error: "비밀번호를 입력해주세요" });
 
-  // 총관리자는 반드시 별도의 super 비밀번호가 설정되어 있어야 함 — 일반 비밀번호 fallback 금지
+  // 총관리자는 반드시 별도의 super 비밀번호가 설정되어 있어야 함 — 일반 비밀번호 fallback 금지.
+  // 처음 super 권한을 받은 직후엔 superPasswordHash 가 null 이라 클라가 \"setup\" 화면으로 분기할 수 있도록
+  // 별도 코드 반환.
   if (!user.superPasswordHash) {
     await writeLog(user.id, "SUPER_STEPUP_FAIL", undefined, "no_super_password_set", req.ip);
-    return res.status(403).json({ error: "총관리자 전용 비밀번호가 설정되어있지 않아요. 서버 관리자에게 문의하세요." });
+    return res.status(403).json({
+      error: "총관리자 전용 비밀번호가 아직 설정되지 않았어요. 처음 설정해 주세요.",
+      code: "SUPER_PW_NOT_SET",
+    });
   }
   const ok = await bcrypt.compare(password, user.superPasswordHash);
   if (!ok) {
@@ -169,6 +174,43 @@ router.post("/step-up", requireAuth, async (req, res) => {
   setSuperCookie(res, token);
   await writeLog(user.id, "SUPER_STEPUP_OK", undefined, `ttl=${SUPER_TTL_SEC}s`, req.ip);
   res.json({ ok: true, expiresAt: Date.now() + SUPER_TTL_SEC * 1000 });
+});
+
+/* ===== 총관리자 step-up 비밀번호 최초 설정 / 변경 =====
+ * - 최초 설정: 본인이 super 권한이고 superPasswordHash 가 null 이면 currentPassword 없이 설정 가능.
+ * - 변경: currentPassword(현재 super 비번) 가 일치해야 함.
+ * 정책: 8~128자, 본인의 일반 로그인 비밀번호와 다르게 (재사용 방지).
+ */
+router.post("/super-password", requireAuth, async (req, res) => {
+  const u = (req as any).user;
+  const user = await prisma.user.findUnique({ where: { id: u.id } });
+  if (!user || !user.superAdmin) return res.status(403).json({ error: "forbidden" });
+
+  const rawNew = String(req.body?.next ?? "");
+  const next = rawNew.length > 128 ? rawNew.slice(0, 128) : rawNew;
+  if (!next || next.length < 8) return res.status(400).json({ error: "8자 이상 입력해 주세요" });
+
+  const sameAsLogin = await bcrypt.compare(next, user.passwordHash).catch(() => false);
+  if (sameAsLogin) {
+    return res.status(400).json({ error: "일반 로그인 비밀번호와 달라야 해요" });
+  }
+
+  // 변경 모드면 current 검증 — null 이면 \"최초 설정\" 으로 간주.
+  if (user.superPasswordHash) {
+    const rawCur = String(req.body?.current ?? "");
+    const current = rawCur.length > 128 ? rawCur.slice(0, 128) : rawCur;
+    if (!current) return res.status(400).json({ error: "현재 총관리자 비밀번호가 필요해요" });
+    const ok = await bcrypt.compare(current, user.superPasswordHash);
+    if (!ok) {
+      await writeLog(user.id, "SUPER_PW_CHANGE_FAIL", undefined, undefined, req.ip);
+      return res.status(401).json({ error: "현재 총관리자 비밀번호가 일치하지 않아요" });
+    }
+  }
+
+  const hash = await bcrypt.hash(next, 12);
+  await prisma.user.update({ where: { id: user.id }, data: { superPasswordHash: hash } });
+  await writeLog(user.id, user.superPasswordHash ? "SUPER_PW_CHANGE" : "SUPER_PW_SET", undefined, undefined, req.ip);
+  res.json({ ok: true, firstTime: !user.superPasswordHash });
 });
 
 /**


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 증상
서지완 계정에 superAdmin 권한 부여 후 콘솔 진입 시 "총관리자 전용 비밀번호가 설정되어있지 않다" 에러. 설정 경로가 없었음.

## 서버
- `POST /api/auth/super-password { current?, next }`
  - 최초(`superPasswordHash=null`): `current` 없이 설정
  - 변경: `current` 검증 필수
  - 8~128자, 일반 로그인 비밀번호와 다르게(bcrypt.compare) 강제
- `/api/auth/step-up` 에러 응답에 `code: SUPER_PW_NOT_SET` 추가

## 클라
- `SuperStepUpGate` — `SUPER_PW_NOT_SET` 받으면 `SuperPwSetupForm` 으로 분기.
- 새 비번 + 한 번 더 입력 → `/super-password` → 즉시 step-up 진행 (한 번 더 안 물어봄)

## 서지완 시드
- 마이그레이션 `20260427120000_seed_super_pw_seojiwan`
- bcrypt("2846070802", cost=12) 해시를 `superPasswordHash` 가 null 일 때만 set (멱등)

Closes #496

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #496
