### PR TITLE
🔀 :: (#567) ErrorBoundary + slow query log + graceful shutdown

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useAuth } from "./auth";
 import UpdateBanner from "./components/UpdateBanner";
 import DesktopUpdateBanner from "./components/DesktopUpdateBanner";
 import ConfirmHost from "./components/ConfirmHost";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import LoginPage from "./pages/LoginPage";
 import SignupPage from "./pages/SignupPage";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage";
@@ -68,11 +69,15 @@ function SuperOnly({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  // 라우트 단위 ErrorBoundary 의 reset 트리거 — 다음 페이지로 이동하면 자동 초기화.
+  // 이렇게 안 하면 한 페이지에서 에러 나면 다른 메뉴로 가도 fallback 이 계속 보임.
+  const { pathname } = useLocation();
   return (
     <>
     <UpdateBanner />
     <DesktopUpdateBanner />
     <ConfirmHost />
+    <ErrorBoundary resetKey={pathname}>
     <Suspense fallback={<RouteFallback />}>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
@@ -127,6 +132,7 @@ export default function App() {
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </Suspense>
+    </ErrorBoundary>
     </>
   );
 }

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,104 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * Route-level Error Boundary — 한 페이지의 렌더 에러가 앱 전체를 흰 화면으로
+ * 만드는 걸 막는다. 잡힌 에러는 fallback UI 로 표시하고, 사용자는 다른 라우트로
+ * 이동하거나 새로고침해서 회복할 수 있다.
+ *
+ * 사용:
+ *   <ErrorBoundary>
+ *     <SomePage />
+ *   </ErrorBoundary>
+ *
+ *   또는 라우트 컨테이너 한 곳에 두르고 location.pathname 으로 reset.
+ *
+ * 비-React 에러(이벤트 핸들러 / setTimeout / Promise rejection) 는 잡지 못한다 —
+ * 그건 window 의 error / unhandledrejection 리스너 + Sentry 같은 외부 도구가
+ * 처리할 영역. ErrorBoundary 는 렌더 단계 에러 전용.
+ */
+
+type Props = {
+  children: ReactNode;
+  /** 라우트 키 — 바뀌면 error 상태 reset. 보통 location.pathname. */
+  resetKey?: string;
+  /** fallback UI 커스텀. 없으면 기본 화면. */
+  fallback?: (err: Error, reset: () => void) => ReactNode;
+};
+
+type State = { error: Error | null };
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // 운영 환경에서 외부 리포터(Sentry/Datadog 등) 가 있다면 여기서 호출.
+    // 사내툴 규모에선 console.error 로도 superadmin 콘솔의 인메모리 버퍼에 잡힘.
+    console.error("[ErrorBoundary] render failure", {
+      message: error.message,
+      stack: error.stack?.split("\n").slice(0, 6).join("\n"),
+      component: info.componentStack?.split("\n").slice(0, 5).join("\n"),
+    });
+  }
+
+  componentDidUpdate(prev: Props) {
+    if (this.state.error && prev.resetKey !== this.props.resetKey) {
+      // 라우트가 바뀌었으면 다음 페이지에는 에러를 끌고 가지 않는다.
+      this.setState({ error: null });
+    }
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) return this.props.fallback(this.state.error, this.reset);
+      return <DefaultFallback error={this.state.error} reset={this.reset} />;
+    }
+    return this.props.children;
+  }
+}
+
+function DefaultFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="min-h-[60vh] flex items-center justify-center px-6"
+      style={{ background: "var(--c-surface)" }}
+    >
+      <div className="max-w-md w-full panel p-7 text-center">
+        <div className="text-[42px] mb-2" aria-hidden>⚠️</div>
+        <h2 className="text-[18px] font-extrabold text-ink-900 mb-1.5">
+          이 페이지를 표시하는 중 문제가 발생했어요
+        </h2>
+        <p className="text-[13px] text-ink-500 leading-relaxed mb-4">
+          새로고침하면 대부분 회복돼요. 같은 문제가 반복되면 다른 메뉴로 이동해 주세요.
+        </p>
+        {/* 에러 메시지는 펼친 상태에선 노출하지 않음 — 운영자 디버깅용으로만 details 안에 */}
+        <details className="text-[11px] text-ink-400 mb-4 text-left">
+          <summary className="cursor-pointer select-none">기술 정보</summary>
+          <code className="block mt-1.5 break-all">{error.message || error.name}</code>
+        </details>
+        <div className="flex items-center justify-center gap-2">
+          <button
+            type="button"
+            className="btn-ghost"
+            onClick={() => { reset(); window.location.assign("/"); }}
+          >
+            홈으로
+          </button>
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={() => window.location.reload()}
+          >
+            새로고침
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -428,7 +428,7 @@ async function backfillNoticeLinks() {
   }
 }
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`[HiNest API] http://localhost:${PORT}`);
   backfillNoticeLinks();
   backfillUserIdentity();
