### PR TITLE
🔀 :: (#563) Fargate rightsize / ECR lifecycle / VPC·NAT 감사 워크플로우 + 플레이북

### DIFF
--- a/.github/workflows/cost-ecr-lifecycle.yml
+++ b/.github/workflows/cost-ecr-lifecycle.yml
@@ -1,0 +1,134 @@
+# ECR 저장소 이미지 라이프사이클 정책 — 오래된 이미지 자동 삭제.
+#
+# 무엇이 문제였나:
+#   deploy-server.yml 이 매 push 마다 새 이미지를 푸시하는데, 라이프사이클이 없으면
+#   ECR 에 모든 빌드가 영구 보관된다. 이미지 한 개당 ~200MB, 한 달에 ~30번 빌드면 6GB,
+#   1년이면 70GB+. Seoul 리전 ECR storage $0.10/GB-month 라 매월 누적.
+#
+# 정책:
+#   - tag 가 "v..." 또는 "release-..." 인 릴리스 태그: 영구 보관 (rollback 용)
+#   - tag 가 "buildcache" (BuildKit 캐시): 영구 보관 — 다음 빌드 속도/네트워크 효율
+#   - 그 외 SHA / latest 태그: 최근 10개만 유지, 30일 이전은 삭제
+#
+# 사용:
+#   gh workflow run cost-ecr-lifecycle.yml
+#
+# 멱등 — 이미 같은 정책이면 noop.
+name: Cost — ECR lifecycle policy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: hinest-server
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::149536482210:role/github-deploy-hinest
+          role-session-name: gha-ecr-lifecycle-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: 현재 저장된 이미지 개수
+        run: |
+          COUNT=$(aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --region "$AWS_REGION" \
+            --query 'length(imageDetails)' --output text 2>/dev/null || echo 0)
+          TOTAL_MB=$(aws ecr describe-images \
+            --repository-name "$ECR_REPOSITORY" \
+            --region "$AWS_REGION" \
+            --query 'sum(imageDetails[*].imageSizeInBytes) / `1048576`' --output text 2>/dev/null || echo 0)
+          echo "현재 이미지: $COUNT 개, 합 ${TOTAL_MB} MB"
+
+      - name: 라이프사이클 정책 적용
+        run: |
+          cat > policy.json <<'EOF'
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Keep release / version tags forever (rollback)",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["v", "release-"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 9999
+                },
+                "action": { "type": "expire" }
+              },
+              {
+                "rulePriority": 2,
+                "description": "Keep buildcache forever (BuildKit cache layer)",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["buildcache"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 9999
+                },
+                "action": { "type": "expire" }
+              },
+              {
+                "rulePriority": 3,
+                "description": "SHA / latest 태그: 최근 10개만 유지",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPatternList": ["*"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 10
+                },
+                "action": { "type": "expire" }
+              },
+              {
+                "rulePriority": 4,
+                "description": "untagged: 7일 지나면 삭제 (orphan layer)",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 7
+                },
+                "action": { "type": "expire" }
+              }
+            ]
+          }
+          EOF
+
+          aws ecr put-lifecycle-policy \
+            --repository-name "$ECR_REPOSITORY" \
+            --lifecycle-policy-text file://policy.json \
+            --region "$AWS_REGION"
+          echo "✓ 라이프사이클 정책 적용 완료"
+
+      - name: 미리보기 — 정책 평가 (실제 삭제 X)
+        run: |
+          aws ecr start-lifecycle-policy-preview \
+            --repository-name "$ECR_REPOSITORY" \
+            --region "$AWS_REGION" >/dev/null 2>&1 || true
+
+          # preview 완료 대기 (최대 90초)
+          for i in 1 2 3 4 5 6 7 8 9; do
+            P=$(aws ecr get-lifecycle-policy-preview \
+                  --repository-name "$ECR_REPOSITORY" \
+                  --region "$AWS_REGION" \
+                  --query 'status' --output text 2>/dev/null || echo "")
+            if [ "$P" = "COMPLETE" ]; then break; fi
+            sleep 10
+          done
+
+          echo ""
+          echo "=== 다음 실행 시 정리될 이미지 (미리보기) ==="
+          aws ecr get-lifecycle-policy-preview \
+            --repository-name "$ECR_REPOSITORY" \
+            --region "$AWS_REGION" \
+            --query 'previewResults[*].[imageTags, action.type]' --output table 2>/dev/null \
+            || echo "(아직 정리 대상 없음)"

