### PR TITLE
🔀 :: (#503) 근태·업무일지 + 개발중 페이지 풀화면 디자인 폴리시

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -78,40 +78,85 @@ function RouteVisibilityGate({
   return <>{children}</>;
 }
 
-/** 비활성된 메뉴 진입 시 안내 — 자물쇠 모양 + 그라데이션 배경. */
+/** 비활성된 메뉴 진입 시 안내 — 풀 화면 그라데이션 + 자물쇠 일러스트. */
 function BlockedPage() {
   return (
-    <div className="grid place-items-center py-10">
-      <div className="w-full max-w-[480px] panel p-0 overflow-hidden text-center">
+    <div
+      className="relative w-full overflow-hidden rounded-3xl"
+      style={{
+        minHeight: "min(78vh, 720px)",
+        background:
+          "radial-gradient(ellipse at top right, rgba(99,102,241,0.18) 0%, transparent 55%), radial-gradient(ellipse at bottom left, rgba(15,23,42,0.65) 0%, transparent 60%), linear-gradient(135deg, #1E293B 0%, #0F172A 100%)",
+        color: "#fff",
+      }}
+    >
+      {/* 큰 배경 자물쇠 — 시각적 hero */}
+      <svg
+        aria-hidden
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{
+          position: "absolute",
+          right: "-6%",
+          bottom: "-12%",
+          width: "min(640px, 70%)",
+          height: "auto",
+          color: "rgba(255,255,255,0.05)",
+          pointerEvents: "none",
+        }}
+      >
+        <rect x="4" y="11" width="16" height="9" rx="2" />
+        <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+      </svg>
+      {/* 격자 패턴 */}
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage:
+            "linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px)",
+          backgroundSize: "44px 44px",
+          maskImage: "radial-gradient(ellipse at center, #000 0%, transparent 75%)",
+          pointerEvents: "none",
+        }}
+      />
+      <div className="relative px-6 sm:px-12 py-14 sm:py-20 max-w-[920px]">
         <div
-          className="px-8 pt-10 pb-7 text-white relative"
+          className="w-20 h-20 rounded-3xl grid place-items-center mb-7"
           style={{
-            background: "linear-gradient(135deg, #475569 0%, #1F2937 100%)",
+            background: "rgba(255,255,255,0.08)",
+            backdropFilter: "blur(10px)",
+            border: "1px solid rgba(255,255,255,0.14)",
           }}
         >
-          <div
-            className="w-16 h-16 rounded-2xl mx-auto grid place-items-center mb-3"
-            style={{
-              background: "rgba(255,255,255,0.14)",
-              backdropFilter: "blur(8px)",
-              border: "1px solid rgba(255,255,255,0.18)",
-            }}
-          >
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <rect x="4" y="11" width="16" height="9" rx="2" />
-              <path d="M8 11V7a4 4 0 0 1 8 0v4" />
-            </svg>
-          </div>
-          <div className="text-[11px] font-extrabold tracking-[0.18em] uppercase opacity-80">Restricted</div>
-          <div className="text-[20px] font-extrabold tracking-tight mt-1">사용할 수 없는 메뉴</div>
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <rect x="4" y="11" width="16" height="9" rx="2" />
+            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+          </svg>
         </div>
-        <div className="px-8 py-7">
-          <div className="text-[13.5px] text-ink-700 leading-relaxed">
-            총관리자가 이 메뉴를 일시적으로 닫아 두었어요.
-            <br />
-            계속 사용해야 한다면 총관리자에게 요청해 주세요.
-          </div>
-          <NavLink to="/" className="btn-primary inline-flex mt-6">
+        <div className="text-[12px] font-extrabold tracking-[0.22em] uppercase opacity-70">Restricted</div>
+        <h1 className="text-[clamp(28px,5vw,44px)] font-extrabold tracking-tight mt-2 leading-tight">
+          이 메뉴는<br />
+          잠겨 있어요
+        </h1>
+        <p className="text-[15px] sm:text-[16px] text-white/75 mt-5 max-w-[560px] leading-relaxed">
+          총관리자가 이 메뉴를 일시적으로 닫아 두었어요.
+          계속 사용해야 한다면 총관리자에게 알려주세요.
+        </p>
+        <div className="flex flex-wrap items-center gap-3 mt-8">
+          <NavLink
+            to="/"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-xl font-bold text-[14px] transition"
+            style={{ background: "#fff", color: "#0F172A" }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M19 12H5M12 19l-7-7 7-7" />
+            </svg>
             개요로 돌아가기
           </NavLink>
         </div>
@@ -120,111 +165,194 @@ function BlockedPage() {
   );
 }
 
-/** \"개발 중\" 페이지 — 망치/도구 아이콘 + 펄스 애니메이션 + 친근한 톤. */
+/** \"개발 중\" 페이지 — 풀 화면 그라데이션 + 회전 톱니바퀴 + 펄스 도형. */
 function UnderConstructionPage({ isDeveloper }: { isDeveloper: boolean }) {
   return (
-    <div className="grid place-items-center py-10">
+    <div
+      className="relative w-full overflow-hidden rounded-3xl"
+      style={{
+        minHeight: "min(78vh, 720px)",
+        background:
+          "radial-gradient(ellipse at top, rgba(167,139,250,0.28) 0%, transparent 55%), radial-gradient(ellipse at bottom right, rgba(56,189,248,0.18) 0%, transparent 55%), linear-gradient(135deg, #3B5CF0 0%, #7C3AED 60%, #581C87 100%)",
+        color: "#fff",
+      }}
+    >
       <style>{`
-        @keyframes hinest-uc-pulse {
-          0%, 100% { transform: scale(1); opacity: 0.55; }
-          50%       { transform: scale(1.18); opacity: 0.9; }
-        }
+        @keyframes hinest-uc-pulse { 0%,100% { transform: scale(1); opacity: .5; } 50% { transform: scale(1.18); opacity: .85; } }
         @keyframes hinest-uc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        @keyframes hinest-uc-spin-rev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+        @keyframes hinest-uc-float { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-8px); } }
       `}</style>
-      <div className="w-full max-w-[520px] panel p-0 overflow-hidden text-center">
-        <div
-          className="px-8 pt-12 pb-9 relative overflow-hidden"
+
+      {/* 배경 펄스 도형들 */}
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          top: "-8%",
+          right: "-10%",
+          width: 380,
+          height: 380,
+          borderRadius: "50%",
+          background: "rgba(255,255,255,0.12)",
+          animation: "hinest-uc-pulse 3.6s ease-in-out infinite",
+          filter: "blur(2px)",
+          pointerEvents: "none",
+        }}
+      />
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          bottom: "-12%",
+          left: "-8%",
+          width: 260,
+          height: 260,
+          borderRadius: "50%",
+          background: "rgba(255,255,255,0.10)",
+          animation: "hinest-uc-pulse 4.4s ease-in-out infinite 0.8s",
+          pointerEvents: "none",
+        }}
+      />
+      {/* 격자 */}
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage:
+            "linear-gradient(rgba(255,255,255,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.06) 1px, transparent 1px)",
+          backgroundSize: "48px 48px",
+          maskImage: "radial-gradient(ellipse at center, #000 0%, transparent 75%)",
+          pointerEvents: "none",
+        }}
+      />
+
+      {/* 큰 배경 톱니바퀴 — hero 일러스트 */}
+      <svg
+        aria-hidden
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="0.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{
+          position: "absolute",
+          right: "-14%",
+          bottom: "-22%",
+          width: "min(720px, 80%)",
+          height: "auto",
+          color: "rgba(255,255,255,0.08)",
+          pointerEvents: "none",
+          animation: "hinest-uc-spin 26s linear infinite",
+        }}
+      >
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33h.04a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.04a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </svg>
+
+      <div className="relative px-6 sm:px-12 py-14 sm:py-20 max-w-[1000px]">
+        {/* 작은 톱니바퀴 (반대 방향) — 깊이감 */}
+        <svg
+          aria-hidden
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="0.6"
           style={{
-            background:
-              "radial-gradient(ellipse at top, rgba(124,58,237,0.18) 0%, transparent 60%), linear-gradient(135deg, #3B5CF0 0%, #7C3AED 100%)",
-            color: "#fff",
+            position: "absolute",
+            top: 40,
+            right: 60,
+            width: 84,
+            height: 84,
+            color: "rgba(255,255,255,0.18)",
+            animation: "hinest-uc-spin-rev 14s linear infinite",
+          }}
+          className="hidden md:block"
+        >
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33h.04a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.04a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+
+        {/* hero 톱니 카드 */}
+        <div
+          className="w-24 h-24 rounded-3xl grid place-items-center mb-8"
+          style={{
+            background: "rgba(255,255,255,0.16)",
+            backdropFilter: "blur(12px)",
+            border: "1px solid rgba(255,255,255,0.24)",
+            boxShadow: "0 12px 40px rgba(0,0,0,0.25)",
+            animation: "hinest-uc-float 4.5s ease-in-out infinite",
           }}
         >
