### PR TITLE
🔀 :: (#559) SSRF / path traversal / 첨부 URL XSS 차단 (HIGH 6건)

### DIFF
--- a/client/src/components/MeetingAttachments.tsx
+++ b/client/src/components/MeetingAttachments.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync, alertAsync } from "./ConfirmHost";
+import { safeAttachmentUrl } from "../lib/safeUrl";
 
 /**
  * 회의록 본문 아래에 떠있는 첨부 섹션 — 파일(이미지/영상/문서) + 외부 링크 모두 한 곳에서 관리.
@@ -246,22 +247,34 @@ export default function MeetingAttachments({
           {attachments.map((att) => {
             const isLink = att.kind === "LINK";
             const display = isLink ? att.name : att.name;
+            // 과거 데이터/혹시 모를 새 입력에 대비해 한 번 더 검증.
+            // 검증 실패 시 링크 없이 텍스트만 렌더(클릭 불가).
+            const safeHref = safeAttachmentUrl(att.url, att.kind);
             return (
               <li key={att.id} className="flex items-center gap-3 px-4 py-2.5 hover:bg-ink-25 transition group">
                 <span className="text-[18px] flex-shrink-0 grid place-items-center w-8 h-8 rounded-md" style={{ background: "var(--c-surface-3)" }}>
                   {kindIcon(att.kind, att.mimeType)}
                 </span>
                 <div className="flex-1 min-w-0">
-                  <a
-                    href={att.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    {...(isLink ? {} : { download: att.name })}
-                    className="text-[13px] font-semibold text-ink-900 hover:text-brand-600 truncate block"
-                    title={isLink ? att.url : att.name}
-                  >
-                    {display}
-                  </a>
+                  {safeHref ? (
+                    <a
+                      href={safeHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      {...(isLink ? {} : { download: att.name })}
+                      className="text-[13px] font-semibold text-ink-900 hover:text-brand-600 truncate block"
+                      title={isLink ? safeHref : att.name}
+                    >
+                      {display}
+                    </a>
+                  ) : (
+                    <span
+                      className="text-[13px] font-semibold text-ink-400 truncate block"
+                      title="유효하지 않은 첨부 URL"
+                    >
+                      {display}
+                    </span>
+                  )}
                   <div className="text-[11px] text-ink-500 truncate">
                     {isLink ? (
                       <span className="text-ink-500" title={att.url}>{att.url}</span>

--- a/client/src/components/ProjectQaList.tsx
+++ b/client/src/components/ProjectQaList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api, apiSWR } from "../api";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
 import DatePicker from "./DatePicker";
+import { safeAttachmentUrl } from "../lib/safeUrl";
 
 type Status = "BUG" | "IN_PROGRESS" | "NEEDS_FIX" | "NEEDS_TEST" | "DONE" | "ON_HOLD";
 type Priority = "LOW" | "NORMAL" | "HIGH";
@@ -1321,12 +1322,23 @@ function AttachmentThumb({
   onRemove?: () => void;
 }) {
   const box = "relative group/thumb rounded-lg overflow-hidden border border-ink-100 bg-ink-25";
+  // 첨부 url 은 서버 스키마에서 /uploads/… 만 허용하지만, 과거 데이터/혹시 모를 우회에 대비해
+  // 렌더 직전에 다시 한 번 검증. 검증 실패 시 href/src 를 안 박는다.
+  const safeHref = safeAttachmentUrl(att.url, att.kind);
   if (att.kind === "IMAGE") {
+    if (!safeHref) {
+      return (
+        <div className={box} style={{ width: 112, height: 112 }} title="유효하지 않은 첨부">
+          <div className="w-full h-full grid place-items-center text-ink-400 text-[11px]">⚠️ invalid</div>
+          {onRemove && <RemoveDot onRemove={onRemove} />}
+        </div>
+      );
+    }
     return (
       <div className={box} style={{ width: 112, height: 112 }}>
-        <a href={att.url} target="_blank" rel="noreferrer" title={att.name}>
+        <a href={safeHref} target="_blank" rel="noreferrer" title={att.name}>
           <img
-            src={att.url}
+            src={safeHref}
             alt={att.name}
             className="w-full h-full object-cover"
             loading="lazy"
@@ -1337,10 +1349,18 @@ function AttachmentThumb({
     );
   }
   if (att.kind === "VIDEO") {
+    if (!safeHref) {
+      return (
+        <div className={box} style={{ width: 180, height: 112 }} title="유효하지 않은 첨부">
+          <div className="w-full h-full grid place-items-center text-ink-400 text-[11px]">⚠️ invalid</div>
+          {onRemove && <RemoveDot onRemove={onRemove} />}
+        </div>
+      );
+    }
     return (
       <div className={box} style={{ width: 180, height: 112 }}>
         <video
-          src={att.url}
+          src={safeHref}
           className="w-full h-full object-cover"
           controls
           preload="metadata"
@@ -1355,15 +1375,19 @@ function AttachmentThumb({
       style={{ maxWidth: 240 }}
     >
       <span>📎</span>
-      <a
-        href={att.url}
-        target="_blank"
-        rel="noreferrer"
-        className="truncate text-ink-700 hover:underline"
-        title={att.name}
-      >
-        {att.name}
-      </a>
+      {safeHref ? (
+        <a
+          href={safeHref}
+          target="_blank"
+          rel="noreferrer"
+          className="truncate text-ink-700 hover:underline"
+          title={att.name}
+        >
+          {att.name}
+        </a>
+      ) : (
+        <span className="truncate text-ink-400" title="유효하지 않은 첨부 URL">{att.name}</span>
+      )}
       <span className="text-ink-400">{humanSize(att.sizeBytes)}</span>
       {onRemove && <RemoveDot onRemove={onRemove} />}
     </div>

--- a/client/src/lib/safeUrl.ts
+++ b/client/src/lib/safeUrl.ts
@@ -1,0 +1,33 @@
+/**
+ * 사용자가 업로드한 파일/이미지/영상의 url 을 React `href`/`src` 에 그대로 박기 전
+ * 한 번 더 검증한다. 서버 Zod 스키마에서 이미 막지만, 과거 데이터가 javascript:/data:
+ * 스킴으로 들어와 있을 수 있고, 새 코드가 또 다른 사용자 입력을 href 에 쓰는 일이
+ * 잦아 클라이언트에도 같은 정책을 박아둔다.
+ *
+ * 정책:
+ *   FILE/IMAGE/VIDEO 첨부 → "/uploads/[A-Za-z0-9._-]+"  만 허용
+ *   LINK 외부 링크          → http(s)://… 만 허용
+ *
+ * 어느 것에도 해당하지 않으면 null 반환 — 호출부는 링크 없는 텍스트로 fallback.
+ */
+
+const UPLOAD_RE = /^\/uploads\/[A-Za-z0-9._-]+$/;
+const HTTP_RE = /^https?:\/\//i;
+
+export function safeUploadUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return UPLOAD_RE.test(url) ? url : null;
+}
+
+export function safeExternalUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return HTTP_RE.test(url) ? url : null;
+}
+
+/** 첨부 종류에 따라 적절한 검증기를 골라준다. */
+export function safeAttachmentUrl(
+  url: string | null | undefined,
+  kind: "FILE" | "IMAGE" | "VIDEO" | "LINK",
+): string | null {
+  return kind === "LINK" ? safeExternalUrl(url) : safeUploadUrl(url);
+}

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -6,6 +6,7 @@ import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
 import ShareLinkModal from "../components/ShareLinkModal";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
