### PR TITLE
🔀 :: (#540) account lockout + admin password reset

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -40,6 +40,8 @@ type UserRow = {
   autoClockOutTime?: string | null;
   workStartTime?: string | null;
   workEndTime?: string | null;
+  failedLoginCount?: number;
+  lockedAt?: string | null;
 };
 
 // 나이 계산 (생년월일 기반)
@@ -990,6 +992,10 @@ function UserDetailEditModal({
                 maxLength={5_000}
               />
             </Field>
+          </Section>
+
+          <Section title="보안" cols={1}>
+            <SecurityBlock user={user} onChanged={onSaved} />
           </Section>
         </div>
 
@@ -2020,4 +2026,116 @@ function TrashIcon() {
   return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#DC2626" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
   </svg>;
+}
+
+/* =================== 보안 블록 (잠금 상태 + 비밀번호 재설정) =================== */
+
+function SecurityBlock({ user, onChanged }: { user: UserRow; onChanged: () => void }) {
+  const [pw1, setPw1] = useState("");
+  const [pw2, setPw2] = useState("");
+  const [busy, setBusy] = useState(false);
+  const locked = !!user.lockedAt;
+  const fails = user.failedLoginCount ?? 0;
+
+  async function unlock() {
+    setBusy(true);
+    try {
+      await api(`/api/admin/users/${user.id}/unlock`, { method: "POST" });
+      await alertAsync({ title: "잠금 해제됨", description: "다음 로그인부터 정상 시도 가능합니다." });
+      onChanged();
+    } catch (e: any) {
+      alertAsync({ title: "해제 실패", description: e?.message ?? String(e) });
+    } finally { setBusy(false); }
+  }
+
+  async function resetPassword(e: React.FormEvent) {
+    e.preventDefault();
+    if (pw1.length < 8) { alertAsync({ title: "8자 이상이어야 합니다" }); return; }
+    if (pw1 !== pw2) { alertAsync({ title: "비밀번호 확인이 일치하지 않습니다" }); return; }
+    if (!(await confirmAsync({ title: `${user.name}님의 비밀번호 재설정`, description: "기존 비밀번호로는 더 이상 로그인할 수 없게 됩니다. 사용자에게 새 비밀번호를 안전한 채널로 전달해 주세요." }))) return;
+    setBusy(true);
+    try {
+      await api(`/api/admin/users/${user.id}/reset-password`, {
+        method: "POST",
+        json: { newPassword: pw1 },
+      });
+      setPw1(""); setPw2("");
+      await alertAsync({ title: "비밀번호 변경됨", description: "잠금 상태도 자동으로 해제됐어요." });
+      onChanged();
+    } catch (err: any) {
+      alertAsync({ title: "변경 실패", description: err?.message ?? String(err) });
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 잠금 상태 */}
+      <div
+        className="rounded-lg p-3.5 border"
+        style={{
+          background: locked ? "rgba(220,38,38,0.08)" : "var(--c-surface-3)",
+          borderColor: locked ? "rgba(220,38,38,0.25)" : "var(--c-border)",
+        }}
+      >
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="w-2 h-2 rounded-full" style={{ background: locked ? "var(--c-danger)" : "var(--c-success)" }} />
+          <span className="text-[13px] font-extrabold text-ink-900">
+            {locked ? "잠긴 계정" : "정상"}
+          </span>
+          <span className="text-[11.5px] text-ink-500">
+            로그인 실패 {fails} / 5회
+            {locked && user.lockedAt && ` · ${new Date(user.lockedAt).toLocaleString("ko-KR")} 잠김`}
+          </span>
+          {locked && (
+            <button
+              type="button"
+              className="btn-ghost btn-xs ml-auto"
+              onClick={unlock}
+              disabled={busy}
+            >
+              잠금 해제
+            </button>
+          )}
+        </div>
+        <div className="text-[11px] text-ink-500 mt-1.5 leading-relaxed">
+          비밀번호 5회 연속 오류 시 자동 잠금됩니다. 관리자가 명시적으로 해제할 때까지 로그인이 차단돼요.
+        </div>
+      </div>
+
+      {/* 비밀번호 재설정 */}
+      <form onSubmit={resetPassword} className="rounded-lg p-3.5 border" style={{ borderColor: "var(--c-border)" }}>
+        <div className="text-[13px] font-extrabold text-ink-900 mb-2.5">비밀번호 재설정</div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <input
+            type="password"
+            className="input"
+            placeholder="새 비밀번호 (8자 이상)"
+            value={pw1}
+            onChange={(e) => setPw1(e.target.value)}
+            minLength={8}
+            maxLength={128}
+            autoComplete="new-password"
+          />
+          <input
+            type="password"
+            className="input"
+            placeholder="새 비밀번호 확인"
+            value={pw2}
+            onChange={(e) => setPw2(e.target.value)}
+            minLength={8}
+            maxLength={128}
+            autoComplete="new-password"
+          />
+        </div>
+        <div className="flex items-center gap-2 mt-2">
+          <div className="text-[11px] text-ink-500 flex-1 leading-relaxed">
+            저장 시 잠금 상태도 함께 해제됩니다. 사용자에게는 안전한 채널(사내톡 DM 등)로만 전달하세요.
+          </div>
+          <button type="submit" className="btn-primary btn-xs" disabled={busy || !pw1 || pw1 !== pw2}>
+            변경
+          </button>
+        </div>
+      </form>
+    </div>
+  );
 }

--- a/server/prisma/migrations/20260505000000_account_lockout/migration.sql
+++ b/server/prisma/migrations/20260505000000_account_lockout/migration.sql
@@ -1,0 +1,6 @@
+-- 로그인 실패 카운터 + 계정 잠금 시각.
+-- failedLoginCount 가 5 에 도달하면 lockedAt 설정 → 다음 로그인부터 401 ACCOUNT_LOCKED.
+-- 관리자가 명시적으로 잠금 해제하기 전엔 풀리지 않음 (시간 기반 자동해제 X — 위 UX 안전).
+ALTER TABLE "User"
+  ADD COLUMN "failedLoginCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "lockedAt" TIMESTAMP(3);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -61,6 +61,9 @@ model User {
   presenceStatus     String?
   presenceMessage    String?
   presenceUpdatedAt  DateTime?
+  // 로그인 실패 누적 — 5회 도달 시 lockedAt 설정 → 관리자가 명시적으로 풀어주기 전엔 로그인 거부.
+  failedLoginCount   Int       @default(0)
+  lockedAt           DateTime?
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -101,6 +101,8 @@ const HR_SELECT = {
   autoClockOutTime: true,
   workStartTime: true,
   workEndTime: true,
+  failedLoginCount: true,
+  lockedAt: true,
 } as const;
 
 router.get("/users", async (req, res) => {
@@ -408,6 +410,40 @@ router.post("/users/:id/resign", async (req, res) => {
  * 퇴사 취소(복직) — 실수로 퇴사 처리한 경우를 되돌리기 위함.
  * 동일하게 관리자 비밀번호 재확인 필요.
  */
+/** 잠긴 계정 해제 — failedLoginCount 0, lockedAt null. ADMIN 권한 필요. */
+router.post("/users/:id/unlock", async (req, res) => {
+  const u = (req as any).user;
+  const target = await prisma.user.findUnique({ where: { id: req.params.id }, select: { id: true, email: true, lockedAt: true, superAdmin: true } });
+  if (!target) return res.status(404).json({ error: "not found" });
+  if (target.superAdmin && !u.superAdmin) return res.status(404).json({ error: "not found" });
+  await prisma.user.update({
+    where: { id: target.id },
+    data: { failedLoginCount: 0, lockedAt: null },
+  });
+  await evictUserCache(target.id);
+  await writeLog(u.id, "USER_UNLOCK", target.id, target.email, req.ip);
+  res.json({ ok: true });
+});
+
+/** 관리자가 유저 비밀번호를 직접 설정. 기존 console 명령은 임시 비번 생성이고, 이건 명시 비번 입력. */
+router.post("/users/:id/reset-password", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = z.object({ newPassword: z.string().min(8).max(128) }).safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "비밀번호는 8자 이상이어야 합니다" });
+  const target = await prisma.user.findUnique({ where: { id: req.params.id }, select: { id: true, email: true, superAdmin: true } });
+  if (!target) return res.status(404).json({ error: "not found" });
+  if (target.superAdmin && !u.superAdmin) return res.status(404).json({ error: "not found" });
+  const passwordHash = await bcrypt.hash(parsed.data.newPassword, 12);
+  await prisma.user.update({
+    where: { id: target.id },
+    // 비밀번호를 새로 설정했으면 잠김도 같이 풀어주는 게 자연스러움.
+    data: { passwordHash, failedLoginCount: 0, lockedAt: null },
+  });
+  await evictUserCache(target.id);
+  await writeLog(u.id, "USER_PW_RESET", target.id, target.email, req.ip);
+  res.json({ ok: true });
+});
+
 router.post("/users/:id/unresign", async (req, res) => {
   const u = (req as any).user;
   const parsed = z.object({ password: z.string().min(1).max(128) }).safeParse(req.body);

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -53,8 +53,46 @@ router.post("/login", async (req, res) => {
 
   const user = await prisma.user.findUnique({ where: { email } });
   if (!user || !user.active) return res.status(401).json({ error: "잘못된 이메일 또는 비밀번호" });
+
+  // 잠금된 계정 — 관리자가 풀어주기 전엔 무조건 거부. 비밀번호 비교까지 가지 않음.
+  if (user.lockedAt) {
+    await writeLog(user.id, "LOGIN_BLOCKED", user.email, "account locked", req.ip);
+    return res.status(401).json({
+      error: "계정이 잠겨있습니다. 관리자에게 문의해 주세요.",
+      code: "ACCOUNT_LOCKED",
+    });
+  }
+
   const ok = await bcrypt.compare(password, user.passwordHash);
-  if (!ok) return res.status(401).json({ error: "잘못된 이메일 또는 비밀번호" });
+  if (!ok) {
+    // 실패 카운터 증가. 5 회 누적 시 잠금.
+    const nextCount = (user.failedLoginCount ?? 0) + 1;
+    const shouldLock = nextCount >= 5;
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { failedLoginCount: nextCount, ...(shouldLock ? { lockedAt: new Date() } : {}) },
+    });
+    if (shouldLock) {
+      await writeLog(user.id, "LOGIN_LOCKED", user.email, `fails=${nextCount}`, req.ip);
+      return res.status(401).json({
+        error: "비밀번호 5회 오류로 계정이 잠겼습니다. 관리자에게 문의해 주세요.",
+        code: "ACCOUNT_LOCKED",
+      });
+    }
+    await writeLog(user.id, "LOGIN_FAIL", user.email, `fails=${nextCount}/5`, req.ip);
+    const remaining = 5 - nextCount;
+    return res.status(401).json({
+      error: `잘못된 이메일 또는 비밀번호 (남은 시도: ${remaining}회)`,
+    });
+  }
+
+  // 성공 시 카운터 리셋.
+  if ((user.failedLoginCount ?? 0) > 0) {
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { failedLoginCount: 0 },
+    });
+  }
 
   const sid = await createSession(user.id, req);
   const token = signToken({ id: user.id, role: user.role, name: user.name, email: user.email }, sid);


### PR DESCRIPTION
## 증상
**account lockout + admin password reset**

보안 취약점을 점검하고 보완합니다.

## 원인
제목·커밋 메시지 기준 자동 정리(상세 원인은 커밋 메시지 본문 참조).

## 수정
**작업 항목 (커밋 단위)**
- feat(security): account lockout after 5 fails + admin password reset

**변경 대상 (5개 파일)**
- `client/src/pages/AdminPage.tsx`
- `server/prisma/migrations/20260505000000_account_lockout/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/routes/admin.ts`
- `server/src/routes/auth.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #116** ↔ **이슈 #540** 로 연결됩니다.

Closes #540
