### PR TITLE
🔀 :: (#517) error dashboard (5xx grouping)

### DIFF
--- a/client/src/components/superadmin/ErrorsPanel.tsx
+++ b/client/src/components/superadmin/ErrorsPanel.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+import { api } from "../../api";
+import { confirmAsync } from "../ConfirmHost";
+
+type Group = {
+  hash: string;
+  message: string;
+  topFrame: string;
+  count: number;
+  firstSeen: number;
+  lastSeen: number;
+  paths: string[];
+  userIds: string[];
+};
+
+type Detail = Group & {
+  recent: { ts: number; status: number; method: string; path: string; message: string; stack: string; userId: string | null; ua: string | null; ip: string | null }[];
+};
+
+const SINCE_OPTS: { key: "1h" | "24h" | "7d" | "all"; label: string }[] = [
+  { key: "1h", label: "1시간" },
+  { key: "24h", label: "24시간" },
+  { key: "7d", label: "7일" },
+  { key: "all", label: "전체" },
+];
+
+/** 5xx 에러 그루핑 — 동일 스택은 한 그룹. 발생 추이 + 영향 사용자 + 스택 상세. */
+export default function ErrorsPanel() {
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [since, setSince] = useState<"1h" | "24h" | "7d" | "all">("24h");
+  const [userIdFilter, setUserIdFilter] = useState("");
+  const [openHash, setOpenHash] = useState<string | null>(null);
+  const [detail, setDetail] = useState<Detail | null>(null);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (since !== "all") params.set("since", since);
+      if (userIdFilter.trim()) params.set("userId", userIdFilter.trim());
+      const r = await api<{ groups: Group[] }>(`/api/admin/errors?${params}`);
+      setGroups(r.groups);
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [since]);
+
+  async function loadDetail(hash: string) {
+    setOpenHash(hash);
+    setDetail(null);
+    const r = await api<{ group: Detail }>(`/api/admin/errors/${hash}`);
+    setDetail(r.group);
+  }
+
+  async function clearAll() {
+    if (!(await confirmAsync({ title: "에러 그룹 모두 비우기?", description: "프로세스 재시작과 같은 효과 (인메모리). 카운터·last_seen 초기화." }))) return;
+    await api("/api/admin/errors", { method: "DELETE" });
+    await load();
+  }
+
+  return (
+    <div className="panel p-4">
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <div className="inline-flex rounded-full p-0.5" style={{ background: "var(--c-surface-3)" }}>
+          {SINCE_OPTS.map((o) => (
+            <button
+              key={o.key}
+              type="button"
+              onClick={() => setSince(o.key)}
+              className="text-[11.5px] font-bold px-2.5 py-1 rounded-full"
+              style={{
+                background: since === o.key ? "var(--c-surface-1)" : "transparent",
+                color: since === o.key ? "var(--c-text-1)" : "var(--c-text-3)",
+              }}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+        <input
+          className="input flex-1 min-w-[180px]"
+          placeholder='사용자 ID 필터 ("이 사용자에게서만" — ID 입력)'
+          value={userIdFilter}
+          onChange={(e) => setUserIdFilter(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") load(); }}
+        />
+        <button className="btn-ghost btn-xs" onClick={load} disabled={loading}>새로고침</button>
+        <button className="btn-ghost btn-xs" style={{ color: "var(--c-danger)" }} onClick={clearAll}>모두 비우기</button>
+      </div>
+      <div className="text-[11px] text-ink-500 mb-2">{loading ? "불러오는 중…" : `${groups.length}개 그룹 · ${groups.reduce((a, g) => a + g.count, 0)}회 발생`}</div>
+
+      <div className="overflow-auto" style={{ maxHeight: "60vh" }}>
+        {groups.length === 0 && !loading && (
+          <div className="py-12 text-center text-ink-500 text-[12px]">에러 없음 ✨</div>
+        )}
+        {groups.map((g) => (
+          <div key={g.hash} className="border-b border-ink-100 py-2.5">
+            <div className="flex items-start gap-3">
+              <div className="flex-shrink-0 px-2 py-0.5 rounded" style={{ background: "rgba(220,38,38,0.12)", color: "var(--c-danger)", fontSize: 10.5, fontWeight: 800 }}>
+                ×{g.count}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-[13px] font-bold text-ink-900 truncate">{g.message}</div>
+                <div className="text-[10.5px] text-ink-500 font-mono mt-0.5 truncate">{g.topFrame || "—"}</div>
+                <div className="text-[10.5px] text-ink-500 mt-1">
+                  {g.paths.slice(0, 4).join(" · ")}{g.paths.length > 4 ? ` …+${g.paths.length - 4}` : ""}
+                  {g.userIds.length > 0 && <span> · {g.userIds.length}명 영향</span>}
+                  <span> · 마지막 {relTime(g.lastSeen)}</span>
+                </div>
+              </div>
+              <button className="btn-ghost btn-xs" onClick={() => loadDetail(g.hash)}>스택</button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {openHash && (
+        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={() => setOpenHash(null)}>
+          <div className="panel w-full max-w-[840px] max-h-[88vh] flex flex-col overflow-hidden" onClick={(e) => e.stopPropagation()}>
+            <div className="px-5 py-3 border-b border-ink-150 flex items-center justify-between">
+              <div className="text-[14px] font-extrabold text-ink-900">에러 상세 · {openHash}</div>
+              <button className="btn-icon" onClick={() => setOpenHash(null)} aria-label="닫기">×</button>
+            </div>
+            <div className="px-5 py-4 overflow-auto text-[12px] flex-1">
+              {!detail ? (
+                <div className="py-8 text-center text-ink-500">불러오는 중…</div>
+              ) : (
+                <>
+                  <div className="font-bold mb-1 text-ink-900">{detail.message}</div>
+                  <div className="text-ink-500 mb-3">발생 {detail.count}회 · {new Date(detail.firstSeen).toLocaleString("ko-KR")} ~ {new Date(detail.lastSeen).toLocaleString("ko-KR")}</div>
+                  {detail.recent.map((ev, i) => (
+                    <div key={i} className="mb-4">
+                      <div className="text-[11px] text-ink-500 mb-1">
+                        {new Date(ev.ts).toLocaleTimeString("ko-KR")} · {ev.method} {ev.path} · {ev.status}
+                        {ev.userId && <span> · user:{ev.userId.slice(0, 8)}</span>}
+                      </div>
+                      <pre
+                        className="text-[10.5px] font-mono p-2 rounded whitespace-pre-wrap"
+                        style={{ background: "var(--c-surface-3)", color: "var(--c-text-1)", maxHeight: 240, overflow: "auto" }}
+                      >
+                        {ev.stack || ev.message}
+                      </pre>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function relTime(ms: number): string {
+  const diff = Date.now() - ms;
+  if (diff < 60_000) return "방금";
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}분 전`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3600_000)}시간 전`;
+  return `${Math.floor(diff / 86_400_000)}일 전`;
+}

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -4,6 +4,7 @@ import { api } from "../api";
 import PageHeader from "../components/PageHeader";
 import SuperStepUpGate from "../components/SuperStepUpGate";
 import SessionsPanel from "../components/superadmin/SessionsPanel";
+import ErrorsPanel from "../components/superadmin/ErrorsPanel";
 
 type Log = {
   id: string;
@@ -39,7 +40,7 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions";
+type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions" | "errors";
 
 type ApiSpecRoute = {
   method: string;
@@ -102,6 +103,7 @@ function SuperAdminContent() {
     : raw === "server" ? "server"
     : raw === "nav" ? "nav"
     : raw === "sessions" ? "sessions"
+    : raw === "errors" ? "errors"
     : "logs";
 
   const setTab = (t: Tab) => {
@@ -171,6 +173,7 @@ function SuperAdminContent() {
         <TabBtn active={tab === "server"} onClick={() => setTab("server")}>서버 로그</TabBtn>
         <TabBtn active={tab === "nav"} onClick={() => setTab("nav")}>메뉴 관리</TabBtn>
         <TabBtn active={tab === "sessions"} onClick={() => setTab("sessions")}>세션</TabBtn>
+        <TabBtn active={tab === "errors"} onClick={() => setTab("errors")}>에러</TabBtn>
       </div>
       {tab === "logs" && <LogsPanel />}
       {tab === "chat" && chatUnlocked && <ChatAuditPanel />}
@@ -179,6 +182,7 @@ function SuperAdminContent() {
       {tab === "server" && <ServerLogsPanel />}
       {tab === "nav" && <NavVisibilityPanel />}
       {tab === "sessions" && <SessionsPanel />}
+      {tab === "errors" && <ErrorsPanel />}
       {chatPwOpen && (
         <ChatAuditPwModal
           onClose={() => setChatPwOpen(false)}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,7 +38,7 @@ import { folderShareLinkAuthedRouter } from "./routes/folderShareLink.js";
 import serviceAccountRouter from "./routes/serviceAccount.js";
 import path from "node:path";
 import mime from "mime-types";
-import { installConsoleHook, pushHttpLog } from "./lib/logBuffer.js";
+import { installConsoleHook, pushHttpLog, pushErrorEvent } from "./lib/logBuffer.js";
 
 // 콘솔 로그를 인메모리 버퍼에도 적재 — 총관리자 \"서버 로그\" 탭에서 조회.
 // 반드시 다른 import 가 끝난 뒤(이 시점), 첫 console.log 이전에 호출.
@@ -301,12 +301,28 @@ function sanitizeDownloadName(s: string): string {
   return s.replace(/[\r\n"]/g, "").slice(0, 255);
 }
 
-app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+app.use((err: any, req: express.Request, res: express.Response, _next: express.NextFunction) => {
   console.error(err);
   const status = typeof err.status === "number" ? err.status : 500;
   // 500 계열 예상치 못한 에러는 내부 메시지 유출 방지 — DB/Prisma 오류가 그대로 나가지 않도록.
   // 4xx 는 우리가 직접 throw 한 의도된 에러라 message 노출 허용.
   const msg = status < 500 ? (err.message ?? "bad request") : "서버 오류가 발생했습니다";
+  // 에러 대시보드용 이벤트 적재 — 5xx 만. 4xx 는 사용자 입력 오류라 분리.
+  if (status >= 500) {
+    try {
+      pushErrorEvent({
+        ts: Date.now(),
+        status,
+        method: req.method,
+        path: req.path,
+        message: String(err?.message ?? err ?? "Unknown"),
+        stack: String(err?.stack ?? ""),
+        userId: (req as any).user?.id ?? null,
+        ua: (req.headers["user-agent"] || "").slice(0, 200) || null,
+        ip: req.ip ?? null,
+      });
+    } catch { /* 로깅 실패가 응답을 막지 않게 */ }
+  }
   res.status(status).json({ error: msg });
 });
 

--- a/server/src/lib/logBuffer.ts
+++ b/server/src/lib/logBuffer.ts
@@ -41,6 +41,93 @@ export function pushHttpLog(line: string) {
   pushEntry("http", line);
 }
 
+/* ===== 에러 이벤트 (Sentry-lite) =====
+ * 5xx 응답을 잡아 stack hash 기준으로 그루핑. 중복 스택은 카운터·last_seen 만 갱신.
+ * 인메모리 — 프로세스 재시작 시 초기화. 외부 Sentry 가 진짜 답이지만, 사내툴 규모엔 이걸로 충분.
+ */
+export type ErrorEvent = {
+  ts: number;
+  status: number;
+  method: string;
+  path: string;
+  message: string;
+  stack: string;
+  userId: string | null;
+  ua: string | null;
+  ip: string | null;
+};
+
+export type ErrorGroup = {
+  hash: string;
+  message: string;
+  topFrame: string;
+  count: number;
+  firstSeen: number;
+  lastSeen: number;
+  paths: string[];
+  userIds: string[];
+  recent: ErrorEvent[];
+};
+
+const MAX_EVENTS = 4000;
+const events: ErrorEvent[] = [];
+const groups = new Map<string, ErrorGroup>();
+
+/** 에러 메시지 + 첫 스택 프레임으로 8자 hash. 동일 에러는 같은 그룹. */
+function hashKey(message: string, stack: string): { hash: string; topFrame: string } {
+  const top = (stack.split("\n").find((l) => l.trim().startsWith("at ")) ?? "").trim();
+  const seed = `${message}|${top}`;
+  // 단순 djb2 — 충돌은 무시할 수준이고 의존성 없음.
+  let h = 5381;
+  for (let i = 0; i < seed.length; i++) h = ((h << 5) + h) ^ seed.charCodeAt(i);
+  return { hash: (h >>> 0).toString(16).slice(0, 8), topFrame: top };
+}
+
+export function pushErrorEvent(ev: ErrorEvent) {
+  events.push(ev);
+  if (events.length > MAX_EVENTS) events.splice(0, events.length - MAX_EVENTS);
+
+  const { hash, topFrame } = hashKey(ev.message, ev.stack);
+  const g = groups.get(hash);
+  if (g) {
+    g.count++;
+    g.lastSeen = ev.ts;
+    if (!g.paths.includes(ev.path) && g.paths.length < 20) g.paths.push(ev.path);
+    if (ev.userId && !g.userIds.includes(ev.userId) && g.userIds.length < 50) g.userIds.push(ev.userId);
+    g.recent.unshift(ev);
+    if (g.recent.length > 10) g.recent.pop();
+  } else {
+    groups.set(hash, {
+      hash,
+      message: ev.message.slice(0, 300),
+      topFrame: topFrame.slice(0, 240),
+      count: 1,
+      firstSeen: ev.ts,
+      lastSeen: ev.ts,
+      paths: [ev.path],
+      userIds: ev.userId ? [ev.userId] : [],
+      recent: [ev],
+    });
+  }
+}
+
+export function getErrorGroups(opts: { userId?: string; sinceMs?: number } = {}): ErrorGroup[] {
+  const since = opts.sinceMs ? Date.now() - opts.sinceMs : 0;
+  let arr = Array.from(groups.values());
+  if (since) arr = arr.filter((g) => g.lastSeen >= since);
+  if (opts.userId) arr = arr.filter((g) => g.userIds.includes(opts.userId!));
+  return arr.sort((a, b) => b.lastSeen - a.lastSeen);
+}
+
+export function getErrorGroup(hash: string): ErrorGroup | null {
+  return groups.get(hash) ?? null;
+}
+
+export function clearErrorGroups() {
+  groups.clear();
+  events.length = 0;
+}
+
 let installed = false;
 
 /** 한 번만 호출 — console 메서드를 가로채 버퍼에 동기화 적재.

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -9,7 +9,7 @@ import {
   signImpersonate, setImpCookie, clearImpCookie,
 } from "../lib/auth.js";
 import { todayStr } from "../lib/dates.js";
-import { getLogs, type LogLevel } from "../lib/logBuffer.js";
+import { getLogs, type LogLevel, getErrorGroups, getErrorGroup, clearErrorGroups } from "../lib/logBuffer.js";
 
 const router = Router();
 router.use(requireAuth, requireAdmin);
@@ -1243,6 +1243,42 @@ router.patch("/users/:id/attendance", async (req, res) => {
  * 보안: super-stepup 필수, 1시간 자동 만료, 시작/종료 모두 audit 기록.
  * 모든 액션은 임퍼소네이팅 중에도 (req as any).realUser 로 진짜 사용자가 추적된다.
  */
+/* ===== Error Dashboard (5xx grouping) ===== */
+
+router.get("/errors", requireSuperAdminStepUp, async (req, res) => {
+  const userId = typeof req.query.userId === "string" ? req.query.userId : undefined;
+  const sinceMs = req.query.since === "1h" ? 60 * 60 * 1000
+    : req.query.since === "24h" ? 24 * 60 * 60 * 1000
+    : req.query.since === "7d" ? 7 * 24 * 60 * 60 * 1000
+    : undefined;
+  const groups = getErrorGroups({ userId, sinceMs });
+  // 사용자 이름 매핑은 클라가 따로 처리 — 여기선 ID 만.
+  res.json({
+    groups: groups.map((g) => ({
+      hash: g.hash,
+      message: g.message,
+      topFrame: g.topFrame,
+      count: g.count,
+      firstSeen: g.firstSeen,
+      lastSeen: g.lastSeen,
+      paths: g.paths,
+      userIds: g.userIds,
+    })),
+  });
+});
+
+router.get("/errors/:hash", requireSuperAdminStepUp, async (req, res) => {
+  const g = getErrorGroup(req.params.hash);
+  if (!g) return res.status(404).json({ error: "not found" });
+  res.json({ group: g });
+});
+
+router.delete("/errors", requireSuperAdminStepUp, async (req, res) => {
+  clearErrorGroups();
+  await writeLog((req as any).user?.id, "ERROR_DASHBOARD_CLEAR", undefined, undefined, req.ip);
+  res.json({ ok: true });
+});
+
 /* ===== Session Manager ===== */
 
 /** 활성 세션 목록. ?userId 로 특정 유저만, 기본은 전체 (최근 활동 순). */


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- Sentry-lite in-memory error grouping by stack-frame hash
- Express error middleware captures 5xx automatically
- `GET /api/admin/errors` (super-stepup) — list groups with count, paths, affected users
- `GET /api/admin/errors/:hash` — full detail with recent 10 events + stacks
- Time filter (1h/24h/7d/all) + userId filter ("이 사용자만")
- Clear endpoint for cleanup

## Test plan
- [ ] 일부러 500 트리거 → 에러 탭에 그룹 1개 + count=1
- [ ] 같은 에러 재발생 → count 증가, 그룹 새로 안 만들어짐
- [ ] 스택 모달에서 최근 10건 stack trace 확인

Closes #517

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #517