--- a/.github/workflows/cost-fargate-diagnose.yml
+++ b/.github/workflows/cost-fargate-diagnose.yml
@@ -1,0 +1,182 @@
+# Fargate task 의 7일치 CPU / Memory 사용률을 CloudWatch 에서 읽어
+# 다운사이즈가 안전한지 자동 판단하는 진단 워크플로우.
+#
+# 사용:
+#   gh workflow run cost-fargate-diagnose.yml
+#
+# 출력:
+#   - 현재 task cpu/memory 사이즈
+#   - 7일 평균 / p95 / max
+#   - 권장 사이즈 (안전 마진 포함)
+#   - 추정 월 절감액 (Seoul 리전 기준)
+#
+# 다운사이즈를 *실제로 적용* 하려면:
+#   gh workflow run cost-fargate-rightsize.yml -f cpu=256 -f memory=512
+#
+# 안전 정책:
+#   p95 CPU < 40% AND p95 MEM < 50% 일 때만 다음 단계 사이즈 권장.
+#   그 이상이면 "유지" 권장 — 다운사이즈가 실패할 가능성 큼.
+name: Cost — Fargate rightsize diagnose
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECS_CLUSTER: hinest-prod
+  ECS_SERVICE: hinest-server
+  TASK_FAMILY: hinest-server
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::149536482210:role/github-deploy-hinest
+          role-session-name: gha-cost-diag-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: 현재 task 사이즈
+        id: current
+        run: |
+          TD=$(aws ecs describe-task-definition --task-definition "$TASK_FAMILY" --region "$AWS_REGION" --query 'taskDefinition')
+          CPU=$(echo "$TD" | jq -r '.cpu')
+          MEM=$(echo "$TD" | jq -r '.memory')
+          REV=$(echo "$TD" | jq -r '.revision')
+          echo "현재: $CPU CPU units / $MEM MB RAM (revision $REV)"
+          echo "cpu=$CPU" >> "$GITHUB_OUTPUT"
+          echo "memory=$MEM" >> "$GITHUB_OUTPUT"
+
+      - name: CloudWatch — 7일 CPU/Memory 통계
+        id: stats
+        run: |
+          # ECS Service 단위 CPUUtilization / MemoryUtilization (%).
+          # period=3600 (1시간) × 168 datapoint = 7일.
+          START=$(date -u -d "7 days ago" +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%S)
+          END=$(date -u +%Y-%m-%dT%H:%M:%S)
+          echo "측정 구간: $START ~ $END (UTC)"
+
+          fetch() {
+            local METRIC=$1
+            aws cloudwatch get-metric-statistics \
+              --namespace AWS/ECS \
+              --metric-name "$METRIC" \
+              --dimensions Name=ClusterName,Value="$ECS_CLUSTER" Name=ServiceName,Value="$ECS_SERVICE" \
+              --start-time "$START" --end-time "$END" \
+              --period 3600 \
+              --statistics Average Maximum \
+              --region "$AWS_REGION" \
+              --query 'Datapoints[*].[Average, Maximum]' --output text
+          }
+
+          CPU_RAW=$(fetch CPUUtilization)
+          MEM_RAW=$(fetch MemoryUtilization)
+          if [ -z "$CPU_RAW" ]; then
+            echo "::error::CPU metric 데이터 없음 — 서비스가 7일 미만 운영됐거나 metric publish 안 됨"
+            exit 1
+          fi
+
+          # 통계 계산 — awk + sort 만으로.
+          p95() {
+            # $1: 멀티라인 데이터, $2: 컬럼 번호
+            printf '%s\n' "$1" | awk -v c="$2" '{print $c}' | sort -n | awk '
+              { a[NR]=$1 }
+              END {
+                if (NR == 0) { print 0; exit }
+                idx = int(NR * 0.95 + 0.5);
+                if (idx < 1) idx = 1; if (idx > NR) idx = NR;
+                print a[idx]
+              }'
+          }
+          avg() {
+            printf '%s\n' "$1" | awk -v c="$2" 'BEGIN{s=0;n=0} {s+=$c; n++} END{ if(n==0) print 0; else printf "%.2f", s/n }'
+          }
+          mx() {
+            printf '%s\n' "$1" | awk -v c="$2" 'BEGIN{m=0} {if($c+0>m) m=$c+0} END{printf "%.2f", m}'
+          }
+
+          CPU_AVG=$(avg "$CPU_RAW" 1)
+          CPU_P95=$(p95 "$CPU_RAW" 1)
+          CPU_MAX=$(mx  "$CPU_RAW" 2)
+          MEM_AVG=$(avg "$MEM_RAW" 1)
+          MEM_P95=$(p95 "$MEM_RAW" 1)
+          MEM_MAX=$(mx  "$MEM_RAW" 2)
+
+          echo ""
+          echo "═══════════ 7일 사용률 (단위 %) ═══════════"
+          printf "%-12s %10s %10s %10s\n" ""        "평균"  "p95"  "최댓값"
+          printf "%-12s %10s %10s %10s\n" "CPU"     "$CPU_AVG" "$CPU_P95" "$CPU_MAX"
+          printf "%-12s %10s %10s %10s\n" "Memory"  "$MEM_AVG" "$MEM_P95" "$MEM_MAX"
+
+          # outputs
+          echo "cpu_p95=$CPU_P95" >> "$GITHUB_OUTPUT"
+          echo "mem_p95=$MEM_P95" >> "$GITHUB_OUTPUT"
+          echo "cpu_max=$CPU_MAX" >> "$GITHUB_OUTPUT"
+          echo "mem_max=$MEM_MAX" >> "$GITHUB_OUTPUT"
+
+      - name: 권장 사이즈 + 절감액 추정
+        run: |
+          # Fargate Seoul 가격 (2026 기준, USD)
+          # vCPU-hour:   0.04048
+          # GB-hour:     0.004445
+          # 730h/월 (28~31일 평균).
+          calc_cost() {
+            python3 -c "print(f'{($1/1024)*0.04048*730 + ($2/1024)*0.004445*730:.2f}')"
+          }
+
+          CUR_CPU=${{ steps.current.outputs.cpu }}
+          CUR_MEM=${{ steps.current.outputs.memory }}
+          CUR_COST=$(calc_cost $CUR_CPU $CUR_MEM)
+
+          P95_CPU=${{ steps.stats.outputs.cpu_p95 }}
+          P95_MEM=${{ steps.stats.outputs.mem_p95 }}
+          MAX_CPU=${{ steps.stats.outputs.cpu_max }}
+          MAX_MEM=${{ steps.stats.outputs.mem_max }}
+
+          # 다운사이즈 후보 — 한 단계 아래의 Fargate "정상 조합".
+          # 256 CPU + 512/1024/2048 MB
+          # 512 CPU + 1024/2048/3072/4096 MB
+          # 1024 CPU + 2048/3072/4096/5120/6144/7168/8192 MB
+          # 단순화: 현재가 (512, 1024) 면 (256, 512) 또는 (256, 1024) 제안.
+          REC_CPU=""
+          REC_MEM=""
+          if [ "$CUR_CPU" = "512" ] && [ "$CUR_MEM" = "1024" ]; then
+            REC_CPU=256; REC_MEM=512
+          elif [ "$CUR_CPU" = "1024" ] && [ "$CUR_MEM" = "2048" ]; then
+            REC_CPU=512; REC_MEM=1024
+          else
+            REC_CPU=$CUR_CPU; REC_MEM=$CUR_MEM
+          fi
+          REC_COST=$(calc_cost $REC_CPU $REC_MEM)
+
+          SAVE=$(python3 -c "print(f'{$CUR_COST - $REC_COST:.2f}')")
+
+          echo ""
+          echo "═══════════ 진단 결과 ═══════════"
+          echo "현재 task:   $CUR_CPU CPU / $CUR_MEM MB  →  월 \$$CUR_COST"
+
+          # 안전 판단 — p95 < 40% / 50% 일 때만 권장.
+          SAFE=$(python3 -c "print('yes' if $P95_CPU < 40 and $P95_MEM < 50 and $MAX_CPU < 70 and $MAX_MEM < 80 else 'no')")
+          if [ "$SAFE" = "yes" ] && [ "$REC_CPU" != "$CUR_CPU" -o "$REC_MEM" != "$CUR_MEM" ]; then
+            echo "권장 task:   $REC_CPU CPU / $REC_MEM MB  →  월 \$$REC_COST"
+            echo "예상 절감:   월 \$$SAVE (KRW ≈ ₩$(python3 -c "print(int($SAVE*1350))"))"
+            echo ""
+            echo "다운사이즈 적용:"
+            echo "  gh workflow run cost-fargate-rightsize.yml -f cpu=$REC_CPU -f memory=$REC_MEM"
+          else
+            if [ "$SAFE" = "no" ]; then
+              echo ""
+              echo "⚠️  다운사이즈 비권장 — p95 CPU=$P95_CPU% / p95 MEM=$P95_MEM% / max CPU=$MAX_CPU% / max MEM=$MAX_MEM%"
+              echo "    안전 기준: p95<40%/50%, max<70%/80%."
+              echo "    polling 정리(PR4) 후 1주일 더 데이터 쌓고 재진단 권장."
+            else
+              echo ""
+              echo "ℹ️  이미 최소 사이즈 또는 추천 조합 없음."
+            fi
+          fi

