### PR TITLE
🔀 :: (#519) soft delete + trash bin

### DIFF
--- a/client/src/components/superadmin/TrashPanel.tsx
+++ b/client/src/components/superadmin/TrashPanel.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+import { api } from "../../api";
+import { confirmAsync, alertAsync } from "../ConfirmHost";
+
+type Item = { id: string; title: string; deletedAt: string; deletedById: string | null; authorId: string; author: { name: string } | null };
+type Trash = { meeting: Item[]; document: Item[]; journal: Item[]; notice: Item[] };
+
+const TYPES: { key: keyof Trash; label: string }[] = [
+  { key: "meeting", label: "회의록" },
+  { key: "document", label: "문서" },
+  { key: "journal", label: "업무일지" },
+  { key: "notice", label: "공지" },
+];
+
+/** 휴지통 — 소프트 삭제된 항목 복구 / 영구 삭제. 30일 초과분 일괄 비우기. */
+export default function TrashPanel() {
+  const [data, setData] = useState<Trash | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [tab, setTab] = useState<keyof Trash>("meeting");
+
+  async function load() {
+    setLoading(true);
+    try { setData(await api<Trash>("/api/admin/trash")); }
+    finally { setLoading(false); }
+  }
+  useEffect(() => { load(); }, []);
+
+  async function restore(type: keyof Trash, id: string, title: string) {
+    if (!(await confirmAsync({ title: `"${title}" 복구?`, description: "원래 위치로 되돌립니다." }))) return;
+    setBusy(true);
+    try {
+      await api(`/api/admin/trash/${type}/${id}/restore`, { method: "POST" });
+      await load();
+    } finally { setBusy(false); }
+  }
+  async function purge(type: keyof Trash, id: string, title: string) {
+    if (!(await confirmAsync({ title: `"${title}" 영구 삭제?`, description: "되돌릴 수 없습니다." }))) return;
+    setBusy(true);
+    try {
+      await api(`/api/admin/trash/${type}/${id}`, { method: "DELETE" });
+      await load();
+    } finally { setBusy(false); }
+  }
+  async function purgeOld() {
+    if (!(await confirmAsync({ title: "30일 초과 항목 모두 영구 삭제?", description: "되돌릴 수 없습니다." }))) return;
+    setBusy(true);
+    try {
+      const r = await api<{ counts: any }>("/api/admin/trash/purge-old", { method: "POST" });
+      await alertAsync({ title: "정리 완료", description: JSON.stringify(r.counts) });
+      await load();
+    } finally { setBusy(false); }
+  }
+
+  const items = data?.[tab] ?? [];
+
+  return (
+    <div className="panel p-4">
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <div className="inline-flex rounded-full p-0.5" style={{ background: "var(--c-surface-3)" }}>
+          {TYPES.map((t) => {
+            const active = tab === t.key;
+            const count = data?.[t.key]?.length ?? 0;
+            return (
+              <button
+                key={t.key}
+                type="button"
+                onClick={() => setTab(t.key)}
+                className="text-[11.5px] font-bold px-2.5 py-1 rounded-full"
+                style={{
+                  background: active ? "var(--c-surface-1)" : "transparent",
+                  color: active ? "var(--c-text-1)" : "var(--c-text-3)",
+                }}
+              >
+                {t.label} {count > 0 && <span className="ml-1 text-ink-500">{count}</span>}
+              </button>
+            );
+          })}
+        </div>
+        <button className="btn-ghost btn-xs" onClick={load} disabled={loading || busy}>새로고침</button>
+        <button className="btn-ghost btn-xs ml-auto" style={{ color: "var(--c-danger)" }} onClick={purgeOld} disabled={busy}>30일 초과 정리</button>
+      </div>
+      <div className="overflow-auto" style={{ maxHeight: "60vh" }}>
+        {loading ? (
+          <div className="py-12 text-center text-ink-500 text-[12px]">불러오는 중…</div>
+        ) : items.length === 0 ? (
+          <div className="py-12 text-center text-ink-500 text-[12px]">비어 있음 ✨</div>
+        ) : (
+          <table className="w-full text-[12px]">
+            <thead>
+              <tr className="text-ink-500 text-left border-b border-ink-150">
+                <th className="py-2 pr-2">제목</th>
+                <th className="py-2 pr-2">작성자</th>
+                <th className="py-2 pr-2">삭제 시각</th>
+                <th className="py-2 pr-2 text-right">액션</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((it) => {
+                const days = Math.floor((Date.now() - new Date(it.deletedAt).getTime()) / 86_400_000);
+                const willPurgeIn = Math.max(0, 30 - days);
+                return (
+                  <tr key={it.id} className="border-b border-ink-100">
+                    <td className="py-2 pr-2 font-bold text-ink-900 truncate max-w-[420px]">{it.title || "(제목 없음)"}</td>
+                    <td className="py-2 pr-2 text-ink-700">{it.author?.name ?? "—"}</td>
+                    <td className="py-2 pr-2 text-ink-700">
+                      {new Date(it.deletedAt).toLocaleString("ko-KR")}
+                      <span className="text-[10px] text-ink-400 ml-1">· {willPurgeIn}일 후 영구</span>
+                    </td>
+                    <td className="py-2 pr-2 text-right">
+                      <button className="btn-ghost btn-xs" onClick={() => restore(tab, it.id, it.title)} disabled={busy}>복구</button>
+                      <button className="btn-ghost btn-xs ml-1" style={{ color: "var(--c-danger)" }} onClick={() => purge(tab, it.id, it.title)} disabled={busy}>영구 삭제</button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -6,6 +6,7 @@ import SuperStepUpGate from "../components/SuperStepUpGate";
 import SessionsPanel from "../components/superadmin/SessionsPanel";
 import ErrorsPanel from "../components/superadmin/ErrorsPanel";
 import HealthPanel from "../components/superadmin/HealthPanel";
+import TrashPanel from "../components/superadmin/TrashPanel";
 
 type Log = {
   id: string;
@@ -41,7 +42,7 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions" | "errors" | "health";
+type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions" | "errors" | "health" | "trash";
 
 type ApiSpecRoute = {
   method: string;
@@ -106,6 +107,7 @@ function SuperAdminContent() {
     : raw === "sessions" ? "sessions"
     : raw === "errors" ? "errors"
     : raw === "health" ? "health"
+    : raw === "trash" ? "trash"
     : "logs";
 
   const setTab = (t: Tab) => {
@@ -177,6 +179,7 @@ function SuperAdminContent() {
         <TabBtn active={tab === "sessions"} onClick={() => setTab("sessions")}>세션</TabBtn>
         <TabBtn active={tab === "errors"} onClick={() => setTab("errors")}>에러</TabBtn>
         <TabBtn active={tab === "health"} onClick={() => setTab("health")}>헬스</TabBtn>
+        <TabBtn active={tab === "trash"} onClick={() => setTab("trash")}>휴지통</TabBtn>
       </div>
       {tab === "logs" && <LogsPanel />}
       {tab === "chat" && chatUnlocked && <ChatAuditPanel />}
@@ -187,6 +190,7 @@ function SuperAdminContent() {
       {tab === "sessions" && <SessionsPanel />}
       {tab === "errors" && <ErrorsPanel />}
       {tab === "health" && <HealthPanel />}
+      {tab === "trash" && <TrashPanel />}
       {chatPwOpen && (
         <ChatAuditPwModal
           onClose={() => setChatPwOpen(false)}

--- a/server/prisma/migrations/20260429100000_soft_delete/migration.sql
+++ b/server/prisma/migrations/20260429100000_soft_delete/migration.sql
@@ -1,0 +1,11 @@
+-- 4개 테이블 (Meeting / Document / Journal / Notice) 에 소프트 삭제 컬럼 추가.
+-- deletedAt 가 NULL 이 아니면 휴지통에 들어간 상태. 30일 후 영구 삭제 권장.
+ALTER TABLE "Meeting"  ADD COLUMN "deletedAt" TIMESTAMP(3), ADD COLUMN "deletedById" TEXT;
+ALTER TABLE "Document" ADD COLUMN "deletedAt" TIMESTAMP(3), ADD COLUMN "deletedById" TEXT;
+ALTER TABLE "Journal"  ADD COLUMN "deletedAt" TIMESTAMP(3), ADD COLUMN "deletedById" TEXT;
+ALTER TABLE "Notice"   ADD COLUMN "deletedAt" TIMESTAMP(3), ADD COLUMN "deletedById" TEXT;
+
+CREATE INDEX "Meeting_deletedAt_idx"  ON "Meeting"("deletedAt");
+CREATE INDEX "Document_deletedAt_idx" ON "Document"("deletedAt");
+CREATE INDEX "Journal_deletedAt_idx"  ON "Journal"("deletedAt");
+CREATE INDEX "Notice_deletedAt_idx"   ON "Notice"("deletedAt");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -377,29 +377,35 @@ model Attendance {
 }
 
 model Journal {
-  id        String   @id @default(cuid())
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  date      String // YYYY-MM-DD
-  title     String
-  content   String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id          String    @id @default(cuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  date        String // YYYY-MM-DD
+  title       String
+  content     String
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deletedAt   DateTime?
+  deletedById String?
 
   @@index([userId, date(sort: Desc)])
+  @@index([deletedAt])
 }
 
 model Notice {
-  id        String           @id @default(cuid())
-  title     String
-  content   String
-  pinned    Boolean          @default(false)
-  authorId  String
-  author    User             @relation(fields: [authorId], references: [id], onDelete: Cascade)
-  createdAt DateTime         @default(now())
-  reactions NoticeReaction[]
+  id          String           @id @default(cuid())
+  title       String
+  content     String
+  pinned      Boolean          @default(false)
+  authorId    String
+  author      User             @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  createdAt   DateTime         @default(now())
+  deletedAt   DateTime?
+  deletedById String?
+  reactions   NoticeReaction[]
 
   @@index([pinned(sort: Desc), createdAt(sort: Desc)])
+  @@index([deletedAt])
 }
 
 /// 공지에 남긴 이모지 반응. (noticeId, userId, emoji) 유니크 — 같은 이모지 중복 반응 방지.
@@ -733,8 +739,11 @@ model Document {
   revisions    DocumentRevision[]
   createdAt    DateTime            @default(now())
   updatedAt    DateTime            @updatedAt
+  deletedAt    DateTime?
+  deletedById  String?
 
   @@index([projectId, updatedAt])
+  @@index([deletedAt])
 }
 
 model Approval {
@@ -796,20 +805,23 @@ model AuditLog {
 ///   SPECIFIC  선택된 개별 유저만 (viewers 릴레이션)
 /// 작성자는 무조건 조회·수정 가능. ADMIN 은 전역 열람.
 model Meeting {
-  id         String            @id @default(cuid())
-  title      String
+  id          String            @id @default(cuid())
+  title       String
   /// TipTap JSON document. HTML 이 아닌 구조화된 노드 트리.
-  content    Json
-  visibility String            @default("ALL") // ALL | PROJECT | SPECIFIC
-  projectId  String?
-  project    Project?          @relation(fields: [projectId], references: [id], onDelete: SetNull)
-  authorId   String
-  author     User              @relation("MeetingAuthor", fields: [authorId], references: [id], onDelete: Cascade)
-  viewers    MeetingViewer[]
-  revisions  MeetingRevision[]
-  createdAt  DateTime          @default(now())
-  updatedAt  DateTime          @updatedAt
+  content     Json
+  visibility  String            @default("ALL") // ALL | PROJECT | SPECIFIC
+  projectId   String?
+  project     Project?          @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  authorId    String
+  author      User              @relation("MeetingAuthor", fields: [authorId], references: [id], onDelete: Cascade)
+  viewers     MeetingViewer[]
+  revisions   MeetingRevision[]
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
+  deletedAt   DateTime?
+  deletedById String?
 
+  @@index([deletedAt])
   @@index([authorId, createdAt])
   @@index([projectId, createdAt])
 }

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1243,6 +1243,88 @@ router.patch("/users/:id/attendance", async (req, res) => {
  * 보안: super-stepup 필수, 1시간 자동 만료, 시작/종료 모두 audit 기록.
  * 모든 액션은 임퍼소네이팅 중에도 (req as any).realUser 로 진짜 사용자가 추적된다.
  */
+/* ===== Soft Trash (휴지통) =====
+ * Meeting / Document / Journal / Notice 의 deletedAt != null 항목을 30일 보관 후 영구 삭제.
+ * 영구 삭제는 별도 cron 이 아니라 관리자가 명시적으로 비우게 — 사고 방지.
+ */
+const TRASH_TYPES = ["meeting", "document", "journal", "notice"] as const;
+type TrashType = typeof TRASH_TYPES[number];
+function trashModel(t: TrashType) {
+  return ({ meeting: prisma.meeting, document: prisma.document, journal: prisma.journal, notice: prisma.notice } as const)[t];
+}
+
+router.get("/trash", requireSuperAdminStepUp, async (_req, res) => {
+  const include = { deletedBy: false }; // we resolve names below
+  void include;
+  const [meetings, documents, journals, notices] = await Promise.all([
+    prisma.meeting.findMany({
+      where: { deletedAt: { not: null } },
+      orderBy: { deletedAt: "desc" },
+      take: 200,
+      select: { id: true, title: true, deletedAt: true, deletedById: true, authorId: true, author: { select: { name: true } } },
+    }),
+    prisma.document.findMany({
+      where: { deletedAt: { not: null } },
+      orderBy: { deletedAt: "desc" },
+      take: 200,
+      select: { id: true, title: true, deletedAt: true, deletedById: true, authorId: true, author: { select: { name: true } } },
+    }),
+    prisma.journal.findMany({
+      where: { deletedAt: { not: null } },
+      orderBy: { deletedAt: "desc" },
+      take: 200,
+      select: { id: true, title: true, deletedAt: true, deletedById: true, userId: true, user: { select: { name: true } } },
+    }),
+    prisma.notice.findMany({
+      where: { deletedAt: { not: null } },
+      orderBy: { deletedAt: "desc" },
+      take: 200,
+      select: { id: true, title: true, deletedAt: true, deletedById: true, authorId: true, author: { select: { name: true } } },
+    }),
+  ]);
+  res.json({
+    meeting: meetings,
+    document: documents,
+    journal: journals.map((j) => ({ ...j, authorId: j.userId, author: j.user })),
+    notice: notices,
+  });
+});
+
+router.post("/trash/:type/:id/restore", requireSuperAdminStepUp, async (req, res) => {
+  const t = req.params.type as TrashType;
+  if (!TRASH_TYPES.includes(t)) return res.status(400).json({ error: "invalid type" });
+  const me = (req as any).user;
+  await (trashModel(t) as any).update({
+    where: { id: req.params.id },
+    data: { deletedAt: null, deletedById: null },
+  });
+  await writeLog(me.id, "TRASH_RESTORE", `${t}:${req.params.id}`, undefined, req.ip);
+  res.json({ ok: true });
+});
+
+router.delete("/trash/:type/:id", requireSuperAdminStepUp, async (req, res) => {
+  const t = req.params.type as TrashType;
+  if (!TRASH_TYPES.includes(t)) return res.status(400).json({ error: "invalid type" });
+  const me = (req as any).user;
+  await (trashModel(t) as any).delete({ where: { id: req.params.id } });
+  await writeLog(me.id, "TRASH_PURGE", `${t}:${req.params.id}`, undefined, req.ip);
+  res.json({ ok: true });
+});
+
+/** 30일 초과 휴지통 항목 일괄 영구 삭제. */
+router.post("/trash/purge-old", requireSuperAdminStepUp, async (req, res) => {
+  const me = (req as any).user;
+  const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const [m, d, j, n] = await Promise.all([
+    prisma.meeting.deleteMany({ where: { deletedAt: { lt: cutoff } } }),
+    prisma.document.deleteMany({ where: { deletedAt: { lt: cutoff } } }),
+    prisma.journal.deleteMany({ where: { deletedAt: { lt: cutoff } } }),
+    prisma.notice.deleteMany({ where: { deletedAt: { lt: cutoff } } }),
+  ]);
+  await writeLog(me.id, "TRASH_PURGE_OLD", undefined, `m=${m.count} d=${d.count} j=${j.count} n=${n.count}`, req.ip);
+  res.json({ ok: true, counts: { meeting: m.count, document: d.count, journal: j.count, notice: n.count } });
+});
+
 /* ===== Health-check Board ===== */
 
 router.get("/health", requireSuperAdminStepUp, async (_req, res) => {

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -392,7 +392,7 @@ router.get("/", async (req, res) => {
     if (!(await assertProjectMember(u, projectId))) {
       return res.status(403).json({ error: "해당 프로젝트에 접근 권한이 없습니다" });
     }
-    const ands: any[] = [{ projectId }];
+    const ands: any[] = [{ projectId }, { deletedAt: null }];
     if (folderId === "root") ands.push({ folderId: null });
     else if (folderId) ands.push({ folderId });
     if (q) ands.push({
@@ -417,7 +417,7 @@ router.get("/", async (req, res) => {
   }
 
   // 전역 문서 — 프로젝트 문서는 숨김.
-  const ands: any[] = [visibilityWhere(u), { projectId: null }];
+  const ands: any[] = [visibilityWhere(u), { projectId: null }, { deletedAt: null }];
   if (folderId === "root") ands.push({ folderId: null });
   else if (folderId) ands.push({ folderId });
   if (q) ands.push({
@@ -503,7 +503,7 @@ router.patch("/:id", async (req, res) => {
   const parsed = docSchema.partial().safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
   const u = (req as any).user;
-  const exist = await prisma.document.findUnique({ where: { id: req.params.id } });
+  const exist = await prisma.document.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!exist) return res.status(404).json({ error: "not found" });
   // 작성자 본인 or ADMIN or (프로젝트 문서라면 프로젝트 멤버) 만 수정.
   // 다만 scope/scopeTeam/scopeUserIds/projectId 처럼 **가시성에 영향을 주는 필드는**
@@ -598,7 +598,7 @@ router.patch("/:id", async (req, res) => {
  */
 router.get("/:id/revisions", async (req, res) => {
   const u = (req as any).user;
-  const exist = await prisma.document.findUnique({ where: { id: req.params.id } });
+  const exist = await prisma.document.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!exist) return res.status(404).json({ error: "not found" });
   const isAuthor = exist.authorId === u.id;
   const isAdmin = u.role === "ADMIN";
@@ -616,7 +616,7 @@ router.get("/:id/revisions", async (req, res) => {
 /** 특정 리비전으로 문서를 되돌림. 되돌리기 직전 값도 한 번 더 스냅샷 → 되돌리기 취소 가능. */
 router.post("/:id/revisions/:revId/restore", async (req, res) => {
   const u = (req as any).user;
-  const exist = await prisma.document.findUnique({ where: { id: req.params.id } });
+  const exist = await prisma.document.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!exist) return res.status(404).json({ error: "not found" });
   const isAuthor = exist.authorId === u.id;
   const isAdmin = u.role === "ADMIN";
@@ -654,7 +654,7 @@ router.post("/:id/revisions/:revId/restore", async (req, res) => {
 
 router.delete("/:id", async (req, res) => {
   const u = (req as any).user;
-  const exist = await prisma.document.findUnique({ where: { id: req.params.id } });
+  const exist = await prisma.document.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!exist) return res.status(404).json({ error: "not found" });
   const isAuthor = exist.authorId === u.id;
   const isAdmin = u.role === "ADMIN";
@@ -663,7 +663,7 @@ router.delete("/:id", async (req, res) => {
     : false;
   if (!isAuthor && !isAdmin && !isProjectMember)
     return res.status(403).json({ error: "forbidden" });
-  await prisma.document.delete({ where: { id: exist.id } });
+  await prisma.document.update({ where: { id: exist.id }, data: { deletedAt: new Date(), deletedById: (req as any).user?.id } });
   await writeLog(u.id, "DOC_DELETE", req.params.id);
   res.json({ ok: true });
 });
@@ -715,7 +715,7 @@ router.get("/folders/:id/download", async (req, res) => {
   const collected: Collected[] = [];
   async function walk(folderId: string, prefix: string) {
     const docs = await prisma.document.findMany({
-      where: { folderId, fileUrl: { not: null } },
+      where: { folderId, fileUrl: { not: null }, deletedAt: null },
       select: { fileUrl: true, fileName: true, title: true },
     });
     for (const d of docs) {

--- a/server/src/routes/journal.ts
+++ b/server/src/routes/journal.ts
@@ -25,7 +25,7 @@ router.get("/", async (req, res) => {
   if (userId !== u.id && u.role === "MEMBER")
     return res.status(403).json({ error: "forbidden" });
   const list = await prisma.journal.findMany({
-    where: { userId },
+    where: { userId, deletedAt: null },
     orderBy: { date: "desc" },
     take: 500,
     include: { user: { select: { name: true } } },
@@ -49,7 +49,7 @@ router.patch("/:id", async (req, res) => {
   const parsed = patchSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
   const u = (req as any).user;
-  const j = await prisma.journal.findUnique({ where: { id: req.params.id } });
+  const j = await prisma.journal.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!j) return res.status(404).json({ error: "not found" });
   if (j.userId !== u.id) return res.status(403).json({ error: "forbidden" });
   const updated = await prisma.journal.update({
@@ -62,11 +62,11 @@ router.patch("/:id", async (req, res) => {
 
 router.delete("/:id", async (req, res) => {
   const u = (req as any).user;
-  const j = await prisma.journal.findUnique({ where: { id: req.params.id } });
+  const j = await prisma.journal.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!j) return res.status(404).json({ error: "not found" });
   if (j.userId !== u.id && u.role !== "ADMIN")
     return res.status(403).json({ error: "forbidden" });
-  await prisma.journal.delete({ where: { id: j.id } });
+  await prisma.journal.update({ where: { id: j.id }, data: { deletedAt: new Date(), deletedById: (req as any).user?.id } });
   await writeLog(u.id, "JOURNAL_DELETE", j.id);
   res.json({ ok: true });
 });

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -102,8 +102,8 @@ router.get("/mentionable", async (req, res) => {
   let authorId: string | undefined;
 
   if (meetingId) {
-    const m = await prisma.meeting.findUnique({
-      where: { id: meetingId },
+    const m = await prisma.meeting.findFirst({
+      where: { id: meetingId, deletedAt: null },
       include: { viewers: { select: { userId: true } } },
     });
     if (!m) return res.status(404).json({ error: "not found" });
@@ -200,6 +200,8 @@ router.get("/", async (req, res) => {
   if (projectId) {
     where.projectId = projectId;
   }
+  // 휴지통 항목은 일반 목록에서 제외.
+  where.deletedAt = null;
 
   const meetings = await prisma.meeting.findMany({
     where,
@@ -282,8 +284,8 @@ async function canRead(meeting: any, userId: string, userRole: string) {
 
 router.get("/:id", async (req, res) => {
   const u = (req as any).user;
-  const meeting = await prisma.meeting.findUnique({
-    where: { id: req.params.id },
+  const meeting = await prisma.meeting.findFirst({
+    where: { id: req.params.id, deletedAt: null },
     include: {
       author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       project: { select: { id: true, name: true, color: true } },
@@ -363,7 +365,7 @@ router.patch("/:id", async (req, res) => {
   const u = (req as any).user;
   const parsed = updateSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
-  const existing = await prisma.meeting.findUnique({ where: { id: req.params.id } });
+  const existing = await prisma.meeting.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!existing) return res.status(404).json({ error: "not found" });
 
   // 권한 모델:
@@ -470,7 +472,7 @@ router.patch("/:id", async (req, res) => {
  */
 router.get("/:id/revisions", async (req, res) => {
   const u = (req as any).user;
-  const existing = await prisma.meeting.findUnique({ where: { id: req.params.id } });
+  const existing = await prisma.meeting.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!existing) return res.status(404).json({ error: "not found" });
   if (!(await canRead(existing, u.id, u.role))) return res.status(403).json({ error: "forbidden" });
   const rows = await prisma.meetingRevision.findMany({
@@ -484,7 +486,7 @@ router.get("/:id/revisions", async (req, res) => {
 
 router.post("/:id/revisions/:revId/restore", async (req, res) => {
   const u = (req as any).user;
-  const existing = await prisma.meeting.findUnique({ where: { id: req.params.id } });
+  const existing = await prisma.meeting.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!existing) return res.status(404).json({ error: "not found" });
   if (!(await canRead(existing, u.id, u.role))) return res.status(403).json({ error: "forbidden" });
   const rev = await prisma.meetingRevision.findUnique({ where: { id: req.params.revId } });
@@ -502,12 +504,16 @@ router.post("/:id/revisions/:revId/restore", async (req, res) => {
 
 router.delete("/:id", async (req, res) => {
   const u = (req as any).user;
-  const existing = await prisma.meeting.findUnique({ where: { id: req.params.id } });
+  const existing = await prisma.meeting.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!existing) return res.status(404).json({ error: "not found" });
   if (existing.authorId !== u.id && u.role !== "ADMIN") {
     return res.status(403).json({ error: "forbidden" });
   }
-  await prisma.meeting.delete({ where: { id: existing.id } });
+  // 소프트 삭제 — 휴지통에서 30일 이내 복구 가능. 영구 삭제는 admin trash 페이지.
+  await prisma.meeting.update({
+    where: { id: existing.id },
+    data: { deletedAt: new Date(), deletedById: u.id },
+  });
   await writeLog(u.id, "MEETING_DELETE", existing.id);
   res.json({ ok: true });
 });

--- a/server/src/routes/notice.ts
+++ b/server/src/routes/notice.ts
@@ -18,6 +18,7 @@ function canWriteNotice(role: unknown): boolean {
 router.get("/", async (req, res) => {
   const u = (req as any).user;
   const list = await prisma.notice.findMany({
+    where: { deletedAt: null },
     orderBy: [{ pinned: "desc" }, { createdAt: "desc" }],
     take: 300,
     include: {
@@ -45,7 +46,7 @@ router.post("/:id/reactions", async (req, res) => {
   const u = (req as any).user;
   const emoji = typeof req.body?.emoji === "string" ? req.body.emoji.slice(0, 16) : "";
   if (!emoji) return res.status(400).json({ error: "emoji required" });
-  const notice = await prisma.notice.findUnique({ where: { id: req.params.id }, select: { id: true } });
+  const notice = await prisma.notice.findFirst({ where: { id: req.params.id, deletedAt: null }, select: { id: true } });
   if (!notice) return res.status(404).json({ error: "not found" });
   try {
     await prisma.noticeReaction.create({ data: { noticeId: notice.id, userId: u.id, emoji } });
@@ -107,7 +108,7 @@ router.patch("/:id", async (req, res) => {
   if (!canWriteNotice(u?.role)) return res.status(403).json({ error: "forbidden" });
   const parsed = patchSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
-  const notice = await prisma.notice.findUnique({ where: { id: req.params.id } });
+  const notice = await prisma.notice.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!notice) return res.status(404).json({ error: "not found" });
   // 작성자 본인이거나 ADMIN 역할이면 수정 가능. MANAGER 는 자신이 쓴 공지만 수정.
   if (u.role !== "ADMIN" && notice.authorId !== u.id) {
@@ -124,12 +125,12 @@ router.patch("/:id", async (req, res) => {
 router.delete("/:id", async (req, res) => {
   const u = (req as any).user;
   if (!canWriteNotice(u?.role)) return res.status(403).json({ error: "forbidden" });
-  const notice = await prisma.notice.findUnique({ where: { id: req.params.id } });
+  const notice = await prisma.notice.findFirst({ where: { id: req.params.id, deletedAt: null } });
   if (!notice) return res.status(404).json({ error: "not found" });
   if (u.role !== "ADMIN" && notice.authorId !== u.id) {
     return res.status(403).json({ error: "본인이 작성한 공지만 삭제할 수 있습니다" });
   }
-  await prisma.notice.delete({ where: { id: notice.id } });
+  await prisma.notice.update({ where: { id: notice.id }, data: { deletedAt: new Date(), deletedById: (req as any).user?.id } });
   await writeLog(u.id, "NOTICE_DELETE", notice.id);
   res.json({ ok: true });
 });

--- a/server/src/routes/pin.ts
+++ b/server/src/routes/pin.ts
@@ -37,10 +37,10 @@ async function hydratePins(pins: { id: string; targetType: string; targetId: str
   }
   const [docs, meetings, rooms, projects, notices] = await Promise.all([
     groups.DOCUMENT.length
-      ? prisma.document.findMany({ where: { id: { in: groups.DOCUMENT } }, select: { id: true, title: true } })
+      ? prisma.document.findMany({ where: { id: { in: groups.DOCUMENT }, deletedAt: null }, select: { id: true, title: true } })
       : Promise.resolve([]),
     groups.MEETING.length
-      ? prisma.meeting.findMany({ where: { id: { in: groups.MEETING } }, select: { id: true, title: true } })
+      ? prisma.meeting.findMany({ where: { id: { in: groups.MEETING }, deletedAt: null }, select: { id: true, title: true } })
       : Promise.resolve([]),
     groups.CHAT_ROOM.length
       ? prisma.chatRoom.findMany({ where: { id: { in: groups.CHAT_ROOM } }, select: { id: true, name: true, type: true } })
@@ -49,7 +49,7 @@ async function hydratePins(pins: { id: string; targetType: string; targetId: str
       ? prisma.project.findMany({ where: { id: { in: groups.PROJECT } }, select: { id: true, name: true, color: true } })
       : Promise.resolve([]),
     groups.NOTICE.length
-      ? prisma.notice.findMany({ where: { id: { in: groups.NOTICE } }, select: { id: true, title: true } })
+      ? prisma.notice.findMany({ where: { id: { in: groups.NOTICE }, deletedAt: null }, select: { id: true, title: true } })
       : Promise.resolve([]),
   ]);
   const nameBy = new Map<string, { name: string; meta?: any }>();

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -98,6 +98,7 @@ router.get("/", async (req, res) => {
     }),
     prisma.notice.findMany({
       where: {
+        deletedAt: null,
         OR: [{ title: ic }, { content: ic }],
       },
       take: 8,
@@ -117,6 +118,7 @@ router.get("/", async (req, res) => {
     prisma.document.findMany({
       where: {
         AND: [
+          { deletedAt: null },
           { OR: [{ title: ic }, { description: ic }, { tags: ic }] },
           { OR: docScopeOr },
         ],
@@ -143,7 +145,7 @@ router.get("/", async (req, res) => {
     // 회의록 — 제목으로만 매칭 (content 는 JSONB 라 단순 LIKE 가 안 되고 비용도 큼).
     prisma.meeting.findMany({
       where: {
-        AND: [{ title: ic }, meetingWhere],
+        AND: [{ deletedAt: null }, { title: ic }, meetingWhere],
       },
       take: 8,
       orderBy: { updatedAt: "desc" },

--- a/server/src/routes/shareLink.ts
+++ b/server/src/routes/shareLink.ts
@@ -31,8 +31,8 @@ const createSchema = z.object({
 });
 
 async function canShareDocument(u: { id: string; role: string }, documentId: string) {
-  const doc = await prisma.document.findUnique({
-    where: { id: documentId },
+  const doc = await prisma.document.findFirst({
+    where: { id: documentId, deletedAt: null },
     select: { id: true, authorId: true, projectId: true, fileUrl: true, fileName: true, title: true },
   });
   if (!doc) return null;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- Migration: add deletedAt + deletedById to 4 tables (Meeting/Document/Journal/Notice)
- Delete handlers now soft-delete instead of physical delete
- All read paths filter `deletedAt: null` (list / detail / search / pin / shareLink)
- Admin endpoints: `/api/admin/trash`, restore, purge, purge-old (30d cutoff)
- New "휴지통" tab in SuperAdmin

## Test plan
- [ ] 회의록 삭제 → 목록·검색에서 사라지고 휴지통 탭에 노출
- [ ] 휴지통에서 "복구" → 원래 위치로
- [ ] "영구 삭제" → DB 에서 row 사라짐
- [ ] 30일 초과 정리 버튼

Closes #519

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #519
