### PR TITLE
🔀 :: (#497) 활성 토글 디자인 깨짐 — inline-style 로 통일

### DIFF
--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -673,23 +673,41 @@ function AccountCard({
             </div>
             {canEdit && (
               <div className="flex items-center gap-1.5 flex-shrink-0">
-                {/* 활성 토글 — absolute 로 thumb 배치해 translate 계산 없이 정확한 위치.
-                     편집/삭제 버튼과는 세로선으로 분리해 시각적으로 다른 그룹임을 표시. */}
+                {/* 활성 토글 — 다른 페이지(슈퍼관리자 메뉴 관리 / 마이페이지 알림)와
+                    동일한 inline-style 패턴으로 통일. 종전 Tailwind inline-block + align-middle
+                    조합이 옆 버튼들의 baseline 정렬과 부딪혀 thumb 가 잘려 보이는 버그가 있었음. */}
                 <button
                   type="button"
                   role="switch"
                   aria-checked={a.active}
                   onClick={onToggleActive}
                   title={a.active ? "비활성화" : "활성화"}
-                  className={`relative inline-block h-[18px] w-8 rounded-full transition-colors align-middle ${
-                    a.active ? "bg-brand-600" : "bg-ink-300"
-                  }`}
+                  style={{
+                    position: "relative",
+                    width: 36,
+                    height: 20,
+                    borderRadius: 999,
+                    border: 0,
+                    cursor: "pointer",
+                    background: a.active ? "var(--c-brand)" : "var(--c-border-strong)",
+                    transition: "background .18s ease",
+                    flexShrink: 0,
+                    padding: 0,
+                  }}
                 >
                   <span
                     aria-hidden
-                    className={`absolute top-[2px] h-[14px] w-[14px] rounded-full bg-white shadow transition-[left] ${
-                      a.active ? "left-[16px]" : "left-[2px]"
-                    }`}
+                    style={{
+                      position: "absolute",
+                      top: 2,
+                      left: a.active ? 18 : 2,
+                      width: 16,
+                      height: 16,
+                      borderRadius: "50%",
+                      background: "#fff",
+                      boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
+                      transition: "left .18s ease",
+                    }}
                   />
                 </button>
                 <span className="h-5 w-px bg-ink-200" aria-hidden />


### PR DESCRIPTION
## 증상
**활성 토글 디자인 깨짐 — inline-style 로 통일**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
ServiceAccountsPage 의 활성/비활성 토글이 옆 편집·삭제 버튼들 baseline 과
부딪혀 thumb 가 잘려 보이는 버그. Tailwind inline-block + align-middle 조합이
원인.

다른 페이지(SuperAdminPage 메뉴 관리 / ProfilePage 알림 / ChatMiniApp 설정)와
동일한 inline-style 패턴 + 명시적 픽셀 사이즈로 통일:
  · 36x20 둥근 트랙 + 16x16 흰 thumb
  · top:2, left:2(off)/18(on)
  · var(--c-brand) / var(--c-border-strong) 토큰 — 다크 테마 자동 대응
  · padding:0 / border:0 으로 브라우저 기본 스타일 영향 차단

## 수정
**작업 항목 (커밋 단위)**
- fix(accounts): 활성 토글 디자인 깨짐 — inline-style 로 통일

**변경 대상 (1개 파일)**
- `client/src/pages/ServiceAccountsPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #75** ↔ **이슈 #497** 로 연결됩니다.

Closes #497