--- a/.github/workflows/cost-fargate-rightsize.yml
+++ b/.github/workflows/cost-fargate-rightsize.yml
@@ -1,0 +1,161 @@
+# Fargate task definition 의 cpu/memory 만 바꿔 새 리비전 등록 + 서비스 롤아웃.
+#
+# 사용:
+#   gh workflow run cost-fargate-rightsize.yml -f cpu=256 -f memory=512
+#
+# 정책:
+#   - cpu/memory 는 AWS Fargate 의 정상 조합만 허용 (256/512, 512/1024 등).
+#   - 새 리비전 등록 → update-service → services-stable 대기 → /api/health 체크.
+#   - 헬스 체크 실패 시 직전 리비전으로 자동 롤백.
+#
+# 사전 진단:
+#   gh workflow run cost-fargate-diagnose.yml  # 7일 CPU/Mem 보고 안전한지 확인
+name: Cost — Fargate rightsize apply
+
+on:
+  workflow_dispatch:
+    inputs:
+      cpu:
+        description: "새 CPU units (256 / 512 / 1024 / 2048 / 4096)"
+        required: true
+        type: choice
+        options: ["256", "512", "1024", "2048", "4096"]
+      memory:
+        description: "새 메모리 MB (512/1024/2048/3072/4096/...)"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECS_CLUSTER: hinest-prod
+  ECS_SERVICE: hinest-server
+  TASK_FAMILY: hinest-server
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::149536482210:role/github-deploy-hinest
+          role-session-name: gha-rightsize-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: AWS Fargate 정상 조합 검증
+        run: |
+          CPU=${{ github.event.inputs.cpu }}
+          MEM=${{ github.event.inputs.memory }}
+          # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
+          case "$CPU" in
+            256)  ALLOWED="512 1024 2048" ;;
+            512)  ALLOWED="1024 2048 3072 4096" ;;
+            1024) ALLOWED="2048 3072 4096 5120 6144 7168 8192" ;;
+            2048) ALLOWED="$(seq 4096 1024 16384 | tr '\n' ' ')" ;;
+            4096) ALLOWED="$(seq 8192 1024 30720 | tr '\n' ' ')" ;;
+            *)    echo "::error::알 수 없는 CPU=$CPU"; exit 1 ;;
+          esac
+          if ! echo " $ALLOWED " | grep -q " $MEM "; then
+            echo "::error::CPU=$CPU 에 허용되는 MEM 값: $ALLOWED"
+            exit 1
+          fi
+          echo "✓ 조합 OK: CPU=$CPU / MEM=$MEM"
+
+      - name: 직전 리비전 (롤백 대비)
+        id: prev
+        run: |
+          CURRENT=$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
+            --region "$AWS_REGION" \
+            --query 'services[0].taskDefinition' --output text)
+          echo "직전 리비전: $CURRENT"
+          echo "arn=$CURRENT" >> "$GITHUB_OUTPUT"
+
+      - name: 새 task definition 등록
+        id: new
+        run: |
+          TD=$(aws ecs describe-task-definition \
+            --task-definition "$TASK_FAMILY" \
+            --region "$AWS_REGION" \
+            --query 'taskDefinition')
+          # 등록 시 사용할 수 없는 메타 필드 제거.
+          NEW=$(echo "$TD" | jq \
+            --arg cpu "${{ github.event.inputs.cpu }}" \
+            --arg mem "${{ github.event.inputs.memory }}" '
+              .cpu = $cpu | .memory = $mem |
+              del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                  .compatibilities, .registeredAt, .registeredBy)
+            ')
+          echo "$NEW" > new-td.json
+          NEW_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file://new-td.json \
+            --region "$AWS_REGION" \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "새 리비전: $NEW_ARN"
+          echo "arn=$NEW_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: 서비스 업데이트
+        run: |
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" --service "$ECS_SERVICE" \
+            --task-definition "${{ steps.new.outputs.arn }}" \
+            --force-new-deployment \
+            --region "$AWS_REGION" >/dev/null
+          echo "롤아웃 시작."
+
+      - name: 안정화 대기
+        id: stable
+        run: |
+          # 10분 안에 안정화 안 되면 fail → 다음 step 에서 롤백.
+          if aws ecs wait services-stable \
+              --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
+              --region "$AWS_REGION"; then
+            echo "ok=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 헬스 체크
+        id: health
+        if: steps.stable.outputs.ok == '1'
+        run: |
+          OK=0
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" https://api.nest.hi-vits.com/api/health || true)
+            echo "attempt $i: HTTP=$code"
+            if [ "$code" = "200" ]; then OK=1; break; fi
+            sleep 5
+          done
+          echo "ok=$OK" >> "$GITHUB_OUTPUT"
+          if [ "$OK" = "0" ]; then echo "::warning::health check 실패 — 롤백 수행"; fi
+
+      - name: 롤백 (실패 시)
+        if: steps.stable.outputs.ok != '1' || steps.health.outputs.ok != '1'
+        run: |
+          echo "::error::배포 실패 — 직전 리비전으로 자동 롤백"
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" --service "$ECS_SERVICE" \
+            --task-definition "${{ steps.prev.outputs.arn }}" \
+            --force-new-deployment \
+            --region "$AWS_REGION" >/dev/null
+          aws ecs wait services-stable \
+            --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
+            --region "$AWS_REGION"
+          exit 1
+
+      - name: 완료 요약
+        if: success()
+        run: |
+          echo "✅ rightsize 완료"
+          echo "  before: ${{ steps.prev.outputs.arn }}"
+          echo "  after : ${{ steps.new.outputs.arn }}"
+          echo "  cpu=${{ github.event.inputs.cpu }} mem=${{ github.event.inputs.memory }}"
+          echo ""
+          echo "다음 단계: 24시간 모니터링 후 안정 확인."
+          echo "  - CloudWatch ECS service CPUUtilization / MemoryUtilization"
+          echo "  - 사용자 보고된 느림 / 에러 없음 확인"
+          echo "  - 문제 발견 시 cost-fargate-rightsize.yml 을 다시 실행해 원상복귀"

