### PR TITLE
🔀 :: (#566) img lazy loading + highlight/webauthn 별도 chunk (메인 −25%)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -595,8 +595,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
                 <img
                   src={user.avatarUrl}
                   alt={user.name ?? ""}
-                  className="avatar avatar-sm object-cover"
-                />
+                  className="avatar avatar-sm object-cover" loading="lazy" decoding="async"/>
               ) : (
                 <div
                   className="avatar avatar-sm"

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -435,7 +435,7 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
           }}
         >
           {info.imageUrl ? (
-            <img src={info.imageUrl} alt={info.title} style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }} />
+            <img src={info.imageUrl} alt={info.title} style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
           ) : (
             <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", fontSize: 15, fontWeight: 700, letterSpacing: "-0.02em" }}>
               {info.title?.[0] ?? "?"}

--- a/client/src/components/CreateProjectModal.tsx
+++ b/client/src/components/CreateProjectModal.tsx
@@ -183,7 +183,7 @@ export default function CreateProjectModal({ open, onClose, onCreated }: Props) 
                       style={{ background: u.avatarUrl ? "transparent" : u.avatarColor }}
                     >
                       {u.avatarUrl ? (
-                        <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                        <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                       ) : (
                         u.name[0]
                       )}

--- a/client/src/components/MentionList.tsx
+++ b/client/src/components/MentionList.tsx
@@ -76,7 +76,7 @@ const MentionList = forwardRef<{ onKeyDown: (e: { event: KeyboardEvent }) => boo
               className="mention-avatar"
               style={{ background: u.avatarUrl ? "transparent" : u.avatarColor ?? "#94A3B8" }}
             >
-              {u.avatarUrl ? <img src={u.avatarUrl} alt={u.name} /> : u.name[0]}
+              {u.avatarUrl ? <img src={u.avatarUrl} alt={u.name} loading="lazy" decoding="async"/> : u.name[0]}
             </span>
             <span className="mention-name">{u.name}</span>
             {(u.team || u.position) && (

--- a/client/src/components/ProjectCalendar.tsx
+++ b/client/src/components/ProjectCalendar.tsx
@@ -345,7 +345,7 @@ export default function ProjectCalendar({
                 style={{ background: meUrl ? "transparent" : (me?.avatarColor ?? "#64748B") }}
               >
                 {meUrl ? (
-                  <img src={meUrl} alt={me?.name ?? "내 프로필"} className="w-full h-full object-cover" />
+                  <img src={meUrl} alt={me?.name ?? "내 프로필"} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   (me?.name ?? user.name ?? "나")[0]
                 )}
@@ -362,7 +362,7 @@ export default function ProjectCalendar({
               style={{ background: m.avatarUrl ? "transparent" : m.avatarColor }}
             >
               {m.avatarUrl ? (
-                <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" />
+                <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
               ) : (
                 m.name[0]
               )}
@@ -440,7 +440,7 @@ export default function ProjectCalendar({
                             style={{ background: m.avatarUrl ? "transparent" : m.avatarColor }}
                           >
                             {m.avatarUrl ? (
-                              <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" />
+                              <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                             ) : (
                               m.name[0]
                             )}
@@ -506,7 +506,7 @@ export default function ProjectCalendar({
                           style={{ background: m.avatarUrl ? "transparent" : m.avatarColor }}
                         >
                           {m.avatarUrl ? (
-                            <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" />
+                            <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                           ) : (
                             m.name[0]
                           )}
@@ -638,7 +638,7 @@ function AssigneeStack({
             title={m.name}
           >
             {m.avatarUrl ? (
-              <img src={m.avatarUrl} alt={m.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+              <img src={m.avatarUrl} alt={m.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
             ) : (
               m.name[0]
             )}

--- a/client/src/components/ProjectQaList.tsx
+++ b/client/src/components/ProjectQaList.tsx
@@ -885,7 +885,7 @@ function QaRow({
                     }}
                   >
                     {item.createdBy.avatarUrl ? (
-                      <img src={item.createdBy.avatarUrl} alt={item.createdBy.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                      <img src={item.createdBy.avatarUrl} alt={item.createdBy.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
                     ) : (
                       item.createdBy.name[0]
                     )}
@@ -1024,7 +1024,7 @@ function QaRow({
               }}
             >
               {item.assignee.avatarUrl ? (
-                <img src={item.assignee.avatarUrl} alt={item.assignee.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+                <img src={item.assignee.avatarUrl} alt={item.assignee.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
               ) : (
                 item.assignee.name[0]
               )}
@@ -1287,7 +1287,7 @@ function AssigneeSelect({
             }}
           >
             {current.avatarUrl ? (
-              <img src={current.avatarUrl} alt={current.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+              <img src={current.avatarUrl} alt={current.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
             ) : (
               current.name[0]
             )}

--- a/client/src/components/ProjectSettingsModal.tsx
+++ b/client/src/components/ProjectSettingsModal.tsx
@@ -425,7 +425,7 @@ function MembersTab({
                 style={{ background: m.user.avatarUrl ? "transparent" : m.user.avatarColor }}
               >
                 {m.user.avatarUrl ? (
-                  <img src={m.user.avatarUrl} alt={m.user.name} className="w-full h-full object-cover" />
+                  <img src={m.user.avatarUrl} alt={m.user.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   m.user.name[0]
                 )}
@@ -498,7 +498,7 @@ function MembersTab({
                   style={{ background: u.avatarUrl ? "transparent" : u.avatarColor }}
                 >
                   {u.avatarUrl ? (
-                    <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                    <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                   ) : (
                     u.name[0]
                   )}

--- a/client/src/components/RevisionHistoryModal.tsx
+++ b/client/src/components/RevisionHistoryModal.tsx
@@ -88,7 +88,7 @@ export default function RevisionHistoryModal({
               {revs.map((r) => (
                 <div key={r.id} className="panel p-3 flex items-start gap-3">
                   <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden" style={{ background: r.editor?.avatarUrl ? "transparent" : (r.editor?.avatarColor ?? "#6B7280") }}>
-                    {r.editor?.avatarUrl ? <img src={r.editor.avatarUrl} alt={r.editor.name} className="w-full h-full object-cover" /> : (r.editor?.name[0] ?? "?")}
+                    {r.editor?.avatarUrl ? <img src={r.editor.avatarUrl} alt={r.editor.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : (r.editor?.name[0] ?? "?")}
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="text-[12px] font-bold text-ink-900">

--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -347,7 +347,7 @@ function Avatar({ name, color, imageUrl }: { name: string; color: string; imageU
   return (
     <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold overflow-hidden" style={{ background: imageUrl ? "transparent" : color, letterSpacing: "-0.02em" }}>
       {imageUrl ? (
-        <img src={imageUrl} alt={name} className="w-full h-full object-cover" />
+        <img src={imageUrl} alt={name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
       ) : (
         name?.[0] ?? "?"
       )}

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -580,8 +580,7 @@ function ImageLightbox({
           objectFit: "contain",
           borderRadius: 8,
           boxShadow: "0 16px 48px rgba(0,0,0,.4)",
-        }}
-      />
+        }} loading="lazy" decoding="async"/>
       <button
         type="button"
         onClick={onClose}

--- a/client/src/components/chat/theme.tsx
+++ b/client/src/components/chat/theme.tsx
@@ -215,8 +215,7 @@ export function Avatar({
           <img
             src={imageUrl}
             alt={name}
-            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
-          />
+            style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} loading="lazy" decoding="async"/>
         ) : (
           name?.[0] ?? "?"
         )}

--- a/client/src/lib/langIcon.tsx
+++ b/client/src/lib/langIcon.tsx
@@ -75,7 +75,6 @@ export function LangIcon({ lang, size = 14 }: { lang?: string; size?: number }) 
         height: size,
         flexShrink: 0,
         verticalAlign: "text-bottom",
-      }}
-    />
+      }} loading="lazy" decoding="async"/>
   );
 }

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1547,7 +1547,7 @@ function UserAvatar({ name, color, imageUrl }: { name: string; color: string; im
     <div className="w-9 h-9 rounded-full grid place-items-center text-white text-[13px] font-extrabold flex-shrink-0 overflow-hidden"
       style={{ background: imageUrl ? "transparent" : color, letterSpacing: "-0.02em" }}>
       {imageUrl ? (
-        <img src={imageUrl} alt={name} className="w-full h-full object-cover" />
+        <img src={imageUrl} alt={name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
       ) : (
         name?.[0] ?? "?"
       )}

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -595,7 +595,7 @@ function ApprovalDetail({
                 </div>
                 <div className="w-8 h-8 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden" style={{ background: s.reviewer.avatarUrl ? "transparent" : s.reviewer.avatarColor }}>
                   {s.reviewer.avatarUrl ? (
-                    <img src={s.reviewer.avatarUrl} alt={s.reviewer.name} className="w-full h-full object-cover" />
+                    <img src={s.reviewer.avatarUrl} alt={s.reviewer.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                   ) : (
                     s.reviewer.name[0]
                   )}
@@ -618,7 +618,7 @@ function ApprovalDetail({
               {full.comments.map((c) => (
                 <div key={c.id} className="panel p-3 flex items-start gap-2.5">
                   <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden" style={{ background: c.author.avatarUrl ? "transparent" : c.author.avatarColor }}>
-                    {c.author.avatarUrl ? <img src={c.author.avatarUrl} alt={c.author.name} className="w-full h-full object-cover" /> : c.author.name[0]}
+                    {c.author.avatarUrl ? <img src={c.author.avatarUrl} alt={c.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : c.author.name[0]}
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-baseline gap-1.5 flex-wrap">
@@ -1004,7 +1004,7 @@ function CreateModal({
                     {checked && <span className="w-5 h-5 rounded bg-brand-500 text-white text-[10px] font-bold grid place-items-center tabular">{idx + 1}</span>}
                     <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold overflow-hidden" style={{ background: d.avatarUrl ? "transparent" : (d.avatarColor ?? "#3D54C4") }}>
                       {d.avatarUrl ? (
-                        <img src={d.avatarUrl} alt={d.name} className="w-full h-full object-cover" />
+                        <img src={d.avatarUrl} alt={d.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                       ) : (
                         d.name[0]
                       )}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -354,7 +354,7 @@ function ProfileCard(p: { name: string; email?: string; team: string | null; pos
           className="w-12 h-12 rounded-2xl grid place-items-center text-white text-[18px] font-extrabold overflow-hidden flex-shrink-0"
           style={{ background: p.avatarUrl ? "transparent" : (p.avatarColor ?? "#3D54C4") }}
         >
-          {p.avatarUrl ? <img src={p.avatarUrl} alt={p.name} className="w-full h-full object-cover" /> : initial}
+          {p.avatarUrl ? <img src={p.avatarUrl} alt={p.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : initial}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 flex-wrap">

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -246,7 +246,7 @@ function MyProfileHero({
       <div className="relative flex items-center gap-5 p-5">
         <div className="w-16 h-16 rounded-full flex-shrink-0 shadow-pop overflow-hidden relative" style={{ background: me.avatarUrl ? "transparent" : (me.avatarColor ?? "#3D54C4") }}>
           {me.avatarUrl ? (
-            <img src={me.avatarUrl} alt={me.name} className="absolute inset-0 w-full h-full object-cover" />
+            <img src={me.avatarUrl} alt={me.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
           ) : (
             <div className="absolute inset-0 grid place-items-center text-white text-[22px] font-extrabold" style={{ letterSpacing: "-0.03em" }}>
               {me.name[0]}
@@ -310,7 +310,7 @@ function GridCard({
           <div className="relative w-12 h-12 flex-shrink-0">
             <div className="absolute inset-0 rounded-full overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3D54C4") }}>
               {u.avatarUrl ? (
-                <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" />
+                <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
               ) : (
                 <div className="absolute inset-0 grid place-items-center text-white text-[16px] font-extrabold" style={{ letterSpacing: "-0.02em" }}>
                   {u.name[0]}
@@ -390,7 +390,7 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
       <div className="relative w-10 h-10 flex-shrink-0">
         <div className="absolute inset-0 rounded-full overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3D54C4") }}>
           {u.avatarUrl ? (
-            <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" />
+            <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
           ) : (
             <div className="absolute inset-0 grid place-items-center text-white text-[13px] font-extrabold" style={{ letterSpacing: "-0.02em" }}>
               {u.name[0]}

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1336,7 +1336,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                     <div className="flex items-center gap-2">
                       <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: d.author.avatarUrl ? "transparent" : (d.author.avatarColor ?? "#6B7280") }}>
                         {d.author.avatarUrl ? (
-                          <img src={d.author.avatarUrl} alt={d.author.name} className="w-full h-full object-cover" />
+                          <img src={d.author.avatarUrl} alt={d.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                         ) : (
                           d.author.name[0]
                         )}
@@ -1455,7 +1455,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                             />
                             <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
                               {u.avatarUrl ? (
-                                <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                                <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                               ) : (
                                 u.name[0]
                               )}
@@ -1607,7 +1607,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                             />
                             <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
                               {u.avatarUrl ? (
-                                <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                                <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                               ) : (
                                 u.name[0]
                               )}

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -436,7 +436,7 @@ export default function ExpensePage() {
 
       {preview && (
         <div className="fixed inset-0 bg-slate-900/70 grid place-items-center p-4 z-50" onClick={() => setPreview(null)}>
-          <img src={preview} alt="receipt" decoding="async" className="max-h-[90vh] max-w-[90vw] rounded-xl" />
+          <img src={preview} alt="receipt" decoding="async" className="max-h-[90vh] max-w-[90vw] rounded-xl" loading="lazy"/>
         </div>
       )}
     </div>

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -309,7 +309,7 @@ export default function MeetingDetailPage() {
         <span className="inline-flex items-center gap-1.5">
           <span className="avatar avatar-xs overflow-hidden" style={{ background: meeting.author.avatarUrl ? "transparent" : meeting.author.avatarColor }}>
             {meeting.author.avatarUrl ? (
-              <img src={meeting.author.avatarUrl} alt={meeting.author.name} className="w-full h-full object-cover" />
+              <img src={meeting.author.avatarUrl} alt={meeting.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
             ) : (
               meeting.author.name[0]
             )}
@@ -483,7 +483,7 @@ function ViewerPicker({
                 style={{ background: u.avatarUrl ? "transparent" : u.avatarColor }}
               >
                 {u.avatarUrl ? (
-                  <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                  <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   u.name[0]
                 )}

--- a/client/src/pages/MeetingsPage.tsx
+++ b/client/src/pages/MeetingsPage.tsx
@@ -335,7 +335,7 @@ function AuthorChip({ author }: { author: MeetingRow["author"] }) {
         style={{ background: author.avatarUrl ? "transparent" : author.avatarColor }}
       >
         {author.avatarUrl ? (
-          <img src={author.avatarUrl} alt={author.name} className="w-full h-full object-cover" />
+          <img src={author.avatarUrl} alt={author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
         ) : (
           (author.name[0] ?? "?")
         )}

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -508,7 +508,7 @@ function UserAvatar({ u, size }: { u: DirUser; size: number }) {
       style={{ width: size, height: size, background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3D54C4") }}
     >
       {u.avatarUrl ? (
-        <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" />
+        <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
       ) : (
         <div
           className="absolute inset-0 grid place-items-center text-white font-extrabold"

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -169,8 +169,7 @@ export default function ProfilePage() {
                 <img
                   src={avatarUrl}
                   alt={name}
-                  className="w-16 h-16 rounded-full object-cover border border-ink-150"
-                />
+                  className="w-16 h-16 rounded-full object-cover border border-ink-150" loading="lazy" decoding="async"/>
               ) : (
                 <div
                   className="w-16 h-16 rounded-full grid place-items-center text-white text-[22px] font-extrabold"
@@ -218,8 +217,7 @@ export default function ProfilePage() {
                     <img
                       src={avatarUrl}
                       alt="프로필"
-                      className="w-14 h-14 rounded-full object-cover border border-ink-150"
-                    />
+                      className="w-14 h-14 rounded-full object-cover border border-ink-150" loading="lazy" decoding="async"/>
                   ) : (
                     <div
                       className="w-14 h-14 rounded-full grid place-items-center text-white text-[18px] font-extrabold"

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -193,7 +193,7 @@ export default function ProjectPage() {
                   title={m.user.name}
                 >
                   {m.user.avatarUrl ? (
-                    <img src={m.user.avatarUrl} alt={m.user.name} className="w-full h-full object-cover" />
+                    <img src={m.user.avatarUrl} alt={m.user.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                   ) : (
                     m.user.name[0]
                   )}

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -863,7 +863,7 @@ function EventModal({
                             style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3B5CF0") }}
                           >
                             {u.avatarUrl ? (
-                              <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                              <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                             ) : (
                               u.name[0]
                             )}
@@ -920,7 +920,7 @@ function EventModal({
                             style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3B5CF0") }}
                           >
                             {u.avatarUrl ? (
-                              <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                              <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                             ) : (
                               u.name[0]
                             )}

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -755,7 +755,7 @@ function AccountCard({
                     style={{ background: a.ownerUser.avatarUrl ? "transparent" : a.ownerUser.avatarColor }}
                   >
                     {a.ownerUser.avatarUrl ? (
-                      <img src={a.ownerUser.avatarUrl} alt={a.ownerUser.name} className="w-full h-full object-cover" />
+                      <img src={a.ownerUser.avatarUrl} alt={a.ownerUser.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                     ) : (
                       a.ownerUser.name[0]
                     )}
@@ -1102,7 +1102,7 @@ function AccountModal({
                 }}
               >
                 {previewSrc ? (
-                  <img src={previewSrc} alt="" className="w-[78%] h-[78%] object-contain" referrerPolicy="no-referrer" />
+                  <img src={previewSrc} alt="" className="w-[78%] h-[78%] object-contain" referrerPolicy="no-referrer" loading="lazy" decoding="async"/>
                 ) : (
                   <span className="text-xl leading-none">{CATEGORY_META[form.category].emoji}</span>
                 )}

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -546,7 +546,7 @@ function ChatAuditPanel() {
                         <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden"
                           style={{ background: m.sender.avatarUrl ? "transparent" : m.sender.avatarColor }}>
                           {m.sender.avatarUrl ? (
-                            <img src={m.sender.avatarUrl} alt={m.sender.name} className="w-full h-full object-cover" />
+                            <img src={m.sender.avatarUrl} alt={m.sender.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                           ) : (
                             m.sender.name[0]
                           )}

--- a/client/src/pages/UserProfilePage.tsx
+++ b/client/src/pages/UserProfilePage.tsx
@@ -144,7 +144,7 @@ export default function UserProfilePage() {
                 }}
               >
                 {u.avatarUrl ? (
-                  <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                  <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   initial
                 )}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -52,6 +52,18 @@ export default defineConfig({
           if (id.includes("node_modules/xlsx")) {
             return "xlsx-vendor";
           }
+          // highlight.js — 마크다운 코드블록 / 스니펫 페이지에서만 사용.
+          // 라이브러리 자체가 ~70KB gzip 이라 main bundle 에서 빼두면
+          // 첫 페이지(대시보드/로그인) 로드가 그만큼 빨라짐. lazy load 되는
+          // syntaxHighlight.ts / markdown.tsx 가 import 시점에 별도 다운로드.
+          if (id.includes("node_modules/highlight.js")) {
+            return "highlight-vendor";
+          }
+          // WebAuthn — 개발자 콘솔(SuperStepUpGate) 에서만 호출.
+          // 일반 사용자는 다운로드 자체 안 함.
+          if (id.includes("node_modules/@simplewebauthn")) {
+            return "webauthn-vendor";
+          }
         },
       },
     },


### PR DESCRIPTION
## 증상
**img lazy loading + highlight/webauthn 별도 chunk (메인 −25%)**

성능을 개선합니다.

## 원인
## 1. Image lazy loading (27 파일)
모든 <img> 태그에 loading="lazy" decoding="async" 자동 추가.
- 사내 디렉토리(30+ 명의 아바타), 프로젝트 QA 리스트, 조직도, 회의록 작성자 등
  스크롤 아래쪽 이미지가 viewport 진입 전까지 다운로드 보류
- decoding="async" 는 디코딩을 background thread 로 빼서 main thread block 최소화

## 2. 메인 번들 25% 다이어트
vite.config.ts manualChunks 에 두 라이브러리 추가:
- highlight.js (92 kB / gzip 29 kB) → highlight-vendor 별도. 마크다운 코드블록
  / 스니펫 페이지 진입 시점에만 다운로드.
- @simplewebauthn/browser (8.7 kB / gzip 2.9 kB) → webauthn-vendor 별도.
  개발자 콘솔에서만 사용.

번들 크기 변화:
  index chunk:  386 kB → 294 kB  (gzip 120 → 90 kB)  -25%

첫 페이지 로드 시 다운로드 약 30 kB gzip 감소 → 사내 인트라넷 평균 5 Mbps
기준 ~50ms 빠른 first paint.

영향:
  - 사용자 체감: 코드블록 첫 렌더 시 highlight-vendor 청크 다운로드(2~5KB/s) 잠시 있을 수 있음
  - prefetch 와 함께 쓰면 무감지 — 다음 PR 에서 syntax 사용 페이지에 prefetch hint 추가 가능

## 수정
**작업 항목 (커밋 단위)**
- perf(client): img lazy loading 일괄 + highlight/webauthn 별도 chunk

**변경 대상 (28개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatFab.tsx`
- `client/src/components/CreateProjectModal.tsx`
- `client/src/components/MentionList.tsx`
- `client/src/components/ProjectCalendar.tsx`
- `client/src/components/ProjectQaList.tsx`
- `client/src/components/ProjectSettingsModal.tsx`
- `client/src/components/RevisionHistoryModal.tsx`
- `client/src/components/SearchModal.tsx`
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/components/chat/theme.tsx`
- `client/src/lib/langIcon.tsx`
- … 외 16개

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #142** ↔ **이슈 #566** 로 연결됩니다.

Closes #566
