### PR TITLE
🔀 :: (#510) superAdmin 숨김 필터 제거 — 조직도/디렉토리에서 정상 노출

### DIFF
--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -11,11 +11,11 @@ router.use(requireAuth);
 
 router.get("/", async (req, res) => {
   const u = (req as any).user;
+  // 종전엔 superAdmin 계정을 다른 사람에게 숨겼지만, \"HiNest 개발자\" 딱지가 별도 정체성으로 자리잡아
+  // 더 이상 숨길 이유가 없음. 모든 활성 사용자를 노출하고 권한 표시는 칩으로.
+  void u;
   const users = await prisma.user.findMany({
-    where: {
-      active: true,
-      OR: [{ superAdmin: false }, { id: u.id }],
-    },
+    where: { active: true },
     orderBy: { name: "asc" },
     take: 5000,
     select: {
@@ -157,10 +157,8 @@ router.get("/:id", async (req, res) => {
     },
   });
   if (!target) return res.status(404).json({ error: "not found" });
-  // 일반 유저에겐 superAdmin 존재 자체를 숨김 — 404 위장.
-  if (target.superAdmin && !me.superAdmin && me.id !== target.id) {
-    return res.status(404).json({ error: "not found" });
-  }
+  // 종전엔 superAdmin 계정을 일반 유저에게 404 위장했으나 \"HiNest 개발자\" 가 별도 정체성으로
+  // 자리잡아 더 이상 숨길 이유가 없음. 누구든 프로필 페이지로 진입 가능.
   const isAdminOrSelf = me.role === "ADMIN" || me.role === "MANAGER" || me.id === target.id;
   // 민감 HR 필드는 ADMIN/MANAGER 또는 본인에게만.
   const masked = {


### PR DESCRIPTION
## 증상
**superAdmin 숨김 필터 제거 — 조직도/디렉토리에서 정상 노출**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
[원인]
GET /api/users 와 GET /api/users/:id 가 superAdmin 계정을 다른 사람에게 숨기도록
필터링하고 있었음. 서지완 계정(superAdmin) 이 다른 사람 화면의 조직도/디렉토리/프로필 검색에서
보이지 않던 이유.

[수정]
"HiNest 개발자" 딱지가 별도 정체성으로 자리잡아 superAdmin 위장 필요성 사라짐.
- GET /api/users: where 에서 OR superAdmin=false 절 제거 — 모든 활성 사용자 노출.
- GET /api/users/:id: 일반 유저에게 404 위장하던 분기 제거 — 누구든 프로필 진입 가능.

기존 권한별 필드 마스킹(employeeNo/phone/hireDate/email) 은 그대로 유지.

## 수정
**작업 항목 (커밋 단위)**
- fix(users): superAdmin 계정 숨기던 필터 제거 — 조직도/디렉토리/프로필에서 정상 노출

**변경 대상 (1개 파일)**
- `server/src/routes/users.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #88** ↔ **이슈 #510** 로 연결됩니다.

Closes #510
