### PR TITLE
🔀 :: (#549) wrap members instead of single nowrap row

### DIFF
--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -595,11 +595,13 @@ function TreeStyles() {
       .org-vtree-members {
         display: flex;
         justify-content: center;
-        gap: 16px;
-        flex-wrap: nowrap;
+        gap: 12px 16px;
+        /* 인원 많은 직급(사원 등)이 한 줄에 늘어져 가로 스크롤만 강요하던 문제 — 다음 줄로 wrap. */
+        flex-wrap: wrap;
+        max-width: min(100%, 1200px);
+        margin: 2px auto 0;
         position: relative;
         padding-top: 18px;
-        margin-top: 2px;
       }
       /* Level 노드에서 내려가는 세로선 */
       .org-vtree-members::after {


### PR DESCRIPTION
## 증상
**wrap members instead of single nowrap row**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
제목·커밋 메시지 기준 자동 정리(상세 원인은 커밋 메시지 본문 참조).

## 수정
**작업 항목 (커밋 단위)**
- fix(orgchart): wrap members onto multiple rows when team is large

**변경 대상 (1개 파일)**
- `client/src/pages/OrgChartPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #125** ↔ **이슈 #549** 로 연결됩니다.

Closes #549