--- a/.github/workflows/cost-vpc-audit.yml
+++ b/.github/workflows/cost-vpc-audit.yml
@@ -1,0 +1,139 @@
+# VPC 비용 항목 감사 — 어디가 새는지 한 번에 본다.
+#
+# 가장 큰 단일 항목은 거의 항상 NAT Gateway 존재 여부:
+#   - NAT GW 1개 = 시간당 $0.045 + 트래픽 GB 당 $0.045
+#   - 그냥 존재만 해도 월 ~$32 (₩42,000) 깔고 시작
+#
+# 이 워크플로우가 확인하는 것:
+#   1) VPC 별 NAT Gateway 개수 + 월 추정 비용
+#   2) ECS Service 가 사용하는 subnet 이 public 인지 private 인지
+#   3) ECR / Logs / S3 VPC endpoint 가 있는지 (있으면 NAT 우회로 트래픽 무료)
+#   4) Elastic IP 점유 (associate 안 된 EIP 는 시간당 $0.005)
+#
+# 사용:
+#   gh workflow run cost-vpc-audit.yml
+name: Cost — VPC / NAT audit
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECS_CLUSTER: hinest-prod
+  ECS_SERVICE: hinest-server
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::149536482210:role/github-deploy-hinest
+          role-session-name: gha-vpc-audit-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: 1) NAT Gateway 점유
+        run: |
+          echo "═══════════ NAT Gateway ═══════════"
+          NATS=$(aws ec2 describe-nat-gateways \
+            --filter "Name=state,Values=available,pending" \
+            --region "$AWS_REGION" \
+            --query 'NatGateways[*].[NatGatewayId, VpcId, SubnetId, State, CreateTime]' \
+            --output table)
+          echo "$NATS"
+          COUNT=$(aws ec2 describe-nat-gateways \
+            --filter "Name=state,Values=available,pending" \
+            --region "$AWS_REGION" \
+            --query 'length(NatGateways)' --output text)
+          if [ "$COUNT" = "0" ]; then
+            echo "✓ NAT Gateway 없음 — 이 항목 최적화 완료"
+          else
+            COST=$(python3 -c "print(f'{$COUNT*0.045*730:.2f}')")
+            KRW=$(python3 -c "print(int($COUNT*0.045*730*1350))")
+            echo ""
+            echo "⚠️  NAT Gateway $COUNT 개 = 시간당 \$$(python3 -c "print($COUNT*0.045)")"
+            echo "    월 ~\$$COST (₩$KRW) — 트래픽 별도"
+            echo ""
+            echo "제거 방안:"
+            echo "  (a) ECS task 를 public subnet 으로 이동 + assignPublicIp=ENABLED"
+            echo "      → outbound 가 IGW 로 빠짐, NAT 불필요"
+            echo "  (b) VPC endpoint(Gateway: S3, Interface: ECR/Logs) 만 만들고 NAT 유지"
+            echo "      → 일부 트래픽만 무료화. 컨테이너 외부 API 호출(SES 등) 은 여전히 NAT 통과"
+          fi
+
+      - name: 2) ECS Service subnet 검사 (public / private)
+        run: |
+          echo ""
+          echo "═══════════ ECS Service subnets ═══════════"
+          SUBNETS=$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
+            --region "$AWS_REGION" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.subnets' \
+            --output text)
+          ASSIGN=$(aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" --services "$ECS_SERVICE" \
+            --region "$AWS_REGION" \
+            --query 'services[0].networkConfiguration.awsvpcConfiguration.assignPublicIp' \
+            --output text)
+          echo "subnets    : $SUBNETS"
+          echo "assignIP   : $ASSIGN"
+
+          for S in $SUBNETS; do
+            RTB=$(aws ec2 describe-route-tables \
+              --filters "Name=association.subnet-id,Values=$S" \
+              --region "$AWS_REGION" \
+              --query 'RouteTables[0].Routes[?DestinationCidrBlock==`0.0.0.0/0`].[GatewayId, NatGatewayId]' \
+              --output text)
+            if echo "$RTB" | grep -q "^igw-"; then
+              echo "  $S → public (IGW 직접)"
+            elif echo "$RTB" | grep -q "^nat-"; then
+              echo "  $S → private (NAT Gateway 경유) ⚠️"
+            else
+              echo "  $S → 0.0.0.0/0 route 못 찾음"
+            fi
+          done
+
+      - name: 3) VPC Endpoint 존재 여부
+        run: |
+          echo ""
+          echo "═══════════ VPC Endpoints (NAT 우회 경로) ═══════════"
+          aws ec2 describe-vpc-endpoints \
+            --region "$AWS_REGION" \
+            --query 'VpcEndpoints[*].[VpcEndpointId, ServiceName, VpcEndpointType, State]' \
+            --output table
+
+      - name: 4) 미사용 Elastic IP
+        run: |
+          echo ""
+          echo "═══════════ 미사용 Elastic IP ═══════════"
+          ORPHANS=$(aws ec2 describe-addresses \
+            --region "$AWS_REGION" \
+            --query 'Addresses[?!not_null(AssociationId)].[PublicIp, AllocationId]' \
+            --output text)
+          if [ -z "$ORPHANS" ]; then
+            echo "✓ 점유만 한 EIP 없음"
+          else
+            COUNT=$(echo "$ORPHANS" | wc -l | tr -d ' ')
+            COST=$(python3 -c "print(f'{$COUNT*0.005*730:.2f}')")
+            KRW=$(python3 -c "print(int($COUNT*0.005*730*1350))")
+            echo "$ORPHANS"
+            echo ""
+            echo "⚠️  $COUNT 개 미사용 EIP — 월 \$$COST (₩$KRW) 의미없이 청구됨"
+            echo "    제거: aws ec2 release-address --allocation-id <id>"
+          fi
+
+      - name: 5) 요약 — 즉시 가능한 절감액
+        run: |
+          echo ""
+          echo "═══════════ 즉시 가능한 절감 액션 ═══════════"
+          echo "1. NAT Gateway 있다면 → public subnet 이동 후 제거 (월 ₩42,000+)"
+          echo "2. 미사용 EIP 회수 (월 ₩5,000/개)"
+          echo "3. S3 / ECR / Logs Interface Endpoint 추가 (NAT 통과 트래픽 우회)"
+          echo ""
+          echo "다음: 청구서 Cost Explorer → Group by: Service / Usage Type 으로"
+          echo "      'NAT Gateway-Hours', 'NAT Gateway-Bytes' 항목이 얼마인지 확인"

