### PR TITLE
🔀 :: (#504) 본인 카드 좁아 배지가 이름 밀어내던 문제 — iconOnly

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -555,9 +555,11 @@ function AppLayoutInner() {
                 </div>
               )}
               <div className="min-w-0 flex-1">
-                <div className="text-[13px] font-semibold text-ink-900 truncate flex items-center gap-1">
-                  <span className="truncate">{user?.name}</span>
-                  {isDevAccount(user) && <DevBadge />}
+                {/* 사이드바 폭이 좁아 라벨 풀버전 배지가 이름을 밀어내는 문제 — iconOnly 로 통일.
+                    풀 라벨은 마이페이지 미리보기에서 별도로 보이므로 정보 손실 없음. */}
+                <div className="text-[13px] font-semibold text-ink-900 flex items-center gap-1.5 min-w-0">
+                  <span className="truncate min-w-0">{user?.name}</span>
+                  {isDevAccount(user) && <DevBadge iconOnly />}
                 </div>
                 <div className="text-[11px] text-ink-500 truncate">{user?.email}</div>
               </div>


### PR DESCRIPTION
## 증상
**본인 카드 좁아 배지가 이름 밀어내던 문제 — iconOnly**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
사이드바 하단의 본인 카드 폭이 좁아 "HiNest 개발자" 풀 라벨 배지가 이름을
밀어내고 한두 글자만 남던 버그. 조직도와 동일하게 iconOnly 로 통일.
풀 라벨은 마이페이지 미리보기에서 별도로 보이므로 정보 손실 없음.

## 수정
**작업 항목 (커밋 단위)**
- fix(sidebar): 본인 정보 영역 좁아 라벨 배지가 이름 밀어내는 문제 — iconOnly 로

**변경 대상 (1개 파일)**
- `client/src/components/AppLayout.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #82** ↔ **이슈 #504** 로 연결됩니다.

Closes #504
