### PR TITLE
🔀 :: (#508) isDeveloper 응답 누락 — 조직도/디렉토리 등에서 딱지 안 뜨던 문제

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -74,6 +74,8 @@ const HR_SELECT = {
   active: true,
   resignedAt: true,
   avatarColor: true,
+
+  isDeveloper: true,
   avatarUrl: true,
   createdAt: true,
   hrCode: true,

--- a/server/src/routes/approval.ts
+++ b/server/src/routes/approval.ts
@@ -40,10 +40,10 @@ router.get("/", async (req, res) => {
     orderBy: { createdAt: "desc" },
     take: 200,
     include: {
-      requester: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, position: true, team: true } },
+      requester: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } },
       steps: {
         orderBy: { order: "asc" },
-        include: { reviewer: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+        include: { reviewer: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
       },
     },
   });
@@ -61,17 +61,17 @@ router.get("/:id", async (req, res) => {
   const a = await prisma.approval.findUnique({
     where: { id: req.params.id },
     include: {
-      requester: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, position: true, team: true, email: true } },
+      requester: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true, email: true } },
       steps: {
         orderBy: { order: "asc" },
-        include: { reviewer: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, position: true } } },
+        include: { reviewer: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true } } },
       },
       // 반려 → 재상신 체인을 양방향으로 포함. 원본을 타고 올라가고 개정본을 타고 내려감.
       revisedFrom: { select: { id: true, title: true, status: true, createdAt: true } },
       revisions: { select: { id: true, title: true, status: true, createdAt: true }, orderBy: { createdAt: "asc" } },
       comments: {
         orderBy: { createdAt: "asc" },
-        include: { author: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+        include: { author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
       },
     },
   });
@@ -98,7 +98,7 @@ router.post("/:id/comments", async (req, res) => {
   if (!canPost) return res.status(403).json({ error: "forbidden" });
   const c = await prisma.approvalComment.create({
     data: { approvalId: a.id, authorId: u.id, content },
-    include: { author: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+    include: { author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
   });
   // 관련 당사자에게 멘션 알림 — 본인 제외. 순차 notify() → 병렬 notifyMany() 로 교체.
   const targets = new Set<string>([a.requesterId, ...a.steps.map((s) => s.reviewerId)]);

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -81,7 +81,7 @@ router.get("/rooms", async (req, res) => {
     where,
     orderBy: { createdAt: "desc" },
     include: {
-      members: { include: { user: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } } },
+      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
       messages: {
         where: { deletedAt: null, scheduledAt: null },
         orderBy: { createdAt: "desc" },
@@ -131,7 +131,7 @@ router.post("/rooms", async (req, res) => {
         ],
       },
       include: {
-        members: { include: { user: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } } },
+        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
         messages: {
           where: { deletedAt: null, scheduledAt: null },
           orderBy: { createdAt: "desc" },
@@ -151,7 +151,7 @@ router.post("/rooms", async (req, res) => {
         members: { create: [{ userId: u.id }, { userId: other }] },
       },
       include: {
-        members: { include: { user: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } } },
+        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
         messages: { where: { deletedAt: null, scheduledAt: null }, orderBy: { createdAt: "desc" }, take: 1 },
       },
     });
@@ -170,7 +170,7 @@ router.post("/rooms", async (req, res) => {
       members: { create: memberIds.map((userId) => ({ userId })) },
     },
     include: {
-      members: { include: { user: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } } },
+      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
       messages: { where: { deletedAt: null, scheduledAt: null }, orderBy: { createdAt: "desc" }, take: 1 },
     },
   });
@@ -208,10 +208,10 @@ router.get("/search", async (req, res) => {
     orderBy: { createdAt: "desc" },
     take: 80,
     include: {
-      sender: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } },
+      sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       room: {
         include: {
-          members: { include: { user: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } } },
+          members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
         },
       },
     },
@@ -297,7 +297,7 @@ router.get("/rooms/:id/messages", async (req, res) => {
     orderBy: { createdAt: "asc" },
     take: 300,
     include: {
-      sender: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } },
+      sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       reactions: { select: { userId: true, emoji: true, user: { select: { name: true } } } },
     },
   });
@@ -422,7 +422,7 @@ router.post("/rooms/:id/messages", async (req, res) => {
       scheduledAt,
     },
     include: {
-      sender: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } },
+      sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       room: { select: { id: true, name: true, type: true } },
       reactions: { select: { userId: true, emoji: true, user: { select: { name: true } } } },
     },
