### PR TITLE
🔀 :: (#565) ZIP slip + CSRF NULL bypass + password-reset rate limit

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -137,14 +137,28 @@ app.use((req, res, next) => {
   const origin = String(req.headers.origin || "");
   const referer = String(req.headers.referer || "");
   // Origin 이 있으면 그걸로 검증. 없으면 Referer 의 origin 을 뽑아 검증.
-  // 둘 다 없으면 브라우저 외 클라이언트(스크립트/네이티브 앱)로 간주해 통과 — 쿠키/JWT 체크는 그대로 작동.
   let sender = origin;
   if (!sender && referer) {
     try { sender = new URL(referer).origin; } catch { sender = ""; }
   }
-  if (!sender) return next();
-  if (CORS_ORIGINS.includes(sender)) return next();
-  return res.status(403).json({ error: "origin not allowed" });
+  if (sender) {
+    if (CORS_ORIGINS.includes(sender)) return next();
+    return res.status(403).json({ error: "origin not allowed" });
+  }
+  // Origin / Referer 둘 다 없는 경우 — CSRF 핵심 위협은 "브라우저가 자동으로 cookie 를
+  // 실어 보내는" 시나리오라, cookie 가 함께 오는 경우만 차단한다.
+  //   - 정상 브라우저 (web/Electron): 항상 Origin 송신
+  //   - 네이티브 앱 / curl / 웹훅: Authorization 또는 토큰 헤더로 인증, cookie 안 씀
+  // 이 정책으로 위 cookie + no Origin 조합(= CSRF 시도)이 차단되고, 정상 비-브라우저는
+  // 영향 없음. 이전엔 무조건 통과해 SameSite 우회 공격에 노출됐었다.
+  const hasCookieAuth =
+    !!req.cookies?.["hinest_token"] ||
+    !!req.cookies?.["hinest_super"] ||
+    !!req.cookies?.["hinest_imp"];
+  if (hasCookieAuth) {
+    return res.status(403).json({ error: "origin required for cookie-authenticated requests" });
+  }
+  return next();
 });
 
 // 레이트 리밋 — 브루트포스/DoS 방어.
@@ -200,6 +214,18 @@ app.use("/api", rateLimitMiddleware);
 // 전역 API 레이트 리밋 — 라우트별 특수 limiter 는 그 뒤에 추가로 씌운다.
 // (login/upload 는 더 엄격한 limiter 가 먼저 적용됨)
 app.use("/api", apiLimiter);
+
+// 비밀번호 재설정 요청은 1회당 메일 1건 발송이라 enumeration 방어가 있어도
+// IP 당 분당 100건씩 던지면 메일 폭격이 된다. IP 당 시간당 10건으로 묶어둔다.
+// 정상 사용자라면 시간당 10건은 절대 도달 불가능 (1번 받고 받았는지 확인 + 재요청 1~2회면 충분).
+const passwordResetLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1시간
+  limit: 10,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: { error: "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요." },
+});
+app.use("/api/auth/password-reset/request", passwordResetLimiter);
 
 app.use("/api/auth", loginLimiter, authRouter);
 app.use("/api/me", meRouter);