@@ -436,4 +436,49 @@ app.listen(PORT, () => {
   import("./jobs/autoClockOut.js").then((m) => m.startAutoClockOut()).catch((e) => {
     console.error("[autoClockOut] 스케줄러 로드 실패:", e);
   });
+});
+
+// === Graceful shutdown ===
+// ECS Fargate 가 배포 중 task 교체할 때 SIGTERM 을 30초 grace 안에 보낸다.
+// 그 30초 동안 진행 중인 요청을 정상 처리하고, 새 요청은 받지 않으며, DB 연결을
+// 닫아야 한다. 그래야 사용자가 "갑자기 끊겼다" / 502 를 안 보고, prisma 연결도
+// pgBouncer/RDS 풀에 dangling 으로 남지 않는다.
+//
+// 흐름:
+//   1) SIGTERM 수신 → server.close() (새 연결 거부, 기존 요청 finish 대기)
+//   2) prisma.$disconnect() (커넥션 풀 cleanup)
+//   3) 25초 안에 안 끝나면 process.exit(1) — Fargate 가 SIGKILL 보내기 직전 자체 종료.
+let shuttingDown = false;
+function shutdown(signal: string) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[shutdown] ${signal} received — draining connections`);
+  const forceTimer = setTimeout(() => {
+    console.error("[shutdown] 25s timeout — forcing exit");
+    process.exit(1);
+  }, 25_000);
+  server.close(async (err) => {
+    if (err) console.error("[shutdown] server.close error:", err);
+    try {
+      const { prisma } = await import("./lib/db.js");
+      await prisma.$disconnect();
+      console.log("[shutdown] prisma disconnected");
+    } catch (e) {
+      console.error("[shutdown] prisma disconnect failed:", e);
+    }
+    clearTimeout(forceTimer);
+    console.log("[shutdown] clean exit");
+    process.exit(0);
+  });
+}
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+// uncaughtException / unhandledRejection — 로깅만 하고 프로세스는 유지.
+// (exit 시키면 ECS 가 재시작하지만 그 사이 사용자는 끊김 — 일시적 에러는 흘려보내는 게 운영상 안전)
+process.on("uncaughtException", (err) => {
+  console.error("[uncaughtException]", err);
+});
+process.on("unhandledRejection", (reason) => {
+  console.error("[unhandledRejection]", reason);
 });

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -11,6 +11,9 @@ import { PrismaClient } from "@prisma/client";
  */
 const CONNECTION_LIMIT = Number(process.env.DB_POOL_SIZE ?? "5");
 
+/** Slow query 경고 임계값 (ms). 환경변수로 조정. 기본 500ms. */
+const SLOW_QUERY_MS = Number(process.env.PRISMA_SLOW_QUERY_MS ?? "500");
+
 export const prisma = new PrismaClient({
   datasources: {
     db: {
@@ -19,4 +22,22 @@ export const prisma = new PrismaClient({
         : undefined,
     },
   },
+  // Prisma 의 "query" 이벤트를 받아 임계값 초과 쿼리만 골라 로깅.
+  // production 에서도 켜둠 — slow query 1개당 한 줄이라 비용 영향 없고, 인덱스 누락
+  // 탐지가 가장 빠른 방법.
+  log: [
+    { emit: "event", level: "query" },
+    { emit: "stdout", level: "warn" },
+    { emit: "stdout", level: "error" },
+  ],
+});
+
+// "query" 이벤트: { query, params, duration, target } — duration 은 ms.
+//   - target=quaint 등 내부 라이브러리 호출은 무시.
+//   - 비밀번호 해시 등 민감한 값을 stderr 에 남기지 않도록 params 는 안 찍는다.
+(prisma as any).$on("query", (e: any) => {
+  if (typeof e?.duration === "number" && e.duration >= SLOW_QUERY_MS) {
+    const q = String(e.query ?? "").slice(0, 200);
+    console.warn(`[prisma:slow] ${e.duration}ms ${q}${q.length >= 200 ? "…" : ""}`);
+  }
 });


### PR DESCRIPTION
## 증상
**ErrorBoundary + slow query log + graceful shutdown**

유지보수 작업을 진행합니다.

## 원인
## 1. Route-level ErrorBoundary
한 페이지의 렌더 에러가 앱 전체를 흰 화면으로 만드는 걸 막는다.
- client/src/components/ErrorBoundary.tsx 신설
- App.tsx 의 Routes 전체를 감싸고, location.pathname 을 resetKey 로 줘서
  다른 메뉴로 이동하면 자동 회복
- 잡힌 에러는 console.error 로 super-admin 콘솔 인메모리 버퍼에 기록
  (별도 외부 리포터 없이도 운영자가 진단 가능)
- fallback UI: "홈으로" / "새로고침" 두 버튼 + 기술 정보 details 토글

## 2. Prisma slow query 로깅
인덱스 누락이나 N+1 패턴을 운영 환경에서 빠르게 잡기 위한 진단.
- server/src/lib/db.ts 에 query 이벤트 핸들러 추가
- 임계값 PRISMA_SLOW_QUERY_MS (기본 500ms) 넘는 쿼리만 [prisma:slow] 마커로 로그
- params 는 절대 안 찍음 (passwordHash 등 민감값 누출 방지)
- 200자 truncate — 거대한 IN(...) 쿼리도 한 줄로

## 3. Graceful shutdown (SIGTERM 처리)
ECS Fargate 가 배포 중 task 교체 시 SIGTERM 30초 grace 안에 보낸다.
이전엔 그 동안 진행 중인 요청이 끊겨 사용자가 502 / 끊김 경험.

- server.close(): 새 연결 거부 + 기존 요청 finish 대기
- prisma.$disconnect(): 커넥션 풀 cleanup (RDS dangling 연결 방지)
- 25초 타임아웃 → force exit (Fargate 의 SIGKILL 직전 자체 종료)
- uncaughtException / unhandledRejection 은 로깅만 — 일시 에러로 프로세스
  죽이지 않음 (사용자 끊김 최소화)

## 수정
**작업 항목 (커밋 단위)**
- reliability(wave4): ErrorBoundary + slow query log + graceful shutdown

**변경 대상 (4개 파일)**
- `client/src/App.tsx`
- `client/src/components/ErrorBoundary.tsx`
- `server/src/index.ts`
- `server/src/lib/db.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #143** ↔ **이슈 #567** 로 연결됩니다.

Closes #567