-          {/* 배경 펄스 도형 */}
-          <div
+          <svg
+            width="44"
+            height="44"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             aria-hidden
-            style={{
-              position: "absolute",
-              top: -40,
-              right: -60,
-              width: 220,
-              height: 220,
-              borderRadius: "50%",
-              background: "rgba(255,255,255,0.14)",
-              animation: "hinest-uc-pulse 3.4s ease-in-out infinite",
-              pointerEvents: "none",
-            }}
-          />
-          <div
-            aria-hidden
-            style={{
-              position: "absolute",
-              bottom: -50,
-              left: -40,
-              width: 160,
-              height: 160,
-              borderRadius: "50%",
-              background: "rgba(255,255,255,0.10)",
-              animation: "hinest-uc-pulse 4.2s ease-in-out infinite 0.8s",
-              pointerEvents: "none",
-            }}
-          />
-          <div className="relative">
-            {/* 회전하는 톱니바퀴 */}
+            style={{ animation: "hinest-uc-spin 9s linear infinite" }}
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33h.04a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.04a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+        </div>
+        <div className="text-[12px] font-extrabold tracking-[0.22em] uppercase opacity-90">Under Construction</div>
+        <h1 className="text-[clamp(32px,5.5vw,52px)] font-extrabold tracking-tight mt-2 leading-[1.05]">
+          더 좋은 모습으로<br />돌아올게요
+        </h1>
+        <p className="text-[15px] sm:text-[16px] text-white/85 mt-5 max-w-[560px] leading-relaxed">
+          이 페이지는 아직 만드는 중이에요. 새 기능이 완성되면 자동으로 활성화돼서 자연스럽게 사용할 수 있어요.
+        </p>
+
+        {/* 진행 표시 — 시각적 데코, 진짜 진행률 아님. 페이지에 활기 추가 */}
+        <div className="mt-7 max-w-[560px]">
+          <div className="text-[11px] font-bold tracking-[0.14em] uppercase opacity-75 mb-2">In progress</div>
+          <div className="h-2 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.16)" }}>
             <div
-              className="w-20 h-20 rounded-2xl mx-auto grid place-items-center mb-3"
               style={{
-                background: "rgba(255,255,255,0.18)",
-                backdropFilter: "blur(8px)",
-                border: "1px solid rgba(255,255,255,0.25)",
+                height: "100%",
+                width: "62%",
+                background: "linear-gradient(90deg, #fff 0%, #C4B5FD 100%)",
+                borderRadius: 999,
               }}
-            >
-              <svg
-                width="34"
-                height="34"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                aria-hidden
-                style={{ animation: "hinest-uc-spin 9s linear infinite" }}
-              >
-                <circle cx="12" cy="12" r="3" />
-                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33h.04a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.04a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
-              </svg>
-            </div>
-            <div className="text-[10.5px] font-extrabold tracking-[0.18em] uppercase opacity-90">Under Construction</div>
-            <div className="text-[22px] font-extrabold tracking-tight mt-1">개발 중인 페이지예요</div>
+            />
           </div>
         </div>