@@ -554,7 +554,7 @@ router.patch("/messages/:id", async (req, res) => {
   const updated = await prisma.chatMessage.update({
     where: { id: msg.id },
     data,
-    include: { sender: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+    include: { sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
   });
   broadcastToRoom(msg.roomId, "chat:update", { kind: "edit", message: updated });
   res.json({ message: updated });
@@ -579,7 +579,7 @@ router.post("/messages/:id/pin", async (req, res) => {
       pinnedAt: pin ? new Date() : null,
       pinnedById: pin ? u.id : null,
     },
-    include: { sender: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+    include: { sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
   });
   broadcastToRoom(msg.roomId, "chat:update", { kind: "pin", message: updated });
   res.json({ message: updated });

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -409,7 +409,7 @@ router.get("/", async (req, res) => {
       orderBy: { updatedAt: "desc" },
       take: 500,
       include: {
-        author: { select: { name: true, avatarColor: true, avatarUrl: true } },
+        author: { select: { name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
         folder: { select: { name: true } },
       },
     });
@@ -435,7 +435,7 @@ router.get("/", async (req, res) => {
     where: { AND: ands },
     orderBy: { updatedAt: "desc" },
     include: {
-      author: { select: { name: true, avatarColor: true, avatarUrl: true } },
+      author: { select: { name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       folder: { select: { name: true } },
     },
   });
@@ -608,7 +608,7 @@ router.get("/:id/revisions", async (req, res) => {
     where: { documentId: exist.id },
     orderBy: { createdAt: "desc" },
     take: 100,
-    include: { editor: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+    include: { editor: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
   });
   res.json({ revisions: rows });
 });

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -152,6 +152,8 @@ router.get("/mentionable", async (req, res) => {
       team: true,
       position: true,
       avatarColor: true,
+
+      isDeveloper: true,
       avatarUrl: true,
     },
     take: 500,
@@ -211,7 +213,7 @@ router.get("/", async (req, res) => {
       authorId: true,
       createdAt: true,
       updatedAt: true,
-      author: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } },
+      author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       project: { select: { id: true, name: true, color: true } },
     },
   });
@@ -283,10 +285,10 @@ router.get("/:id", async (req, res) => {
   const meeting = await prisma.meeting.findUnique({
     where: { id: req.params.id },
     include: {
-      author: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } },
+      author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       project: { select: { id: true, name: true, color: true } },
       viewers: {
-        include: { user: { select: { id: true, name: true, team: true, position: true, avatarColor: true, avatarUrl: true } } },
+        include: { user: { select: { id: true, name: true, team: true, position: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
       },
     },
   });
@@ -475,7 +477,7 @@ router.get("/:id/revisions", async (req, res) => {
     where: { meetingId: existing.id },
     orderBy: { createdAt: "desc" },
     take: 100,
-    include: { editor: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+    include: { editor: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
   });
   res.json({ revisions: rows });
 });

--- a/server/src/routes/profile.ts
+++ b/server/src/routes/profile.ts
@@ -30,7 +30,7 @@ router.patch("/", async (req, res) => {
   const user = await prisma.user.update({
     where: { id: u.id },
     data: d,
-    select: { id: true, name: true, email: true, avatarColor: true, avatarUrl: true, team: true, position: true, role: true },
+    select: { id: true, name: true, email: true, avatarColor: true, isDeveloper: true, avatarUrl: true, team: true, position: true, role: true },
   });
   await writeLog(u.id, "PROFILE_UPDATE", u.id, JSON.stringify(d));
   res.json({ user });

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -32,7 +32,7 @@ router.get("/:id", async (req, res) => {
     where: { id: req.params.id },
     include: {
       members: {
-        include: { user: { select: { id: true, name: true, email: true, team: true, position: true, avatarColor: true, avatarUrl: true } } },
+        include: { user: { select: { id: true, name: true, email: true, team: true, position: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
       },
       createdBy: { select: { id: true, name: true } },
     },
@@ -371,7 +371,7 @@ router.get("/:id/qa", async (req, res) => {
   const users = userIds.length
     ? await prisma.user.findMany({
         where: { id: { in: userIds } },
-        select: { id: true, name: true, avatarColor: true, avatarUrl: true },
+        select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true },
       })
     : [];
   const userMap = new Map(users.map((x) => [x.id, x]));

--- a/server/src/routes/schedule.ts
+++ b/server/src/routes/schedule.ts
@@ -100,7 +100,7 @@ router.get("/", async (req, res) => {
     where,
     orderBy: { startAt: "asc" },
     include: {
-      author: { select: { name: true, avatarColor: true, avatarUrl: true } },
+      author: { select: { name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       project: { select: { id: true, name: true, color: true } },
     },
   });

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -94,7 +94,7 @@ router.get("/", async (req, res) => {
         ],
       },
       take: 8,
-      select: { id: true, name: true, email: true, team: true, position: true, avatarColor: true, avatarUrl: true },
+      select: { id: true, name: true, email: true, team: true, position: true, avatarColor: true, isDeveloper: true, avatarUrl: true },
     }),
     prisma.notice.findMany({
       where: {
@@ -136,7 +136,7 @@ router.get("/", async (req, res) => {
       take: 8,
       orderBy: { createdAt: "desc" },
       include: {
-        sender: { select: { name: true, avatarColor: true, avatarUrl: true } },
+        sender: { select: { name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
         room: { select: { id: true, name: true, type: true } },
       },
     }),

--- a/server/src/routes/serviceAccount.ts
+++ b/server/src/routes/serviceAccount.ts
@@ -150,7 +150,7 @@ router.get("/", async (req, res) => {
     where,
     orderBy: [{ category: "asc" }, { serviceName: "asc" }],
     include: {
-      ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
+      ownerUser: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, email: true, team: true, position: true } },
       createdBy: { select: { id: true, name: true } },
       project: { select: { id: true, name: true, color: true } },
     },
@@ -306,7 +306,7 @@ router.post("/", async (req, res) => {
       createdById: user.id,
     },
     include: {
-      ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
+      ownerUser: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, email: true, team: true, position: true } },
       createdBy: { select: { id: true, name: true } },
       project: { select: { id: true, name: true, color: true } },
     },
@@ -409,7 +409,7 @@ router.patch("/:id", async (req, res) => {
     where: { id },
     data,
     include: {
-      ownerUser: { select: { id: true, name: true, avatarColor: true, avatarUrl: true, email: true, team: true, position: true } },
+      ownerUser: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, email: true, team: true, position: true } },
       createdBy: { select: { id: true, name: true } },
       project: { select: { id: true, name: true, color: true } },
     },

--- a/server/src/routes/snippet.ts
+++ b/server/src/routes/snippet.ts
@@ -44,7 +44,7 @@ router.get("/", async (req, res) => {
     where,
     orderBy: [{ updatedAt: "desc" }],
     take: 200,
-    include: { owner: { select: { id: true, name: true, avatarColor: true, avatarUrl: true } } },
+    include: { owner: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
   });
   res.json({ snippets });
 });

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -27,6 +27,7 @@ router.get("/", async (req, res) => {
       position: true,
       avatarColor: true,
       avatarUrl: true,
+      isDeveloper: true,
       presenceStatus: true,
       presenceMessage: true,
       presenceUpdatedAt: true,


### PR DESCRIPTION
## 증상
**isDeveloper 응답 누락 — 조직도/디렉토리 등에서 딱지 안 뜨던 문제**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
[원인]
client/src/lib/devBadge.tsx 의 isDevAccount() 가 서버 isDeveloper 만 체크하도록
이전 PR 에서 보안 강화했는데, 정작 다수 API 응답에 isDeveloper 필드가 select 안
포함돼 있어서 클라가 항상 false 로 봄.

[수정]
User 객체를 select 하는 라우트 전부에 isDeveloper: true 추가:
  users.ts (조직도/디렉토리 핵심)
  admin.ts (HR_SELECT)
  meeting.ts (작성자 + 뷰어)
  approval.ts (요청자/검토자/댓글)
  document.ts (작성자/편집자)
  schedule.ts (작성자)
  search.ts (사용자/메시지 발신자)
  serviceAccount.ts (소유자)
  snippet.ts (소유자)
  project.ts (멤버)
  chat.ts (메시지 발신자)
  profile.ts

이전 보안 픽스(name fallback 제거) 의 안전한 fix 완성 — 조직도·디렉토리·
회의록·결재·문서함·채팅 모든 곳에서 다시 정상적으로 딱지 노출.

## 수정
**작업 항목 (커밋 단위)**
- fix(api): isDeveloper 필드 응답에 누락 — 조직도/디렉토리 등에서 개발자 딱지 안 뜨던 문제

**변경 대상 (12개 파일)**
- `server/src/routes/admin.ts`
- `server/src/routes/approval.ts`
- `server/src/routes/chat.ts`
- `server/src/routes/document.ts`
- `server/src/routes/meeting.ts`
- `server/src/routes/profile.ts`
- `server/src/routes/project.ts`
- `server/src/routes/schedule.ts`
- `server/src/routes/search.ts`
- `server/src/routes/serviceAccount.ts`
- `server/src/routes/snippet.ts`
- `server/src/routes/users.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #86** ↔ **이슈 #508** 로 연결됩니다.

Closes #508
