### PR TITLE
🔀 :: (#537) role permissions + meeting A4 print + picker/UI polish

### DIFF
--- a/client/src/components/superadmin/RolePermissionsPanel.tsx
+++ b/client/src/components/superadmin/RolePermissionsPanel.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../../api";
+import { confirmAsync } from "../ConfirmHost";
+
+type Role = "ADMIN" | "MANAGER" | "MEMBER";
+type Catalog = {
+  key: string;
+  label: string;
+  group: string;
+  defaults: Record<Role, boolean>;
+};
+type Matrix = Record<Role, Record<string, boolean>>;
+
+const ROLES: { key: Role; label: string }[] = [
+  { key: "ADMIN", label: "관리자" },
+  { key: "MANAGER", label: "매니저" },
+  { key: "MEMBER", label: "팀원" },
+];
+
+/**
+ * 역할별 권한 매트릭스 — 그룹별로 묶고, 토글 = 즉시 저장.
+ * 기본값과 다르면 \"기본값 다름\" 표시. 우측 \"기본값 복원\" 버튼으로 catalog default 로 되돌림.
+ */
+export default function RolePermissionsPanel() {
+  const [catalog, setCatalog] = useState<Catalog[]>([]);
+  const [matrix, setMatrix] = useState<Matrix | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const r = await api<{ catalog: Catalog[]; matrix: Matrix }>("/api/admin/role-permissions");
+      setCatalog(r.catalog);
+      setMatrix(r.matrix);
+    } finally { setLoading(false); }
+  }
+  useEffect(() => { load(); }, []);
+
+  async function toggle(role: Role, key: string, next: boolean) {
+    if (!matrix) return;
+    setBusy(true);
+    setMatrix({ ...matrix, [role]: { ...matrix[role], [key]: next } });
+    try {
+      await api("/api/admin/role-permissions", { method: "POST", json: { role, permKey: key, enabled: next } });
+    } catch {
+      await load(); // 실패 시 서버 상태로 재정합
+    } finally { setBusy(false); }
+  }
+
+  async function resetToDefault(role: Role, key: string) {
+    setBusy(true);
+    try {
+      await api(`/api/admin/role-permissions/${role}/${encodeURIComponent(key)}`, { method: "DELETE" });
+      await load();
+    } finally { setBusy(false); }
+  }
+
+  async function resetAll() {
+    if (!(await confirmAsync({ title: "모든 권한을 기본값으로?", description: "현재 변경사항이 모두 사라지고 코드 기본값으로 복원됩니다." }))) return;
+    setBusy(true);
+    try {
+      // 순회 — 변경된 row 만 지움.
+      if (!matrix) return;
+      const ops: Promise<unknown>[] = [];
+      for (const c of catalog) {
+        for (const r of ROLES) {
+          const eff = matrix[r.key][c.key];
+          const def = c.defaults[r.key];
+          if (eff !== def) ops.push(api(`/api/admin/role-permissions/${r.key}/${encodeURIComponent(c.key)}`, { method: "DELETE" }));
+        }
+      }
+      await Promise.all(ops);
+      await load();
+    } finally { setBusy(false); }
+  }
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Catalog[]>();
+    for (const c of catalog) {
+      if (!map.has(c.group)) map.set(c.group, []);
+      map.get(c.group)!.push(c);
+    }
+    return Array.from(map.entries());
+  }, [catalog]);
+
+  return (
+    <div className="panel p-4">
+      <div className="flex items-center mb-3">
+        <div className="text-[12.5px] text-ink-500">
+          역할별로 기능 권한을 토글합니다. 코드 기본값과 다르면 칸 좌측 상단에 점이 표시됩니다.
+        </div>
+        <button className="btn-ghost btn-xs ml-auto" onClick={resetAll} disabled={busy || !matrix}>모두 기본값으로</button>
+      </div>
+
+      <div className="overflow-auto" style={{ maxHeight: "65vh" }}>
+        <table className="w-full text-[12.5px]">
+          <thead>
+            <tr className="text-ink-500 text-left border-b border-ink-150">
+              <th className="py-2 pr-3 w-[42%]">권한</th>
+              {ROLES.map((r) => (
+                <th key={r.key} className="py-2 px-3 text-center w-[18%]">{r.label}</th>
+              ))}
+              <th className="py-2 pl-3 w-[4%]"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {grouped.map(([group, items]) => (
+              <>
+                <tr key={`g-${group}`}>
+                  <td colSpan={5} className="pt-4 pb-1 text-[10.5px] font-extrabold tracking-[0.06em] uppercase text-ink-500">
+                    {group}
+                  </td>
+                </tr>
+                {items.map((c) => (
+                  <tr key={c.key} className="border-b border-ink-100">
+                    <td className="py-2 pr-3">
+                      <div className="font-bold text-ink-900">{c.label}</div>
+                      <div className="text-[10.5px] text-ink-400 font-mono">{c.key}</div>
+                    </td>
+                    {ROLES.map((r) => {
+                      const eff = matrix?.[r.key]?.[c.key] ?? c.defaults[r.key];
+                      const def = c.defaults[r.key];
+                      const overridden = eff !== def;
+                      return (
+                        <td key={r.key} className="py-2 px-3 text-center align-middle">
+                          <div className="inline-flex items-center justify-center relative">
+                            {overridden && (
+                              <span
+                                className="absolute -top-0.5 -left-0.5 w-1.5 h-1.5 rounded-full"
+                                style={{ background: "var(--c-warning)" }}
+                                title="기본값과 다름"
+                              />
+                            )}
+                            <button
+                              onClick={() => toggle(r.key, c.key, !eff)}
+                              disabled={busy}
+                              style={{
+                                width: 36,
+                                height: 20,
+                                borderRadius: 10,
+                                background: eff ? "var(--c-success)" : "var(--c-surface-3)",
+                                position: "relative",
+                                transition: "background 0.15s",
+                              }}
+                              title={eff ? "허용 — 클릭하면 차단" : "차단 — 클릭하면 허용"}
+                            >
+                              <span
+                                style={{
+                                  position: "absolute",
+                                  top: 2,
+                                  left: eff ? 18 : 2,
+                                  width: 16,
+                                  height: 16,
+                                  borderRadius: 8,
+                                  background: "#fff",
+                                  transition: "left 0.15s",
+                                  boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
+                                }}
+                              />
+                            </button>
+                          </div>
+                        </td>
+                      );
+                    })}
+                    <td className="py-2 pl-3 text-right">
+                      {/* 어느 role 이든 기본값과 다르면 row 단위 reset 버튼 */}
+                      {ROLES.some((r) => (matrix?.[r.key]?.[c.key] ?? c.defaults[r.key]) !== c.defaults[r.key]) && (
+                        <button
+                          className="text-[10.5px] text-ink-500 hover:text-ink-800"
+                          onClick={() => Promise.all(ROLES.map((r) => resetToDefault(r.key, c.key)))}
+                          disabled={busy}
+                          title="이 권한 행 전체를 기본값으로"
+                        >
+                          ↺
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </>
+            ))}
+          </tbody>
+        </table>
+        {loading && <div className="py-8 text-center text-[12px] text-ink-500">불러오는 중…</div>}
+      </div>
+
+      <div className="text-[10.5px] text-ink-400 mt-3 leading-relaxed">
+        ※ 권한 카탈로그는 코드(<span className="font-mono">server/src/lib/permissions.ts</span>) 에 정의됩니다.
+        새 권한 키 추가 시 카탈로그에 한 줄 추가하면 자동으로 이 화면에 노출됩니다.
+        실제 enforcement 는 라우트별 <span className="font-mono">hasPermission()</span> 호출이 필요해요.
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/superadmin/SecurityPanel.tsx
+++ b/client/src/components/superadmin/SecurityPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync } from "../ConfirmHost";
+import DateTimePicker from "../DateTimePicker";
 
 type Rate = { id: string; routeGlob: string; perMin: number; perHour: number; scope: string; enabled: boolean; note: string | null; createdAt: string };
 type Block = { id: string; cidr: string; country: string | null; reason: string | null; enabled: boolean; expiresAt: string | null; createdAt: string };
@@ -160,7 +161,7 @@ function IpBlocks() {
             <input className="input font-mono" maxLength={2} value={editing.country ?? ""} onChange={(e) => setEditing({ ...editing, country: e.target.value.toUpperCase(), cidr: "" })} placeholder="예: CN, RU" />
           </Field>
           <Field label="사유"><input className="input" value={editing.reason ?? ""} onChange={(e) => setEditing({ ...editing, reason: e.target.value })} /></Field>
-          <Field label="만료 (선택)"><input className="input" type="datetime-local" value={editing.expiresAt ?? ""} onChange={(e) => setEditing({ ...editing, expiresAt: e.target.value })} /></Field>
+          <Field label="만료 (선택)"><DateTimePicker value={editing.expiresAt ?? ""} onChange={(v) => setEditing({ ...editing, expiresAt: v })} /></Field>
           <Field label="활성">
             <select className="input" value={editing.enabled ? "1" : "0"} onChange={(e) => setEditing({ ...editing, enabled: e.target.value === "1" })}>
               <option value="1">차단 중</option><option value="0">OFF</option>

--- a/client/src/components/superadmin/TokensPanel.tsx
+++ b/client/src/components/superadmin/TokensPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync, alertAsync } from "../ConfirmHost";
+import DateTimePicker from "../DateTimePicker";
 
 type Token = {
   id: string;
@@ -74,7 +75,7 @@ export default function TokensPanel() {
         </div>
         <div className="min-w-[160px]">
           <label className="field-label">만료 (선택)</label>
-          <input className="input" type="datetime-local" value={expiresAt} onChange={(e) => setExpiresAt(e.target.value)} />
+          <DateTimePicker value={expiresAt} onChange={setExpiresAt} />
         </div>
         <button type="submit" className="btn-primary" disabled={creating}>{creating ? "발급 중…" : "+ 발급"}</button>
       </form>

--- a/client/src/lib/useApprovalCounts.ts
+++ b/client/src/lib/useApprovalCounts.ts
@@ -18,7 +18,7 @@ export function useApprovalCounts() {
       } catch { /* 401 등은 무시 */ }
     }
     load();
-    const t = setInterval(load, 30_000);
+    const t = setInterval(load, 15_000);
     function onVis() { if (document.visibilityState === "visible") load(); }
     function onSignal() { load(); }
     document.addEventListener("visibilitychange", onVis);

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -142,6 +142,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
             //  같은 유저 세션이 동시에 여러 번 GET /api/notification 치는 문제 → 서버 부하 증가.
             //  30초 주기 poll + visibilitychange poll 으로 서버 기준 재싱크는 이미 커버됨.)
             setItems((prev) => (prev.some((x) => x.id === n.id) ? prev : [n, ...prev]));
+            // 결재 관련 알림이 도착하면 사이드바 배지/탭 카운트 즉시 새로고침.
+            if (n.type === "APPROVAL_REQUEST" || n.type === "APPROVAL_REVIEW") {
+              window.dispatchEvent(new Event("hinest:approvalCountsRefresh"));
+            }
             // 동일 가드 — 음소거된 방의 SSE 푸시는 OS 알림 띄우지 않음.
             if (shouldDeliverNotif(n)) {
               deliverPendingNotifications([

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -937,11 +937,11 @@ function UserDetailEditModal({
               <div className="grid grid-cols-2 gap-2">
                 <div>
                   <div className="text-[11px] font-bold text-ink-500 mb-1">출근</div>
-                  <TimePicker value={form.workStartTime} onChange={(v) => set("workStartTime", v)} placeholder="09:00" />
+                  <TimePicker value={form.workStartTime} onChange={(v) => set("workStartTime", v)} placeholder="(기본 09:00)" />
                 </div>
                 <div>
                   <div className="text-[11px] font-bold text-ink-500 mb-1">퇴근</div>
-                  <TimePicker value={form.workEndTime} onChange={(v) => set("workEndTime", v)} placeholder="18:00" />
+                  <TimePicker value={form.workEndTime} onChange={(v) => set("workEndTime", v)} placeholder="(기본 18:00)" />
                 </div>
               </div>
               {(form.workStartTime || form.workEndTime) && (
@@ -950,11 +950,11 @@ function UserDetailEditModal({
                   className="btn-ghost btn-xs mt-2"
                   onClick={() => { set("workStartTime", ""); set("workEndTime", ""); }}
                 >
-                  기본값으로 (09:00 / 18:00)
+                  기본값으로 되돌리기
                 </button>
               )}
               <div className="text-[11px] text-ink-500 mt-1.5">
-                개요 페이지의 근무 진행률 바가 이 시간을 기준으로 표시돼요. 미설정 시 기본 09:00 / 18:00.
+                개요 페이지의 근무 진행률 바가 이 시간을 기준으로 표시돼요. 비워두면 기본 09:00 / 18:00.
               </div>
             </Field>
           </Section>

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -226,8 +226,24 @@ export default function MeetingDetailPage() {
   if (!meeting) return null;
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="flex items-center justify-between gap-2 mb-3 flex-wrap">
+    <div className="max-w-4xl mx-auto print-area">
+      {/* A4 인쇄 — 본문만 출력하고 사이드바/버튼/네비를 숨김. 1.5cm 여백, 12pt 본문. */}
+      <style>{`
+        @media print {
+          @page { size: A4; margin: 1.5cm; }
+          html, body { background: #fff !important; color: #000 !important; }
+          body * { visibility: hidden; }
+          .print-area, .print-area * { visibility: visible; }
+          .print-area { position: absolute; left: 0; top: 0; width: 100%; max-width: none !important; padding: 0; }
+          .no-print { display: none !important; }
+          .ProseMirror, article, h1, h2, h3, p, li, td, th { color: #000 !important; }
+          a { color: #000 !important; text-decoration: underline; }
+          img { max-width: 100% !important; page-break-inside: avoid; }
+          h1, h2, h3 { page-break-after: avoid; }
+          table, pre, blockquote { page-break-inside: avoid; }
+        }
+      `}</style>
+      <div className="flex items-center justify-between gap-2 mb-3 flex-wrap no-print">
         <Link to="/meetings" className="text-[13px] text-slate-500 hover:text-brand-600 flex-shrink-0">
           ← 회의록 목록
         </Link>
@@ -250,6 +266,7 @@ export default function MeetingDetailPage() {
             링크 복사
           </button>
           <PinButton type="MEETING" id={meeting.id} label={meeting.title} />
+          <button className="btn-ghost no-print" onClick={() => window.print()} title="A4 인쇄">인쇄</button>
           <button className="btn-ghost" onClick={() => setHistoryOpen(true)} title="버전 히스토리">히스토리</button>
           {canEdit && !edit && (
             <button className="btn-ghost" onClick={() => { setEdit(true); setSearchParams({ edit: "1" }); }}>

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -12,6 +12,7 @@ import FlagsPanel from "../components/superadmin/FlagsPanel";
 import TokensPanel from "../components/superadmin/TokensPanel";
 import SecurityPanel from "../components/superadmin/SecurityPanel";
 import TwoFAPanel from "../components/superadmin/TwoFAPanel";
+import RolePermissionsPanel from "../components/superadmin/RolePermissionsPanel";
 
 type Log = {
   id: string;
@@ -47,7 +48,7 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions" | "errors" | "health" | "trash" | "audit" | "flags" | "tokens" | "security" | "twofa";
+type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions" | "errors" | "health" | "trash" | "audit" | "flags" | "tokens" | "security" | "twofa" | "roles";
 
 type ApiSpecRoute = {
   method: string;
@@ -118,6 +119,7 @@ function SuperAdminContent() {
     : raw === "tokens" ? "tokens"
     : raw === "security" ? "security"
     : raw === "twofa" ? "twofa"
+    : raw === "roles" ? "roles"
     : "logs";
 
   const setTab = (t: Tab) => {
@@ -195,6 +197,7 @@ function SuperAdminContent() {
         <TabBtn active={tab === "tokens"} onClick={() => setTab("tokens")}>API 토큰</TabBtn>
         <TabBtn active={tab === "security"} onClick={() => setTab("security")}>보안 룰</TabBtn>
         <TabBtn active={tab === "twofa"} onClick={() => setTab("twofa")}>2FA 정책</TabBtn>
+        <TabBtn active={tab === "roles"} onClick={() => setTab("roles")}>역할 권한</TabBtn>
       </div>
       {tab === "logs" && <LogsPanel />}
       {tab === "chat" && chatUnlocked && <ChatAuditPanel />}
@@ -211,6 +214,7 @@ function SuperAdminContent() {
       {tab === "tokens" && <TokensPanel />}
       {tab === "security" && <SecurityPanel />}
       {tab === "twofa" && <TwoFAPanel />}
+      {tab === "roles" && <RolePermissionsPanel />}
       {chatPwOpen && (
         <ChatAuditPwModal
           onClose={() => setChatPwOpen(false)}

--- a/server/prisma/migrations/20260430100000_role_permissions/migration.sql
+++ b/server/prisma/migrations/20260430100000_role_permissions/migration.sql
@@ -1,0 +1,9 @@
+-- 역할별 권한 토글 — (role, key) 한 쌍에 boolean. 기본값(default catalog) 과 다를 때만 row 생성.
+CREATE TABLE "RolePermission" (
+    "role" TEXT NOT NULL,             -- ADMIN | MANAGER | MEMBER
+    "permKey" TEXT NOT NULL,          -- 예: "meeting.create"
+    "enabled" BOOLEAN NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedById" TEXT,
+    CONSTRAINT "RolePermission_pkey" PRIMARY KEY ("role", "permKey")
+);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -911,6 +911,18 @@ model Snippet {
   @@index([trigger])
 }
 
+/// 역할(ADMIN/MANAGER/MEMBER) 별 기능 권한 토글. 기본값과 다를 때만 row 생성.
+/// 존재하지 않는 (role, permKey) 는 코드 카탈로그의 default 를 따름.
+model RolePermission {
+  role        String // ADMIN | MANAGER | MEMBER
+  permKey     String
+  enabled     Boolean
+  updatedAt   DateTime @updatedAt
+  updatedById String?
+
+  @@id([role, permKey])
+}
+
 /// 2FA(패스키) 강제 정책 — role 별로 필수 여부와 유예 기간. 미충족 사용자는 별도 화면 안내.
 model TwoFactorPolicy {
   role            String   @id // ADMIN | MANAGER | MEMBER

--- a/server/src/lib/permissions.ts
+++ b/server/src/lib/permissions.ts
@@ -1,0 +1,98 @@
+import { prisma } from "./db.js";
+
+/**
+ * 역할(role) 별 기능 권한 — 카탈로그(코드) + 오버라이드(DB).
+ *
+ * 카탈로그의 \`defaults\` 가 출고 시 기본값. 관리자가 SuperAdmin 페이지에서
+ * 켜고 끄면 \`RolePermission\` row 가 생성/갱신되어 default 를 덮어쓴다.
+ *
+ * 사용:
+ *   import { hasPermission } from "../lib/permissions.js";
+ *   if (!(await hasPermission(u.role, "meeting.delete.any"))) return res.status(403)...
+ */
+
+export type Role = "ADMIN" | "MANAGER" | "MEMBER";
+
+export type PermKey =
+  | "meeting.create"
+  | "meeting.delete.any"
+  | "notice.create"
+  | "notice.delete.any"
+  | "approval.review"
+  | "expense.create"
+  | "expense.approve"
+  | "document.delete.any"
+  | "user.invite"
+  | "user.edit"
+  | "chat.audit"
+  | "project.create";
+
+type Catalog = {
+  key: PermKey;
+  label: string;
+  group: "회의록" | "공지" | "결재" | "지출" | "문서" | "사용자" | "기타";
+  defaults: Record<Role, boolean>;
+};
+
+export const PERMISSION_CATALOG: Catalog[] = [
+  // 회의록
+  { key: "meeting.create",      label: "회의록 작성",          group: "회의록", defaults: { ADMIN: true,  MANAGER: true,  MEMBER: true  } },
+  { key: "meeting.delete.any",  label: "다른 사람 회의록 삭제", group: "회의록", defaults: { ADMIN: true,  MANAGER: false, MEMBER: false } },
+  // 공지
+  { key: "notice.create",       label: "공지 작성",            group: "공지",   defaults: { ADMIN: true,  MANAGER: true,  MEMBER: false } },
+  { key: "notice.delete.any",   label: "다른 사람 공지 삭제",   group: "공지",   defaults: { ADMIN: true,  MANAGER: false, MEMBER: false } },
+  // 결재
+  { key: "approval.review",     label: "결재자 지정 가능",      group: "결재",   defaults: { ADMIN: true,  MANAGER: true,  MEMBER: false } },
+  // 지출
+  { key: "expense.create",      label: "지출 등록",            group: "지출",   defaults: { ADMIN: true,  MANAGER: true,  MEMBER: true  } },
+  { key: "expense.approve",     label: "지출 승인",            group: "지출",   defaults: { ADMIN: true,  MANAGER: true,  MEMBER: false } },
+  // 문서
+  { key: "document.delete.any", label: "다른 사람 문서 삭제",   group: "문서",   defaults: { ADMIN: true,  MANAGER: false, MEMBER: false } },
+  // 사용자
+  { key: "user.invite",         label: "초대 키 발급",          group: "사용자", defaults: { ADMIN: true,  MANAGER: false, MEMBER: false } },
+  { key: "user.edit",           label: "사용자 정보 편집",      group: "사용자", defaults: { ADMIN: true,  MANAGER: false, MEMBER: false } },
+  // 기타
+  { key: "chat.audit",          label: "사내톡 감사 접근",      group: "기타",   defaults: { ADMIN: false, MANAGER: false, MEMBER: false } }, // 개발자 전용
+  { key: "project.create",      label: "프로젝트 생성",         group: "기타",   defaults: { ADMIN: true,  MANAGER: true,  MEMBER: true  } },
+];
+
+const ALL_KEYS = new Set(PERMISSION_CATALOG.map((p) => p.key));
+
+/* 인메모리 캐시 — 60s. RolePermission row 가 바뀌면 evictPermissionCache(). */
+let _cache: { rows: { role: string; permKey: string; enabled: boolean }[]; exp: number } | null = null;
+const TTL = 60_000;
+
+async function getOverrides() {
+  if (_cache && _cache.exp > Date.now()) return _cache.rows;
+  const rows = await prisma.rolePermission.findMany({
+    select: { role: true, permKey: true, enabled: true },
+  });
+  _cache = { rows, exp: Date.now() + TTL };
+  return rows;
+}
+
+export function evictPermissionCache() { _cache = null; }
+
+/** role 의 특정 권한 활성 여부. row 가 없으면 catalog default. */
+export async function hasPermission(role: string, key: PermKey): Promise<boolean> {
+  if (!ALL_KEYS.has(key)) return false;
+  const r = role as Role;
+  const overrides = await getOverrides();
+  const found = overrides.find((o) => o.role === r && o.permKey === key);
+  if (found) return found.enabled;
+  const cat = PERMISSION_CATALOG.find((c) => c.key === key);
+  return cat?.defaults[r] ?? false;
+}
+
+/** 모든 role × key 에 대한 현재 effective 매트릭스 — 관리 화면이 한 번에 표시할 때. */
+export async function getEffectiveMatrix(): Promise<Record<Role, Record<PermKey, boolean>>> {
+  const overrides = await getOverrides();
+  const out: any = { ADMIN: {}, MANAGER: {}, MEMBER: {} };
+  for (const c of PERMISSION_CATALOG) {
+    for (const r of ["ADMIN", "MANAGER", "MEMBER"] as const) {
+      const ov = overrides.find((o) => o.role === r && o.permKey === c.key);
+      out[r][c.key] = ov ? ov.enabled : c.defaults[r];
+    }
+  }
+  return out;
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1298,6 +1298,40 @@ router.delete("/feature-flags/:key", requireSuperAdminStepUp, async (req, res) =
   res.json({ ok: true });
 });
 
+/* ===== 역할 권한 (RolePermission) ===== */
+import { PERMISSION_CATALOG, getEffectiveMatrix, evictPermissionCache, type PermKey } from "../lib/permissions.js";
+
+router.get("/role-permissions", requireSuperAdminStepUp, async (_req, res) => {
+  const matrix = await getEffectiveMatrix();
+  res.json({ catalog: PERMISSION_CATALOG, matrix });
+});
+
+router.post("/role-permissions", requireSuperAdminStepUp, async (req, res) => {
+  const me = (req as any).user;
+  const { role, permKey, enabled } = req.body ?? {};
+  if (!["ADMIN", "MANAGER", "MEMBER"].includes(role)) return res.status(400).json({ error: "invalid role" });
+  const known = PERMISSION_CATALOG.some((c) => c.key === permKey);
+  if (!known) return res.status(400).json({ error: "unknown permKey" });
+  await prisma.rolePermission.upsert({
+    where: { role_permKey: { role, permKey } },
+    update: { enabled: !!enabled, updatedById: me.id },
+    create: { role, permKey, enabled: !!enabled, updatedById: me.id },
+  });
+  evictPermissionCache();
+  await writeLog(me.id, "ROLE_PERM_UPSERT", `${role}:${permKey}`, `enabled=${!!enabled}`, req.ip);
+  res.json({ ok: true });
+});
+
+router.delete("/role-permissions/:role/:permKey", requireSuperAdminStepUp, async (req, res) => {
+  const me = (req as any).user;
+  await prisma.rolePermission.deleteMany({
+    where: { role: req.params.role, permKey: req.params.permKey as PermKey },
+  });
+  evictPermissionCache();
+  await writeLog(me.id, "ROLE_PERM_RESET", `${req.params.role}:${req.params.permKey}`, undefined, req.ip);
+  res.json({ ok: true });
+});
+
 /* ===== 2FA(패스키) 정책 ===== */
 
 router.get("/2fa-policy", requireSuperAdminStepUp, async (_req, res) => {


### PR DESCRIPTION
## 증상
**role permissions + meeting A4 print + picker/UI polish**

새 기능을 추가합니다.

## 원인
제목·커밋 메시지 기준 자동 정리(상세 원인은 커밋 메시지 본문 참조).

## 수정
**작업 항목 (커밋 단위)**
- feat: role permissions matrix + meeting A4 print + picker/UI polish

**변경 대상 (12개 파일)**
- `client/src/components/superadmin/RolePermissionsPanel.tsx`
- `client/src/components/superadmin/SecurityPanel.tsx`
- `client/src/components/superadmin/TokensPanel.tsx`
- `client/src/lib/useApprovalCounts.ts`
- `client/src/notifications.tsx`
- `client/src/pages/AdminPage.tsx`
- `client/src/pages/MeetingDetailPage.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/prisma/migrations/20260430100000_role_permissions/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/lib/permissions.ts`
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #113** ↔ **이슈 #537** 로 연결됩니다.

Closes #537
