### PR TITLE
🔀 :: (#498) 메뉴 3-state(활성/개발중/끔) + isDeveloper 권한 + 서버로그 9999줄

### DIFF
--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -11,6 +11,7 @@ export type User = {
   avatarColor?: string;
   avatarUrl?: string | null;
   superAdmin?: boolean;
+  isDeveloper?: boolean;
   employeeNo?: string | null;
   presenceStatus?: string | null;
   presenceMessage?: string | null;

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -11,6 +11,7 @@ import { NotificationProvider, useNotifications } from "../notifications";
 import { PinsProvider, usePins, pinLinkUrl } from "../pins";
 import { ROUTE_PREFETCH, loadProject } from "../routes";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
+import { getDevPagesEnabled } from "../lib/devPagesPref";
 
 /**
  * 사이드바 hover/focus prefetch — 사용자가 클릭하기 전에 해당 페이지 청크를
@@ -30,13 +31,10 @@ function prefetchRoute(to: string) {
 
 type NavItem = { to: string; label: string; icon: (p: { active?: boolean }) => JSX.Element; end?: boolean };
 
-/** 토글 path → 영향받는 자식 path prefix 매핑.
- *  /meetings 끄면 /meetings/123 도 막아야 하니까 startsWith 비교. */
-function isPathBlocked(pathname: string, disabled: Set<string>): string | null {
-  if (disabled.size === 0) return null;
-  // 정확히 일치하거나(/journal), 자식 경로(/meetings/abc) 도 차단.
-  for (const p of disabled) {
-    // "/" 자체를 끈 경우는 정확 매치만 (다른 모든 경로의 prefix 라 너무 광범위).
+/** 토글 path → 영향받는 자식 path prefix 매핑. /meetings 끄면 /meetings/123 도 차단. */
+function matchPath(pathname: string, set: Set<string>): string | null {
+  if (set.size === 0) return null;
+  for (const p of set) {
     if (p === "/") {
       if (pathname === "/") return p;
       continue;
@@ -46,44 +44,92 @@ function isPathBlocked(pathname: string, disabled: Set<string>): string | null {
   return null;
 }
 
-/** 끈 메뉴는 라우트 진입도 차단 — Outlet 자리에 안내 화면. */
-function RouteVisibilityGate({ disabled, children }: { disabled: Set<string>; children: React.ReactNode }) {
+/** 끈 메뉴는 라우트 진입도 차단 / 개발중은 \"개발 중\" 안내 (단, 개발자 + 토글 ON 이면 통과). */
+function RouteVisibilityGate({
+  disabled,
+  dev,
+  children,
+}: {
+  disabled: Set<string>;
+  dev: Set<string>;
+  children: React.ReactNode;
+}) {
   const loc = useLocation();
-  const blocked = isPathBlocked(loc.pathname, disabled);
-  if (!blocked) return <>{children}</>;
-  return (
-    <div className="panel p-10 text-center">
-      <div className="text-[18px] font-extrabold text-ink-900 mb-2">사용할 수 없는 메뉴</div>
-      <div className="text-[13px] text-ink-600 leading-relaxed">
-        이 메뉴는 총관리자가 비활성화 했어요.
-        <br />
-        다시 사용하려면 총관리자에게 요청해 주세요.
+  const { user } = useAuth();
+  const [devPagesOn, setOn] = useState(getDevPagesEnabled);
+  useEffect(() => {
+    function refresh() { setOn(getDevPagesEnabled()); }
+    window.addEventListener("hinest:devPagesChange", refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener("hinest:devPagesChange", refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+  const isDeveloper = !!user?.isDeveloper;
+  if (matchPath(loc.pathname, disabled)) {
+    return (
+      <div className="panel p-10 text-center">
+        <div className="text-[18px] font-extrabold text-ink-900 mb-2">사용할 수 없는 메뉴</div>
+        <div className="text-[13px] text-ink-600 leading-relaxed">
+          이 메뉴는 총관리자가 비활성화 했어요.
+          <br />
+          다시 사용하려면 총관리자에게 요청해 주세요.
+        </div>
+        <NavLink to="/" className="btn-primary inline-flex mt-5">
+          개요로 돌아가기
+        </NavLink>
       </div>
-      <NavLink to="/" className="btn-primary inline-flex mt-5">
-        개요로 돌아가기
-      </NavLink>
-    </div>
-  );
+    );
+  }
+  if (matchPath(loc.pathname, dev)) {
+    // 개발자 + 토글 ON 이면 안내 없이 그대로 페이지 진입.
+    if (isDeveloper && devPagesOn) return <>{children}</>;
+    return (
+      <div className="panel p-10 text-center">
+        <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10.5px] font-extrabold tracking-[0.06em] uppercase mb-3"
+          style={{ background: "var(--c-warning)", color: "#fff" }}>
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <path d="M12 9v4" /><path d="M12 17h.01" /><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          </svg>
+          개발 중
+        </div>
+        <div className="text-[18px] font-extrabold text-ink-900 mb-2">아직 준비 중인 페이지예요</div>
+        <div className="text-[13px] text-ink-600 leading-relaxed">
+          기능이 완성되면 자동으로 활성화돼요. 조금만 기다려 주세요.
+        </div>
+        {isDeveloper && (
+          <div className="text-[12px] text-ink-500 mt-3">
+            개발자 권한 보유 — 마이페이지 \"개발자 옵션\" 에서 토글을 켜면 우회할 수 있어요.
+          </div>
+        )}
+        <NavLink to="/" className="btn-primary inline-flex mt-5">
+          개요로 돌아가기
+        </NavLink>
+      </div>
+    );
+  }
+  return <>{children}</>;
 }
 
-/** 총관리자가 끈 사이드바 path 들. /api/nav/visibility 응답 + storage 이벤트로 다른 탭 동기화. */
-function useDisabledNav() {
+/** 총관리자가 끈/개발중 사이드바 path 들. /api/nav/visibility 응답 + 이벤트로 다른 탭 동기화. */
+function useNavStatus() {
   const [disabled, setDisabled] = useState<Set<string>>(new Set());
+  const [dev, setDev] = useState<Set<string>>(new Set());
   useEffect(() => {
     let cancelled = false;
     function load() {
-      api<{ disabled: string[] }>("/api/nav/visibility")
+      api<{ disabled: string[]; dev?: string[] }>("/api/nav/visibility")
         .then((r) => {
           if (cancelled) return;
           setDisabled(new Set(r.disabled ?? []));
+          setDev(new Set(r.dev ?? []));
         })
         .catch(() => {});
     }
     load();
-    // 다른 탭/창에서 토글이 바뀌면 즉시 반영.
     function onChange() { load(); }
     window.addEventListener("hinest:navVisibilityChange", onChange);
-    // 페이지 포커스 복귀 시에도 한 번 더 — 다른 디바이스의 토글까지.
     window.addEventListener("focus", onChange);
     return () => {
       cancelled = true;
@@ -91,7 +137,7 @@ function useDisabledNav() {
       window.removeEventListener("focus", onChange);
     };
   }, []);
-  return disabled;
+  return { disabled, dev };
 }
 
 const WORK_NAV: NavItem[] = [
@@ -131,7 +177,7 @@ function AppLayoutInner() {
   const { user, logout } = useAuth();
   const nav = useNavigate();
   const loc = useLocation();
-  const disabledNav = useDisabledNav();
+  const { disabled: disabledNav, dev: devNav } = useNavStatus();
   const filterByVisibility = (items: NavItem[]) => items.filter((i) => !disabledNav.has(i.to));
   const isMacDesktop = !!window.hinest?.isDesktop && window.hinest?.platform === "darwin";
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -195,9 +241,9 @@ function AppLayoutInner() {
 
         <nav className="flex-1 overflow-y-auto px-2 py-3 space-y-5">
           {/* 총관리자가 끈 항목은 메뉴에서 제외. 섹션 자체가 비면 라벨도 안 보이게. */}
-          {(() => { const items = filterByVisibility(WORK_NAV); return items.length > 0 && <NavSection label="워크스페이스" items={items} />; })()}
-          {(() => { const items = filterByVisibility(COMM_NAV); return items.length > 0 && <NavSection label="커뮤니케이션" items={items} />; })()}
-          {(() => { const items = filterByVisibility(RESOURCE_NAV); return items.length > 0 && <NavSection label="자료·재무" items={items} />; })()}
+          {(() => { const items = filterByVisibility(WORK_NAV); return items.length > 0 && <NavSection label="워크스페이스" items={items} dev={devNav} />; })()}
+          {(() => { const items = filterByVisibility(COMM_NAV); return items.length > 0 && <NavSection label="커뮤니케이션" items={items} dev={devNav} />; })()}
+          {(() => { const items = filterByVisibility(RESOURCE_NAV); return items.length > 0 && <NavSection label="자료·재무" items={items} dev={devNav} />; })()}
           <PinsSection />
           <ProjectsSection />
 
@@ -302,7 +348,7 @@ function AppLayoutInner() {
         <TopBar draggable={showTitlebarSpace} onOpenNav={() => setMobileNavOpen(true)} />
         <main className="flex-1 overflow-y-auto">
           <div className="max-w-[1400px] mx-auto px-4 md:px-8 py-4 md:py-6">
-            <RouteVisibilityGate disabled={disabledNav}>
+            <RouteVisibilityGate disabled={disabledNav} dev={devNav}>
               <Outlet />
             </RouteVisibilityGate>
           </div>
@@ -313,7 +359,7 @@ function AppLayoutInner() {
   );
 }
 
-function NavSection({ label, items }: { label: string; items: NavItem[] }) {
+function NavSection({ label, items, dev }: { label: string; items: NavItem[]; dev?: Set<string> }) {
   // 공지사항 미읽음 알림 개수 — 사이드바에 배지로 표시
   const { bellItems, ready } = useNotifications();
   const noticeUnread = bellItems.filter((n) => n.type === "NOTICE" && !n.readAt).length;
@@ -355,7 +401,18 @@ function NavSection({ label, items }: { label: string; items: NavItem[] }) {
               {({ isActive }) => (
                 <>
                   <Icon active={isActive} />
-                  <span className="flex-1">{n.label}</span>
+                  <span className="flex-1 inline-flex items-center gap-1.5 min-w-0">
+                    <span className="truncate min-w-0">{n.label}</span>
+                    {dev?.has(n.to) && (
+                      <span
+                        className="text-[9px] font-extrabold uppercase tracking-[0.06em] px-1 py-0.5 rounded-[3px] flex-shrink-0"
+                        style={{ background: "var(--c-warning)", color: "#fff", lineHeight: 1 }}
+                        title="개발 중 — 들어가면 안내 화면이 뜹니다"
+                      >
+                        DEV
+                      </span>
+                    )}
+                  </span>
                   {badgeCount > 0 && (
                     <span className="ml-auto min-w-[18px] h-[18px] px-1.5 rounded-full bg-danger text-white text-[10px] font-bold grid place-items-center tabular">
                       {badgeCount > 99 ? "99+" : badgeCount}

--- a/client/src/lib/devBadge.tsx
+++ b/client/src/lib/devBadge.tsx
@@ -1,12 +1,17 @@
 /**
- * \"HiNest 개발자\" 딱지 — 서지완(이 앱 만든 사람) 계정에만 노출.
+ * \"HiNest 개발자\" 딱지 — 총관리자가 사용자에게 부여하는 권한 플래그.
  *
- * 식별 기준은 이름. 동일 회사에 동명 이인이 생기면 그 때 DB 컬럼으로 승격.
- * (지금은 한 명이라 어디든 import 해서 isDevAccount(user) 만 체크하면 됨.)
+ * 우선순위:
+ *  1) 명시적 isDeveloper 필드 (서버 응답에 포함된 경우)
+ *  2) 이름이 \"서지완\" 인 경우 (서버 필드가 빠진 응답을 받았을 때의 fallback —
+ *     마이그레이션 직전 캐시된 페이로드 등)
  */
 
-export function isDevAccount(u: { name?: string | null } | null | undefined): boolean {
+export function isDevAccount(
+  u: { isDeveloper?: boolean | null; name?: string | null } | null | undefined,
+): boolean {
   if (!u) return false;
+  if (typeof u.isDeveloper === "boolean") return u.isDeveloper;
   return u.name === "서지완";
 }
 

--- a/client/src/lib/devPagesPref.ts
+++ b/client/src/lib/devPagesPref.ts
@@ -1,0 +1,22 @@
+/**
+ * 개발자 본인의 \"개발 중 페이지 접근\" 토글 — localStorage 기반.
+ * 개발자 권한이 없는 사용자에게도 키는 존재할 수 있지만 RouteVisibilityGate 가 무시.
+ */
+
+const KEY = "hinest.devPagesEnabled";
+
+export function getDevPagesEnabled(): boolean {
+  try {
+    const v = localStorage.getItem(KEY);
+    return v === null ? true : v === "1";
+  } catch {
+    return true;
+  }
+}
+
+export function setDevPagesEnabled(on: boolean) {
+  try {
+    localStorage.setItem(KEY, on ? "1" : "0");
+    window.dispatchEvent(new Event("hinest:devPagesChange"));
+  } catch {}
+}

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -20,6 +20,7 @@ import {
   type NotifPrefs,
 } from "../lib/notifPrefs";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
+import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
 
 // 아바타 색상 팔레트.
 // 다크 모드 surface (#17191F 부근) 와 거의 같은 `#17191F` 를 빼고
@@ -181,7 +182,7 @@ export default function ProfilePage() {
               <div className="min-w-0">
                 <div className="text-[18px] font-extrabold text-ink-900 tracking-tight truncate flex items-center gap-1.5 min-w-0">
                   <span className="truncate min-w-0">{name}</span>
-                  {isDevAccount({ name }) && <DevBadge size="md" />}
+                  {isDevAccount(user) && <DevBadge size="md" />}
                 </div>
                 <div className="text-[12px] text-ink-500 truncate">{user.email}</div>
               </div>
@@ -299,6 +300,7 @@ export default function ProfilePage() {
           <DesktopNotifyPanel />
           <ShortcutsPanel />
           <SessionInfoPanel />
+          {user.isDeveloper && <DevOptionsPanel />}
 
           <div className="panel p-6">
             <div className="h-sub mb-4">비밀번호 변경</div>
@@ -886,6 +888,75 @@ function PresencePanel() {
           "근무중" · "오프라인" 은 자동 판정이라 여기서 선택할 수 없어요. "자동" 을 선택하면 오늘 출퇴근 여부에 따라 자동으로 표시됩니다.
         </div>
       </div>
+    </div>
+  );
+}
+
+/* ===== 개발자 옵션 — isDeveloper 가 true 일 때만 노출 ===== */
+function DevOptionsPanel() {
+  const [on, setOn] = useState<boolean>(() => getDevPagesEnabled());
+  useEffect(() => {
+    function refresh() { setOn(getDevPagesEnabled()); }
+    window.addEventListener("hinest:devPagesChange", refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener("hinest:devPagesChange", refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+  function toggle(next: boolean) {
+    setOn(next);
+    setDevPagesEnabled(next);
+  }
+  return (
+    <div className="panel p-6">
+      <div className="h-sub mb-1 inline-flex items-center gap-2">
+        <DevBadge size="md" />
+        개발자 옵션
+      </div>
+      <div className="t-caption mb-4">
+        \"개발 중\" 으로 표시된 메뉴를 안내 페이지 없이 바로 진입할지 선택할 수 있어요.
+      </div>
+      <label className="flex items-center justify-between gap-3 p-3 rounded-lg bg-ink-25 border border-ink-150 cursor-pointer">
+        <div>
+          <div className="text-[13px] font-bold text-ink-900">개발 중 페이지 바로 진입</div>
+          <div className="text-[11.5px] text-ink-500 mt-0.5">
+            끄면 다른 사용자처럼 "개발 중" 안내 화면을 봐요. (각 디바이스/브라우저별 저장)
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => toggle(!on)}
+          aria-label={on ? "끄기" : "켜기"}
+          style={{
+            position: "relative",
+            width: 46,
+            height: 26,
+            borderRadius: 999,
+            border: 0,
+            cursor: "pointer",
+            background: on ? "var(--c-brand)" : "var(--c-border-strong)",
+            transition: "background .18s ease",
+            flexShrink: 0,
+            padding: 0,
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: 2,
+              left: on ? 22 : 2,
+              width: 22,
+              height: 22,
+              borderRadius: "50%",
+              background: "#fff",
+              boxShadow: "0 1px 3px rgba(0,0,0,.15)",
+              transition: "left .18s ease",
+            }}
+          />
+        </button>
+      </label>
     </div>
   );
 }

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -1336,7 +1336,7 @@ function ServerLogsPanel() {
       const params = new URLSearchParams();
       if (level) params.set("level", level);
       if (q) params.set("q", q);
-      params.set("limit", "1000");
+      params.set("limit", "9999");
       const r = await api<{ logs: ServerLog[] }>(`/api/admin/server-logs?${params}`);
       if (!aliveRef.current) return;
       setLogs(r.logs);
@@ -1441,7 +1441,7 @@ function ServerLogsPanel() {
         )}
       </div>
       <div className="text-[11px] text-ink-500 mt-2">
-        프로세스 재기동(배포 등) 시 버퍼 초기화. 디스크/CloudWatch 영속화 없음 — 최근 2,000줄만 메모리에 보관.
+        프로세스 재기동(배포 등) 시 버퍼 초기화. 디스크/CloudWatch 영속화 없음 — 최근 9,999줄만 메모리에 보관.
       </div>
     </div>
   );
@@ -1480,7 +1480,54 @@ const NAV_GROUPS: { label: string; items: { to: string; label: string }[] }[] = 
   },
 ];
 
-type NavConfigRow = { path: string; enabled: boolean; updatedAt: string; updatedBy?: string | null };
+type NavConfigRow = { path: string; enabled: boolean; inDev?: boolean; updatedAt: string; updatedBy?: string | null };
+type NavStatus = "ON" | "DEV" | "OFF";
+
+function NavStatusGroup({ value, saving, onChange }: { value: NavStatus; saving: boolean; onChange: (s: NavStatus) => void }) {
+  const opts: { v: NavStatus; label: string; color: string }[] = [
+    { v: "ON", label: "활성", color: "var(--c-brand)" },
+    { v: "DEV", label: "개발중", color: "var(--c-warning)" },
+    { v: "OFF", label: "끔", color: "var(--c-border-strong)" },
+  ];
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        background: "var(--c-surface-3)",
+        borderRadius: 8,
+        padding: 2,
+        gap: 2,
+        flexShrink: 0,
+        opacity: saving ? 0.6 : 1,
+      }}
+    >
+      {opts.map((o) => {
+        const active = value === o.v;
+        return (
+          <button
+            key={o.v}
+            type="button"
+            disabled={saving}
+            onClick={() => onChange(o.v)}
+            style={{
+              padding: "5px 10px",
+              borderRadius: 6,
+              border: 0,
+              cursor: "pointer",
+              fontSize: 11.5,
+              fontWeight: 700,
+              background: active ? o.color : "transparent",
+              color: active ? "#fff" : "var(--c-text-2)",
+              transition: "background .15s ease",
+            }}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 function NavVisibilityPanel() {
   const [items, setItems] = useState<NavConfigRow[]>([]);
@@ -1509,28 +1556,28 @@ function NavVisibilityPanel() {
 
   useEffect(() => { void load(); }, []);
 
-  const disabledMap = useMemo(() => {
-    const m = new Set<string>();
-    for (const r of items) if (!r.enabled) m.add(r.path);
-    return m;
-  }, [items]);
+  function statusOf(path: string): NavStatus {
+    const r = items.find((x) => x.path === path);
+    if (!r) return "ON"; // 행 없으면 기본값
+    if (!r.enabled) return "OFF";
+    if (r.inDev) return "DEV";
+    return "ON";
+  }
 
-  async function toggle(path: string, nextEnabled: boolean) {
+  async function setStatus(path: string, next: NavStatus) {
     setSaving(path);
     try {
-      await api("/api/admin/nav-visibility", {
-        method: "POST",
-        json: { path, enabled: nextEnabled },
-      });
+      const body =
+        next === "ON" ? { path, enabled: true, inDev: false }
+        : next === "DEV" ? { path, enabled: true, inDev: true }
+        : { path, enabled: false, inDev: false };
+      await api("/api/admin/nav-visibility", { method: "POST", json: body });
       // 낙관적 업데이트.
       setItems((prev) => {
         const exist = prev.find((r) => r.path === path);
-        if (exist) {
-          return prev.map((r) => (r.path === path ? { ...r, enabled: nextEnabled } : r));
-        }
-        return [...prev, { path, enabled: nextEnabled, updatedAt: new Date().toISOString() }];
+        const merged = { ...(exist ?? { path, updatedAt: new Date().toISOString() }), enabled: body.enabled, inDev: body.inDev };
+        return exist ? prev.map((r) => (r.path === path ? merged as NavConfigRow : r)) : [...prev, merged as NavConfigRow];
       });
-      // 같은 탭 / 다른 탭의 AppLayout 사이드바도 즉시 갱신.
       window.dispatchEvent(new Event("hinest:navVisibilityChange"));
     } catch (e: any) {
       alert(e?.message ?? "저장 실패");
@@ -1544,8 +1591,10 @@ function NavVisibilityPanel() {
 
   return (
     <div className="space-y-4">
-      <div className="text-[12px] text-ink-500">
-        끈 항목은 사이드바에서 즉시 사라져요 (전사 적용). 페이지 자체는 직접 URL 입력으로 들어갈 순 있고, 라우트는 살아있어요.
+      <div className="text-[12px] text-ink-500 leading-relaxed">
+        <b className="text-ink-700">활성</b> — 사이드바 노출 + 정상 동작.
+        &nbsp;<b className="text-amber-700">개발중</b> — 사이드바 노출 + 진입 시 \"개발 중\" 안내(개발자 권한 사용자는 통과).
+        &nbsp;<b className="text-ink-700">끔</b> — 사이드바 숨김 + 라우트 차단.
       </div>
       {NAV_GROUPS.map((g) => (
         <div key={g.label} className="panel p-0 overflow-hidden">
@@ -1554,7 +1603,7 @@ function NavVisibilityPanel() {
           </div>
           <ul className="divide-y divide-ink-100">
             {g.items.map((it) => {
-              const off = disabledMap.has(it.to);
+              const cur = statusOf(it.to);
               const isSaving = saving === it.to;
               return (
                 <li key={it.to} className="px-4 py-3 flex items-center gap-3">
@@ -1562,32 +1611,11 @@ function NavVisibilityPanel() {
                     <div className="text-[13.5px] font-semibold text-ink-900">{it.label}</div>
                     <code className="text-[11px] text-ink-500 font-mono">{it.to}</code>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => toggle(it.to, off)}
-                    disabled={isSaving}
-                    aria-label={off ? "켜기" : "끄기"}
-                    style={{
-                      width: 46, height: 26, borderRadius: 999,
-                      background: off ? "var(--c-border-strong)" : "var(--c-brand)",
-                      position: "relative",
-                      transition: "background .18s ease",
-                      flexShrink: 0,
-                      border: 0, cursor: "pointer",
-                      opacity: isSaving ? 0.6 : 1,
-                    }}
-                  >
-                    <div
-                      style={{
-                        position: "absolute",
-                        top: 2, left: off ? 2 : 22,
-                        width: 22, height: 22, borderRadius: "50%",
-                        background: "#fff",
-                        boxShadow: "0 1px 3px rgba(0,0,0,.15)",
-                        transition: "left .18s ease",
-                      }}
-                    />
-                  </button>
+                  <NavStatusGroup
+                    value={cur}
+                    saving={isSaving}
+                    onChange={(next) => setStatus(it.to, next)}
+                  />
                 </li>
               );
             })}

--- a/server/prisma/migrations/20260428000000_navconfig_indev/migration.sql
+++ b/server/prisma/migrations/20260428000000_navconfig_indev/migration.sql
@@ -1,0 +1,2 @@
+-- 사이드바 메뉴 항목 \"개발 중\" 상태 — 사이드바에는 정상 노출하지만 라우트 진입 시 안내 화면.
+ALTER TABLE "NavConfig" ADD COLUMN "inDev" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/migrations/20260428100000_user_isdeveloper/migration.sql
+++ b/server/prisma/migrations/20260428100000_user_isdeveloper/migration.sql
@@ -1,0 +1,4 @@
+-- "HiNest 개발자" 딱지 — UI 칩 노출 + "개발 중" 페이지 접근 권한.
+ALTER TABLE "User" ADD COLUMN "isDeveloper" BOOLEAN NOT NULL DEFAULT false;
+-- 서지완 계정에 자동 부여 (최초 부트스트랩).
+UPDATE "User" SET "isDeveloper" = true WHERE name = '서지완';

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -20,6 +20,8 @@ model User {
   superPasswordHash  String?
   role               String    @default("MEMBER") // ADMIN | MANAGER | MEMBER
   superAdmin         Boolean   @default(false) // 최상위 관리자 - DM/팀 채팅 감사 권한 보유
+  // \"HiNest 개발자\" 딱지 — UI 칩 노출 + \"개발 중\" 표시된 페이지 접근 권한.
+  isDeveloper        Boolean   @default(false)
   position           String? // 사원/대리/과장/팀장/이사 등
   team               String?
   active             Boolean   @default(true)
@@ -879,6 +881,8 @@ model Snippet {
 model NavConfig {
   path      String   @id // 예: "/snippets", "/expense"
   enabled   Boolean  @default(true)
+  /// 개발 중 — 사이드바에는 정상 노출, 라우트 진입 시 "개발 중" 안내 화면.
+  inDev     Boolean  @default(false)
   updatedAt DateTime @updatedAt
   updatedBy String?
 }

--- a/server/src/lib/logBuffer.ts
+++ b/server/src/lib/logBuffer.ts
@@ -16,7 +16,7 @@ export type LogEntry = {
   msg: string;
 };
 
-const MAX = 2000;
+const MAX = 9999;
 const buf: LogEntry[] = [];
 
 function pushEntry(level: LogLevel, msg: string) {
@@ -25,7 +25,7 @@ function pushEntry(level: LogLevel, msg: string) {
 }
 
 export function getLogs(opts: { since?: number; level?: LogLevel; q?: string; limit?: number } = {}): LogEntry[] {
-  const limit = Math.min(2000, Math.max(1, opts.limit ?? 500));
+  const limit = Math.min(9999, Math.max(1, opts.limit ?? 500));
   let arr = buf;
   if (opts.since) arr = arr.filter((e) => e.ts > opts.since!);
   if (opts.level) arr = arr.filter((e) => e.level === opts.level);

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -795,8 +795,8 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
         "",
         "  [유저 권한·계정]",
         "  user role <id> <MEMBER|MANAGER|ADMIN>   role 직접 지정",
-        "  user grant admin|super <id>          ADMIN 또는 superAdmin true",
-        "  user revoke admin|super <id>         ADMIN→MEMBER / superAdmin false",
+        "  user grant admin|super|dev <id>      ADMIN / superAdmin / HiNest 개발자 부여",
+        "  user revoke admin|super|dev <id>     ADMIN→MEMBER / superAdmin false / 개발자 해제",
         "  user lock <id>                       active=false (로그인 차단)",
         "  user unlock <id>                     active=true",
         "  user resign <id> [YYYY-MM-DD]        퇴사 처리 (resignedAt + active=false)",
@@ -893,8 +893,13 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
         await prisma.user.update({ where: { id: target.id }, data: { superAdmin: next } });
         await evictUserCache(target.id);
         result = out(`OK · ${target.email} superAdmin: ${target.superAdmin} → ${next}`);
+      } else if (what === "dev" || what === "developer") {
+        const next = sub === "grant";
+        await prisma.user.update({ where: { id: target.id }, data: { isDeveloper: next } });
+        await evictUserCache(target.id);
+        result = out(`OK · ${target.email} isDeveloper: ${(target as any).isDeveloper ?? false} → ${next}`);
       } else {
-        result = err(`알 수 없는 권한: ${arg1}. admin 또는 super 만 지원.`);
+        result = err(`알 수 없는 권한: ${arg1}. admin / super / dev 만 지원.`);
       }
     } else if (head === "user" && (sub === "lock" || sub === "unlock")) {
       const target = await findUser(arg1);
@@ -1073,16 +1078,27 @@ router.get("/nav-visibility", requireSuperAdminStepUp, async (_req, res) => {
 
 router.post("/nav-visibility", requireSuperAdminStepUp, async (req, res) => {
   const u = (req as any).user;
-  const schema = z.object({ path: z.string().min(1).max(120), enabled: z.boolean() });
+  const schema = z.object({
+    path: z.string().min(1).max(120),
+    enabled: z.boolean().optional(),
+    inDev: z.boolean().optional(),
+  });
   const parsed = schema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
-  const { path: p, enabled } = parsed.data;
+  const { path: p, enabled, inDev } = parsed.data;
+  if (enabled === undefined && inDev === undefined) {
+    return res.status(400).json({ error: "enabled 또는 inDev 중 하나는 필요해요" });
+  }
+  // partial update — 클라가 한 필드만 보내도 다른 필드는 유지.
+  const existing = await prisma.navConfig.findUnique({ where: { path: p } });
+  const nextEnabled = enabled ?? existing?.enabled ?? true;
+  const nextInDev = inDev ?? existing?.inDev ?? false;
   await prisma.navConfig.upsert({
     where: { path: p },
-    create: { path: p, enabled, updatedBy: u.id },
-    update: { enabled, updatedBy: u.id },
+    create: { path: p, enabled: nextEnabled, inDev: nextInDev, updatedBy: u.id },
+    update: { enabled: nextEnabled, inDev: nextInDev, updatedBy: u.id },
   });
-  await writeLog(u.id, "NAV_TOGGLE", p, JSON.stringify({ enabled }), req.ip).catch(() => {});
+  await writeLog(u.id, "NAV_TOGGLE", p, JSON.stringify({ enabled: nextEnabled, inDev: nextInDev }), req.ip).catch(() => {});
   res.json({ ok: true });
 });
 
@@ -1094,7 +1110,7 @@ router.get("/server-logs", requireSuperAdminStepUp, async (req, res) => {
     ? (levelRaw as LogLevel)
     : undefined;
   const q = typeof req.query.q === "string" ? req.query.q : undefined;
-  const limit = req.query.limit ? Math.min(2000, Math.max(1, Number(req.query.limit))) : 500;
+  const limit = req.query.limit ? Math.min(9999, Math.max(1, Number(req.query.limit))) : 500;
   const logs = getLogs({ since, level, q, limit });
   res.json({ logs, now: Date.now() });
 });

--- a/server/src/routes/me.ts
+++ b/server/src/routes/me.ts
@@ -21,6 +21,7 @@ router.get("/", requireAuth, async (req, res) => {
       avatarColor: user.avatarColor,
       avatarUrl: user.avatarUrl,
       superAdmin: user.superAdmin,
+      isDeveloper: user.isDeveloper,
       employeeNo: user.employeeNo,
       presenceStatus: user.presenceStatus,
       presenceMessage: user.presenceMessage,

--- a/server/src/routes/nav.ts
+++ b/server/src/routes/nav.ts
@@ -12,14 +12,17 @@ import { requireAuth } from "../lib/auth.js";
 const router = Router();
 router.use(requireAuth);
 
-/** 사이드바 메뉴 가시성 — 총관리자가 NavConfig 에서 끈 항목 path 목록 반환.
- *  행이 없는 path 는 기본 노출(true) 로 간주 → 클라는 disabled set 만 알면 됨. */
+/** 사이드바 메뉴 상태:
+ *  - disabled: 사이드바에서 숨김 + 라우트 차단 (enabled=false 인 path)
+ *  - dev:       사이드바엔 노출하되 진입 시 \"개발 중\" 안내 (enabled=true && inDev=true)
+ *  행이 없는 path 는 기본 enabled=true / inDev=false 로 간주 — 클라는 두 set 만 알면 됨. */
 router.get("/visibility", async (_req, res) => {
   const rows = await prisma.navConfig.findMany({
-    where: { enabled: false },
-    select: { path: true },
+    select: { path: true, enabled: true, inDev: true },
   });
-  res.json({ disabled: rows.map((r) => r.path) });
+  const disabled = rows.filter((r) => !r.enabled).map((r) => r.path);
+  const dev = rows.filter((r) => r.enabled && r.inDev).map((r) => r.path);
+  res.json({ disabled, dev });
 });
 
 function parseSince(v: unknown): Date | null {


### PR DESCRIPTION
## 증상
**메뉴 3-state(활성/개발중/끔) + isDeveloper 권한 + 서버로그 9999줄**

새 기능을 추가합니다.

## 원인
[메뉴 가시성 3-state]
- NavConfig 에 inDev 컬럼 + 마이그레이션.
- /api/nav/visibility — disabled[] + dev[] 둘 다 반환.
- POST /api/admin/nav-visibility — { enabled?, inDev? } 부분 업데이트 지원.
- 슈퍼관리자 "메뉴 관리": 토글 → 3-segment 스위치(활성 / 개발중 / 끔).
- AppLayout NavSection: dev 항목엔 노란 "DEV" 미니 칩.
- RouteVisibilityGate: dev 경로 진입 시 안내 화면(개발자+토글 ON 이면 통과).

[isDeveloper 권한]
- User.isDeveloper Boolean — 마이그레이션 시 서지완에게 자동 true.
- /api/me 응답에 isDeveloper 포함.
- 콘솔: `user grant|revoke dev <id>` 명령 추가, help 갱신.
- devBadge.isDevAccount: isDeveloper 필드 우선, 없으면 이름='서지완' fallback.
- ProfilePage: isDeveloper 인 사용자에게만 "개발자 옵션" 패널 노출.
  · localStorage hinest.devPagesEnabled 토글 (기본 ON).
  · 끄면 다른 사용자처럼 "개발 중" 안내 화면 보임.

[서버 로그]
- logBuffer MAX 2000 → 9999.
- /api/admin/server-logs limit 상한 9999.
- 클라 안내 문구 "최근 9,999줄" 로 갱신.

## 수정
**작업 항목 (커밋 단위)**
- feat(super-admin/dev): 메뉴 "개발 중" 3-state + isDeveloper 권한 + 서버로그 9999줄

**변경 대상 (13개 파일)**
- `client/src/auth.tsx`
- `client/src/components/AppLayout.tsx`
- `client/src/lib/devBadge.tsx`
- `client/src/lib/devPagesPref.ts`
- `client/src/pages/ProfilePage.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/prisma/migrations/20260428000000_navconfig_indev/migration.sql`
- `server/prisma/migrations/20260428100000_user_isdeveloper/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/lib/logBuffer.ts`
- `server/src/routes/admin.ts`
- `server/src/routes/me.ts`
- … 외 1개

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #76** ↔ **이슈 #498** 로 연결됩니다.

Closes #498
