### PR TITLE
🔀 :: (#539) hide chat.audit from role matrix UI

### DIFF
--- a/server/src/lib/permissions.ts
+++ b/server/src/lib/permissions.ts
@@ -87,6 +87,8 @@ type Catalog = {
   label: string;
   group: Group;
   defaults: Record<Role, boolean>;
+  /** UI 에서 숨김 — 개발자 전용 / 직접 토글하면 안 되는 키. hasPermission() 평가는 정상 동작. */
+  hidden?: boolean;
 };
 
 export const PERMISSION_CATALOG: Catalog[] = [
@@ -142,7 +144,7 @@ export const PERMISSION_CATALOG: Catalog[] = [
   // 채팅
   { key: "chat.room.create",        label: "채팅방 생성",              group: "채팅",      defaults: { ADMIN: true,  MANAGER: true,  MEMBER: true  } },
   { key: "chat.room.kick",          label: "채팅방 멤버 추방",          group: "채팅",      defaults: { ADMIN: true,  MANAGER: true,  MEMBER: false } },
-  { key: "chat.audit",              label: "사내톡 감사 접근",          group: "채팅",      defaults: { ADMIN: false, MANAGER: false, MEMBER: false } }, // 개발자 전용
+  { key: "chat.audit",              label: "사내톡 감사 접근",          group: "채팅",      defaults: { ADMIN: false, MANAGER: false, MEMBER: false }, hidden: true }, // 개발자 stepup 전용 — UI 노출 X
 
   // 프로젝트
   { key: "project.create",          label: "프로젝트 생성",            group: "프로젝트",  defaults: { ADMIN: true,  MANAGER: true,  MEMBER: true  } },

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1303,7 +1303,17 @@ import { PERMISSION_CATALOG, getEffectiveMatrix, evictPermissionCache, type Perm
 
 router.get("/role-permissions", requireSuperAdminStepUp, async (_req, res) => {
   const matrix = await getEffectiveMatrix();
-  res.json({ catalog: PERMISSION_CATALOG, matrix });
+  // hidden 키는 UI 에서 노출 안 함 — 카탈로그/매트릭스 둘 다에서 제거.
+  const catalog = PERMISSION_CATALOG.filter((c) => !c.hidden);
+  const visibleKeys = new Set(catalog.map((c) => c.key));
+  const trimmed: Record<string, Record<string, boolean>> = {};
+  for (const [role, perms] of Object.entries(matrix)) {
+    trimmed[role] = {};
+    for (const [k, v] of Object.entries(perms as Record<string, boolean>)) {
+      if (visibleKeys.has(k as any)) trimmed[role][k] = v;
+    }
+  }
+  res.json({ catalog, matrix: trimmed });
 });
 
 router.post("/role-permissions", requireSuperAdminStepUp, async (req, res) => {


### PR DESCRIPTION
## 증상
**hide chat.audit from role matrix UI**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
제목·커밋 메시지 기준 자동 정리(상세 원인은 커밋 메시지 본문 참조).

## 수정
**작업 항목 (커밋 단위)**
- fix(permissions): hide chat.audit from role matrix UI

**변경 대상 (2개 파일)**
- `server/src/lib/permissions.ts`
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #115** ↔ **이슈 #539** 로 연결됩니다.

Closes #539