-        <div className="px-8 py-7">
-          <div className="text-[13.5px] text-ink-700 leading-relaxed">
-            아직 만드는 중이라 완성되면 알려드릴게요.
-            <br />
-            기능이 마무리되면 자동으로 켜져요.
+
+        {isDeveloper && (
+          <div
+            className="mt-7 inline-flex items-center gap-2 px-4 py-2 rounded-full text-[12px] font-bold"
+            style={{
+              background: "rgba(255,255,255,0.18)",
+              backdropFilter: "blur(10px)",
+              border: "1px solid rgba(255,255,255,0.22)",
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <polyline points="16 18 22 12 16 6" />
+              <polyline points="8 6 2 12 8 18" />
+            </svg>
+            HiNest 개발자 — 사이드바 \"개발 페이지 보기\" 토글로 우회 가능
           </div>
-          {isDeveloper && (
-            <div
-              className="mt-4 mx-auto inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-bold"
-              style={{
-                background: "var(--c-brand-soft)",
-                color: "var(--c-brand-soft-fg)",
-              }}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                <polyline points="16 18 22 12 16 6" />
-                <polyline points="8 6 2 12 8 18" />
-              </svg>
-              개발자 — 마이페이지에서 \"개발 페이지 보기\" 토글로 우회 가능
-            </div>
-          )}
-          <div className="flex justify-center gap-2 mt-6">
-            <NavLink to="/" className="btn-primary">
-              개요로 돌아가기
-            </NavLink>
-          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-3 mt-8">
+          <NavLink
+            to="/"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-xl font-bold text-[14px] transition"
+            style={{ background: "#fff", color: "#3B5CF0" }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M19 12H5M12 19l-7-7 7-7" />
+            </svg>
+            개요로 돌아가기
+          </NavLink>
         </div>
       </div>
     </div>

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
 import { useAuth } from "../auth";
 import MonthPicker from "../components/MonthPicker";
 import DateTimePicker from "../components/DateTimePicker";
 import { alertAsync } from "../components/ConfirmHost";
+import { useModalDismiss } from "../lib/useModalDismiss";
 
 type Attendance = {
   id: string;
@@ -29,6 +30,16 @@ function ymNow() {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
 }
 
+const KST_TODAY_FMT = new Intl.DateTimeFormat("sv-SE", {
+  timeZone: "Asia/Seoul",
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+function todayKST() {
+  return KST_TODAY_FMT.format(new Date());
+}
+
 export default function AttendancePage() {
   const { user } = useAuth();
   const [month, setMonth] = useState(ymNow());
@@ -41,16 +52,16 @@ export default function AttendancePage() {
   const [reviewingId, setReviewingId] = useState<string | null>(null);
 
   // 제출/승인 직후 load() 가 다시 돌 때, 사용자가 빠르게 탭 이탈하면
-  // setState 가 언마운트된 컴포넌트에 박혀 경고+누수. 승인/반려/제출이 연달아 쏟아져도
-  // 마지막 응답만 반영하도록 monotonic token 도 같이 사용.
+  // setState 가 언마운트된 컴포넌트에 박혀 경고+누수. 마지막 응답만 반영하도록 monotonic token.
   const aliveRef = useRef(true);
   const loadTokenRef = useRef(0);
   useEffect(() => {
     aliveRef.current = true;
-    return () => {
-      aliveRef.current = false;
-    };
+    return () => { aliveRef.current = false; };
   }, []);
+
+  // 모달 Esc·배경 잠금.
+  useModalDismiss(open && !saving, () => setOpen(false));
 
   async function load() {
     const myToken = ++loadTokenRef.current;
@@ -72,8 +83,6 @@ export default function AttendancePage() {
   // SWR — 월별 출퇴근과 휴가 목록은 탭 재진입 시 캐시로 즉시 채움.
   const isReviewer = user?.role === "ADMIN" || user?.role === "MANAGER";
   useEffect(() => {
-    // month 를 빠르게 넘기면 이전 달의 onFresh 가 새 달의 setRecords 를 덮어쓰는 race 가 있음.
-    // 의존성 변경으로 effect 가 재실행되는 순간 alive=false 로 만들어 이전 요청 응답은 조용히 무시.
     let alive = true;
     apiSWR<{ attendances: Attendance[] }>(`/api/attendance/month?month=${month}`, {
       onCached: (d) => { if (alive) setRecords(d.attendances); },
@@ -129,13 +138,34 @@ export default function AttendancePage() {
     }
   }
 
-  function duration(c?: string, o?: string) {
-    if (!c || !o) return "-";
-    const ms = new Date(o).getTime() - new Date(c).getTime();
-    const h = Math.floor(ms / 3600000);
-    const m = Math.floor((ms % 3600000) / 60000);
-    return `${h}시간 ${m}분`;
-  }
+  // === 통계 계산 ===
+  const stats = useMemo(() => {
+    const completed = records.filter((r) => r.checkIn && r.checkOut);
+    const totalMs = completed.reduce(
+      (acc, r) => acc + (new Date(r.checkOut!).getTime() - new Date(r.checkIn!).getTime()),
+      0,
+    );
+    const avgMs = completed.length ? totalMs / completed.length : 0;
+    const usedDays = leaves
+      .filter((l) => l.status === "APPROVED")
+      .reduce((acc, l) => acc + dayDiff(l.startDate, l.endDate), 0);
+    const pending = leaves.filter((l) => l.status === "PENDING").length;
+    return {
+      workDays: completed.length,
+      avgHours: avgMs ? msToHM(avgMs) : "—",
+      usedDays,
+      pending,
+    };
+  }, [records, leaves]);
+
+  const pendingForReviewer = useMemo(
+    () => allLeaves.filter((l) => l.status === "PENDING"),
+    [allLeaves],
+  );
+  const handledForReviewer = useMemo(
+    () => allLeaves.filter((l) => l.status !== "PENDING"),
+    [allLeaves],
+  );
 
   return (
     <div>
@@ -145,7 +175,6 @@ export default function AttendancePage() {
         right={
           <div className="flex gap-2 flex-wrap items-center">
             <MonthPicker value={month} onChange={setMonth} />
-            {/* MonthPicker(=.input, h=44px, radius=10px) 와 높이/둥글기 맞추려면 btn-lg 필요 */}
             <button className="btn-primary btn-lg" onClick={() => setOpen(true)}>
               + 휴가 신청
             </button>
@@ -153,159 +182,302 @@ export default function AttendancePage() {
         }
       />
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2 card">
-          <h2 className="text-lg font-bold mb-4">{month} 출퇴근 기록</h2>
-          <div className="overflow-hidden rounded-xl border border-slate-100 overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
-            <table className="w-full text-sm min-w-[480px]">
-              <thead className="bg-slate-50 text-slate-500 text-xs">
-                <tr>
-                  <th className="text-left px-4 py-3">일자</th>
-                  <th className="text-left px-4 py-3">출근</th>
-                  <th className="text-left px-4 py-3">퇴근</th>
-                  <th className="text-left px-4 py-3">근무시간</th>
-                </tr>
-              </thead>
-              <tbody>
-                {records.length === 0 && (
-                  <tr>
-                    <td colSpan={4} className="px-4 py-8 text-center text-slate-400">
-                      기록이 없습니다.
-                    </td>
-                  </tr>
-                )}
-                {records.map((r) => (
-                  <tr key={r.id} className="border-t border-slate-100">
-                    <td className="px-4 py-3 font-medium">{r.date}</td>
-                    <td className="px-4 py-3">
-                      {r.checkIn ? new Date(r.checkIn).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" }) : "-"}
-                    </td>
-                    <td className="px-4 py-3">
-                      {r.checkOut ? new Date(r.checkOut).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" }) : "-"}
-                    </td>
-                    <td className="px-4 py-3 text-slate-600">{duration(r.checkIn, r.checkOut)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      {/* 상단 통계 카드 — 전체 페이지의 시각적 앵커. */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+        <StatCard
+          label={`${month} 근무일`}
+          value={`${stats.workDays}일`}
+          accent="brand"
+          icon={
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="5" width="18" height="16" rx="2" />
+              <path d="M3 10h18M8 3v4M16 3v4" />
+            </svg>
+          }
+        />
+        <StatCard
+          label="평균 근무시간"
+          value={stats.avgHours}
+          accent="success"
+          icon={
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="9" />
+              <path d="M12 7v5l3.5 2" />
+            </svg>
+          }
+        />
+        <StatCard
+          label="사용한 휴가"
+          value={`${stats.usedDays}일`}
+          accent="warning"
+          icon={
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 2v6M5 8a7 7 0 0 1 14 0c0 8 -7 14 -7 14s-7 -6 -7 -14z" />
+            </svg>
+          }
+        />
+        <StatCard
+          label="승인 대기"
+          value={`${stats.pending}건`}
+          accent="violet"
+          icon={
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="9" />
+              <path d="M12 8v4l2 2" />
+            </svg>
+          }
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+        {/* 출퇴근 기록 */}
+        <div className="lg:col-span-2 panel p-0 overflow-hidden">
+          <div className="px-5 py-4 border-b border-ink-100 flex items-center justify-between">
+            <div>
+              <div className="text-[15px] font-extrabold text-ink-900">{month} 출퇴근 기록</div>
+              <div className="text-[12px] text-ink-500 mt-0.5">총 {records.length}일 기록</div>
+            </div>
           </div>
+          {records.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="5" width="18" height="16" rx="2" />
+                  <path d="M3 10h18M8 3v4M16 3v4" />
+                </svg>
+              }
+              title="기록이 없어요"
+              hint="이 달은 아직 출퇴근 기록이 없어요. 다른 달도 확인해 보세요."
+            />
+          ) : (
+            <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
+              <table className="w-full text-[13px] min-w-[480px]">
+                <thead className="bg-ink-25 text-ink-500 text-[11px] uppercase tracking-[0.06em]">
+                  <tr>
+                    <th className="text-left px-5 py-2.5 font-bold">일자</th>
+                    <th className="text-left px-5 py-2.5 font-bold">출근</th>
+                    <th className="text-left px-5 py-2.5 font-bold">퇴근</th>
+                    <th className="text-right px-5 py-2.5 font-bold">근무시간</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {records.map((r) => {
+                    const d = new Date(r.date + "T00:00:00");
+                    const dow = d.getDay();
+                    const isWeekend = dow === 0 || dow === 6;
+                    const isToday = r.date === todayKST();
+                    return (
+                      <tr
+                        key={r.id}
+                        className="border-t border-ink-100"
+                        style={{ background: isToday ? "var(--c-brand-soft)" : undefined }}
+                      >
+                        <td className="px-5 py-3">
+                          <div className="font-bold text-ink-900">{r.date.slice(5)}</div>
+                          <div className="text-[10.5px] mt-0.5" style={{ color: isWeekend ? "var(--c-danger)" : "var(--c-text-3)" }}>
+                            {dowLabel(dow)}
+                            {isToday && <span className="ml-1 chip chip-brand !text-[9.5px] !py-0">오늘</span>}
+                          </div>
+                        </td>
+                        <td className="px-5 py-3 font-mono text-ink-800">
+                          {r.checkIn ? formatHM(r.checkIn) : <span className="text-ink-400">—</span>}
+                        </td>
+                        <td className="px-5 py-3 font-mono text-ink-800">
+                          {r.checkOut ? formatHM(r.checkOut) : <span className="text-ink-400">—</span>}
+                        </td>
+                        <td className="px-5 py-3 text-right">
+                          {r.checkIn && r.checkOut ? (
+                            <span className="font-bold text-ink-900">{durationLabel(r.checkIn, r.checkOut)}</span>
+                          ) : (
+                            <span className="text-ink-400">—</span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
 
-        <div className="card">
-          <h2 className="text-lg font-bold mb-4">내 휴가 신청</h2>
-          <div className="space-y-3">
-            {leaves.length === 0 && <div className="text-sm text-slate-400">신청 내역이 없습니다.</div>}
-            {leaves.map((l) => (
-              <div key={l.id} className="p-3 rounded-xl border border-slate-100">
-                <div className="flex items-center justify-between">
-                  <div className="font-semibold">{typeLabel(l.type)}</div>
-                  <StatusChip status={l.status} />
-                </div>
-                <div className="text-xs text-slate-500 mt-1">
-                  {new Date(l.startDate).toLocaleDateString("ko-KR")} ~ {new Date(l.endDate).toLocaleDateString("ko-KR")}
-                </div>
-                {l.reason && <div className="text-sm text-slate-600 mt-1">{l.reason}</div>}
+        {/* 내 휴가 신청 */}
+        <div className="panel p-0 overflow-hidden">
+          <div className="px-5 py-4 border-b border-ink-100 flex items-center justify-between">
+            <div>
+              <div className="text-[15px] font-extrabold text-ink-900">내 휴가 신청</div>
+              <div className="text-[12px] text-ink-500 mt-0.5">최근 신청 {leaves.length}건</div>
+            </div>
+          </div>
+          <div className="p-3 space-y-2 max-h-[60vh] overflow-y-auto">
+            {leaves.length === 0 ? (
+              <div className="px-2 py-10 text-center text-[12.5px] text-ink-500">
+                신청 내역이 없어요.
+                <br />
+                <button className="btn-ghost btn-xs mt-2" onClick={() => setOpen(true)}>+ 휴가 신청</button>
               </div>
-            ))}
+            ) : (
+              leaves.map((l) => <LeaveRow key={l.id} l={l} />)
+            )}
           </div>
         </div>
       </div>
 
-      {(user?.role === "ADMIN" || user?.role === "MANAGER") && (
-        <div className="card mt-6">
-          <h2 className="text-lg font-bold mb-4">전체 휴가 승인 대기</h2>
-          <div className="overflow-hidden rounded-xl border border-slate-100 overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
-            <table className="w-full text-sm min-w-[720px]">
-              <thead className="bg-slate-50 text-slate-500 text-xs">
-                <tr>
-                  <th className="text-left px-4 py-3">이름</th>
-                  <th className="text-left px-4 py-3">종류</th>
-                  <th className="text-left px-4 py-3">기간</th>
-                  <th className="text-left px-4 py-3">사유</th>
-                  <th className="text-left px-4 py-3">상태</th>
-                  <th className="text-right px-4 py-3">처리</th>
-                </tr>
-              </thead>
-              <tbody>
-                {allLeaves.map((l) => (
-                  <tr key={l.id} className="border-t border-slate-100">
-                    <td className="px-4 py-3 font-medium">{l.user?.name}</td>
-                    <td className="px-4 py-3">{typeLabel(l.type)}</td>
-                    <td className="px-4 py-3 text-slate-600">
-                      {new Date(l.startDate).toLocaleDateString("ko-KR")} ~ {new Date(l.endDate).toLocaleDateString("ko-KR")}
-                    </td>
-                    <td className="px-4 py-3 text-slate-600">{l.reason || "-"}</td>
-                    <td className="px-4 py-3">
-                      <StatusChip status={l.status} />
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      {l.status === "PENDING" && (
-                        <div className="inline-flex gap-1">
-                          <button
-                            className="text-xs px-3 py-1 rounded-lg bg-brand-400 text-white disabled:opacity-60"
-                            onClick={() => review(l.id, "APPROVED")}
-                            disabled={reviewingId === l.id}
-                          >
-                            {reviewingId === l.id ? "처리 중…" : "승인"}
-                          </button>
-                          <button
-                            className="text-xs px-3 py-1 rounded-lg bg-rose-500 text-white disabled:opacity-60"
-                            onClick={() => review(l.id, "REJECTED")}
-                            disabled={reviewingId === l.id}
-                          >
-                            반려
-                          </button>
-                        </div>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+      {/* 관리자 — 전체 휴가 처리 */}
+      {isReviewer && (
+        <div className="panel p-0 overflow-hidden mt-5">
+          <div className="px-5 py-4 border-b border-ink-100 flex items-center justify-between">
+            <div>
+              <div className="text-[15px] font-extrabold text-ink-900">전체 휴가 신청</div>
+              <div className="text-[12px] text-ink-500 mt-0.5">
+                대기 <b className="text-ink-900">{pendingForReviewer.length}</b> · 처리됨 {handledForReviewer.length}
+              </div>
+            </div>
           </div>
+          {allLeaves.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="5" width="18" height="16" rx="2" />
+                  <path d="M3 10h18M8 3v4M16 3v4" />
+                </svg>
+              }
+              title="신청이 없어요"
+              hint="구성원의 휴가 신청이 들어오면 여기에 표시돼요."
+            />
+          ) : (
+            <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
+              <table className="w-full text-[13px] min-w-[720px]">
+                <thead className="bg-ink-25 text-ink-500 text-[11px] uppercase tracking-[0.06em]">
+                  <tr>
+                    <th className="text-left px-5 py-2.5 font-bold">이름</th>
+                    <th className="text-left px-5 py-2.5 font-bold">종류</th>
+                    <th className="text-left px-5 py-2.5 font-bold">기간</th>
+                    <th className="text-left px-5 py-2.5 font-bold">사유</th>
+                    <th className="text-left px-5 py-2.5 font-bold">상태</th>
+                    <th className="text-right px-5 py-2.5 font-bold">처리</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...pendingForReviewer, ...handledForReviewer].map((l) => (
+                    <tr key={l.id} className="border-t border-ink-100">
+                      <td className="px-5 py-3 font-bold text-ink-900">{l.user?.name}</td>
+                      <td className="px-5 py-3">
+                        <span className="inline-flex items-center gap-1.5">
+                          <LeaveTypeDot type={l.type} />
+                          <span className="text-ink-800">{typeLabel(l.type)}</span>
+                        </span>
+                      </td>
+                      <td className="px-5 py-3 text-ink-700">
+                        {formatRange(l.startDate, l.endDate)}
+                        <span className="ml-1 text-[11px] text-ink-500">({dayDiff(l.startDate, l.endDate)}일)</span>
+                      </td>
+                      <td className="px-5 py-3 text-ink-600 max-w-[240px] truncate" title={l.reason ?? ""}>
+                        {l.reason || <span className="text-ink-400">—</span>}
+                      </td>
+                      <td className="px-5 py-3">
+                        <StatusChip status={l.status} />
+                      </td>
+                      <td className="px-5 py-3 text-right">
+                        {l.status === "PENDING" && (
+                          <div className="inline-flex gap-1.5">
+                            <button
+                              className="btn-primary btn-xs"
+                              onClick={() => review(l.id, "APPROVED")}
+                              disabled={reviewingId === l.id}
+                            >
+                              {reviewingId === l.id ? "처리 중…" : "승인"}
+                            </button>
+                            <button
+                              className="btn-ghost btn-xs"
+                              style={{ color: "var(--c-danger)" }}
+                              onClick={() => review(l.id, "REJECTED")}
+                              disabled={reviewingId === l.id}
+                            >
+                              반려
+                            </button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       )}
 
+      {/* 신청 모달 */}
       {open && (
-        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4" onClick={() => setOpen(false)}>
-          <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-lg font-bold mb-4">휴가 신청</h3>
-            <form onSubmit={submit} className="space-y-3">
+        <div
+          className="fixed inset-0 z-50 grid place-items-center p-4"
+          style={{ background: "rgba(0,0,0,0.45)", backdropFilter: "blur(4px)" }}
+          onClick={() => !saving && setOpen(false)}
+        >
+          <div className="panel p-0 w-full max-w-[480px] overflow-hidden" onClick={(e) => e.stopPropagation()}>
+            <div
+              className="px-5 py-4"
+              style={{
+                background: "linear-gradient(135deg, var(--c-brand) 0%, #7C3AED 100%)",
+                color: "#fff",
+              }}
+            >
+              <div className="text-[10.5px] font-extrabold tracking-[0.18em] uppercase opacity-90">New Request</div>
+              <div className="text-[18px] font-extrabold tracking-tight mt-0.5">휴가 신청</div>
+            </div>
+            <form onSubmit={submit} className="p-5 space-y-4">
               <div>
-                <label className="label">종류</label>
-                <select className="input" value={form.type} onChange={(e) => setForm({ ...form, type: e.target.value })}>
-                  <option value="ANNUAL">연차</option>
-                  <option value="HALF">반차</option>
-                  <option value="SICK">병가</option>
-                  <option value="TRIP">외근</option>
-                  <option value="OTHER">기타</option>
-                </select>
+                <label className="field-label">종류</label>
+                <div className="grid grid-cols-5 gap-1.5">
+                  {LEAVE_TYPES.map((t) => (
+                    <button
+                      key={t.value}
+                      type="button"
+                      onClick={() => setForm({ ...form, type: t.value })}
+                      className={`flex flex-col items-center justify-center gap-1 py-2 rounded-xl border text-[11.5px] font-bold transition ${
+                        form.type === t.value
+                          ? "border-brand-500 bg-brand-50 text-brand-700"
+                          : "border-ink-150 text-ink-600 hover:bg-ink-25"
+                      }`}
+                    >
+                      <span className="w-2 h-2 rounded-full" style={{ background: t.color }} />
+                      {t.label}
+                    </button>
+                  ))}
+                </div>
               </div>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                 <div>
-                  <label className="label">시작일</label>
+                  <label className="field-label">시작일</label>
                   <DateTimePicker mode="date" value={form.startDate} onChange={(v) => setForm({ ...form, startDate: v })} />
                 </div>
                 <div>
-                  <label className="label">종료일</label>
+                  <label className="field-label">종료일</label>
                   <DateTimePicker mode="date" value={form.endDate} onChange={(v) => setForm({ ...form, endDate: v })} min={form.startDate} />
                 </div>
               </div>
+              {form.startDate && form.endDate && new Date(form.endDate) >= new Date(form.startDate) && (
+                <div className="px-3 py-2 rounded-lg bg-brand-soft text-[12.5px] font-semibold" style={{ color: "var(--c-brand-soft-fg)" }}>
+                  총 <b>{dayDiff(form.startDate, form.endDate)}일</b> · {formatRange(form.startDate, form.endDate)}
+                </div>
+              )}
               <div>
-                <label className="label">사유</label>
+                <label className="field-label">사유 (선택)</label>
                 <textarea
                   className="input"
                   rows={3}
                   maxLength={1000}
                   value={form.reason}
                   onChange={(e) => setForm({ ...form, reason: e.target.value })}
+                  placeholder="비워두어도 신청 가능"
                 />
               </div>
-              <div className="flex justify-end gap-2 pt-2">
+              <div className="flex justify-end gap-2 pt-1">
                 <button type="button" className="btn-ghost" onClick={() => setOpen(false)} disabled={saving}>
                   취소
                 </button>
-                <button className="btn-primary" disabled={saving}>{saving ? "신청 중…" : "신청"}</button>
+                <button className="btn-primary" disabled={saving}>{saving ? "신청 중…" : "신청하기"}</button>
               </div>
             </form>
           </div>
@@ -315,20 +487,121 @@ export default function AttendancePage() {
   );
 }
 
+const LEAVE_TYPES = [
+  { value: "ANNUAL", label: "연차", color: "#3B5CF0" },
+  { value: "HALF",   label: "반차", color: "#7C3AED" },
+  { value: "SICK",   label: "병가", color: "#DC2626" },
+  { value: "TRIP",   label: "외근", color: "#16A34A" },
+  { value: "OTHER",  label: "기타", color: "#64748B" },
+];
+
 function typeLabel(t: string) {
-  return { ANNUAL: "연차", HALF: "반차", SICK: "병가", TRIP: "외근", OTHER: "기타" }[t] ?? t;
+  return LEAVE_TYPES.find((x) => x.value === t)?.label ?? t;
+}
+
+function LeaveTypeDot({ type }: { type: string }) {
+  const t = LEAVE_TYPES.find((x) => x.value === type);
+  return <span className="w-2 h-2 rounded-full" style={{ background: t?.color ?? "#94A3B8" }} />;
+}
+
+function LeaveRow({ l }: { l: Leave }) {
+  return (
+    <div className="px-3 py-2.5 rounded-xl border border-ink-100 hover:bg-ink-25 transition">
+      <div className="flex items-center gap-2">
+        <LeaveTypeDot type={l.type} />
+        <span className="text-[13px] font-bold text-ink-900">{typeLabel(l.type)}</span>
+        <span className="text-[11px] text-ink-500">· {dayDiff(l.startDate, l.endDate)}일</span>
+        <span className="ml-auto"><StatusChip status={l.status} /></span>
+      </div>
+      <div className="text-[11.5px] text-ink-500 mt-1 font-mono">
+        {formatRange(l.startDate, l.endDate)}
+      </div>
+      {l.reason && (
+        <div className="text-[12px] text-ink-700 mt-1.5 leading-relaxed line-clamp-2">{l.reason}</div>
+      )}
+    </div>
+  );
 }
 
 function StatusChip({ status }: { status: string }) {
-  const map: Record<string, string> = {
-    PENDING: "bg-amber-100 text-amber-700",
-    APPROVED: "bg-brand-100 text-brand-700",
-    REJECTED: "bg-rose-100 text-rose-700",
-  };
-  const label: Record<string, string> = {
-    PENDING: "대기",
-    APPROVED: "승인",
-    REJECTED: "반려",
-  };
-  return <span className={`chip ${map[status] ?? ""}`}>{label[status] ?? status}</span>;
+  if (status === "APPROVED") return <span className="chip chip-green">승인</span>;
+  if (status === "REJECTED") return <span className="chip chip-red">반려</span>;
+  if (status === "PENDING") return <span className="chip chip-amber">대기</span>;
+  return <span className="chip chip-gray">{status}</span>;
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  accent,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  accent: "brand" | "success" | "warning" | "violet";
+}) {
+  const accentStyle = {
+    brand: { bg: "var(--c-brand-soft)", fg: "var(--c-brand)" },
+    success: { bg: "rgba(22,163,74,0.10)", fg: "var(--c-success)" },
+    warning: { bg: "rgba(217,119,6,0.10)", fg: "var(--c-warning)" },
+    violet: { bg: "rgba(124,58,237,0.10)", fg: "#7C3AED" },
+  }[accent];
+  return (
+    <div className="panel p-4 flex items-center gap-3">
+      <div
+        className="w-10 h-10 rounded-xl grid place-items-center flex-shrink-0"
+        style={{ background: accentStyle.bg, color: accentStyle.fg }}
+      >
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <div className="text-[11px] font-bold text-ink-500 uppercase tracking-[0.06em] truncate">{label}</div>
+        <div className="text-[19px] font-extrabold text-ink-900 mt-0.5 tracking-tight tabular-nums">{value}</div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ icon, title, hint }: { icon: React.ReactNode; title: string; hint: string }) {
+  return (
+    <div className="px-6 py-14 text-center">
+      <div className="w-12 h-12 mx-auto rounded-2xl grid place-items-center mb-3" style={{ background: "var(--c-surface-3)", color: "var(--c-text-3)" }}>
+        {icon}
+      </div>
+      <div className="text-[14px] font-bold text-ink-900">{title}</div>
+      <div className="text-[12.5px] text-ink-500 mt-1">{hint}</div>
+    </div>
+  );
+}
+
+// === 유틸 ===
+function dowLabel(n: number) {
+  return ["일", "월", "화", "수", "목", "금", "토"][n] ?? "";
+}
+function formatHM(iso: string) {
+  return new Date(iso).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" });
+}
+function durationLabel(c: string, o: string) {
+  const ms = new Date(o).getTime() - new Date(c).getTime();
+  if (ms <= 0) return "-";
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  return `${h}h ${m}m`;
+}
+function msToHM(ms: number) {
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  return `${h}h ${m}m`;
+}
+function dayDiff(a: string, b: string) {
+  // 양 끝 포함 일수.
+  const start = new Date(a + "T00:00:00").getTime();
+  const end = new Date(b + "T00:00:00").getTime();
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return 0;
+  return Math.round((end - start) / 86400000) + 1;
+}
+function formatRange(a: string, b: string) {
+  if (a === b) return a;
+  return `${a} ~ ${b}`;
 }

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
 import DateTimePicker from "../components/DateTimePicker";
@@ -14,8 +14,7 @@ type Journal = {
 };
 
 /**
- * "오늘" 은 항상 KST 기준. 브라우저 로케일이 한국이 아니어도 일지 날짜 기본값이 서울 날짜가 되도록
- * 명시적 timeZone 사용. 서버 쪽도 동일 규칙(server/src/lib/dates.ts 참고)을 쓰도록 최근 수정됨.
+ * "오늘" 은 항상 KST 기준. 브라우저 로케일이 한국이 아니어도 일지 날짜 기본값이 서울 날짜가 되도록.
  */
 const KST_TODAY = new Intl.DateTimeFormat("sv-SE", {
   timeZone: "Asia/Seoul",
@@ -36,20 +35,17 @@ export default function JournalPage() {
   const [mode, setMode] = useState<Mode>("view");
   const [saving, setSaving] = useState(false);
   const [err, setErr] = useState("");
+  const [q, setQ] = useState("");
   // 삭제 버튼 중복 클릭 방지 + native confirm() 대체용 모달 상태.
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
   // 삭제 확인 모달: 실행 중이 아니면 Esc / 배경 클릭으로 닫기.
   useModalDismiss(!!confirmRemoveId && !removingId, () => setConfirmRemoveId(null));
 
-  // save/remove 후 setState 가 또 돌고, 이때 사용자가 이탈하면 언마운트된 컴포넌트에
-  // setState 가 박히며 경고+누수. apiSWR 의 stale→fresh 콜백도 가드 대상.
   const aliveRef = useRef(true);
   useEffect(() => {
     aliveRef.current = true;
-    return () => {
-      aliveRef.current = false;
-    };
+    return () => { aliveRef.current = false; };
   }, []);
 
   // SWR — 탭 안에서 재진입 시 즉시 리스트 렌더.
@@ -95,14 +91,11 @@ export default function JournalPage() {
           json: form,
         });
         if (!aliveRef.current) return;
-        // 낙관적 업데이트 — 전체 load() 대신 응답값으로 리스트 내 해당 항목만 교체.
-        // 서버 왕복 한 번 아끼고 스크롤 위치·선택 상태 유지.
         setList((arr) => arr.map((j) => (j.id === res.journal.id ? res.journal : j)));
         setSelected(res.journal);
       } else {
         const res = await api<{ journal: Journal }>("/api/journal", { method: "POST", json: form });
         if (!aliveRef.current) return;
-        // 새 일지를 리스트 맨 앞에 넣음 — 서버도 createdAt desc 로 정렬하므로 동일 순서.
         setList((arr) => [res.journal, ...arr.filter((j) => j.id !== res.journal.id)]);
         setSelected(res.journal);
       }
@@ -136,6 +129,23 @@ export default function JournalPage() {
   }
 
   const editing = mode !== "view";
+  const filtered = useMemo(() => {
+    const k = q.trim().toLowerCase();
+    if (!k) return list;
+    return list.filter(
+      (j) => j.title.toLowerCase().includes(k) || j.content.toLowerCase().includes(k) || j.date.includes(k),
+    );
+  }, [list, q]);
+  // 같은 달끼리 그룹핑 — 사이드바 시각 구조 강화.
+  const grouped = useMemo(() => {
+    const map = new Map<string, Journal[]>();
+    for (const j of filtered) {
+      const ym = j.date.slice(0, 7);
+      if (!map.has(ym)) map.set(ym, []);
+      map.get(ym)!.push(j);
+    }
+    return Array.from(map.entries());
+  }, [filtered]);
 
   return (
     <div>
@@ -143,65 +153,151 @@ export default function JournalPage() {
         title="업무일지"
         description="하루의 업무를 기록하고 회고하세요."
         right={
-          <button className="btn-primary" onClick={openCreate}>
+          <button className="btn-primary btn-lg" onClick={openCreate}>
             + 새 일지
           </button>
         }
       />
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="card p-0 overflow-hidden">
-          <div className="p-4 border-b border-slate-100 text-sm font-bold text-slate-800">
-            내 일지 ({list.length})
-          </div>
-          <div className="divide-y divide-slate-100 max-h-[70vh] overflow-auto">
-            {list.map((j) => (
-              <button
-                key={j.id}
-                onClick={() => { setSelected(j); setMode("view"); }}
-                className={`w-full text-left px-4 py-3 hover:bg-slate-50 ${selected?.id === j.id && mode === "view" ? "bg-brand-50" : ""}`}
+      <div className="grid grid-cols-1 lg:grid-cols-[320px_minmax(0,1fr)] gap-5">
+        {/* 사이드 리스트 */}
+        <aside className="panel p-0 overflow-hidden flex flex-col" style={{ maxHeight: "calc(100vh - 220px)" }}>
+          <div className="px-4 py-3 border-b border-ink-100">
+            <div className="flex items-center justify-between mb-2">
+              <div className="text-[13.5px] font-extrabold text-ink-900">내 일지</div>
+              <span className="chip chip-gray !text-[10.5px]">{list.length}</span>
+            </div>
+            <div className="relative">
+              <input
+                className="input !h-9 !text-[12.5px] !pl-8"
+                placeholder="제목·날짜·본문 검색"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+              />
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                style={{
+                  position: "absolute",
+                  left: 10,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  color: "var(--c-text-3)",
+                }}
               >
-                <div className="text-xs text-slate-500">{j.date}</div>
-                <div className="font-semibold text-slate-900 truncate">{j.title}</div>
-              </button>
-            ))}
-            {list.length === 0 && <div className="px-4 py-10 text-center text-sm text-slate-400">일지가 없습니다.</div>}
+                <circle cx="11" cy="11" r="7" />
+                <path d="m20 20-3.5-3.5" />
+              </svg>
+            </div>
           </div>
-        </div>
-
-        <div className="lg:col-span-2 card">
-          {editing ? (
-            <form onSubmit={save} className="space-y-3">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div>
-                  <label className="label">날짜</label>
-                  <DateTimePicker mode="date" value={form.date} onChange={(v) => setForm({ ...form, date: v })} />
+          <div className="flex-1 overflow-auto">
+            {filtered.length === 0 ? (
+              <div className="px-4 py-12 text-center">
+                <div className="text-[34px] mb-2">📝</div>
+                <div className="text-[13px] font-bold text-ink-900">{q ? "검색 결과가 없어요" : "아직 일지가 없어요"}</div>
+                <div className="text-[11.5px] text-ink-500 mt-1">{q ? "다른 키워드로 찾아보세요" : "오늘 한 일을 정리해 보세요"}</div>
+                {!q && (
+                  <button className="btn-ghost btn-xs mt-3" onClick={openCreate}>+ 새 일지 작성</button>
+                )}
+              </div>
+            ) : (
+              grouped.map(([ym, items]) => (
+                <div key={ym}>
+                  <div className="sticky top-0 z-[1] px-4 py-1.5 bg-ink-25 text-[10.5px] font-extrabold text-ink-500 uppercase tracking-[0.06em] border-b border-ink-100">
+                    {formatYearMonth(ym)}
+                  </div>
+                  {items.map((j) => {
+                    const active = selected?.id === j.id && mode === "view";
+                    return (
+                      <button
+                        key={j.id}
+                        onClick={() => { setSelected(j); setMode("view"); }}
+                        className="w-full text-left px-4 py-3 hover:bg-ink-25 transition border-b border-ink-100 flex items-start gap-3"
+                        style={active ? { background: "var(--c-brand-soft)" } : undefined}
+                      >
+                        <div
+                          className="flex-shrink-0 w-10 h-10 rounded-xl grid place-items-center text-[10.5px] font-extrabold leading-none"
+                          style={{
+                            background: active ? "var(--c-brand)" : "var(--c-surface-3)",
+                            color: active ? "#fff" : "var(--c-text)",
+                          }}
+                        >
+                          <div>
+                            <div className="text-[15px] font-extrabold tabular-nums text-center">
+                              {parseInt(j.date.slice(8, 10), 10)}
+                            </div>
+                            <div className="text-[9px] opacity-80 text-center">{dowOf(j.date)}</div>
+                          </div>
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-[13.5px] font-bold text-ink-900 truncate">{j.title || "(제목 없음)"}</div>
+                          <div className="text-[11px] text-ink-500 mt-0.5 line-clamp-1">
+                            {j.content.replace(/\s+/g, " ").trim() || "(내용 없음)"}
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })}
                 </div>
-                <div>
-                  <label className="label">제목</label>
-                  <input
-                    className="input"
-                    value={form.title}
-                    onChange={(e) => setForm({ ...form, title: e.target.value })}
-                    required
-                    maxLength={200}
-                  />
+              ))
+            )}
+          </div>
+        </aside>
+
+        {/* 본문 */}
+        <main className="panel p-0 overflow-hidden flex flex-col" style={{ minHeight: "60vh" }}>
+          {editing ? (
+            <form onSubmit={save} className="flex flex-col h-full">
+              <div className="px-6 pt-5 pb-4 border-b border-ink-100">
+                <div className="text-[10.5px] font-extrabold tracking-[0.18em] uppercase text-brand-600">
+                  {mode === "edit" ? "EDIT" : "NEW"}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-[180px_minmax(0,1fr)] gap-3 mt-2">
+                  <div>
+                    <label className="field-label">날짜</label>
+                    <DateTimePicker mode="date" value={form.date} onChange={(v) => setForm({ ...form, date: v })} />
+                  </div>
+                  <div>
+                    <label className="field-label">제목</label>
+                    <input
+                      className="input !text-[15px] !font-bold"
+                      value={form.title}
+                      onChange={(e) => setForm({ ...form, title: e.target.value })}
+                      required
+                      maxLength={200}
+                      placeholder="오늘 한 일 한 줄 요약"
+                      autoFocus={mode === "create"}
+                    />
+                  </div>
                 </div>
               </div>
-              <div>
-                <label className="label">내용</label>
+              <div className="flex-1 px-6 py-4 overflow-auto">
+                <div className="flex items-center justify-between mb-1.5">
+                  <label className="field-label !mb-0">내용</label>
+                  <span className="text-[11px] text-ink-500 tabular-nums">
+                    {form.content.length.toLocaleString()} / 20,000
+                  </span>
+                </div>
                 <textarea
                   className="input"
-                  rows={14}
+                  rows={16}
                   value={form.content}
                   onChange={(e) => setForm({ ...form, content: e.target.value })}
                   required
                   maxLength={20_000}
+                  placeholder="오늘 한 일 / 잘된 점 / 막힌 점 / 내일 할 일 ..."
+                  style={{ resize: "vertical", lineHeight: 1.6, minHeight: 320 }}
                 />
+                {err && (
+                  <div className="mt-3 text-[12px] font-semibold text-red-600">{err}</div>
+                )}
               </div>
-              {err && (
-                <div className="text-[12px] font-semibold text-red-600">{err}</div>
-              )}
-              <div className="flex justify-end gap-2">
+              <div className="px-6 py-3 border-t border-ink-100 flex justify-end gap-2">
                 <button
                   type="button"
                   className="btn-ghost"
@@ -209,7 +305,6 @@ export default function JournalPage() {
                   onClick={() => {
                     setMode("view");
                     setErr("");
-                    // 편집 중이었다면 원본이 그대로 selected 로 유지되어 바로 보기 화면으로 복귀.
                   }}
                 >
                   취소
@@ -220,46 +315,70 @@ export default function JournalPage() {
               </div>
             </form>
           ) : selected ? (
-            <div>
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="text-xs text-slate-500">{selected.date}</div>
-                  <h2 className="text-xl font-bold mt-1 break-words">{selected.title}</h2>
-                </div>
-                <div className="flex items-center gap-1.5 flex-shrink-0">
-                  <button className="btn-ghost btn-xs" onClick={() => openEdit(selected)} disabled={removingId === selected.id}>
-                    수정
-                  </button>
-                  <button
-                    className="btn-ghost btn-xs text-red-600 hover:text-red-700 disabled:opacity-60"
-                    onClick={() => setConfirmRemoveId(selected.id)}
-                    disabled={removingId === selected.id}
-                  >
-                    {removingId === selected.id ? "삭제 중…" : "삭제"}
-                  </button>
+            <article className="flex flex-col h-full">
+              <div className="px-6 pt-5 pb-4 border-b border-ink-100">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="inline-flex items-center gap-2 text-[11.5px] text-ink-500 font-bold">
+                      <span className="chip chip-brand !text-[10.5px]">{formatDateLong(selected.date)}</span>
+                      <span>·</span>
+                      <span className="font-mono tabular-nums">{selected.date}</span>
+                    </div>
+                    <h2 className="text-[24px] font-extrabold mt-2 break-words tracking-tight text-ink-900">
+                      {selected.title || "(제목 없음)"}
+                    </h2>
+                  </div>
+                  <div className="flex items-center gap-1.5 flex-shrink-0">
+                    <button className="btn-ghost btn-xs" onClick={() => openEdit(selected)} disabled={removingId === selected.id}>
+                      수정
+                    </button>
+                    <button
+                      className="btn-ghost btn-xs"
+                      style={{ color: "var(--c-danger)" }}
+                      onClick={() => setConfirmRemoveId(selected.id)}
+                      disabled={removingId === selected.id}
+                    >
+                      {removingId === selected.id ? "삭제 중…" : "삭제"}
+                    </button>
+                  </div>
                 </div>
               </div>
-              <div className="mt-6 whitespace-pre-wrap text-slate-700 leading-relaxed break-words">
-                {selected.content}
+              <div className="flex-1 px-6 py-6 overflow-auto">
+                <div className="whitespace-pre-wrap text-[14.5px] text-ink-800 leading-[1.75] break-words">
+                  {selected.content || <span className="text-ink-400">(내용 없음)</span>}
+                </div>
               </div>
-            </div>
+            </article>
           ) : (
-            <div className="text-center text-slate-400 py-20">일지를 선택하거나 새로 작성하세요.</div>
+            <EmptyDetail onCreate={openCreate} />
           )}
-        </div>
+        </main>
       </div>
 
       {confirmRemoveId && (
         <div
-          className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-50"
+          className="fixed inset-0 z-50 grid place-items-center p-4"
+          style={{ background: "rgba(0,0,0,0.45)", backdropFilter: "blur(4px)" }}
           onClick={() => removingId ? null : setConfirmRemoveId(null)}
         >
-          <div className="card w-full max-w-[400px]" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-lg font-bold">일지 삭제</h3>
-            <p className="text-sm text-slate-600 mt-2">
-              이 일지를 삭제하시겠습니까? 삭제 후에는 복구할 수 없습니다.
-            </p>
-            <div className="flex justify-end gap-2 mt-4">
+          <div className="panel p-5 w-full max-w-[420px]" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-start gap-3">
+              <div
+                className="w-10 h-10 rounded-xl grid place-items-center flex-shrink-0"
+                style={{ background: "rgba(220,38,38,0.10)", color: "var(--c-danger)" }}
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <h3 className="text-[15px] font-extrabold text-ink-900">일지 삭제</h3>
+                <p className="text-[12.5px] text-ink-600 mt-1 leading-relaxed">
+                  이 일지를 삭제할까요? 삭제 후에는 복구할 수 없어요.
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 mt-5">
               <button
                 className="btn-ghost"
                 onClick={() => setConfirmRemoveId(null)}
@@ -268,7 +387,8 @@ export default function JournalPage() {
                 취소
               </button>
               <button
-                className="btn-primary bg-red-600 hover:bg-red-700"
+                className="btn-primary"
+                style={{ background: "var(--c-danger)" }}
                 onClick={() => remove(confirmRemoveId)}
                 disabled={!!removingId}
               >
@@ -280,4 +400,34 @@ export default function JournalPage() {
       )}
     </div>
   );
+}
+
+function EmptyDetail({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="flex-1 grid place-items-center px-6 py-16">
+      <div className="text-center max-w-[360px]">
+        <div className="text-[40px] mb-3">📝</div>
+        <div className="text-[16px] font-extrabold text-ink-900">일지를 선택하거나 새로 작성하세요</div>
+        <div className="text-[12.5px] text-ink-500 mt-1.5 leading-relaxed">
+          하루를 기록해 두면 회고가 쉬워져요.
+          <br />
+          오늘 한 일·막힌 점·내일 할 일 셋만 남겨도 충분.
+        </div>
+        <button className="btn-primary mt-5" onClick={onCreate}>+ 새 일지 작성</button>
+      </div>
+    </div>
+  );
+}
+
+function dowOf(date: string) {
+  const d = new Date(date + "T00:00:00");
+  return ["일", "월", "화", "수", "목", "금", "토"][d.getDay()] ?? "";
+}
+function formatYearMonth(ym: string) {
+  const [y, m] = ym.split("-");
+  return `${y}년 ${parseInt(m, 10)}월`;
+}
+function formatDateLong(date: string) {
+  const d = new Date(date + "T00:00:00");
+  return d.toLocaleDateString("ko-KR", { month: "long", day: "numeric", weekday: "short" });
 }


### PR DESCRIPTION
## 증상
**근태·업무일지 + 개발중 페이지 풀화면 디자인 폴리시**

새 기능을 추가합니다.

## 원인
[근태·월차]
- 상단 4개 통계 카드: 근무일 / 평균 근무시간 / 사용한 휴가 / 승인 대기.
  각 색상 토큰 + 아이콘 칩.
- 출퇴근 표 폴리시: 일자 셀에 dow + 주말 빨간색 + 오늘 강조 + 시각 모노스페이스.
- 내 휴가 신청을 카드 행으로 — 휴가 종류 색 점 + 일수 + 상태 칩.
- 관리자 처리: 대기/처리됨 그룹핑, 상태 칩 통일.
- 신청 모달: 그라데이션 헤더(브랜드→바이올렛) + 휴가 종류 5개 시각 칩 +
  날짜 범위 일수 미리보기. useModalDismiss(Esc).

[업무일지]
- 사이드 리스트:
  · 검색 박스 (제목·날짜·본문 부분 매치)
  · 월별 sticky 헤더로 그룹핑
  · 날짜 칩(일+요일) + 본문 1줄 프리뷰
- 본문 영역:
  · 헤더에 한국어 긴 날짜 + 액션
  · 제목 24px 굵게, 본문 1.75 line-height 가독성 ↑
  · 빈 상태 일러스트 + 새 일지 CTA
- 폼:
  · 글자수 카운터(20,000)
  · placeholder 가이드("오늘 한 일 / 잘된 점 / 막힌 점 / 내일 할 일")
  · 헤더에 EDIT/NEW 캡션
- 삭제 확인 모달: 빨간 휴지통 아이콘 + Esc/배경 닫기.

[개발 중 / 차단 페이지 — 이전 PR 보강]

## 수정
**작업 항목 (커밋 단위)**
- feat(ux): 근태·업무일지 페이지 + 개발중 페이지 풀화면 디자인 폴리시

**변경 대상 (3개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/pages/AttendancePage.tsx`
- `client/src/pages/JournalPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #81** ↔ **이슈 #503** 로 연결됩니다.

Closes #503