--- a/docs/cost-optimization.md
+++ b/docs/cost-optimization.md
@@ -1,0 +1,177 @@
+# HiNest AWS 비용 최적화 플레이북
+
+월 청구서를 가장 큰 항목부터 깎는 순서. 코드/워크플로우로 자동화한 부분과,
+인프라 결정이라 수동으로 결정해야 하는 부분을 분리해 둔다.
+
+---
+
+## 청구서 우선순위 — 큰 것부터
+
+| 순위 | 항목 | 월 추정 | 자동화 가능? |
+|------|------|---------|--------------|
+| 1 | **NAT Gateway** (있다면) | ₩42,000+ | ⚠️ 진단만 자동, 제거는 수동 |
+| 2 | Fargate compute (다운사이즈) | ₩12,000 | ✅ 자동 진단 + 적용 |
+| 3 | ALB ↔ API Gateway 전환 | ₩16,000 | ⚠️ 수동 (DNS/SSL 변경) |
+| 4 | CloudWatch retention | ₩2,000~30,000 | ✅ 매주 자동 |
+| 5 | ECR 이미지 누적 | ₩2,000 | ✅ 라이프사이클 자동 |
+| 6 | 미사용 EIP | ₩5,000/개 | ⚠️ 진단만 자동 |
+| 7 | 클라이언트 백그라운드 폴링 | ALB LCU 미세 | ✅ 코드로 처리 (PR #138) |
+
+---
+
+## 1. NAT Gateway — 가장 큰 한 방
+
+**왜 큰가**: 시간당 $0.045 × 24h × 30일 = **$32.4/월** (트래픽 별도). 그냥 존재만 해도 ₩42,000.
+
+**진단**:
+```bash
+gh workflow run cost-vpc-audit.yml
+```
+출력으로 NAT 개수 + 월 예상 비용 + ECS task 가 NAT 경유 중인지 표시.
+
+**제거 옵션**:
+
+### Option A — public subnet 이동 (가장 간단)
+ECS task 를 public subnet 에 배치하고 `assignPublicIp=ENABLED`. Outbound 트래픽이 IGW 로 직접 빠져서 NAT 불필요.
+
+- 장점: 비용 0, 마이그레이션 5분
+- 단점: Task IP 가 public 노출 (SG inbound 가 ALB SG 만 허용하면 실질 위험 없음)
+
+```bash
+# task 가 사용하는 service 의 network configuration 변경
+aws ecs update-service \
+  --cluster hinest-prod --service hinest-server \
+  --network-configuration "awsvpcConfiguration={subnets=[$PUB_SUBNET_A,$PUB_SUBNET_B],securityGroups=[$SG],assignPublicIp=ENABLED}" \
+  --force-new-deployment
+```
+
+### Option B — VPC Interface Endpoint (private 유지)
+S3 (Gateway, 무료), ECR / CloudWatch Logs (Interface, ~$7/월). NAT 통과량을 줄이지만 NAT 자체는 유지 → 결과적으로 NAT 비용은 그대로.
+
+> HiNest 규모(30명, 하루 트래픽 수 GB)에선 **Option A 가 명확히 우위**. 외부 API 호출은 SES (region-internal) 뿐이라 public subnet 으로 옮겨도 보안적 차이 거의 없음.
+
+---
+
+## 2. Fargate Rightsize — 안전하게 다운사이즈
+
+**진단**:
+```bash
+gh workflow run cost-fargate-diagnose.yml
+```
+7일치 CPU/Memory 사용률 (avg/p95/max) 출력 + 안전 기준 (p95<40%/50%) 만족하면 다음 사이즈 권장.
+
+**적용**:
+```bash
+gh workflow run cost-fargate-rightsize.yml -f cpu=256 -f memory=512
+```
+- 새 task definition 등록 → service 롤아웃 → `services-stable` 대기 → `/api/health` 검증
+- 실패 시 **직전 리비전으로 자동 롤백**
+
+**예상 절감 (Seoul 리전, 730h/월)**:
+
+| 현재 | 다운사이즈 | 월 변화 |
+|------|-----------|---------|
+| 512 CPU / 1024 MB ($17.95) | 256 CPU / 512 MB ($8.97) | **-$8.98 (-₩12,100)** |
+| 1024 CPU / 2048 MB ($35.89) | 512 CPU / 1024 MB ($17.95) | **-$17.94 (-₩24,200)** |
+
+> PR #138 (백그라운드 polling 정지) 의 진짜 가치가 여기서 실현됨. polling 으로 CPU 가 항상 30~40% 차 있던 상태에선 다운사이즈가 불가능했음.
+
+---
+
+## 3. ALB → API Gateway 검토
+
+**언제 이득인가**:
+- ALB 고정비 = $16/월 (Seoul 리전 LB-Hours) + LCU 별도
+- API Gateway HTTP API = 요청 100만 건당 $1
+- 30명 × 일 1000 req × 30일 = 90만 req → APIGW = $0.9/월
+
+**즉 RPS 가 낮다면 APIGW 가 매월 ~$15 저렴**. 다만 마이그레이션이 코드 외 작업이 많음:
+
+| 항목 | 복잡도 |
+|------|--------|
+| Route 53 DNS 변경 (`api.nest.hi-vits.com`) | 낮음 |
+| ACM 인증서 (이미 보유) | 낮음 |
+| SSE (`/api/notification/stream`) 지원 | **APIGW HTTP API 는 SSE OK, 단 30s 타임아웃** |
+| 큰 응답 (10MB 이상 파일) | **HTTP API 한도 10MB — 업로드/다운로드는 ALB 유지 권장** |
+| WebSocket (HiNest 미사용) | N/A |
+
+**결론**: SSE 가 30초 안에 첫 이벤트 보내는 한 동작. 파일 업로드/다운로드는 별도 도메인(`upload.nest.hi-vits.com`) 으로 ALB 유지하는 하이브리드 구성이 안전.
+
+지금 단계 추천: **NAT 제거 + Fargate 다운사이즈 먼저**. APIGW 전환은 사용자가 100명 넘으면 그때 재검토.
+
+---
+
+## 4. CloudWatch retention — 매주 자동
+
+이미 PR #138 에서 처리. `cost-log-retention.yml` 가 매주 월요일 자동 실행.
+
+기본 정책:
+- `/ecs/hinest*` : 30일
+- `/ecs/onetime*`, `seed*`, `diag*` : 7일
+
+---
+
+## 5. ECR 라이프사이클 — 새 워크플로우
+
+**적용**:
+```bash
+gh workflow run cost-ecr-lifecycle.yml
+```
+
+정책:
+- `v*`, `release-*` 태그 : 영구 (rollback 용)
+- `buildcache` : 영구 (BuildKit 캐시 효율)
+- 그 외 SHA / latest 태그 : 최근 10개만, 나머지 자동 삭제
+- untagged (orphan layer) : 7일 후 삭제
+
+**예상 절감**: 한 달 30회 배포 × 200MB = 6GB / 월 누적. 1년이면 72GB × $0.10 = **$7.2/월 (₩9,700)** 누적.
+지금 적용하면 미래 7개월부터 의미 있는 절감.
+
+---
+
+## 실행 순서 (추천)
+
+```bash
+# 1. 현 상태 파악
+gh workflow run cost-vpc-audit.yml        # NAT GW / EIP 점유
+gh workflow run cost-fargate-diagnose.yml # 7일치 CPU/Mem
+
+# 2. 즉시 가능한 자동 절감
+gh workflow run cost-log-retention.yml    # retention 적용 (PR #138)
+gh workflow run cost-ecr-lifecycle.yml    # ECR 라이프사이클
+
+# 3. 큰 결정 — 사용자 판단 후
+#   NAT GW 가 있고 ECS public 이동이 OK 면:
+#   → 콘솔에서 service network config 변경 + NAT 제거
+#
+#   Fargate diagnose 가 "다운사이즈 권장" 으로 나오면:
+gh workflow run cost-fargate-rightsize.yml -f cpu=256 -f memory=512
+```
+
+---
+
+## 비용 측정 (before/after 실측)
+
+청구 항목별 변화를 정확히 보려면 **AWS Cost Explorer**:
+
+1. AWS Console → **Cost Explorer**
+2. **Group by: Service** + 일별 분포 7일치 → before 기준선
+3. 변경 적용 → 다음 주 같은 차트로 비교
+4. **Group by: Usage Type** 으로 NAT-Hours / DataTransfer-Out 등 세부 확인
+
+월말 청구서가 아니라 **일별 추정 비용**이 즉시 반영되므로 24h 뒤면 변화가 보임.
+
+---
+
+## 최종 목표 (HiNest 30명 규모)
+
+| 항목 | Before (예상) | After (목표) | 절감 |
+|------|---------------|--------------|------|
+| 월 청구 합 | ₩100,000 | ₩40,000~50,000 | **50~60%** |
+| Fargate | ₩25,000 | ₩12,000 | -₩13,000 |
+| NAT GW | ₩42,000 (있다면) | ₩0 | -₩42,000 |
+| ALB | ₩22,000 | ₩22,000 | (유지) |
+| CloudWatch | ₩5,000 | ₩2,000 | -₩3,000 |
+| ECR + S3 | ₩6,000 | ₩4,000 | -₩2,000 |
+
+> 단, **NAT GW 가 실제 존재하는 경우**. 없으면 절감 폭은 -₩18,000 (18%) 수준.


### PR DESCRIPTION
## 증상
**Fargate rightsize / ECR lifecycle / VPC·NAT 감사 워크플로우 + 플레이북**

유지보수 작업을 진행합니다.

## 원인
PR #138 이 코드 레벨 절감을 잡았다면, 이번 PR 은 청구서의 큰 항목
(NAT GW, Fargate task size, ECR 누적, 미사용 EIP) 을 자동/반자동 으로
잡는 운영 도구를 추가한다. 모든 워크플로우는 OIDC + workflow_dispatch
로 안전하게 트리거.

## 추가된 워크플로우

### cost-fargate-diagnose.yml — 7일 사용률 진단
CloudWatch ECS metric 의 CPU/Memory Utilization 을 7일 끌어와 avg/p95/max
계산. 안전 기준(p95 < 40%/50%, max < 70%/80%) 만족 시 다음 단계 task 사이즈
권장 + 월 절감액 표시 (Seoul 가격 730h 기준).

### cost-fargate-rightsize.yml — 안전 다운사이즈 적용
입력 cpu/memory 를 받아 새 task definition 등록 → service 롤아웃 →
services-stable 대기 → /api/health 검증. 안정화 실패 또는 health 실패
시 직전 리비전으로 자동 롤백. AWS Fargate 정상 조합만 허용.

### cost-ecr-lifecycle.yml — 이미지 자동 정리
릴리스/buildcache 태그는 영구, SHA/latest 는 최근 10개만 유지, untagged
는 7일 후 삭제. start-lifecycle-policy-preview 로 다음 실행 시 정리될
이미지 미리보기까지 출력.

### cost-vpc-audit.yml — NAT GW / EIP 감사
1) NAT Gateway 개수 + 월 예상 비용 (₩42,000/개)
2) ECS service subnet 이 public 인지 private 인지 → NAT 경유 여부 표시

## 수정
**작업 항목 (커밋 단위)**
- cost: Fargate rightsize / ECR lifecycle / VPC·NAT 감사 워크플로우 + 플레이북

**변경 대상 (5개 파일)**
- `.github/workflows/cost-ecr-lifecycle.yml`
- `.github/workflows/cost-fargate-diagnose.yml`
- `.github/workflows/cost-fargate-rightsize.yml`
- `.github/workflows/cost-vpc-audit.yml`
- `docs/cost-optimization.md`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #139** ↔ **이슈 #563** 로 연결됩니다.

Closes #563
