### PR TITLE
🔀 :: (#509) 유저 프로필 상세 페이지 + 개발중/차단 페이지 테마 대응

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,6 +26,7 @@ import {
   MeetingDetailPage,
   ServiceAccountsPage,
   SnippetsPage,
+  UserProfilePage,
   AdminPage,
   SuperAdminPage,
 } from "./routes";
@@ -99,6 +100,7 @@ export default function App() {
           <Route path="meetings/:id" element={<MeetingDetailPage />} />
           <Route path="accounts" element={<ServiceAccountsPage />} />
           <Route path="snippets" element={<SnippetsPage />} />
+          <Route path="users/:id" element={<UserProfilePage />} />
           <Route
             path="admin"
             element={

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
+import { useTheme } from "../theme";
 import { api } from "../api";
 import Logo from "./Logo";
 import NotificationBell from "./NotificationBell";
@@ -80,14 +81,21 @@ function RouteVisibilityGate({
 
 /** 비활성된 메뉴 진입 시 안내 — 풀 화면 그라데이션 + 자물쇠 일러스트. */
 function BlockedPage() {
+  // 라이트 — 차분한 슬레이트 그레이 (텍스트 흰색 유지하면서 너무 어둡지 않게)
+  // 다크 — 잉크 톤에 맞춘 더 깊은 검정 그라데이션 (서라운딩 surface 와 자연스럽게 이어짐)
+  const { resolved } = useTheme();
+  const isDark = resolved === "dark";
+  const bg = isDark
+    ? "radial-gradient(ellipse at top right, rgba(99,102,241,0.10) 0%, transparent 55%), radial-gradient(ellipse at bottom left, rgba(0,0,0,0.5) 0%, transparent 60%), linear-gradient(135deg, #14161B 0%, #0A0C10 100%)"
+    : "radial-gradient(ellipse at top right, rgba(99,102,241,0.16) 0%, transparent 55%), radial-gradient(ellipse at bottom left, rgba(15,23,42,0.5) 0%, transparent 60%), linear-gradient(135deg, #2C3340 0%, #1A1F2A 100%)";
   return (
     <div
       className="relative w-full overflow-hidden rounded-3xl"
       style={{
         minHeight: "min(78vh, 720px)",
-        background:
-          "radial-gradient(ellipse at top right, rgba(99,102,241,0.18) 0%, transparent 55%), radial-gradient(ellipse at bottom left, rgba(15,23,42,0.65) 0%, transparent 60%), linear-gradient(135deg, #1E293B 0%, #0F172A 100%)",
+        background: bg,
         color: "#fff",
+        border: isDark ? "1px solid rgba(255,255,255,0.06)" : "none",
       }}
     >
       {/* 큰 배경 자물쇠 — 시각적 hero */}
@@ -167,14 +175,21 @@ function BlockedPage() {
 
 /** \"개발 중\" 페이지 — 풀 화면 그라데이션 + 회전 톱니바퀴 + 펄스 도형. */
 function UnderConstructionPage({ isDeveloper }: { isDeveloper: boolean }) {
+  const { resolved } = useTheme();
+  const isDark = resolved === "dark";
+  // 라이트 — 비비드 브랜드 → 바이올렛 (현재 톤과 비슷하지만 약간 부드럽게)
+  // 다크 — 어두운 잉크 위에 브랜드 글로우만 살짝 — 다크 surrounding 과 자연스럽게 융합
+  const bg = isDark
+    ? "radial-gradient(ellipse at top, rgba(120,150,255,0.18) 0%, transparent 50%), radial-gradient(ellipse at bottom right, rgba(56,189,248,0.10) 0%, transparent 55%), linear-gradient(135deg, #1A1F2A 0%, #2A1F40 60%, #1F1530 100%)"
+    : "radial-gradient(ellipse at top, rgba(167,139,250,0.32) 0%, transparent 55%), radial-gradient(ellipse at bottom right, rgba(56,189,248,0.20) 0%, transparent 55%), linear-gradient(135deg, #3B5CF0 0%, #7C3AED 60%, #581C87 100%)";
   return (
     <div
       className="relative w-full overflow-hidden rounded-3xl"
       style={{
         minHeight: "min(78vh, 720px)",
-        background:
-          "radial-gradient(ellipse at top, rgba(167,139,250,0.28) 0%, transparent 55%), radial-gradient(ellipse at bottom right, rgba(56,189,248,0.18) 0%, transparent 55%), linear-gradient(135deg, #3B5CF0 0%, #7C3AED 60%, #581C87 100%)",
+        background: bg,
         color: "#fff",
+        border: isDark ? "1px solid rgba(255,255,255,0.06)" : "none",
       }}
     >
       <style>{`

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import { useNotifications } from "../notifications";
@@ -1899,6 +1900,13 @@ function RoomView({
   const slashRef = useRef<SnippetSlashHandle | null>(null);
   const [reactingId, setReactingId] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
+  const nav = useNavigate();
+  // 채팅 메시지의 발신자 이름·아바타 클릭 → 사용자 프로필 페이지로. 채팅 팝업은 닫고 이동.
+  function openProfile(userId: string) {
+    if (!userId) return;
+    window.dispatchEvent(new CustomEvent("chat:close"));
+    nav(`/users/${userId}`);
+  }
   const prevCountRef = useRef(0);
   const stuckToBottomRef = useRef(true);
 
@@ -2117,14 +2125,22 @@ function RoomView({
                         (p?.workStatus ?? null) as any,
                       );
                       return (
-                        <Avatar
-                          name={m.sender.name}
-                          color={m.sender.avatarColor ?? C.blue}
-                          imageUrl={m.sender.avatarUrl ?? null}
-                          size={26}
-                          presenceColor={info.color}
-                          presenceTitle={info.label + (p?.presenceMessage ? ` · ${p.presenceMessage}` : "")}
-                        />
+                        <button
+                          type="button"
+                          onClick={() => openProfile(m.sender.id)}
+                          style={{ background: "transparent", border: 0, padding: 0, cursor: "pointer", flexShrink: 0 }}
+                          title="프로필 보기"
+                          aria-label={`${m.sender.name} 프로필 보기`}
+                        >
+                          <Avatar
+                            name={m.sender.name}
+                            color={m.sender.avatarColor ?? C.blue}
+                            imageUrl={m.sender.avatarUrl ?? null}
+                            size={26}
+                            presenceColor={info.color}
+                            presenceTitle={info.label + (p?.presenceMessage ? ` · ${p.presenceMessage}` : "")}
+                          />
+                        </button>
                       );
                     })()
                   ) : !mine ? (
@@ -2132,10 +2148,21 @@ function RoomView({
                   ) : null}
                   <div style={{ minWidth: 0, flex: "0 1 auto", position: "relative" }}>
                     {!mine && m.showMeta && (
-                      <div style={{ fontSize: 11.5, fontWeight: 600, color: C.gray600, marginLeft: 4, marginBottom: 3, display: "inline-flex", alignItems: "center", gap: 4 }}>
-                        {m.sender.name}
+                      <button
+                        type="button"
+                        onClick={() => openProfile(m.sender.id)}
+                        style={{
+                          fontSize: 11.5, fontWeight: 600, color: C.gray600,
+                          marginLeft: 4, marginBottom: 3,
+                          display: "inline-flex", alignItems: "center", gap: 4,
+                          background: "transparent", border: 0, padding: 0, cursor: "pointer",
+                          fontFamily: "inherit",
+                        }}
+                        title="프로필 보기"
+                      >
+                        <span style={{ textDecoration: "none" }}>{m.sender.name}</span>
                         {isDevAccount(m.sender) && <DevBadge />}
-                      </div>
+                      </button>
                     )}
                     <div
                       style={{

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -5,6 +5,7 @@ import PageHeader from "../components/PageHeader";
 import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
 import { alertAsync } from "../components/ConfirmHost";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
+import { Link } from "react-router-dom";
 
 type DirectoryUser = {
   id: string;
@@ -318,7 +319,7 @@ function GridCard({
             </div>
             <PresenceDot u={u} size={12} ring={2} />
           </div>
-          <div className="min-w-0 flex-1">
+          <Link to={`/users/${u.id}`} className="min-w-0 flex-1 hover:opacity-80 transition">
             <div className="text-[15px] font-extrabold text-ink-900 tracking-tight truncate inline-flex items-center gap-1.5">
               {u.name}
               {isDevAccount(u) && <DevBadge />}
@@ -326,7 +327,7 @@ function GridCard({
             <div className="text-[12px] text-ink-600 truncate mt-0.5">
               {u.position ?? "—"}
             </div>
-          </div>
+          </Link>
           {u.team && <span className="chip-blue flex-shrink-0">{u.team}</span>}
         </div>
         <div className="text-[11px] text-ink-500 tabular truncate">{u.email}</div>
@@ -398,7 +399,7 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
         </div>
         <PresenceDot u={u} size={12} ring={2} />
       </div>
-      <div className="min-w-0 flex-1 md:w-[28%] md:flex-initial">
+      <Link to={`/users/${u.id}`} className="min-w-0 flex-1 md:w-[28%] md:flex-initial hover:opacity-80 transition">
         <div className="flex items-center gap-1.5">
           <div className="text-[14px] font-extrabold text-ink-900 truncate tracking-tight inline-flex items-center gap-1.5">
             {u.name}
@@ -407,7 +408,7 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
           <PresenceBadge u={u} />
         </div>
         <div className="text-[11px] text-ink-500 tabular truncate">{u.email}</div>
-      </div>
+      </Link>
       <div className="hidden md:block md:w-[14%]">
         <div className="text-[12px] font-semibold text-ink-800">{u.position ?? "—"}</div>
       </div>

--- a/client/src/pages/UserProfilePage.tsx
+++ b/client/src/pages/UserProfilePage.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { api, apiSWR } from "../api";
+import { useAuth } from "../auth";
+import PageHeader from "../components/PageHeader";
+import { alertAsync } from "../components/ConfirmHost";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
+import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
+
+type ProfileUser = {
+  id: string;
+  name: string;
+  email: string;
+  team: string | null;
+  position: string | null;
+  role: string;
+  avatarColor: string;
+  avatarUrl: string | null;
+  isDeveloper: boolean;
+  active: boolean;
+  employeeNo: string | null;
+  hireDate: string | null;
+  phone: string | null;
+  presenceStatus: PresenceStatus | null;
+  presenceMessage: string | null;
+  presenceUpdatedAt: string | null;
+  createdAt: string;
+};
+
+export default function UserProfilePage() {
+  const { id } = useParams();
+  const nav = useNavigate();
+  const { user: me } = useAuth();
+  const [u, setU] = useState<ProfileUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [openingDM, setOpeningDM] = useState(false);
+
+  // 본인 페이지면 자체 마이페이지로 리다이렉트 — /profile 이 풀 편집 가능 화면.
+  useEffect(() => {
+    if (me && id && me.id === id) {
+      nav("/profile", { replace: true });
+    }
+  }, [me, id, nav]);
+
+  useEffect(() => {
+    if (!id) return;
+    let alive = true;
+    apiSWR<{ user: ProfileUser }>(`/api/users/${id}`, {
+      onCached: (r) => { if (alive) { setU(r.user); setLoading(false); } },
+      onFresh: (r) => { if (alive) { setU(r.user); setLoading(false); } },
+      onError: () => { if (alive) { setErr("불러오기 실패"); setLoading(false); } },
+    });
+    return () => { alive = false; };
+  }, [id]);
+
+  async function startDM() {
+    if (!u || openingDM) return;
+    setOpeningDM(true);
+    try {
+      const r = await api<{ room: { id: string } }>("/api/chat/rooms", {
+        method: "POST",
+        json: { type: "DIRECT", memberIds: [u.id] },
+      });
+      window.dispatchEvent(new CustomEvent("chat:open"));
+      window.dispatchEvent(new CustomEvent("chat:open-room", { detail: { roomId: r.room.id } }));
+    } catch (e: any) {
+      alertAsync({ title: "대화방 열기 실패", description: e?.message ?? "잠시 후 다시 시도해 주세요." });
+    } finally {
+      setOpeningDM(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div>
+        <PageHeader eyebrow="팀원" title="프로필" />
+        <div className="panel p-12 text-center text-ink-500 text-[13px]">불러오는 중…</div>
+      </div>
+    );
+  }
+  if (err || !u) {
+    return (
+      <div>
+        <PageHeader eyebrow="팀원" title="프로필" />
+        <div className="panel p-12 text-center">
+          <div className="text-[14px] font-bold text-ink-900">프로필을 찾을 수 없어요</div>
+          <div className="text-[12.5px] text-ink-500 mt-1">{err ?? "사용자가 없거나 접근 권한이 없습니다."}</div>
+          <button className="btn-ghost mt-4" onClick={() => nav(-1)}>돌아가기</button>
+        </div>
+      </div>
+    );
+  }
+
+  const presence = resolvePresence(u.presenceStatus, null as WorkStatus | null);
+  const isReviewer = me?.role === "ADMIN" || me?.role === "MANAGER";
+  const initial = (u.name?.[0] ?? "?").toUpperCase();
+
+  return (
+    <div>
+      <PageHeader
+        eyebrow="팀원"
+        title="프로필"
+        right={
+          <button className="btn-ghost" onClick={() => nav(-1)}>
+            ← 돌아가기
+          </button>
+        }
+      />
+
+      {/* 히어로 카드 — 그라데이션 헤더 + 큰 아바타 + 액션 */}
+      <div className="panel p-0 overflow-hidden mb-4">
+        <div
+          className="relative px-6 sm:px-10 py-10"
+          style={{
+            background:
+              "linear-gradient(135deg, var(--c-brand) 0%, #7C3AED 100%)",
+            color: "#fff",
+          }}
+        >
+          {/* 격자 패턴 */}
+          <div
+            aria-hidden
+            style={{
+              position: "absolute",
+              inset: 0,
+              backgroundImage:
+                "linear-gradient(rgba(255,255,255,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.06) 1px, transparent 1px)",
+              backgroundSize: "44px 44px",
+              maskImage: "radial-gradient(ellipse at center, #000 0%, transparent 75%)",
+              pointerEvents: "none",
+            }}
+          />
+          <div className="relative flex flex-col sm:flex-row items-start sm:items-center gap-5">
+            {/* 아바타 */}
+            <div className="relative">
+              <div
+                className="w-24 h-24 rounded-2xl grid place-items-center text-[36px] font-extrabold overflow-hidden"
+                style={{
+                  background: u.avatarUrl ? "transparent" : u.avatarColor,
+                  color: "#fff",
+                  border: "3px solid rgba(255,255,255,0.32)",
+                  boxShadow: "0 12px 32px rgba(0,0,0,0.25)",
+                }}
+              >
+                {u.avatarUrl ? (
+                  <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                ) : (
+                  initial
+                )}
+              </div>
+              {/* presence 점 */}
+              <span
+                className="absolute -bottom-1 -right-1 w-5 h-5 rounded-full"
+                style={{
+                  background: presence.color,
+                  border: "3px solid #fff",
+                }}
+                title={presence.label}
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex flex-wrap items-center gap-2 mb-1">
+                <h1 className="text-[28px] font-extrabold tracking-tight">{u.name}</h1>
+                {u.isDeveloper && <DevBadge size="md" />}
+                {!u.active && (
+                  <span className="chip" style={{ background: "rgba(255,255,255,0.18)", color: "#fff" }}>비활성</span>
+                )}
+              </div>
+              <div className="text-[14px] text-white/85">
+                {[u.team, u.position].filter(Boolean).join(" · ") || "—"}
+              </div>
+              <div className="text-[12.5px] text-white/70 mt-1 inline-flex items-center gap-1.5">
+                <span className="w-1.5 h-1.5 rounded-full" style={{ background: presence.color }} />
+                {presence.label}
+                {u.presenceMessage && <span> · {u.presenceMessage}</span>}
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2 sm:flex-col sm:gap-2">
+              <button
+                onClick={startDM}
+                disabled={openingDM}
+                className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-bold text-[13px] transition"
+                style={{ background: "#fff", color: "var(--c-brand)" }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+                </svg>
+                {openingDM ? "여는 중…" : "1:1 대화"}
+              </button>
+              {u.email !== "" && (
+                <a
+                  href={`mailto:${u.email}`}
+                  className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-bold text-[13px] transition"
+                  style={{
+                    background: "rgba(255,255,255,0.18)",
+                    color: "#fff",
+                    backdropFilter: "blur(8px)",
+                    border: "1px solid rgba(255,255,255,0.22)",
+                  }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                    <polyline points="22,6 12,13 2,6" />
+                  </svg>
+                  메일
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 정보 카드들 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="panel p-5">
+          <div className="text-[10.5px] font-extrabold tracking-[0.06em] uppercase text-ink-500 mb-3">기본 정보</div>
+          <Field label="이름" value={u.name} />
+          <Field label="이메일" value={u.email} mono />
+          <Field label="권한" value={roleLabel(u.role)} />
+          <Field label="팀" value={u.team ?? "—"} />
+          <Field label="직급" value={u.position ?? "—"} />
+        </div>
+        <div className="panel p-5">
+          <div className="text-[10.5px] font-extrabold tracking-[0.06em] uppercase text-ink-500 mb-3">근무 정보</div>
+          <Field label="사번" value={u.employeeNo ?? "—"} mono />
+          <Field label="입사일" value={u.hireDate ?? "—"} />
+          <Field label="연락처" value={u.phone ?? "—"} mono />
+          <Field label="가입일" value={new Date(u.createdAt).toLocaleDateString("ko-KR")} />
+          {!isReviewer && (u.employeeNo === null || u.phone === null || u.hireDate === null) && (
+            <div className="text-[10.5px] text-ink-400 mt-3 leading-relaxed">
+              일부 정보는 관리자만 볼 수 있어요.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="panel p-3 mt-4 flex items-center gap-2 flex-wrap">
+        <Link to="/directory" className="btn-ghost btn-xs">팀원 전체 보기</Link>
+        <Link to="/org" className="btn-ghost btn-xs">조직도</Link>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-3 py-2 border-b border-ink-100 last:border-0">
+      <div className="text-[12px] text-ink-500">{label}</div>
+      <div className={`text-[13px] font-semibold text-ink-900 text-right ${mono ? "font-mono tracking-[0.02em]" : ""} truncate`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function roleLabel(r: string): string {
+  if (r === "ADMIN") return "관리자";
+  if (r === "MANAGER") return "매니저";
+  if (r === "MEMBER") return "팀원";
+  return r;
+}

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -23,6 +23,7 @@ export const loadMeetings = () => import("./pages/MeetingsPage");
 export const loadMeetingDetail = () => import("./pages/MeetingDetailPage");
 export const loadAccounts = () => import("./pages/ServiceAccountsPage");
 export const loadSnippets = () => import("./pages/SnippetsPage");
+export const loadUserProfile = () => import("./pages/UserProfilePage");
 export const loadAdmin = () => import("./pages/AdminPage");
 export const loadSuperAdmin = () => import("./pages/SuperAdminPage");
 
@@ -41,6 +42,7 @@ export const MeetingsPage = lazy(loadMeetings);
 export const MeetingDetailPage = lazy(loadMeetingDetail);
 export const ServiceAccountsPage = lazy(loadAccounts);
 export const SnippetsPage = lazy(loadSnippets);
+export const UserProfilePage = lazy(loadUserProfile);
 export const AdminPage = lazy(loadAdmin);
 export const SuperAdminPage = lazy(loadSuperAdmin);
 

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -129,6 +129,60 @@ router.get("/presence", async (_req, res) => {
   res.json({ users: result });
 });
 
+/** 단일 유저 상세 — 다른 사람 프로필 페이지에서 사용. 본인이 아니어도 조회 가능하지만
+ *  민감 정보(이메일/사번 등 HR 필드)는 ADMIN+ 가 아니면 가림. */
+router.get("/:id", async (req, res) => {
+  const me = (req as any).user;
+  const target = await prisma.user.findUnique({
+    where: { id: req.params.id },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      team: true,
+      position: true,
+      role: true,
+      avatarColor: true,
+      avatarUrl: true,
+      isDeveloper: true,
+      active: true,
+      employeeNo: true,
+      hireDate: true,
+      phone: true,
+      presenceStatus: true,
+      presenceMessage: true,
+      presenceUpdatedAt: true,
+      superAdmin: true,
+      createdAt: true,
+    },
+  });
+  if (!target) return res.status(404).json({ error: "not found" });
+  // 일반 유저에겐 superAdmin 존재 자체를 숨김 — 404 위장.
+  if (target.superAdmin && !me.superAdmin && me.id !== target.id) {
+    return res.status(404).json({ error: "not found" });
+  }
+  const isAdminOrSelf = me.role === "ADMIN" || me.role === "MANAGER" || me.id === target.id;
+  // 민감 HR 필드는 ADMIN/MANAGER 또는 본인에게만.
+  const masked = {
+    ...target,
+    employeeNo: isAdminOrSelf ? target.employeeNo : null,
+    hireDate: isAdminOrSelf ? target.hireDate : null,
+    phone: isAdminOrSelf ? target.phone : null,
+    email: isAdminOrSelf ? target.email : maskEmail(target.email),
+  };
+  // superAdmin 필드는 응답에서 제거 — 클라가 알 필요 없음.
+  delete (masked as any).superAdmin;
+  res.json({ user: masked });
+});
+
+function maskEmail(email: string): string {
+  // a***@domain.com — 디렉토리·검색 결과처럼 정체성은 살리되 정확한 ID 는 가림.
+  const [local, domain] = email.split("@");
+  if (!local || !domain) return email;
+  const head = local[0] ?? "";
+  return `${head}***@${domain}`;
+}
+
 // 팀 목록 — 60초 in-process 캐시. 팀 목록은 관리자가 유저를 편집할 때만 바뀜.
 let _teamsCache: { teams: string[]; exp: number } | null = null;
 


### PR DESCRIPTION
## 증상
**유저 프로필 상세 페이지 + 개발중/차단 페이지 테마 대응**

새 기능을 추가합니다.

## 원인
[유저 프로필 상세]
- GET /api/users/:id (auth) — 본인/관리자에겐 풀 정보, 그 외엔 employeeNo·hireDate·phone null 마스킹 + email 부분 마스킹.
  superAdmin 계정은 일반 유저에게 404 위장.
- /users/:id 라우트 + UserProfilePage:
  · 그라데이션 hero + 큰 아바타 + presence 점
  · 1:1 대화 시작 버튼 (chat:open / chat:open-room 이벤트)
  · 메일 보내기 (mailto)
  · 기본/근무 정보 카드 2개
  · 본인 페이지면 /profile 로 자동 리다이렉트.
- 채팅 메시지 발신자 이름·아바타 클릭 → 프로필 (chat:close 후 nav).
- 디렉토리 카드/행에서 이름 영역 → /users/:id 링크.

[개발중/차단 페이지 테마 대응]
종전 그라데이션이 라이트/다크 무관하게 동일했음 — 다크 모드에서 페이지 surrounding(어두운 ink) 과 그라데이션 패널이 톤이 안 맞아 부유한 느낌.
- useTheme().resolved 로 라이트/다크 분기:
  · 라이트: 종전 비비드 브랜드→바이올렛 톤 유지.
  · 다크: 어두운 잉크(#14161B / #1A1F2A) 위에 브랜드 글로우만 살짝 — 주변 surface 와 자연스럽게 융합.
- 다크 모드에선 1px rgba(255,255,255,0.06) 보더 추가 — 패널 경계 명확화.

## 수정
**작업 항목 (커밋 단위)**
- feat(ux): 유저 프로필 상세 페이지 + 개발중/차단 페이지 테마 대응

**변경 대상 (7개 파일)**
- `client/src/App.tsx`
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatMiniApp.tsx`
- `client/src/pages/DirectoryPage.tsx`
- `client/src/pages/UserProfilePage.tsx`
- `client/src/routes.ts`
- `server/src/routes/users.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #87** ↔ **이슈 #509** 로 연결됩니다.

Closes #509