--- a/server/src/lib/zipSafe.ts
+++ b/server/src/lib/zipSafe.ts
@@ -1,0 +1,78 @@
+/**
+ * archiver 로 ZIP 을 만들 때 entry name 을 안전하게 정규화한다.
+ *
+ * 문제 (ZIP slip):
+ *   document.fileName / document.title / folder.name 같은 사용자 입력이
+ *   ZIP 내부 path 로 들어가는데, 거기에 "../" 가 섞이면 추출 시
+ *   상위 디렉토리에 파일이 생긴다.
+ *
+ * 정책:
+ *   - 각 segment 의 ".." / "." 제거
+ *   - 경로 구분자(`/`, `\`)는 segment 단위로 분리해서 처리
+ *   - 절대경로 prefix(`/`, `C:\`) 제거
+ *   - segment 가 비면 "_" 로 대체
+ *   - segment 별로 200자 캡 (윈도우 NTFS 호환)
+ *
+ *   sanitizeZipPath("../../etc/passwd")          → "etc/passwd"
+ *   sanitizeZipPath("a/../../../b")              → "a/b"
+ *   sanitizeZipPath("a/b/../c")                  → "a/c"
+ *   sanitizeZipPath("/leading/slash")            → "leading/slash"
+ *   sanitizeZipPath("C:\\Windows\\System32")     → "C/Windows/System32"
+ *   sanitizeZipPath("")                          → "_"
+ */
+export function sanitizeZipPath(p: string): string {
+  if (!p) return "_";
+  // 통합 구분자
+  const normalized = p.replace(/\\/g, "/");
+  const parts = normalized.split("/");
+  const out: string[] = [];
+  for (const raw of parts) {
+    const s = raw.trim();
+    if (!s) continue;          // 빈 segment (`//` 등) 무시
+    if (s === ".") continue;
+    if (s === "..") continue;  // 상위 이동 제거
+    // 윈도우 드라이브 prefix (C:) → "C"
+    const cleaned = s
+      .replace(/^([A-Za-z]):$/, "$1")
+      // OS 예약 문자 일부 정리 — 이름이 깨지진 않도록 underscore 로
+      .replace(/[\x00-\x1f<>"|?*]/g, "_")
+      .slice(0, 200);
+    out.push(cleaned || "_");
+  }
+  return out.length ? out.join("/") : "_";
+}
+
+/**
+ * ZIP 한 회의 entry name 들이 unique 하도록 collide 시 "(2)", "(3)" 접미.
+ *   기존 코드의 uniqueName() 와 동일 의도 — but path traversal 방어가 추가됨.
+ */
+export function safeUniqueZipEntry(
+  takenSet: Set<string>,
+  relPath: string,
+  fileName: string,
+): string {
+  const dir = sanitizeZipPath(relPath || "");
+  const base = sanitizeZipPath(fileName || "file");
+  const joined = dir && dir !== "_" ? `${dir}/${base}` : base;
+  if (!takenSet.has(joined)) {
+    takenSet.add(joined);
+    return joined;
+  }
+  // 확장자 분리 후 (2), (3) ...
+  const dot = base.lastIndexOf(".");
+  const stem = dot > 0 ? base.slice(0, dot) : base;
+  const ext = dot > 0 ? base.slice(dot) : "";
+  for (let i = 2; i < 1000; i++) {
+    const candidate = dir && dir !== "_"
+      ? `${dir}/${stem} (${i})${ext}`
+      : `${stem} (${i})${ext}`;
+    if (!takenSet.has(candidate)) {
+      takenSet.add(candidate);
+      return candidate;
+    }
+  }
+  // 비현실적인 충돌 — 안전을 위해 cuid 비슷한 suffix
+  const fallback = `${stem}-${Date.now().toString(36)}${ext}`;
+  takenSet.add(fallback);
+  return fallback;
+}

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -5,6 +5,7 @@ import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { downloadFile, isStorageEnabled } from "../lib/storage.js";
 import { UPLOAD_DIR } from "./upload.js";
+import { safeUniqueZipEntry } from "../lib/zipSafe.js";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -736,21 +737,10 @@ router.get("/folders/:id/download", async (req, res) => {
     return res.status(404).json({ error: "폴더에 다운로드할 파일이 없어요" });
   }
 
-  // 파일명 중복 시 "(1)" "(2)" 같은 꼬리 번호를 붙여 덮어쓰기 방지 (경로별로 별도 카운터).
-  const usedByPath = new Map<string, Set<string>>();
-  function uniqueName(dir: string, base: string): string {
-    let used = usedByPath.get(dir);
-    if (!used) { used = new Set(); usedByPath.set(dir, used); }
-    if (!used.has(base)) { used.add(base); return base; }
-    const ext = path.extname(base);
-    const stem = base.slice(0, base.length - ext.length);
-    for (let i = 1; i < 1000; i++) {
-      const c = `${stem} (${i})${ext}`;
-      if (!used.has(c)) { used.add(c); return c; }
-    }
-    used.add(base);
-    return base;
-  }
+  // 파일명 중복 시 "(2)" "(3)" 꼬리 번호. safeUniqueZipEntry 가 ZIP slip 방어
+  // (sanitizeZipPath) + 중복 회피를 한 번에 처리. fileName / title / 폴더 name 에
+  // "../" 가 섞여 들어와도 추출 시 상위 디렉토리로 빠지지 않음.
+  const usedEntries = new Set<string>();
 
   const zipName = `${folder.name.replace(/[\\/:*?"<>|]/g, "_")}.zip`;
   res.setHeader("Content-Type", "application/zip");
@@ -786,8 +776,7 @@ router.get("/folders/:id/download", async (req, res) => {
         console.error("[doc:zip] fetch failed", key, err);
       }
       if (!buf) continue;
-      const display = uniqueName(d.relPath, d.fileName || d.title || key);
-      const entryName = d.relPath ? `${d.relPath}/${display}` : display;
+      const entryName = safeUniqueZipEntry(usedEntries, d.relPath || "", d.fileName || d.title || key);
       archive.append(buf, { name: entryName });
       added++;
     }

--- a/server/src/routes/folderShareLink.ts
+++ b/server/src/routes/folderShareLink.ts
@@ -7,6 +7,7 @@ import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { downloadFile, isStorageEnabled } from "../lib/storage.js";
 import { UPLOAD_DIR } from "./upload.js";
+import { safeUniqueZipEntry } from "../lib/zipSafe.js";
 import path from "node:path";
 import fs from "node:fs";
 
@@ -175,6 +176,10 @@ export async function streamFolderZip(
   archive.pipe(res);
 
   let added = 0;
+  // ZIP slip 방어 — fileName / title / folder.name 모두 사용자 입력이라
+  // "../" 같은 segment 가 섞이면 추출 시 상위 디렉토리로 빠질 수 있음.
+  // sanitizeZipPath 가 각 segment 의 .. / . 제거 + 절대경로 prefix 제거.
+  const usedEntryNames = new Set<string>();
   for (const doc of docs) {
     const key = doc.fileUrl!.replace(/^\/uploads\//, "");
     try {
@@ -182,7 +187,7 @@ export async function streamFolderZip(
       if (!buf) continue;
       const prefix = folderPath(doc.folderId);
       const fname = doc.fileName ?? `${doc.title}`;
-      const entryPath = prefix ? `${prefix}/${fname}` : fname;
+      const entryPath = safeUniqueZipEntry(usedEntryNames, prefix, fname);
       archive.append(buf, { name: entryPath });
       added++;
     } catch (e) {


### PR DESCRIPTION
## 증상
**ZIP slip + CSRF NULL bypass + password-reset rate limit**

보안 취약점을 점검하고 보완합니다.

## 원인
## 1. ZIP slip 방어 (HIGH)
folderShareLink / document 의 ZIP 다운로드가 사용자 입력(fileName / title /
folder.name) 을 그대로 entry path 에 박아 ZIP 내부에 "../" segment 가 들어가
추출 시 상위 디렉토리로 빠질 수 있던 패턴 차단.

신설: server/src/lib/zipSafe.ts
  - sanitizeZipPath: 각 segment 의 .. / . 제거, 절대경로 prefix 제거,
    구분자 정규화, NTFS 예약 문자 underscore 치환
  - safeUniqueZipEntry: sanitize + 중복 회피(꼬리 번호) 한 번에

document.ts: uniqueName 헬퍼를 safeUniqueZipEntry 로 대체
folderShareLink.ts: 동일 적용

## 2. CSRF NULL Origin 우회 차단 (MEDIUM)
이전엔 Origin/Referer 둘 다 없으면 무조건 통과 → SameSite=lax 우회 가능했음.
이제: cookie 가 함께 오는 경우만 차단. 네이티브 앱/curl/웹훅 (Bearer/토큰
인증) 은 cookie 안 쓰므로 영향 없음.

차단 대상: hinest_token / hinest_super / hinest_imp 쿠키 중 하나라도 보유

## 3. password-reset 전용 rate limit (MEDIUM)
이전엔 loginLimiter (10분 30회) 만 적용 — 그 안에서 같은 이메일로 30회
요청 가능 → 메일 폭격 / SES 비용 폭증 / 피해자 inbox 도배.
이제: /api/auth/password-reset/request 전용 limiter — IP 당 시간당 10회.
정상 사용자는 절대 도달 불가능한 수치.

## 수정
**작업 항목 (커밋 단위)**
- security(wave2): ZIP slip + CSRF NULL bypass + password-reset rate limit

**변경 대상 (4개 파일)**
- `server/src/index.ts`
- `server/src/lib/zipSafe.ts`
- `server/src/routes/document.ts`
- `server/src/routes/folderShareLink.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #141** ↔ **이슈 #565** 로 연결됩니다.

Closes #565