+import { safeUploadUrl } from "../lib/safeUrl";
 
 type Folder = {
   id: string;
@@ -1326,11 +1327,21 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                     </div>
                   </td>
                   <td>
-                    {d.fileUrl ? (
-                      <a href={d.fileUrl} target="_blank" rel="noreferrer" className="text-[12px] font-bold text-brand-600 hover:underline tabular">
-                        {d.fileName} <span className="text-ink-400">({humanSize(d.fileSize ?? 0)})</span>
-                      </a>
-                    ) : <span className="text-ink-400 text-[12px]">—</span>}
+                    {(() => {
+                      // 과거 데이터에 javascript:/외부 URL 이 남아있을 수 있어 렌더 직전에 한 번 더 검증.
+                      const safe = safeUploadUrl(d.fileUrl);
+                      if (!d.fileUrl) return <span className="text-ink-400 text-[12px]">—</span>;
+                      if (!safe) return (
+                        <span className="text-[12px] text-ink-400" title="유효하지 않은 파일 URL">
+                          {d.fileName} <span className="text-ink-300">(invalid)</span>
+                        </span>
+                      );
+                      return (
+                        <a href={safe} target="_blank" rel="noreferrer" className="text-[12px] font-bold text-brand-600 hover:underline tabular">
+                          {d.fileName} <span className="text-ink-400">({humanSize(d.fileSize ?? 0)})</span>
+                        </a>
+                      );
+                    })()}
                   </td>
                   <td>
                     <div className="flex items-center gap-2">

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -348,11 +348,14 @@ router.delete("/folders/:id", async (req, res) => {
 });
 
 /* ===== 문서 ===== */
+// fileUrl 은 반드시 우리 업로드 경로 형식이어야 함 — javascript:, data:, 외부 URL,
+// 그리고 path traversal(../) 모두 차단. (chat.ts 와 동일 정책)
+const SAFE_UPLOAD_URL = /^\/uploads\/[A-Za-z0-9._-]+$/;
 const docSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
   folderId: z.string().max(64).optional().nullable(),
-  fileUrl: z.string().max(2000).optional(),
+  fileUrl: z.string().regex(SAFE_UPLOAD_URL).max(2000).optional(),
   fileName: z.string().max(255).optional(),
   fileType: z.string().max(80).optional(),
   // 업로드 크기는 upload 라우트에서 파일 용량 체크로 방어하고, 여기서는 int 한도만.
@@ -676,16 +679,24 @@ router.delete("/:id", async (req, res) => {
  * 폴더 자체를 못 보면 애초에 이 엔드포인트로 접근 불가.
  */
 
-/** 저장소/디스크 어디든 해당 파일의 Buffer 를 꺼낸다. 없으면 null. */
+/** 저장소/디스크 어디든 해당 파일의 Buffer 를 꺼낸다. 없으면 null.
+ *  path traversal 2차 방어 — key 가 안전한 charset 이 아니거나 resolve 결과가
+ *  UPLOAD_DIR 바깥이면 거부. (1차 방어는 docSchema.fileUrl regex.) */
 async function fetchFileBuffer(key: string): Promise<Buffer | null> {
+  if (!/^[A-Za-z0-9._-]+$/.test(key)) return null;
   if (isStorageEnabled()) {
     const f = await downloadFile(key);
     if (f) return f.buffer;
   }
   // 디스크 fallback (dev / legacy)
   const diskPath = path.join(UPLOAD_DIR, key);
-  if (fs.existsSync(diskPath)) {
-    return fs.promises.readFile(diskPath);
+  const resolved = path.resolve(diskPath);
+  const uploadDirResolved = path.resolve(UPLOAD_DIR);
+  if (!resolved.startsWith(uploadDirResolved + path.sep) && resolved !== uploadDirResolved) {
+    return null;
+  }
+  if (fs.existsSync(resolved)) {
+    return fs.promises.readFile(resolved);
   }
   return null;
 }

--- a/server/src/routes/folderShareLink.ts
+++ b/server/src/routes/folderShareLink.ts
@@ -197,12 +197,20 @@ export async function streamFolderZip(
 }
 
 async function readFileKey(key: string): Promise<Buffer | null> {
+  // path traversal 2차 방어 — key 가 안전한 charset 이 아니거나
+  // resolve 결과가 UPLOAD_DIR 바깥이면 거부. (1차 방어는 docSchema.fileUrl regex.)
+  if (!/^[A-Za-z0-9._-]+$/.test(key)) return null;
   if (isStorageEnabled()) {
     const f = await downloadFile(key);
     if (f) return f.buffer;
   }
   const diskPath = path.join(UPLOAD_DIR, key);
-  if (fs.existsSync(diskPath)) return fs.promises.readFile(diskPath);
+  const resolved = path.resolve(diskPath);
+  const uploadDirResolved = path.resolve(UPLOAD_DIR);
+  if (!resolved.startsWith(uploadDirResolved + path.sep) && resolved !== uploadDirResolved) {
+    return null;
+  }
+  if (fs.existsSync(resolved)) return fs.promises.readFile(resolved);
   return null;
 }
 

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -309,9 +309,11 @@ router.get("/:id", async (req, res) => {
 /* =========================== 첨부 (파일·이미지·영상·링크) =========================== */
 
 const ATTACHMENT_KINDS = ["FILE", "IMAGE", "VIDEO", "LINK"] as const;
+// 파일 첨부의 url 은 반드시 우리 업로드 경로 — 외부/javascript: 스킴 차단.
+const SAFE_UPLOAD_URL = /^\/uploads\/[A-Za-z0-9._-]+$/;
 const fileAttachmentSchema = z.object({
   kind: z.enum(["FILE", "IMAGE", "VIDEO"]),
-  url: z.string().min(1).max(500),
+  url: z.string().min(1).max(500).regex(SAFE_UPLOAD_URL, { message: "/uploads/ 경로만 가능합니다" }),
   name: z.string().min(1).max(200),
   mimeType: z.string().min(1).max(100),
   sizeBytes: z.number().int().min(0).max(1_000_000_000),

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -385,8 +385,10 @@ router.get("/:id/qa", async (req, res) => {
   });
 });
 
+// QA 첨부 url 은 반드시 우리 업로드 경로 — javascript:, data:, 외부 URL 모두 차단.
+const SAFE_UPLOAD_URL = /^\/uploads\/[A-Za-z0-9._-]+$/;
 const qaAttachmentInput = z.object({
-  url: z.string().min(1).max(500),
+  url: z.string().min(1).max(500).regex(SAFE_UPLOAD_URL, { message: "/uploads/ 경로만 가능합니다" }),
   name: z.string().min(1).max(200),
   mimeType: z.string().min(1).max(100),
   sizeBytes: z.number().int().min(0).max(1_000_000_000),

--- a/server/src/routes/shareLink.ts
+++ b/server/src/routes/shareLink.ts
@@ -235,12 +235,21 @@ pub.post("/:token/download", async (req, res) => {
 });
 
 async function readFile(key: string): Promise<Buffer | null> {
+  // path traversal 2차 방어 — key 는 반드시 안전한 문자만, ../ 같은 게 끼면 거부.
+  // (1차 방어는 docSchema.fileUrl regex; DB 에 과거 데이터가 남아있을 수 있어 여기서 또 막는다.)
+  if (!/^[A-Za-z0-9._-]+$/.test(key)) return null;
   if (isStorageEnabled()) {
     const f = await downloadFile(key);
     if (f) return f.buffer;
   }
   const diskPath = path.join(UPLOAD_DIR, key);
-  if (fs.existsSync(diskPath)) return fs.promises.readFile(diskPath);
+  // 한 번 더: 절대경로 resolve 후 UPLOAD_DIR 밖이면 거부.
+  const resolved = path.resolve(diskPath);
+  const uploadDirResolved = path.resolve(UPLOAD_DIR);
+  if (!resolved.startsWith(uploadDirResolved + path.sep) && resolved !== uploadDirResolved) {
+    return null;
+  }
+  if (fs.existsSync(resolved)) return fs.promises.readFile(resolved);
   return null;
 }
 

--- a/server/src/routes/unfurl.ts
+++ b/server/src/routes/unfurl.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { z } from "zod";
+import { lookup } from "node:dns/promises";
 import { requireAuth } from "../lib/auth.js";
 
 /**
@@ -52,20 +53,64 @@ function cacheSet(k: string, v: Meta) {
   cache.set(k, { data: v, expires: Date.now() + CACHE_TTL_MS });
 }
 
-/** 사설망 / loopback / link-local IP 호스트 차단. DNS resolve 까지 하면 좋지만 일단
- *  hostname 문자열 기반 차단으로도 흔한 SSRF 시도는 막힘. */
+/** 사설망 / loopback / link-local 호스트명 차단(1차).
+ *  실제 SSRF 방어는 아래 isBlockedIp + assertHostSafe 로 DNS resolve 결과까지 검증. */
 function isBlockedHost(hostname: string): boolean {
   const h = hostname.toLowerCase();
   if (h === "localhost" || h.endsWith(".localhost")) return true;
   if (h === "metadata.google.internal") return true; // GCP IMDS
-  if (h === "169.254.169.254") return true; // AWS IMDS v1/v2
-  if (/^127\./.test(h)) return true;
-  if (/^10\./.test(h)) return true;
-  if (/^192\.168\./.test(h)) return true;
-  if (/^172\.(1[6-9]|2\d|3[01])\./.test(h)) return true;
-  if (h === "::1" || h.startsWith("[::1]")) return true;
-  if (/^fc[0-9a-f]{2}:/.test(h) || /^fd[0-9a-f]{2}:/.test(h)) return true; // ULA
+  if (h === "metadata.goog") return true;
   return false;
+}
+
+/** v4 / v6 모두 커버하는 사설·loopback·link-local·ULA·CGNAT 검사.
+ *  Fargate 의 ECS Task Metadata(169.254.170.2), AWS IMDS(169.254.169.254) 모두 link-local 로 잡힘. */
+function isBlockedIp(addr: string, family: 4 | 6): boolean {
+  if (family === 4) {
+    const m = addr.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+    if (!m) return true; // 파싱 실패 → 안전하게 차단
+    const [a, b] = [Number(m[1]), Number(m[2])];
+    if (a === 0) return true; // "this network"
+    if (a === 10) return true; // RFC1918
+    if (a === 127) return true; // loopback
+    if (a === 169 && b === 254) return true; // link-local (IMDS 포함)
+    if (a === 172 && b >= 16 && b <= 31) return true; // RFC1918
+    if (a === 192 && b === 168) return true; // RFC1918
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+    if (a >= 224) return true; // multicast / reserved
+    return false;
+  }
+  // v6
+  const v = addr.toLowerCase();
+  if (v === "::" || v === "::1") return true;
+  if (v.startsWith("fe80:")) return true; // link-local
+  if (/^f[cd][0-9a-f]{2}:/.test(v)) return true; // ULA
+  if (v.startsWith("ff")) return true; // multicast
+  // IPv4-mapped: ::ffff:a.b.c.d → 안쪽 v4 로 재검사
+  const mapped = v.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isBlockedIp(mapped[1], 4);
+  return false;
+}
+
+/** hostname 을 DNS resolve 해서 모든 IP 가 public 인지 검증. 하나라도 사설/loopback 이면 throw. */
+async function assertHostSafe(hostname: string): Promise<void> {
+  if (isBlockedHost(hostname)) throw new Error("host not allowed");
+  // IP 리터럴이면 그 자체로 검사
+  const ipLiteralV4 = /^\d+\.\d+\.\d+\.\d+$/.test(hostname);
+  const ipLiteralV6 = hostname.includes(":");
+  if (ipLiteralV4) {
+    if (isBlockedIp(hostname, 4)) throw new Error("host not allowed");
+    return;
+  }
+  if (ipLiteralV6) {
+    if (isBlockedIp(hostname.replace(/^\[|\]$/g, ""), 6)) throw new Error("host not allowed");
+    return;
+  }
+  const addrs = await lookup(hostname, { all: true });
+  if (!addrs.length) throw new Error("host not allowed");
+  for (const { address, family } of addrs) {
+    if (isBlockedIp(address, family as 4 | 6)) throw new Error("host not allowed");
+  }
 }
 
 const META_RE = /<meta[^>]+>/gi;
@@ -161,7 +206,9 @@ router.post("/", async (req, res) => {
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     return res.status(400).json({ error: "http(s) only" });
   }
-  if (isBlockedHost(url.hostname)) {
+  try {
+    await assertHostSafe(url.hostname);
+  } catch {
     return res.status(400).json({ error: "host not allowed" });
   }
 
@@ -171,15 +218,45 @@ router.post("/", async (req, res) => {
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), 5000);
   try {
-    const r = await fetch(url.toString(), {
-      signal: ac.signal,
-      redirect: "follow",
-      headers: {
-        // 일부 사이트(GitHub, X)는 user-agent 가 비면 차단/404. 일반 브라우저 처럼 위장.
-        "user-agent": "Mozilla/5.0 (compatible; HiNestBot/1.0; +unfurl)",
-        accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-      },
-    });
+    // redirect: "manual" 로 직접 처리 — 매 hop 마다 호스트 재검증해서 SSRF 우회 차단.
+    // 30x → Location 헤더 추출 → 다시 assertHostSafe → 최대 3회.
+    let target = url;
+    let r: Response | null = null;
+    const MAX_HOPS = 3;
+    for (let hop = 0; hop < MAX_HOPS + 1; hop++) {
+      r = await fetch(target.toString(), {
+        signal: ac.signal,
+        redirect: "manual",
+        headers: {
+          // 일부 사이트(GitHub, X)는 user-agent 가 비면 차단/404. 일반 브라우저 처럼 위장.
+          "user-agent": "Mozilla/5.0 (compatible; HiNestBot/1.0; +unfurl)",
+          accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      // 30x 면 Location 따라가기 전에 재검증
+      if (r.status >= 300 && r.status < 400) {
+        const loc = r.headers.get("location");
+        if (!loc) break;
+        let next: URL;
+        try {
+          next = new URL(loc, target);
+        } catch {
+          return res.status(400).json({ error: "bad redirect" });
+        }
+        if (next.protocol !== "http:" && next.protocol !== "https:") {
+          return res.status(400).json({ error: "http(s) only" });
+        }
+        try {
+          await assertHostSafe(next.hostname);
+        } catch {
+          return res.status(400).json({ error: "host not allowed" });
+        }
+        target = next;
+        continue;
+      }
+      break;
+    }
+    if (!r) return res.status(200).json({ url: url.toString() });
     if (!r.ok) {
       return res.status(200).json({ url: url.toString() });
     }
@@ -192,7 +269,7 @@ router.post("/", async (req, res) => {
     const buf = await r.arrayBuffer();
     const limited = buf.byteLength > 1_000_000 ? buf.slice(0, 1_000_000) : buf;
     const html = new TextDecoder("utf-8", { fatal: false }).decode(limited);
-    const meta = extractMeta(html, new URL(r.url));
+    const meta = extractMeta(html, target);
     cacheSet(url.toString(), meta);
     res.json(meta);
   } catch (e: any) {


### PR DESCRIPTION
## 증상
**SSRF / path traversal / 첨부 URL XSS 차단 (HIGH 6건)**

보안 취약점을 점검하고 보완합니다.

## 원인
외부 또는 일반 멤버 권한으로 트리거 가능한 HIGH 6건을 한 번에 막는다.

## 1. SSRF (unfurl)
- `isBlockedHost` 가 호스트명 문자열만 보던 걸 DNS resolve 결과 IP 검사로 교체
- IPv4 사설/loopback/link-local/CGNAT 전부 차단, IPv6 link-local/ULA/IPv4-mapped 포함
- redirect: "follow" → "manual" + 매 hop 마다 호스트 재검증, 최대 3 hop
- Fargate ECS 메타데이터(169.254.170.2) / IMDS(169.254.169.254) 우회 완전 차단

## 2. Path traversal (document fileUrl)
- 서버 docSchema.fileUrl 에 /^\/uploads\/[A-Za-z0-9._-]+$/ regex 강제 (1차 방어)
- shareLink/folderShareLink/document 디스크 싱크 3곳에 charset 화이트리스트 +
  path.resolve 결과가 UPLOAD_DIR 바깥이면 거부 (2차 방어, 과거 데이터 대비)
- 같은 정책을 회의록 file/image/video 첨부, 프로젝트 QA 첨부 스키마에도 적용

## 3. Stored XSS via 첨부 url (javascript: 스킴)
- client/src/lib/safeUrl.ts 신설 — safeUploadUrl / safeExternalUrl / safeAttachmentUrl
- DocumentsPage / ProjectQaList(AttachmentThumb) / MeetingAttachments 세 곳에서
  href·src 바인딩 전에 한 번 더 검증, 실패 시 inert 텍스트로 fallback
- 서버 스키마와 별개로 클라에서도 막아두면 과거 데이터/혹시 모를 새 경로에서 재발 방지

영향 받은 사용자 시나리오: 없음 — 정상 업로드 흐름(/api/upload 응답을 그대로 사용)은
모두 /uploads/<hex>.<ext> 형식이라 새 regex 를 자연스럽게 만족함.

## 수정
**작업 항목 (커밋 단위)**
- security: SSRF / path traversal / 첨부 URL XSS 차단

**변경 대상 (10개 파일)**
- `client/src/components/MeetingAttachments.tsx`
- `client/src/components/ProjectQaList.tsx`
- `client/src/lib/safeUrl.ts`
- `client/src/pages/DocumentsPage.tsx`
- `server/src/routes/document.ts`
- `server/src/routes/folderShareLink.ts`
- `server/src/routes/meeting.ts`
- `server/src/routes/project.ts`
- `server/src/routes/shareLink.ts`
- `server/src/routes/unfurl.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #135** ↔ **이슈 #559** 로 연결됩니다.

Closes #559
