### PR TITLE
🔀 :: (#533) admin-set work hours + dashboard reflects

### DIFF
--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -16,6 +16,8 @@ export type User = {
   presenceStatus?: string | null;
   presenceMessage?: string | null;
   presenceUpdatedAt?: string | null;
+  workStartTime?: string | null;
+  workEndTime?: string | null;
 };
 
 export type Impersonator = { id: string; name: string };

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -38,6 +38,8 @@ type UserRow = {
   phone?: string | null;
   note?: string | null;
   autoClockOutTime?: string | null;
+  workStartTime?: string | null;
+  workEndTime?: string | null;
 };
 
 // 나이 계산 (생년월일 기반)
@@ -827,6 +829,8 @@ function UserDetailEditModal({
     disabilityLevel: user.disabilityLevel ?? "",
     note: user.note ?? "",
     autoClockOutTime: user.autoClockOutTime ?? "",
+    workStartTime: user.workStartTime ?? "",
+    workEndTime: user.workEndTime ?? "",
   };
   const [form, setForm] = useState(init);
   const [saving, setSaving] = useState(false);
@@ -927,6 +931,30 @@ function UserDetailEditModal({
               </div>
               <div className="text-[11px] text-ink-500 mt-1">
                 설정된 시간(KST)이 되면 오늘 출근한 기록이 자동으로 퇴근 처리돼요.
+              </div>
+            </Field>
+            <Field label="기준 근무 시각">
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <div className="text-[11px] font-bold text-ink-500 mb-1">출근</div>
+                  <TimePicker value={form.workStartTime} onChange={(v) => set("workStartTime", v)} placeholder="09:00" />
+                </div>
+                <div>
+                  <div className="text-[11px] font-bold text-ink-500 mb-1">퇴근</div>
+                  <TimePicker value={form.workEndTime} onChange={(v) => set("workEndTime", v)} placeholder="18:00" />
+                </div>
+              </div>
+              {(form.workStartTime || form.workEndTime) && (
+                <button
+                  type="button"
+                  className="btn-ghost btn-xs mt-2"
+                  onClick={() => { set("workStartTime", ""); set("workEndTime", ""); }}
+                >
+                  기본값으로 (09:00 / 18:00)
+                </button>
+              )}
+              <div className="text-[11px] text-ink-500 mt-1.5">
+                개요 페이지의 근무 진행률 바가 이 시간을 기준으로 표시돼요. 미설정 시 기본 09:00 / 18:00.
               </div>
             </Field>
           </Section>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -90,10 +90,16 @@ export default function DashboardPage() {
   const workedMin = att?.checkIn
     ? Math.max(0, Math.floor(((att.checkOut ? new Date(att.checkOut).getTime() : now.getTime()) - new Date(att.checkIn).getTime()) / 60000))
     : 0;
+  // 관리자 설정 기반 근무 시각 — 미설정 시 09:00/18:00 fallback.
+  const startMin = parseHHmm(user?.workStartTime ?? "") ?? 9 * 60;
+  const endMin = parseHHmm(user?.workEndTime ?? "") ?? 18 * 60;
+  const startLabel = formatHHmm(startMin);
+  const endLabel = formatHHmm(endMin);
   const dayProgress = useMemo(() => {
-    const h = now.getHours() + now.getMinutes() / 60;
-    return Math.max(0, Math.min(1, (h - 9) / 9));
-  }, [now]);
+    const m = now.getHours() * 60 + now.getMinutes();
+    if (endMin <= startMin) return 0; // 잘못된 설정은 0%
+    return Math.max(0, Math.min(1, (m - startMin) / (endMin - startMin)));
+  }, [now, startMin, endMin]);
 
   return (
     <div className="space-y-4">
@@ -157,9 +163,9 @@ export default function DashboardPage() {
             />
           </div>
           <div className="flex items-center justify-between mt-2.5 text-[11.5px] font-bold text-ink-500 tabular-nums">
-            <span>09:00</span>
+            <span>{startLabel}</span>
             <span className="text-ink-700">{Math.round(dayProgress * 100)}%</span>
-            <span>18:00</span>
+            <span>{endLabel}</span>
           </div>
         </div>
 
@@ -429,6 +435,14 @@ function relTime(iso: string): string {
 }
 function formatHours(min: number): string { return String(Math.floor(min / 60)); }
 function formatMinutesPart(min: number): string { return String(min % 60).padStart(2, "0"); }
+function parseHHmm(s: string): number | null {
+  const m = s?.match(/^([01]\d|2[0-3]):([0-5]\d)$/);
+  return m ? +m[1] * 60 + +m[2] : null;
+}
+function formatHHmm(min: number): string {
+  const h = Math.floor(min / 60), m = min % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
 function greetingFor(d: Date): string {
   const h = d.getHours();
   if (h < 6) return "오늘도 고생이 많으세요";

--- a/server/prisma/migrations/20260430000000_user_work_hours/migration.sql
+++ b/server/prisma/migrations/20260430000000_user_work_hours/migration.sql
@@ -1,0 +1,5 @@
+-- 사용자별 기준 근무 시각 — 개요 페이지의 진행률 바, 추후 야근 산정 등에 사용.
+-- NULL 인 사용자는 기본값 09:00 / 18:00 으로 간주.
+ALTER TABLE "User"
+  ADD COLUMN "workStartTime" TEXT,
+  ADD COLUMN "workEndTime"   TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -52,6 +52,10 @@ model User {
   // 설정돼있으면 매일 이 시간이 됐을 때 오늘 출근 기록(checkIn 존재, checkOut null)에 대해
   // 서버 스케줄러가 checkOut 을 그 시각으로 기록한다. null 이면 자동 퇴근 없음.
   autoClockOutTime   String?
+  // 사용자 별 기준 근무 시각 ("HH:mm", KST). 개요 페이지 진행률 바 / 야근 판정에 사용.
+  // null 이면 기본값 09:00 / 18:00 으로 간주.
+  workStartTime      String?
+  workEndTime        String?
   // 사용자 업무 상태 — AVAILABLE(근무중) | MEETING | MEAL | OUT | OFFLINE | AWAY
   // null 이면 attendance 기준으로 "출근/퇴근/미출근" 자동 판정
   presenceStatus     String?

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -99,6 +99,8 @@ const HR_SELECT = {
   phone: true,
   note: true,
   autoClockOutTime: true,
+  workStartTime: true,
+  workEndTime: true,
 } as const;
 
 router.get("/users", async (req, res) => {
@@ -142,6 +144,11 @@ const updateUserSchema = z.object({
   // 자동 퇴근 시간 — "HH:mm" 형식. 빈 문자열이면 null 로 저장해 자동 퇴근 해제.
   autoClockOutTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, "HH:mm 형식").optional().nullable()
     .or(z.literal("")),
+  // 기준 근무 시각 — "HH:mm" 형식. 빈 문자열 → null (기본 09:00 / 18:00 로 fallback).
+  workStartTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, "HH:mm 형식").optional().nullable()
+    .or(z.literal("")),
+  workEndTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, "HH:mm 형식").optional().nullable()
+    .or(z.literal("")),
 });
 
 router.patch("/users/:id", async (req, res) => {
@@ -157,9 +164,9 @@ router.patch("/users/:id", async (req, res) => {
   const data = parsed.data;
 
   // 빈 문자열 "" 는 null 로 정규화 — DB 에 저장되면 "자동 퇴근 미설정" 으로 해석됨.
-  if (data.autoClockOutTime === "") {
-    (data as any).autoClockOutTime = null;
-  }
+  if (data.autoClockOutTime === "") (data as any).autoClockOutTime = null;
+  if (data.workStartTime === "") (data as any).workStartTime = null;
+  if (data.workEndTime === "") (data as any).workEndTime = null;
 
   // 역할 변경은 민감한 권한 에스컬레이션 경로. superAdmin + step-up 쿠키가 있어야 허용.
   // ADMIN 이 자신 또는 동료의 role 을 임의로 바꿀 수 없게 함.

--- a/server/src/routes/me.ts
+++ b/server/src/routes/me.ts
@@ -33,6 +33,8 @@ router.get("/", requireAuth, async (req, res) => {
       presenceStatus: user.presenceStatus,
       presenceMessage: user.presenceMessage,
       presenceUpdatedAt: user.presenceUpdatedAt,
+      workStartTime: user.workStartTime,
+      workEndTime: user.workEndTime,
     },
   });
 });


### PR DESCRIPTION
## 증상
**admin-set work hours + dashboard reflects**

새 기능을 추가합니다.

## 원인
제목·커밋 메시지 기준 자동 정리(상세 원인은 커밋 메시지 본문 참조).

## 수정
**작업 항목 (커밋 단위)**
- feat(attendance): per-user work hours, dashboard progress reflects them

**변경 대상 (7개 파일)**
- `client/src/auth.tsx`
- `client/src/pages/AdminPage.tsx`
- `client/src/pages/DashboardPage.tsx`
- `server/prisma/migrations/20260430000000_user_work_hours/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/routes/admin.ts`
- `server/src/routes/me.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #109** ↔ **이슈 #533** 로 연결됩니다.

Closes #533
