### PR TITLE
🔀 :: (#535) detail panel refreshes after action

### DIFF
--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -181,7 +181,10 @@ export default function ApprovalsPage() {
     }
     setActingId(id);
     try {
-      await api(`/api/approval/${id}/act`, { method: "POST", json: { action } });
+      const r = await api<{ approval: Approval }>(`/api/approval/${id}/act`, { method: "POST", json: { action } });
+      // selected 가 \"승인/반려 후\" 상태로 즉시 반영되도록 응답값을 사용.
+      // load() 가 새 목록을 가져와도 pending scope 에선 이 항목이 빠져있어 selected 갱신이 안 되는 문제 회피.
+      if (r?.approval) setSelected(r.approval);
       await load();
     } catch (err: any) {
       alertAsync({ title: "처리 실패", description: err?.message ?? "처리에 실패했어요" });
@@ -196,10 +199,11 @@ export default function ApprovalsPage() {
     setRejectingId(null);
     setActingId(id);
     try {
-      await api(`/api/approval/${id}/act`, {
+      const r = await api<{ approval: Approval }>(`/api/approval/${id}/act`, {
         method: "POST",
         json: { action: "reject", comment: rejectComment.trim() || undefined },
       });
+      if (r?.approval) setSelected(r.approval);
       await load();
     } catch (err: any) {
       alertAsync({ title: "반려 실패", description: err?.message ?? "반려에 실패했어요" });

--- a/server/src/routes/approval.ts
+++ b/server/src/routes/approval.ts
@@ -288,11 +288,20 @@ router.post("/:id/act", async (req, res) => {
   const refreshed = await prisma.approval.findUnique({
     where: { id: a.id },
     include: {
-      requester: { select: { id: true, name: true } },
-      steps: { orderBy: { order: "asc" }, include: { reviewer: { select: { id: true, name: true } } } },
+      requester: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } },
+      steps: {
+        orderBy: { order: "asc" },
+        include: { reviewer: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+      },
     },
   });
-  res.json({ approval: refreshed });
+  // 목록 응답과 같은 shape — currentReviewerId / currentStepOrder 포함해야 클라가 즉시 selected 갱신 가능.
+  const cur = refreshed?.steps.find((s) => s.status === "PENDING");
+  res.json({
+    approval: refreshed
+      ? { ...refreshed, currentStepOrder: cur?.order ?? null, currentReviewerId: cur?.reviewerId ?? null }
+      : null,
+  });
 });
 
 router.post("/:id/cancel", async (req, res) => {


### PR DESCRIPTION
## 증상
**detail panel refreshes after action**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
…eject

## 수정
**작업 항목 (커밋 단위)**
- fix(approval): refresh detail panel state immediately after approve/r…

**변경 대상 (2개 파일)**
- `client/src/pages/ApprovalsPage.tsx`
- `server/src/routes/approval.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #111** ↔ **이슈 #535** 로 연결됩니다.

Closes #535
