### PR TITLE
🔀 :: (#562) CloudWatch 보존/access log 다이어트 + 클라 백그라운드 폴링 정지

### DIFF
--- a/.github/workflows/cost-log-retention.yml
+++ b/.github/workflows/cost-log-retention.yml
@@ -1,0 +1,81 @@
+# CloudWatch Log Groups 보존 기간 표준화 — 비용 절감.
+#
+# 무엇이 문제였나:
+#   ECS Fargate 가 자동으로 만드는 로그 그룹들은 retention = "Never expire" 기본값이라
+#   영구 보관된다. ingestion 은 USD/GB(가장 큰 비용), 저장은 USD/GB-month 로 매월 누적.
+#
+# 정책:
+#   - 운영 서버 / ECS exec 컨텍스트 : 30 일
+#   - 일회성 진단/마이그레이션 (`/ecs/onetime-*`)  :  7 일
+#
+# 운영:
+#   gh workflow run cost-log-retention.yml — 멱등. 이미 같은 retention 이면 noop.
+#   새 로그 그룹이 생기면 다시 한 번 실행하면 됨.
+name: Cost — CloudWatch log retention
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 매주 월요일 KST 09:00 (UTC 00:00) — 새로 생긴 log group 도 자동으로 잡아준다.
+    - cron: "0 0 * * 1"
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::149536482210:role/github-deploy-hinest
+          role-session-name: gha-log-retention-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set retention 30d on long-lived ECS / app log groups
+        run: |
+          set -e
+          echo "운영 로그 그룹 — 30일"
+          aws logs describe-log-groups --region "$AWS_REGION" \
+            --query 'logGroups[?starts_with(logGroupName, `/ecs/hinest`) || starts_with(logGroupName, `/aws/ecs/hinest`)].logGroupName' \
+            --output text | tr '\t' '\n' | while read -r g; do
+              [ -z "$g" ] && continue
+              CURRENT=$(aws logs describe-log-groups --log-group-name-prefix "$g" --region "$AWS_REGION" \
+                --query "logGroups[?logGroupName=='$g'].retentionInDays | [0]" --output text)
+              if [ "$CURRENT" = "30" ]; then
+                echo "  $g (이미 30일)"
+              else
+                echo "  $g  ← 설정"
+                aws logs put-retention-policy --log-group-name "$g" --retention-in-days 30 --region "$AWS_REGION"
+              fi
+            done
+
+      - name: Set retention 7d on one-off / diag log groups
+        run: |
+          set -e
+          echo "일회성 로그 그룹 — 7일"
+          aws logs describe-log-groups --region "$AWS_REGION" \
+            --query 'logGroups[?starts_with(logGroupName, `/ecs/onetime`) || contains(logGroupName, `seed`) || contains(logGroupName, `diag`)].logGroupName' \
+            --output text | tr '\t' '\n' | while read -r g; do
+              [ -z "$g" ] && continue
+              CURRENT=$(aws logs describe-log-groups --log-group-name-prefix "$g" --region "$AWS_REGION" \
+                --query "logGroups[?logGroupName=='$g'].retentionInDays | [0]" --output text)
+              if [ "$CURRENT" = "7" ]; then
+                echo "  $g (이미 7일)"
+              else
+                echo "  $g  ← 설정"
+                aws logs put-retention-policy --log-group-name "$g" --retention-in-days 7 --region "$AWS_REGION"
+              fi
+            done
+
+      - name: Summary — 보존 기간 미설정 그룹 확인
+        run: |
+          echo ""
+          echo "=== 'Never expire' 상태로 남아있는 로그 그룹 (있다면 확인 필요) ==="
+          aws logs describe-log-groups --region "$AWS_REGION" \
+            --query 'logGroups[?!not_null(retentionInDays)].logGroupName' --output text | tr '\t' '\n'

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -114,8 +114,18 @@ export default function ChatMiniApp({
       } catch {}
     };
     fetchPresence();
-    const t = setInterval(fetchPresence, 30_000);
-    return () => { cancelled = true; clearInterval(t); };
+    // presence 는 사이드패널이 열려 있을 때만 polling. 탭 hidden 이면 polling 중단해서
+    // 백그라운드 탭 다수 운영 시 서버 RPS 누적을 막는다 (SSE 가 실시간 이벤트는 별도 채널).
+    let t: number | null = null;
+    function start() { if (t === null) t = window.setInterval(fetchPresence, 30_000); }
+    function stop() { if (t !== null) { window.clearInterval(t); t = null; } }
+    if (document.visibilityState === "visible") start();
+    function onVis() {
+      if (document.visibilityState === "visible") { fetchPresence(); start(); }
+      else { stop(); }
+    }
+    document.addEventListener("visibilitychange", onVis);
+    return () => { cancelled = true; stop(); document.removeEventListener("visibilitychange", onVis); };
   }, [isPanelOpen]);
 
   const patchRoomSetting = (roomId: string, patch: { nickname?: string; muted?: boolean }) => {

--- a/client/src/lib/useApprovalCounts.ts
+++ b/client/src/lib/useApprovalCounts.ts
@@ -3,29 +3,44 @@ import { api } from "../api";
 
 /**
  * 결재 대기 / 내 미결 개수 — 사이드바 배지 + 탭 표시용.
- * - 30초 폴링 + 탭 가시성 복귀 시 즉시 새로고침.
- * - 다른 페이지에서 결재 처리 후 즉시 반영하려면 \`window.dispatchEvent(new Event("hinest:approvalCountsRefresh"))\`.
+ *
+ * 비용 절감:
+ *   - 폴링 주기 15초 → 60초. 사내 결재는 분 단위 SLA 가 충분.
+ *   - 탭이 hidden 인 동안은 폴링 정지(setInterval clear). 다시 visible 이 되면 즉시 한 번 load 하고
+ *     interval 재무장. 백그라운드 탭 수십 개에서 매분 4회씩 누적되던 요청을 0회로.
+ *   - 결재 화면이 처리 직후 dispatch 하는 hinest:approvalCountsRefresh 이벤트는 그대로 사용.
  */
 export function useApprovalCounts() {
   const [counts, setCounts] = useState<{ pending: number; mine: number }>({ pending: 0, mine: 0 });
 
   useEffect(() => {
     let alive = true;
+    let timer: number | null = null;
     async function load() {
       try {
         const r = await api<{ pending: number; mine: number }>("/api/approval/counts");
         if (alive) setCounts(r);
       } catch { /* 401 등은 무시 */ }
     }
+    function startTimer() {
+      if (timer !== null) return;
+      timer = window.setInterval(load, 60_000);
+    }
+    function stopTimer() {
+      if (timer !== null) { window.clearInterval(timer); timer = null; }
+    }
     load();
-    const t = setInterval(load, 15_000);
-    function onVis() { if (document.visibilityState === "visible") load(); }
+    if (document.visibilityState === "visible") startTimer();
+    function onVis() {
+      if (document.visibilityState === "visible") { load(); startTimer(); }
+      else { stopTimer(); }
+    }
     function onSignal() { load(); }
     document.addEventListener("visibilitychange", onVis);
     window.addEventListener("hinest:approvalCountsRefresh", onSignal);
     return () => {
       alive = false;
-      clearInterval(t);
+      stopTimer();
       document.removeEventListener("visibilitychange", onVis);
       window.removeEventListener("hinest:approvalCountsRefresh", onSignal);
     };

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -183,10 +183,19 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     }
     connect();
 
-    const t = setInterval(reload, 30_000);
+    // SSE fallback 폴링 — SSE 가 끊겼을 때만 의미가 있다.
+    // 비용 절감:
+    //   - 30초 → 90초. SSE 가 살아있으면 어차피 push 로 동기화되므로 fallback 빈도 낮춰도 안전.
+    //   - 탭 hidden 이면 폴링 자체를 중단 (visibility 복귀 시 한 번 reload + interval 재무장).
+    let t: number | null = null;
+    function startPoll() { if (t === null) t = window.setInterval(reload, 90_000); }
+    function stopPoll() { if (t !== null) { window.clearInterval(t); t = null; } }
+    if (document.visibilityState === "visible") startPoll();
 
     function onVisibility() {
-      if (document.visibilityState !== "visible") return;
+      if (document.visibilityState !== "visible") { stopPoll(); return; }
+      // 보이는 상태로 복귀 — fallback 폴링 재무장.
+      startPoll();
       // SSE 가 살아있으면 실시간 push 로 이미 동기화됨 — reload() 생략.
       // SSE 가 끊긴 상태(재연결 대기 중)에서만 전체 재조회.
       if (esRef.current && esRef.current.readyState !== EventSource.CLOSED) return;
@@ -196,7 +205,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
     return () => {
       if (retry) clearTimeout(retry);
-      clearInterval(t);
+      stopPoll();
       esRef.current?.close();
       esRef.current = null;
       document.removeEventListener("visibilitychange", onVisibility);

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -1714,12 +1714,23 @@ function ServerLogsPanel() {
     }
   }
 
-  // 검색·레벨 변경 시 즉시 reload, 그리고 follow 켜져 있으면 3초마다 자동 갱신.
+  // 검색·레벨 변경 시 즉시 reload, follow 켜져 있으면 자동 갱신.
+  // 비용 절감:
+  //   - 3초 → 5초. 운영자가 실시간 디버깅할 때 5초면 충분, 시간당 요청 수 1200 → 720.
+  //   - 탭 hidden 이거나 follow off 면 폴링 정지.
   useEffect(() => {
     void load();
     if (!follow) return;
-    const id = window.setInterval(load, 3000);
-    return () => window.clearInterval(id);
+    let id: number | null = null;
+    function start() { if (id === null) id = window.setInterval(load, 5000); }
+    function stop() { if (id !== null) { window.clearInterval(id); id = null; } }
+    if (document.visibilityState === "visible") start();
+    function onVis() {
+      if (document.visibilityState === "visible") { void load(); start(); }
+      else { stop(); }
+    }
+    document.addEventListener("visibilitychange", onVis);
+    return () => { stop(); document.removeEventListener("visibilitychange", onVis); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [level, q, follow]);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -116,9 +116,18 @@ function scrubUrl(raw: string): string {
   const qs = params.toString();
   return qs ? `${path}?${qs}` : path;
 }
+// HTTP access log — 매 요청마다 in-memory 링버퍼에 적재.
+// 비용 절감:
+//   - ALB/Fargate healthcheck 가 GET /api/health 를 매 30초씩 두드리는데, 200 OK 만
+//     남기는 라인은 정보가 없고 CloudWatch ingestion(=USD/GB) 만 가산된다.
+//   - GET /api/notification/stream 도 SSE long-poll 시작 핸드셰이크가 끊임없이 찍힘.
+//   - 위 두 경로는 정상 200/204 일 때만 스킵. 비정상 응답(5xx, 4xx)은 그대로 기록해야
+//     장애 진단이 가능.
+const ACCESS_LOG_SKIP_PATHS = new Set(["/api/health", "/api/notification/stream"]);
 app.use((req, res, next) => {
   const start = Date.now();
   res.on("finish", () => {
+    if (ACCESS_LOG_SKIP_PATHS.has(req.path) && res.statusCode < 400) return;
     const dur = Date.now() - start;
     const url = req.originalUrl || req.url;
     pushHttpLog(`${req.method} ${scrubUrl(url)} ${res.statusCode} ${dur}ms`);

--- a/server/src/lib/logBuffer.ts
+++ b/server/src/lib/logBuffer.ts
@@ -16,11 +16,19 @@ export type LogEntry = {
   msg: string;
 };
 
-const MAX = 9999;
+// in-memory 링버퍼 크기.
+// 비용/메모리 관점:
+//   각 항목은 평균 200B (시각 + 레벨 + 메시지). MAX 9999 일 땐 약 2MB 가 ECS task
+//   RSS 에 상주. 운영 시 superadmin 콘솔에서 보는 윈도우는 보통 500~1000줄이고,
+//   2000줄 이상은 grep 으로 보는 게 더 빠름. 2000 으로 줄여 컨테이너 메모리 여유를 확보.
+//   (장기 보관은 CloudWatch — 이건 어디까지나 실시간 뷰어용.)
+const MAX = 2000;
 const buf: LogEntry[] = [];
 
+// 한 줄 상한도 2000자로 축소 — stack trace 한 덩어리도 충분히 들어가고, 그 이상은
+// 메시지가 큰 객체 dump 라 보통 의미보단 노이즈. CloudWatch 비용 + RSS 둘 다 절감.
 function pushEntry(level: LogLevel, msg: string) {
-  buf.push({ ts: Date.now(), level, msg: msg.length > 4000 ? msg.slice(0, 4000) + "…" : msg });
+  buf.push({ ts: Date.now(), level, msg: msg.length > 2000 ? msg.slice(0, 2000) + "…" : msg });
   if (buf.length > MAX) buf.splice(0, buf.length - MAX);
 }
 


### PR DESCRIPTION
## 증상
**CloudWatch 보존/access log 다이어트 + 클라 백그라운드 폴링 정지**

유지보수 작업을 진행합니다.

## 원인
월 청구서에 가장 크게 영향 주는 항목들부터.

## 1. CloudWatch Logs 비용 (월 청구의 큰 부분)
- 새 워크플로우 cost-log-retention.yml — /ecs/hinest* / /aws/ecs/hinest* 는 30일,
  /ecs/onetime* + seed* + diag* 는 7일. workflow_dispatch + 매주 월요일 cron 으로
  새로 생긴 log group 까지 자동으로 잡아준다. (지금까지는 retention = "Never expire"
  로 무한 누적되며 저장비가 매월 가산됐다.)
- ALB / Fargate 헬스체크의 GET /api/health 와 SSE 핸드셰이크의 GET /api/notification/stream
  은 200 응답일 때 access log 스킵 — ingestion 폭이 큰 두 경로만 정확히 제외.
- 인메모리 링버퍼 9999 → 2000줄, 1줄 4000자 → 2000자.
  컨테이너 RSS ~2MB 절감 + monkey-patched console 가 가로채는 모든 로그가 작아져
  CloudWatch ingestion 도 함께 줄어듦.

## 2. 클라이언트 백그라운드 폴링 (Fargate RPS / EgressGB 감소)
사내 직원 30명이 탭을 켜놓고 있을 때, hidden 탭에서도 polling 이 끊임없이
서버를 두드려 ECS 컨테이너가 idle 가 아닌 상태로 유지됐다.
- useApprovalCounts: 15s → 60s, 탭 hidden 시 interval clear/restart.
  결재 화면이 처리 후 dispatch 하는 즉시 갱신 이벤트는 그대로.
- notifications fallback poll: 30s → 90s, SSE 가 primary 라 줄여도 안전.
  hidden 탭에서 polling 자체 정지.
- ChatMiniApp presence: hidden 탭에서 polling 정지.
- SuperAdminPage 로그뷰: 3s → 5s + hidden 시 정지.
  운영자 한 명이 follow 켜놓으면 시간당 1200 → 720 요청.

영향:

## 수정
**작업 항목 (커밋 단위)**
- cost: CloudWatch 보존/access log 다이어트 + 클라 백그라운드 폴링 정지

**변경 대상 (7개 파일)**
- `.github/workflows/cost-log-retention.yml`
- `client/src/components/ChatMiniApp.tsx`
- `client/src/lib/useApprovalCounts.ts`
- `client/src/notifications.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/index.ts`
- `server/src/lib/logBuffer.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #138** ↔ **이슈 #562** 로 연결됩니다.

Closes #562
