### PR TITLE
🔀 :: (#561) step-up 게이트 / user enumeration / Host header injection / admin 권한 강화 (MEDIUM 8건)

### DIFF
--- a/client/src/components/SuperStepUpGate.tsx
+++ b/client/src/components/SuperStepUpGate.tsx
@@ -115,13 +115,16 @@ export default function SuperStepUpGate({ children }: { children: React.ReactNod
     } finally { setLoading(false); }
   }
 
-  async function submitSetup(next: string, confirm: string) {
+  async function submitSetup(next: string, confirm: string, loginPassword: string) {
     setErr("");
     if (next !== confirm) { setErr("새 비밀번호가 일치하지 않아요"); return; }
     if (next.length < 8) { setErr("8자 이상 입력해 주세요"); return; }
+    if (!loginPassword) { setErr("로그인 비밀번호로 본인 확인이 필요해요"); return; }
     setLoading(true);
     try {
-      await api("/api/auth/super-password", { method: "POST", json: { next } });
+      // 세션 쿠키만 탈취된 공격자가 super 비번을 마음대로 처음 설정하지 못하도록
+      // 로그인 비번을 함께 보내 본인 확인 (서버 정책과 일치).
+      await api("/api/auth/super-password", { method: "POST", json: { next, loginPassword } });
       // 설정 직후 자동으로 step-up 진행 — 사용자 한 번 더 입력 안 해도 되도록.
       const res = await api<{ expiresAt: number }>("/api/auth/step-up", { method: "POST", json: { password: next } });
       setNeedsSetup(false);
@@ -661,28 +664,35 @@ function SuperPwSetupForm({
   loading,
   onCancel,
 }: {
-  onSubmit: (next: string, confirm: string) => void;
+  onSubmit: (next: string, confirm: string, loginPassword: string) => void;
   err: string;
   loading: boolean;
   onCancel: () => void;
 }) {
   const [next, setNext] = useState("");
   const [confirm, setConfirm] = useState("");
+  const [loginPw, setLoginPw] = useState("");
   return (
     <form
-      onSubmit={(e) => { e.preventDefault(); onSubmit(next, confirm); }}
+      onSubmit={(e) => { e.preventDefault(); onSubmit(next, confirm, loginPw); }}
       className="space-y-3"
     >
       <div className="p-3 rounded-md bg-brand-50 border border-brand-100 text-[12px] text-brand-700">
-        개발자 권한이 부여됐어요. 처음 진입이라 <b>개발자 전용 비밀번호</b> 를 설정해 주세요. (8자 이상, 일반 로그인 비밀번호와 달라야 함)
+        개발자 권한이 부여됐어요. 처음 진입이라 <b>개발자 전용 비밀번호</b> 를 설정해 주세요.
+        (8자 이상, 일반 로그인 비밀번호와 달라야 함)
+        <div className="mt-1.5 text-ink-500">본인 확인을 위해 <b>현재 로그인 비밀번호</b> 도 함께 입력해 주세요.</div>
+      </div>
+      <div>
+        <label className="field-label">현재 로그인 비밀번호</label>
+        <input className="input" type="password" autoFocus value={loginPw} onChange={(e) => setLoginPw(e.target.value)} minLength={1} maxLength={128} required autoComplete="current-password" />
       </div>
       <div>
         <label className="field-label">새 개발자 비밀번호</label>
-        <input className="input" type="password" autoFocus value={next} onChange={(e) => setNext(e.target.value)} minLength={8} maxLength={128} required />
+        <input className="input" type="password" value={next} onChange={(e) => setNext(e.target.value)} minLength={8} maxLength={128} required autoComplete="new-password" />
       </div>
       <div>
         <label className="field-label">한 번 더 입력</label>
-        <input className="input" type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} minLength={8} maxLength={128} required />
+        <input className="input" type="password" value={confirm} onChange={(e) => setConfirm(e.target.value)} minLength={8} maxLength={128} required autoComplete="new-password" />
       </div>
       {err && (
         <div className="flex items-start gap-2 p-2.5 rounded-md bg-red-50 border border-red-100 text-[12px] font-semibold text-red-700">
@@ -694,7 +704,7 @@ function SuperPwSetupForm({
       )}
       <div className="flex items-center gap-2 pt-1">
         <button type="button" className="btn-ghost" onClick={onCancel} disabled={loading}>취소</button>
-        <button className="btn-primary btn-lg flex-1" disabled={loading || !next || !confirm}>
+        <button className="btn-primary btn-lg flex-1" disabled={loading || !next || !confirm || !loginPw}>
           {loading ? "설정 중…" : "설정하고 진입"}
         </button>
       </div>

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -466,13 +466,32 @@ router.post("/users/:id/reset-password", async (req, res) => {
   if (!parsed.success) return res.status(400).json({ error: "비밀번호는 8자 이상이어야 합니다" });
   const target = await prisma.user.findUnique({ where: { id: req.params.id }, select: { id: true, email: true, superAdmin: true } });
   if (!target) return res.status(404).json({ error: "not found" });
+  // super-admin 의 비밀번호는 super-admin 끼리만 리셋 가능 — 404 로 위장(존재 노출 X).
   if (target.superAdmin && !u.superAdmin) return res.status(404).json({ error: "not found" });
+  // super-admin 끼리의 비번 리셋(자기 자신 포함)은 step-up 필요. (쿠키 단독 탈취 시
+  // super 비밀번호까지 덮어쓰는 우회 차단.)
+  if (target.superAdmin) {
+    const v = verifySuperToken(req, u.id);
+    if (!v) return res.status(401).json({ error: "step-up 필요", code: "SUPER_STEPUP_REQUIRED" });
+  }
   const passwordHash = await bcrypt.hash(parsed.data.newPassword, 12);
-  await prisma.user.update({
-    where: { id: target.id },
-    // 비밀번호를 새로 설정했으면 잠김도 같이 풀어주는 게 자연스러움.
-    data: { passwordHash, failedLoginCount: 0, lockedAt: null },
+  // 새 비번 발효 + 잠김 해제 + 대상의 모든 활성 세션 revoke (다른 기기 자동 로그아웃).
+  // 이전엔 세션 그대로라 공격자가 ADMIN 의 잔존 세션으로 계속 활동 가능했다.
+  const sessionsToEvict = await prisma.session.findMany({
+    where: { userId: target.id, revokedAt: null },
+    select: { id: true },
   });
+  await prisma.$transaction(async (tx) => {
+    await tx.user.update({
+      where: { id: target.id },
+      data: { passwordHash, failedLoginCount: 0, lockedAt: null },
+    });
+    await tx.session.updateMany({
+      where: { userId: target.id, revokedAt: null },
+      data: { revokedAt: new Date(), revokedById: u.id },
+    });
+  });
+  for (const s of sessionsToEvict) evictSessionCache(s.id);
   await evictUserCache(target.id);
   await writeLog(u.id, "USER_PW_RESET", target.id, target.email, req.ip);
   res.json({ ok: true });
@@ -1277,7 +1296,12 @@ router.get("/logs", requireSuperAdminStepUp, async (req, res) => {
 
 /* ===== 출근 기록 조회 — 특정 유저의 특정 날짜 ===== */
 router.get("/users/:id/attendance", async (req, res) => {
+  const u = (req as any).user;
   const { id } = req.params;
+  // super-admin 의 출근 기록은 super-admin 끼리만 열람 가능 — 다른 관리자에게는
+  // 존재 자체를 숨겨 출근 패턴/근무 시간 노출 차단.
+  const target = await prisma.user.findUnique({ where: { id }, select: { superAdmin: true } });
+  if (target?.superAdmin && !u.superAdmin) return res.status(404).json({ error: "not found" });
   const defaultDate = todayStr();
   const qdate = typeof req.query.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(req.query.date) ? req.query.date : defaultDate;
   const rec = await prisma.attendance.findUnique({
@@ -1290,9 +1314,12 @@ router.get("/users/:id/attendance", async (req, res) => {
 // body: { date?: "YYYY-MM-DD" 생략시 오늘, checkIn?: ISO|null, checkOut?: ISO|null }
 // 문자열 생략 → 미변경, null 명시 → 해당 필드 지움.
 router.patch("/users/:id/attendance", async (req, res) => {
+  const u = (req as any).user;
   const { id } = req.params;
   const user = await prisma.user.findUnique({ where: { id } });
   if (!user) return res.status(404).json({ error: "not found" });
+  // super-admin 의 출퇴근을 일반 관리자가 조작 못 하도록 차단 — 존재 노출 X.
+  if (user.superAdmin && !u.superAdmin) return res.status(404).json({ error: "not found" });
   const body = req.body ?? {};
   const defaultDate = todayStr();
   const date = typeof body.date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(body.date) ? body.date : defaultDate;
@@ -1312,6 +1339,8 @@ router.patch("/users/:id/attendance", async (req, res) => {
     update: data,
     create: { userId: id, date, checkIn: checkIn ?? null, checkOut: checkOut ?? null },
   });
+  // 출근 기록은 임금/평가 근거가 되는 민감 데이터 — 변경 감사 추적 필수.
+  await writeLog(u.id, "ATTENDANCE_EDIT", id, `${date} in=${body.checkIn ?? "·"} out=${body.checkOut ?? "·"}`, req.ip);
   res.json({ attendance: rec });
 });
 

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -14,6 +14,7 @@ import {
   signSuper,
   setSuperCookie,
   clearSuperCookie,
+  clearImpCookie,
   verifySuperToken,
   SUPER_TTL_SEC,
   requireSuperAdminStepUp,
@@ -58,6 +59,13 @@ export async function generateUniqueEmployeeNo(): Promise<string> {
   return `HB${Date.now().toString().slice(-8)}`;
 }
 
+// === User enumeration 방어 ===
+// 로그인 응답 본문은 4가지 분기(존재X / 비활성 / 잠금 / 비번오답) 모두 같은 모양이어야 한다.
+// 이전엔 "남은 시도: N회" 접미사 / ACCOUNT_LOCKED 코드 / 잠금 안내 메시지가 분기마다 달라서
+// 공격자가 응답만 보고 "이 이메일이 가입돼 있나?" 를 100% 판정할 수 있었다.
+// 잠겨있던 본인은 메일로 받은 재설정 링크로 해제할 수 있으니 안내가 없어도 막히지 않는다.
+const GENERIC_LOGIN_ERROR = "잘못된 이메일 또는 비밀번호";
+
 router.post("/login", async (req, res) => {
   const parsed = loginSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
@@ -67,21 +75,19 @@ router.post("/login", async (req, res) => {
 
   // === 타이밍 공격 방어 ===
   // 이메일이 없어도 / 비활성이어도 / 잠겨있어도, 일단 bcrypt.compare 는 항상 한 번 수행.
-  // 그래야 \"가입된 이메일\" 과 \"없는 이메일\" 의 응답 시간 차이가 사라져 이메일 enumeration 불가.
+  // 그래야 "가입된 이메일" 과 "없는 이메일" 의 응답 시간 차이가 사라져 이메일 enumeration 불가.
   // 분기 결과(로그/응답)는 그 후 균일하게 처리.
   const hashToCompare = user?.passwordHash ?? TIMING_DUMMY_HASH;
   const compareOk = await bcrypt.compare(password, hashToCompare);
 
-  // 사용자 부재 / 비활성 / 잠금 — 메시지는 같게(이메일 존재 노출 X). 잠금 케이스만 별도 코드 반환.
+  // 사용자 부재 / 비활성 — 응답은 다른 분기와 같은 모양.
   if (!user || !user.active) {
-    return res.status(401).json({ error: "잘못된 이메일 또는 비밀번호" });
+    return res.status(401).json({ error: GENERIC_LOGIN_ERROR });
   }
+  // 잠금 — 감사 로그는 남기되, 응답 본문은 일반 실패와 동일하게 (enumeration 방어).
   if (user.lockedAt) {
     await writeLog(user.id, "LOGIN_BLOCKED", user.email, "account locked", req.ip);
-    return res.status(401).json({
-      error: "계정이 잠겨있습니다. 관리자에게 문의해 주세요.",
-      code: "ACCOUNT_LOCKED",
-    });
+    return res.status(401).json({ error: GENERIC_LOGIN_ERROR });
   }
 
   const ok = compareOk;
@@ -95,16 +101,11 @@ router.post("/login", async (req, res) => {
     });
     if (shouldLock) {
       await writeLog(user.id, "LOGIN_LOCKED", user.email, `fails=${nextCount}`, req.ip);
-      return res.status(401).json({
-        error: "비밀번호 5회 오류로 계정이 잠겼습니다. 관리자에게 문의해 주세요.",
-        code: "ACCOUNT_LOCKED",
-      });
+    } else {
+      await writeLog(user.id, "LOGIN_FAIL", user.email, `fails=${nextCount}/5`, req.ip);
     }
-    await writeLog(user.id, "LOGIN_FAIL", user.email, `fails=${nextCount}/5`, req.ip);
-    const remaining = 5 - nextCount;
-    return res.status(401).json({
-      error: `잘못된 이메일 또는 비밀번호 (남은 시도: ${remaining}회)`,
-    });
+    // 응답은 일관 — "남은 시도", "잠겼습니다" 등 enumeration 단서가 되는 정보 제거.
+    return res.status(401).json({ error: GENERIC_LOGIN_ERROR });
   }
 
   // 성공 시 카운터 리셋.
@@ -257,6 +258,10 @@ router.post("/logout", requireAuth, async (req, res) => {
   }
   clearAuthCookie(res);
   clearSuperCookie(res);
+  // 임퍼소네이트 쿠키도 함께 클리어 — 같은 브라우저로 다시 로그인했을 때 이전 impersonation
+  // 컨텍스트가 의도치 않게 되살아나는 걸 막는다. 이전엔 clearImpCookie 호출이 빠져서
+  // 1시간 동안 잔류하다 같은 super-admin 로그인 시 자동 재활성화됐었다.
+  clearImpCookie(res);
   res.json({ ok: true });
 });
 
@@ -294,9 +299,11 @@ router.post("/step-up", requireAuth, async (req, res) => {
 });
 
 /* ===== 총관리자 step-up 비밀번호 최초 설정 / 변경 =====
- * - 최초 설정: 본인이 super 권한이고 superPasswordHash 가 null 이면 currentPassword 없이 설정 가능.
- * - 변경: currentPassword(현재 super 비번) 가 일치해야 함.
- * 정책: 8~128자, 본인의 일반 로그인 비밀번호와 다르게 (재사용 방지).
+ * 보안 정책:
+ *   - 최초 설정: 본인의 "일반 로그인 비밀번호" 를 다시 입력해야 함 — 세션 쿠키만 탈취된
+ *     공격자가 step-up 비번을 마음대로 처음 설정하고 그 비번으로 step-up 하는 우회를 차단.
+ *   - 변경: 기존 super 비번 검증.
+ *   - 8~128자, 본인의 일반 로그인 비밀번호와 다르게 (재사용 방지).
  */
 router.post("/super-password", requireAuth, async (req, res) => {
   const u = (req as any).user;
@@ -312,8 +319,8 @@ router.post("/super-password", requireAuth, async (req, res) => {
     return res.status(400).json({ error: "일반 로그인 비밀번호와 달라야 해요" });
   }
 
-  // 변경 모드면 current 검증 — null 이면 \"최초 설정\" 으로 간주.
   if (user.superPasswordHash) {
+    // 변경 모드 — 기존 super 비번으로 본인 확인.
     const rawCur = String(req.body?.current ?? "");
     const current = rawCur.length > 128 ? rawCur.slice(0, 128) : rawCur;
     if (!current) return res.status(400).json({ error: "현재 총관리자 비밀번호가 필요해요" });
@@ -321,6 +328,17 @@ router.post("/super-password", requireAuth, async (req, res) => {
     if (!ok) {
       await writeLog(user.id, "SUPER_PW_CHANGE_FAIL", undefined, undefined, req.ip);
       return res.status(401).json({ error: "현재 총관리자 비밀번호가 일치하지 않아요" });
+    }
+  } else {
+    // 최초 설정 모드 — 세션 쿠키 단독으로 super 비번을 새로 만드는 우회를 막기 위해
+    // "일반 로그인 비밀번호" 를 다시 입력받아 검증한다. (cookie != "본인 확인")
+    const rawLogin = String(req.body?.loginPassword ?? "");
+    const loginPw = rawLogin.length > 128 ? rawLogin.slice(0, 128) : rawLogin;
+    if (!loginPw) return res.status(400).json({ error: "로그인 비밀번호로 본인 확인이 필요해요" });
+    const ok = await bcrypt.compare(loginPw, user.passwordHash);
+    if (!ok) {
+      await writeLog(user.id, "SUPER_PW_SET_FAIL", undefined, "login-pw mismatch", req.ip);
+      return res.status(401).json({ error: "로그인 비밀번호가 일치하지 않아요" });
     }
   }
 
@@ -449,10 +467,22 @@ function hashToken(token: string) {
   return crypto.createHash("sha256").update(token).digest("hex");
 }
 
+/**
+ * 비밀번호 재설정 메일에 들어가는 base URL.
+ *
+ * 보안:
+ *   프로덕션에서는 반드시 환경변수 PUBLIC_APP_URL 을 사용한다. 요청 Host 헤더 fallback 을
+ *   허용하면 공격자가 password-reset/request 호출 시 Host: attacker.example 로 위장해
+ *   피해자에게 자기 도메인이 박힌 리셋 링크를 메일로 보내게 만들 수 있다 (Host header injection).
+ *
+ *   - NODE_ENV === "production" 이고 PUBLIC_APP_URL 이 없으면 안전하게 default 운영 도메인 사용.
+ *   - 개발 환경에서만 Host 헤더 fallback 허용.
+ */
+const PROD_DEFAULT_APP_URL = "https://nest.hi-vits.com";
 function appBaseUrl(req: { headers: { host?: string }; protocol?: string }) {
-  // 프로덕션 도메인은 PUBLIC_APP_URL 로 명시. 미설정 시 요청 호스트 fallback (개발 편의).
   const fromEnv = process.env.PUBLIC_APP_URL?.replace(/\/$/, "");
   if (fromEnv) return fromEnv;
+  if (process.env.NODE_ENV === "production") return PROD_DEFAULT_APP_URL;
   const host = req.headers?.host ?? "localhost:5173";
   const proto = host.startsWith("localhost") ? "http" : "https";
   return `${proto}://${host}`;
@@ -560,7 +590,12 @@ router.post("/password-reset/confirm", async (req, res) => {
 
   const passwordHash = await bcrypt.hash(newPassword, 12);
 
-  // 트랜잭션: 비밀번호 교체 + 잠금 해제 + 모든 세션 revoke + 토큰 사용 처리 + 같은 유저 다른 미사용 토큰 무효화
+  // 트랜잭션: 비밀번호 교체 + 잠금 해제 + 모든 세션 revoke + 토큰 사용 처리 + 같은 유저 다른 미사용 토큰 무효화.
+  // revoke 대상 세션 id 를 미리 수집해서 트랜잭션 후에 캐시 evict 까지 묶는다.
+  const sessionsToEvict = await prisma.session.findMany({
+    where: { userId: row.userId, revokedAt: null },
+    select: { id: true },
+  });
   await prisma.$transaction(async (tx) => {
     await tx.user.update({
       where: { id: row.userId },
@@ -580,10 +615,9 @@ router.post("/password-reset/confirm", async (req, res) => {
     });
   });
 
-  // 캐시된 세션 revoke 상태 즉시 반영 — 다른 기기에서 다음 요청에 401.
-  // (Session 모델의 revokedAt 을 _sessionCache 가 30초 캐싱하지만 evictSessionCache 로 즉시 무효화.)
-  // ※ 모든 세션을 일일이 evict 하긴 비싸므로, 캐시는 TTL 만 신뢰. 30초 이내 잔존 세션이 있을 수 있음 — 허용 범위.
-  // (필요시 evictSessionCache 를 모든 sessionId 에 대해 호출하도록 확장.)
+  // 캐시 evict — _sessionCache 30초 TTL 동안 공격자 세션이 통과하던 잔류 윈도우 제거.
+  // 사용자가 비번 재설정으로 공격자를 끊어내려는 시나리오에선 이 30초가 치명적이라 즉시 무효화.
+  for (const s of sessionsToEvict) evictSessionCache(s.id);
 
   await writeLog(row.userId, "PWD_RESET_CONFIRM", row.user.email, undefined, req.ip);
 
@@ -603,7 +637,5 @@ function escapeAttr(s: string) {
   return escapeHtml(s);
 }
 
-// evictSessionCache 가 import 만 되고 미사용 시 lint 경고 — 향후 확장 자리표시.
-void evictSessionCache;
 
 export default router;

--- a/server/src/routes/passkey.ts
+++ b/server/src/routes/passkey.ts
@@ -79,13 +79,13 @@ function fromB64Url(s: string) {
 }
 
 /* ================ 등록(registration) ================
- * - 본인 확인된(step-up 완료) 사용자만 새 패스키 등록 가능
- * - 총관리자든 일반 사용자든 본인 계정에 추가
+ * 정책 (보안 우선):
+ *   - 패스키 = step-up 인증 자격증 자체이므로, 새 패스키를 추가하려면 반드시 step-up 완료 상태여야 한다.
+ *   - 세션 쿠키만 탈취된 공격자가 자기 기기 패스키를 등록 → 영구 super 접근을 얻는 시나리오 차단.
+ *   - 현재 UI 도 SuperStepUpGate 안에서만 등록을 트리거하므로 UX 영향 없음.
  */
-router.post("/register/options", requireAuth, async (req, res) => {
+router.post("/register/options", requireAuth, requireSuperAdminStepUp, async (req, res) => {
   const u = (req as any).user;
-  // 총관리자가 새 기기 등록하려면 우선 비번 step-up 필요 (관리자 페이지에서만 표시)
-  // requireSuperAdminStepUp 는 총관리자 전용이라, 여기선 일반 유저도 등록 가능하게 allow
   const user = await prisma.user.findUnique({ where: { id: u.id } });
   if (!user) return res.status(404).json({ error: "not found" });
 
@@ -113,7 +113,7 @@ router.post("/register/options", requireAuth, async (req, res) => {
   res.json(options);
 });
 
-router.post("/register/verify", requireAuth, async (req, res) => {
+router.post("/register/verify", requireAuth, requireSuperAdminStepUp, async (req, res) => {
   const u = (req as any).user;
   const expected = takeChallenge(u.id, "register");
   if (!expected) return res.status(400).json({ error: "챌린지가 만료되었어요. 다시 시도해주세요." });


### PR DESCRIPTION
## 증상
**step-up 게이트 / user enumeration / Host header injection / admin 권한 강화 (MEDIUM 8건)**

보안 취약점을 점검하고 보완합니다.

## 원인
## 1. Login user enumeration 차단 (MEDIUM)
응답 본문 4가지 분기 모두 동일 메시지("잘못된 이메일 또는 비밀번호") 로 통일.
"남은 시도: N회" / ACCOUNT_LOCKED 코드 / 잠금 안내 메시지가 분기마다 달라
응답만으로 가입 여부 100% 판정 가능했던 문제 해결. 잠긴 본인은 footer
"비밀번호 찾기" 링크로 메일 받아 해제 가능.

## 2. super-password 최초 설정 우회 차단 (MEDIUM)
super 비번이 아직 없을 때 currentPassword 없이 통과해서 — 세션 쿠키만 탈취된
공격자가 step-up 비번을 마음대로 설정 → 그 비번으로 step-up → 영구 super 접근
가능했다. 최초 설정 모드에서도 일반 로그인 비밀번호로 본인 확인 강제.
클라이언트 SuperPwSetupForm 에 로그인 비밀번호 입력 필드 추가.

## 3. logout 시 imp 쿠키 클리어 (MEDIUM)
이전 impersonation 컨텍스트가 1시간 잔류하다 다음 같은 super-admin
로그인 시 자동 재활성화되는 시나리오 차단.

## 4. 비번 재설정 시 세션 캐시 즉시 evict (MEDIUM)
public password-reset/confirm 트랜잭션 후 _sessionCache 의 30초 TTL 동안
revoke 된 공격자 세션이 통과하던 잔류 윈도우 제거. evictSessionCache 를
revoke 대상 세션 id 마다 호출.

## 5. 패스키 등록에 step-up 강제 (MEDIUM)
/api/passkey/register/options + verify 에 requireSuperAdminStepUp 추가.
세션 쿠키만 탈취된 공격자가 자기 기기 패스키를 등록 → 영구 super 접근을
얻는 시나리오 차단. UI 가 이미 SuperStepUpGate 내에서만 트리거하므로

## 수정
**작업 항목 (커밋 단위)**
- security: step-up 게이트 / user enumeration / 호스트 헤더 인젝션 / admin 권한 강화

**변경 대상 (4개 파일)**
- `client/src/components/SuperStepUpGate.tsx`
- `server/src/routes/admin.ts`
- `server/src/routes/auth.ts`
- `server/src/routes/passkey.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #137** ↔ **이슈 #561** 로 연결됩니다.

Closes #561
