### PR TITLE
🔀 :: (#516) server-side sessions with force logout

### DIFF
--- a/client/src/components/superadmin/SessionsPanel.tsx
+++ b/client/src/components/superadmin/SessionsPanel.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { api } from "../../api";
+import { confirmAsync, alertAsync } from "../ConfirmHost";
+
+type Session = {
+  id: string;
+  userId: string;
+  ua: string | null;
+  ip: string | null;
+  createdAt: string;
+  lastSeenAt: string;
+  revokedAt: string | null;
+  user: { id: string; name: string; email: string };
+};
+
+/** 활성 로그인 세션 목록 + 강제 로그아웃. 사고 대응(계정 탈취 의심) 시 핵심 도구. */
+export default function SessionsPanel() {
+  const [rows, setRows] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [q, setQ] = useState("");
+
+  async function load() {
+    setLoading(true);
+    try {
+      const r = await api<{ sessions: Session[] }>("/api/admin/sessions?limit=300");
+      setRows(r.sessions);
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => { load(); }, []);
+
+  async function revokeOne(id: string, name: string) {
+    if (!(await confirmAsync({ title: "이 세션 강제 로그아웃?", description: `${name} 의 디바이스 1개에서 즉시 로그아웃됩니다.` }))) return;
+    setBusy(true);
+    try {
+      await api(`/api/admin/sessions/${id}`, { method: "DELETE" });
+      await load();
+    } finally { setBusy(false); }
+  }
+  async function revokeUser(userId: string, name: string) {
+    if (!(await confirmAsync({ title: `${name} 의 모든 세션 종료?`, description: "비밀번호 변경/계정 탈취 의심 시 사용. 모든 디바이스에서 즉시 로그아웃." }))) return;
+    setBusy(true);
+    try {
+      const r = await api<{ count: number }>(`/api/admin/sessions/revoke-user/${userId}`, { method: "POST" });
+      await alertAsync({ title: "완료", description: `${r.count}개 세션 종료됨` });
+      await load();
+    } finally { setBusy(false); }
+  }
+  async function revokeAll() {
+    if (!(await confirmAsync({
+      title: "전사 강제 로그아웃 (위험)",
+      description: "모든 사용자가 즉시 로그아웃됩니다. 시크릿 로테이트·데이터 유출 의심 시에만 사용하세요. 본인도 다음 요청부터 풀려나갑니다.",
+    }))) return;
+    if (!(await confirmAsync({ title: "정말로?", description: "되돌릴 수 없습니다. 한 번 더 확인합니다." }))) return;
+    setBusy(true);
+    try {
+      const r = await api<{ count: number }>("/api/admin/sessions/revoke-all", { method: "POST" });
+      await alertAsync({ title: "전사 로그아웃 완료", description: `${r.count}개 세션 종료됨` });
+      await load();
+    } finally { setBusy(false); }
+  }
+
+  const filtered = rows.filter((s) => {
+    const k = q.trim().toLowerCase();
+    if (!k) return true;
+    return s.user.name.toLowerCase().includes(k) || s.user.email.toLowerCase().includes(k) || (s.ip ?? "").includes(k);
+  });
+
+  return (
+    <div className="panel p-4">
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <input className="input flex-1 min-w-[200px]" placeholder="이름·이메일·IP 검색" value={q} onChange={(e) => setQ(e.target.value)} />
+        <button className="btn-ghost btn-xs" onClick={load} disabled={loading || busy}>{loading ? "불러오는 중…" : "새로고침"}</button>
+        <button className="btn-ghost btn-xs" style={{ color: "var(--c-danger)" }} onClick={revokeAll} disabled={busy}>전사 강제 로그아웃</button>
+      </div>
+      <div className="text-[11px] text-ink-500 mb-2">총 {filtered.length}개 활성 세션</div>
+      <div className="overflow-auto" style={{ maxHeight: "60vh" }}>
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="text-ink-500 text-left border-b border-ink-150">
+              <th className="py-2 pr-2">사용자</th>
+              <th className="py-2 pr-2">디바이스</th>
+              <th className="py-2 pr-2">IP</th>
+              <th className="py-2 pr-2">최근 활동</th>
+              <th className="py-2 pr-2 text-right">액션</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((s) => (
+              <tr key={s.id} className="border-b border-ink-100">
+                <td className="py-2 pr-2">
+                  <div className="font-bold text-ink-900">{s.user.name}</div>
+                  <div className="text-[10.5px] text-ink-500">{s.user.email}</div>
+                </td>
+                <td className="py-2 pr-2 text-ink-700 truncate max-w-[280px]" title={s.ua ?? ""}>{shortenUA(s.ua)}</td>
+                <td className="py-2 pr-2 text-ink-700 font-mono text-[11px]">{s.ip ?? "—"}</td>
+                <td className="py-2 pr-2 text-ink-700">{relTime(s.lastSeenAt)}</td>
+                <td className="py-2 pr-2 text-right">
+                  <button className="btn-ghost btn-xs" onClick={() => revokeOne(s.id, s.user.name)} disabled={busy}>이 세션 종료</button>
+                  <button className="btn-ghost btn-xs ml-1" onClick={() => revokeUser(s.userId, s.user.name)} disabled={busy}>전 디바이스</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {!loading && filtered.length === 0 && (
+          <div className="py-8 text-center text-ink-500 text-[12px]">활성 세션 없음</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function shortenUA(ua: string | null): string {
+  if (!ua) return "—";
+  // 흔한 패턴만 짧게 추려서 보여줌. 정확한 풀 UA 는 title 로 노출.
+  const m = ua.match(/(Chrome|Safari|Firefox|Edge|Opera)\/([\d.]+)/);
+  const os = ua.match(/\(([^)]+)\)/);
+  return [m ? `${m[1]} ${m[2].split(".")[0]}` : "Browser", os ? os[1].split(";")[0] : ""].filter(Boolean).join(" · ");
+}
+
+function relTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 60_000) return "방금";
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}분 전`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3600_000)}시간 전`;
+  return `${Math.floor(diff / 86_400_000)}일 전`;
+}

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { api } from "../api";
 import PageHeader from "../components/PageHeader";
 import SuperStepUpGate from "../components/SuperStepUpGate";
+import SessionsPanel from "../components/superadmin/SessionsPanel";
 
 type Log = {
   id: string;
@@ -38,7 +39,7 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav";
+type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions";
 
 type ApiSpecRoute = {
   method: string;
@@ -100,6 +101,7 @@ function SuperAdminContent() {
     : raw === "console" ? "console"
     : raw === "server" ? "server"
     : raw === "nav" ? "nav"
+    : raw === "sessions" ? "sessions"
     : "logs";
 
   const setTab = (t: Tab) => {
@@ -168,6 +170,7 @@ function SuperAdminContent() {
         <TabBtn active={tab === "console"} onClick={() => setTab("console")}>콘솔</TabBtn>
         <TabBtn active={tab === "server"} onClick={() => setTab("server")}>서버 로그</TabBtn>
         <TabBtn active={tab === "nav"} onClick={() => setTab("nav")}>메뉴 관리</TabBtn>
+        <TabBtn active={tab === "sessions"} onClick={() => setTab("sessions")}>세션</TabBtn>
       </div>
       {tab === "logs" && <LogsPanel />}
       {tab === "chat" && chatUnlocked && <ChatAuditPanel />}
@@ -175,6 +178,7 @@ function SuperAdminContent() {
       {tab === "console" && <ConsolePanel />}
       {tab === "server" && <ServerLogsPanel />}
       {tab === "nav" && <NavVisibilityPanel />}
+      {tab === "sessions" && <SessionsPanel />}
       {chatPwOpen && (
         <ChatAuditPwModal
           onClose={() => setChatPwOpen(false)}

--- a/server/prisma/migrations/20260429000000_session_table/migration.sql
+++ b/server/prisma/migrations/20260429000000_session_table/migration.sql
@@ -1,0 +1,20 @@
+-- Session 테이블 — 서버측 세션 무효화로 강제 로그아웃 가능.
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "ua" TEXT,
+    "ip" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt" TIMESTAMP(3),
+    "revokedById" TEXT,
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Session_userId_revokedAt_idx" ON "Session"("userId", "revokedAt");
+CREATE INDEX "Session_lastSeenAt_idx" ON "Session"("lastSeenAt" DESC);
+
+ALTER TABLE "Session"
+  ADD CONSTRAINT "Session_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -93,6 +93,25 @@ model User {
   serviceAccountsOwned    ServiceAccount[]       @relation("ServiceAccountOwner")
   serviceAccountsCreated  ServiceAccount[]       @relation("ServiceAccountCreator")
   snippets                Snippet[]              @relation("SnippetOwner")
+  sessions                Session[]
+}
+
+/// 활성 로그인 세션 — JWT 만 쓸 땐 서버측 강제 로그아웃이 불가했음.
+/// 토큰에 sessionId 클레임을 박아 두고 row 의 revokedAt 로 무효화.
+/// 클레임 없는 레거시 토큰은 그대로 통과시켜 호환성 유지 (만료=7일이라 자동 사라짐).
+model Session {
+  id          String    @id @default(cuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  ua          String? // user-agent 첫 200자
+  ip          String?
+  createdAt   DateTime  @default(now())
+  lastSeenAt  DateTime  @default(now())
+  revokedAt   DateTime?
+  revokedById String? // 누가 revoke 했는지 (강제 로그아웃 추적)
+
+  @@index([userId, revokedAt])
+  @@index([lastSeenAt(sort: Desc)])
 }
 
 /// 팀/프로젝트 — 사이드바 "팀" 카테고리 아래에 자신이 참여중인 프로젝트가 표시됨.

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -50,6 +50,27 @@ export function evictUserCache(id: string) {
   _userCache.delete(id);
 }
 
+/** 세션 유효성 캐시 — revoke 이후 최대 30초 지연 반영. 강제 로그아웃에 충분히 빠른 반응성. */
+const _sessionCache = new Map<string, { revoked: boolean; exp: number }>();
+const SESSION_CACHE_TTL = 30_000;
+
+async function isSessionRevoked(sid: string): Promise<boolean> {
+  const hit = _sessionCache.get(sid);
+  if (hit && hit.exp > Date.now()) return hit.revoked;
+  const row = await prisma.session.findUnique({
+    where: { id: sid },
+    select: { revokedAt: true },
+  });
+  // row 없는 케이스 = 레거시 클라이언트가 보낸 가짜 sid 거나, DB 정리됨. 안전하게 revoked 처리.
+  const revoked = !row || row.revokedAt !== null;
+  _sessionCache.set(sid, { revoked, exp: Date.now() + SESSION_CACHE_TTL });
+  return revoked;
+}
+
+export function evictSessionCache(sid: string) {
+  _sessionCache.delete(sid);
+}
+
 const COOKIE = "hinest_token";
 const SUPER_COOKIE = "hinest_super";
 const IMP_COOKIE = "hinest_imp";
@@ -70,8 +91,20 @@ export interface AuthUser {
   superAdmin: boolean;
 }
 
-export function signToken(user: { id: string; role: string; name: string; email: string }) {
-  return jwt.sign(user, SECRET, { expiresIn: "7d" });
+export function signToken(user: { id: string; role: string; name: string; email: string }, sessionId?: string) {
+  return jwt.sign({ ...user, sid: sessionId }, SECRET, { expiresIn: "7d" });
+}
+
+/** 로그인 성공 시 호출 — 새 Session row 생성 후 sessionId 반환. JWT 에 박아두면
+ *  서버에서 revokedAt 로 즉시 무효화 가능. */
+export async function createSession(userId: string, req: Request): Promise<string> {
+  const ua = (req.headers["user-agent"] || "").slice(0, 200) || null;
+  const ip = req.ip ?? null;
+  const s = await prisma.session.create({
+    data: { userId, ua, ip },
+    select: { id: true },
+  });
+  return s.id;
 }
 
 export function setAuthCookie(res: Response, token: string) {
@@ -90,6 +123,10 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
   if (!token) return res.status(401).json({ error: "unauthorized" });
   try {
     const payload = jwt.verify(token, SECRET) as any;
+    // sessionId(sid) 클레임이 있는 토큰은 서버측 무효화 검사. 없는 레거시 토큰은 그대로 통과 (7일이면 만료).
+    if (payload.sid && (await isSessionRevoked(payload.sid))) {
+      return res.status(401).json({ error: "session revoked", code: "SESSION_REVOKED" });
+    }
     const realUser = await getCachedUser(payload.id);
     if (!realUser || !realUser.active) return res.status(401).json({ error: "unauthorized" });
 
@@ -126,6 +163,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
     (req as any).userRecord = activeUser;
     (req as any).realUser = realUser;
     (req as any).impersonatedById = impersonatedById;
+    (req as any).sessionId = payload.sid ?? null;
     next();
   } catch {
     return res.status(401).json({ error: "unauthorized" });

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -5,7 +5,7 @@ import bcrypt from "bcryptjs";
 import { prisma } from "../lib/db.js";
 import {
   requireAdmin, requireAuth, requireSuperAdminStepUp, verifySuperToken,
-  writeLog, evictUserCache,
+  writeLog, evictUserCache, evictSessionCache,
   signImpersonate, setImpCookie, clearImpCookie,
 } from "../lib/auth.js";
 import { todayStr } from "../lib/dates.js";
@@ -1243,6 +1243,60 @@ router.patch("/users/:id/attendance", async (req, res) => {
  * 보안: super-stepup 필수, 1시간 자동 만료, 시작/종료 모두 audit 기록.
  * 모든 액션은 임퍼소네이팅 중에도 (req as any).realUser 로 진짜 사용자가 추적된다.
  */
+/* ===== Session Manager ===== */
+
+/** 활성 세션 목록. ?userId 로 특정 유저만, 기본은 전체 (최근 활동 순). */
+router.get("/sessions", requireSuperAdminStepUp, async (req, res) => {
+  const userId = typeof req.query.userId === "string" ? req.query.userId : undefined;
+  const onlyActive = req.query.active !== "false";
+  const limit = Math.min(500, parseInt(String(req.query.limit ?? "100"), 10) || 100);
+  const sessions = await prisma.session.findMany({
+    where: {
+      ...(userId ? { userId } : {}),
+      ...(onlyActive ? { revokedAt: null } : {}),
+    },
+    orderBy: { lastSeenAt: "desc" },
+    take: limit,
+    include: { user: { select: { id: true, name: true, email: true } } },
+  });
+  res.json({ sessions });
+});
+
+/** 특정 세션 강제 로그아웃. */
+router.delete("/sessions/:id", requireSuperAdminStepUp, async (req, res) => {
+  const me = (req as any).user;
+  const s = await prisma.session.findUnique({ where: { id: req.params.id }, select: { id: true, userId: true, revokedAt: true } });
+  if (!s) return res.status(404).json({ error: "not found" });
+  if (s.revokedAt) return res.json({ ok: true, alreadyRevoked: true });
+  await prisma.session.update({ where: { id: s.id }, data: { revokedAt: new Date(), revokedById: me.id } });
+  evictSessionCache(s.id);
+  await writeLog(me.id, "SESSION_REVOKE", s.id, `user=${s.userId}`, req.ip);
+  res.json({ ok: true });
+});
+
+/** 특정 유저의 모든 세션 강제 로그아웃. 비밀번호 변경 / 계정 탈취 의심 시 사용. */
+router.post("/sessions/revoke-user/:userId", requireSuperAdminStepUp, async (req, res) => {
+  const me = (req as any).user;
+  const r = await prisma.session.updateMany({
+    where: { userId: req.params.userId, revokedAt: null },
+    data: { revokedAt: new Date(), revokedById: me.id },
+  });
+  // 캐시는 다음 30초 내 자연 갱신 (개별 evict 는 ID 모름).
+  await writeLog(me.id, "SESSION_REVOKE_USER", req.params.userId, `count=${r.count}`, req.ip);
+  res.json({ ok: true, count: r.count });
+});
+
+/** 전사 강제 로그아웃 — 매우 위험. 시크릿 로테이트 / 데이터 유출 의심 시 사용. */
+router.post("/sessions/revoke-all", requireSuperAdminStepUp, async (req, res) => {
+  const me = (req as any).user;
+  const r = await prisma.session.updateMany({
+    where: { revokedAt: null },
+    data: { revokedAt: new Date(), revokedById: me.id },
+  });
+  await writeLog(me.id, "SESSION_REVOKE_ALL", undefined, `count=${r.count}`, req.ip);
+  res.json({ ok: true, count: r.count });
+});
+
 router.post("/impersonate/:id", requireSuperAdminStepUp, async (req, res) => {
   const me = (req as any).user;
   // 임퍼소네이션 중에 또 다른 임퍼소네이션 시작은 금지 — 책임 추적이 흐려짐.

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -14,6 +14,8 @@ import {
   verifySuperToken,
   SUPER_TTL_SEC,
   requireSuperAdminStepUp,
+  createSession,
+  evictSessionCache,
 } from "../lib/auth.js";
 
 const router = Router();
@@ -54,9 +56,10 @@ router.post("/login", async (req, res) => {
   const ok = await bcrypt.compare(password, user.passwordHash);
   if (!ok) return res.status(401).json({ error: "잘못된 이메일 또는 비밀번호" });
 
-  const token = signToken({ id: user.id, role: user.role, name: user.name, email: user.email });
+  const sid = await createSession(user.id, req);
+  const token = signToken({ id: user.id, role: user.role, name: user.name, email: user.email }, sid);
   setAuthCookie(res, token);
-  await writeLog(user.id, "LOGIN", user.email, undefined, req.ip);
+  await writeLog(user.id, "LOGIN", user.email, `sid=${sid}`, req.ip);
 
   res.json({
     user: {
@@ -118,9 +121,10 @@ router.post("/signup", async (req, res) => {
     data: { used: true, usedAt: new Date(), usedById: user.id },
   });
 
-  const token = signToken({ id: user.id, role: user.role, name: user.name, email: user.email });
+  const sid = await createSession(user.id, req);
+  const token = signToken({ id: user.id, role: user.role, name: user.name, email: user.email }, sid);
   setAuthCookie(res, token);
-  await writeLog(user.id, "SIGNUP", user.email, `invite:${inviteKey}`, req.ip);
+  await writeLog(user.id, "SIGNUP", user.email, `invite:${inviteKey} sid=${sid}`, req.ip);
 
   res.json({
     user: {
@@ -137,7 +141,18 @@ router.post("/signup", async (req, res) => {
   });
 });
 
-router.post("/logout", async (req, res) => {
+router.post("/logout", requireAuth, async (req, res) => {
+  // 현재 세션 row 도 revoke — 다른 디바이스 세션은 유지.
+  const sid = (req as any).sessionId as string | null;
+  if (sid) {
+    try {
+      await prisma.session.update({
+        where: { id: sid },
+        data: { revokedAt: new Date(), revokedById: (req as any).user?.id },
+      });
+      evictSessionCache(sid);
+    } catch { /* ignore */ }
+  }
   clearAuthCookie(res);
   clearSuperCookie(res);
   res.json({ ok: true });


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- Add `Session` model + migration (id, userId, ua, ip, createdAt, lastSeenAt, revokedAt)
- JWT now carries `sid` claim; requireAuth checks revoked sessions (30s cache)
- Login/signup creates row, logout revokes current session
- Admin UI "세션" tab: list active sessions, revoke single, revoke all-for-user, revoke all (panic button)
- Legacy tokens (no sid) still work until 7d expiry — graceful rollout

## Test plan
- [ ] 로그인 후 \ 한 행 확인
- [ ] 세션 탭에서 "이 세션 종료" → 다음 요청부터 401 SESSION_REVOKED
- [ ] "전 디바이스" → 모든 디바이스 즉시 풀림
- [ ] 전사 강제 로그아웃 후 본인도 30초 내 풀림

Closes #516

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #516
