### PR TITLE
🔀 :: (#501) isDeveloper 조회 추가

### DIFF
--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -840,7 +840,7 @@ const CMD_TREE: Record<string, any> = {
   whoami: {},
   clear: {},
   cls: {},
-  users: { list: { "arg:limit": {} }, find: { "arg:query": {} } },
+  users: { list: { "arg:limit": {} }, find: { "arg:query": {} }, devs: {} },
   user: {
     info: { "arg:user": {} },
     role: { "arg:user": { MEMBER: {}, MANAGER: {}, ADMIN: {} } },

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -791,6 +791,7 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
         "  [유저 조회]",
         "  users list [limit]                  최근 가입 N명 (기본 20, 최대 200)",
         "  users find <query>                  이름/이메일/사번 부분 매치",
+        "  users devs                           개발자 권한 보유자 전체",
         "  user info <id|email|사번>            유저 상세",
         "",
         "  [유저 권한·계정]",
@@ -827,13 +828,13 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
       const list = await prisma.user.findMany({
         orderBy: { createdAt: "desc" },
         take: limit,
-        select: { id: true, name: true, email: true, role: true, superAdmin: true, active: true, createdAt: true },
+        select: { id: true, name: true, email: true, role: true, superAdmin: true, isDeveloper: true, active: true, createdAt: true },
       });
       const rows = list.map(
         (x) =>
-          `${x.id}  ${x.role.padEnd(7)} ${x.superAdmin ? "S" : " "} ${x.active ? "A" : "X"}  ${x.email.padEnd(28)} ${x.name}`,
+          `${x.id}  ${x.role.padEnd(7)} ${x.superAdmin ? "S" : " "}${x.isDeveloper ? "D" : " "} ${x.active ? "A" : "X"}  ${x.email.padEnd(28)} ${x.name}`,
       );
-      result = out([`최근 ${list.length}명 (역할 / S=super / A=active):`, ...rows]);
+      result = out([`최근 ${list.length}명 (역할 / S=super / D=developer / A=active):`, ...rows]);
     } else if (head === "users" && sub === "find") {
       const q = arg1;
       if (!q) { result = err("쿼리가 비었어요. 예: users find 김"); }
@@ -848,32 +849,47 @@ router.post("/console", requireSuperAdminStepUp, async (req, res) => {
             ],
           },
           take: 50,
-          select: { id: true, name: true, email: true, role: true, superAdmin: true, active: true, employeeNo: true },
+          select: { id: true, name: true, email: true, role: true, superAdmin: true, isDeveloper: true, active: true, employeeNo: true },
         });
         if (list.length === 0) { result = out("매치 0건"); }
         else {
           const rows = list.map(
             (x) =>
-              `${x.id}  ${x.role.padEnd(7)} ${x.superAdmin ? "S" : " "} ${x.active ? "A" : "X"}  ${(x.employeeNo ?? "-").padEnd(12)} ${x.email.padEnd(28)} ${x.name}`,
+              `${x.id}  ${x.role.padEnd(7)} ${x.superAdmin ? "S" : " "}${x.isDeveloper ? "D" : " "} ${x.active ? "A" : "X"}  ${(x.employeeNo ?? "-").padEnd(12)} ${x.email.padEnd(28)} ${x.name}`,
           );
-          result = out([`매치 ${list.length}건:`, ...rows]);
+          result = out([`매치 ${list.length}건 (S=super / D=developer / A=active):`, ...rows]);
         }
+      }
+    } else if (head === "users" && sub === "devs") {
+      const list = await prisma.user.findMany({
+        where: { isDeveloper: true },
+        orderBy: { name: "asc" },
+        select: { id: true, name: true, email: true, role: true, active: true },
+      });
+      if (list.length === 0) { result = out("개발자 권한을 가진 사용자가 없어요."); }
+      else {
+        const rows = list.map(
+          (x) =>
+            `${x.id}  ${x.role.padEnd(7)} ${x.active ? "A" : "X"}  ${x.email.padEnd(28)} ${x.name}`,
+        );
+        result = out([`개발자 ${list.length}명:`, ...rows]);
       }
     } else if (head === "user" && sub === "info") {
       const target = await findUser(arg1);
       if (!target) { result = err(`유저를 찾을 수 없음: ${arg1}`); }
       else {
         result = out([
-          `id        : ${target.id}`,
-          `name      : ${target.name}`,
-          `email     : ${target.email}`,
-          `employeeNo: ${target.employeeNo ?? "-"}`,
-          `role      : ${target.role}`,
-          `superAdmin: ${target.superAdmin ? "true" : "false"}`,
-          `active    : ${target.active ? "true" : "false"}`,
-          `team      : ${target.team ?? "-"}`,
-          `position  : ${target.position ?? "-"}`,
-          `createdAt : ${target.createdAt.toISOString()}`,
+          `id         : ${target.id}`,
+          `name       : ${target.name}`,
+          `email      : ${target.email}`,
+          `employeeNo : ${target.employeeNo ?? "-"}`,
+          `role       : ${target.role}`,
+          `superAdmin : ${target.superAdmin ? "true" : "false"}`,
+          `isDeveloper: ${(target as any).isDeveloper ? "true" : "false"}`,
+          `active     : ${target.active ? "true" : "false"}`,
+          `team       : ${target.team ?? "-"}`,
+          `position   : ${target.position ?? "-"}`,
+          `createdAt  : ${target.createdAt.toISOString()}`,
         ]);
       }
     } else if (head === "user" && (sub === "grant" || sub === "revoke")) {


### PR DESCRIPTION
## 증상
**isDeveloper 조회 추가**

새 기능을 추가합니다.

## 원인
[추가]
- user info <id> 출력에 isDeveloper 필드 추가 (true/false).
- users list / users find 출력 플래그 칸에 D 추가 (S=super / D=developer / A=active).
- users devs — 개발자 권한 보유 전체 사용자 한 줄 명령.
- help 갱신, 클라 CMD_TREE 에 users.devs 등록(자동완성용).

## 수정
**작업 항목 (커밋 단위)**
- feat(super-console): isDeveloper 조회 — user info 출력 + users devs 명령

**변경 대상 (2개 파일)**
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #79** ↔ **이슈 #501** 로 연결됩니다.

Closes #501
