### PR TITLE
🔀 :: (#568) request id 미들웨어 + $transaction 명시 timeout

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -96,6 +96,20 @@ app.use(
 app.use(express.json({ limit: "2mb" }));
 app.use(cookieParser());
 
+// === Request ID 미들웨어 ===
+// 각 요청에 고유 ID 를 붙여 access log / error log / superadmin 로그 뷰에서
+// "이 5xx 가 그 요청이었음" 을 상호참조할 수 있게 한다. 응답 헤더 X-Request-ID 로
+// 클라에도 노출 — 사용자 버그 리포트 시 그 ID 만 받으면 서버 로그 즉시 검색 가능.
+//
+// 형식: <epoch36>-<rand36>  (예: l4hk2x-a3f9)
+import crypto from "node:crypto";
+app.use((req, res, next) => {
+  const rid = `${Date.now().toString(36)}-${crypto.randomBytes(3).toString("hex")}`;
+  (req as any).requestId = rid;
+  res.setHeader("X-Request-ID", rid);
+  next();
+});
+
 // HTTP 액세스 라인을 인메모리 버퍼에 적재 — \"GET /api/x 200 12ms\" 형식.
 // query string 안의 token/password/secret/key 같은 값은 마스킹해 개발자 콘솔의 \"서버 로그\" 탭에서
 // 우연히 노출되지 않도록 차단.
@@ -121,7 +135,8 @@ app.use((req, res, next) => {
   res.on("finish", () => {
     const dur = Date.now() - start;
     const url = req.originalUrl || req.url;
-    pushHttpLog(`${req.method} ${scrubUrl(url)} ${res.statusCode} ${dur}ms`);
+    const rid = (req as any).requestId;
+    pushHttpLog(`${rid} ${req.method} ${scrubUrl(url)} ${res.statusCode} ${dur}ms`);
   });
   next();
 });
@@ -309,7 +324,9 @@ function sanitizeDownloadName(s: string): string {
 }
 
 app.use((err: any, req: express.Request, res: express.Response, _next: express.NextFunction) => {
-  console.error(err);
+  const rid = (req as any).requestId;
+  // request id 를 stack 앞에 박아 access log 와 error log 를 한 줄로 검색 가능.
+  console.error(`[err:${rid}]`, err);
   const status = typeof err.status === "number" ? err.status : 500;
   // 500 계열 예상치 못한 에러는 내부 메시지 유출 방지 — DB/Prisma 오류가 그대로 나가지 않도록.
   // 4xx 는 우리가 직접 throw 한 의도된 에러라 message 노출 허용.
@@ -322,7 +339,7 @@ app.use((err: any, req: express.Request, res: express.Response, _next: express.N
         status,
         method: req.method,
         path: req.path,
-        message: String(err?.message ?? err ?? "Unknown"),
+        message: `[${rid}] ${String(err?.message ?? err ?? "Unknown")}`,
         stack: String(err?.stack ?? ""),
         userId: (req as any).user?.id ?? null,
         ua: (req.headers["user-agent"] || "").slice(0, 200) || null,
@@ -330,7 +347,9 @@ app.use((err: any, req: express.Request, res: express.Response, _next: express.N
       });
     } catch { /* 로깅 실패가 응답을 막지 않게 */ }
   }
-  res.status(status).json({ error: msg });
+  // 응답에도 request id 박아서 (이미 미들웨어가 헤더로 보냄) 클라가 알 수 있게 body 에도 포함.
+  // 사용자 버그 리포트 → 우리가 이 ID 만 있으면 서버 로그 한 번에 검색.
+  res.status(status).json({ error: msg, requestId: rid });
 });
 
 // 방어: Prisma 등 async 에러로 프로세스가 죽지 않도록

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -600,11 +600,12 @@ router.post("/positions/reorder", async (req, res) => {
     return res.status(400).json({ error: "ids 가 현재 직급 목록과 일치하지 않습니다" });
   }
 
-  await prisma.$transaction(
-    ids.map((id: string, i: number) =>
-      prisma.position.update({ where: { id }, data: { rank: i } }),
-    ),
-  );
+  // 배열 형태는 timeout 미지원이라 callback 형태로 변경 — 직급 수십 개 reorder 안전.
+  await prisma.$transaction(async (tx) => {
+    for (let i = 0; i < ids.length; i++) {
+      await tx.position.update({ where: { id: ids[i] }, data: { rank: i } });
+    }
+  }, { timeout: 8_000 });
   await writeLog(u.id, "POSITION_REORDER", undefined, `${ids.length}건`);
   res.json({ ok: true });
 });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -202,7 +202,13 @@ router.post("/signup", async (req, res) => {
         team: created.team, position: created.position,
         avatarColor: created.avatarColor, avatarUrl: created.avatarUrl, superAdmin: created.superAdmin,
       };
-    }, { isolationLevel: "Serializable" });
+    }, {
+      isolationLevel: "Serializable",
+      // 명시적 timeout — 기본 5초는 bcrypt 비번 해싱이 끝나기 전 lock 잡을 수 있음을
+      // 고려하면 짧다. 트랜잭션은 짧고 (updateMany + create + update), Serializable
+      // retry 까지 고려해 10초.
+      timeout: 10_000,
+    });
   } catch (e: any) {
     // 동시성 충돌 또는 race 결과. 메시지는 통일.
     if (e?._http === 400) return res.status(400).json({ error: e.message });
@@ -578,6 +584,10 @@ router.post("/password-reset/confirm", async (req, res) => {
       where: { userId: row.userId, id: { not: row.id }, usedAt: null, expiresAt: { gt: new Date() } },
       data: { expiresAt: new Date() },
     });
+  }, {
+    // 4 step 트랜잭션 — 사용자 update + session revoke + 토큰 사용 처리 + 다른 토큰 무효화.
+    // 명시적 8초 timeout — 기본 5초보다 여유. 그래도 응답 30초 안엔 끝나도록.
+    timeout: 8_000,
   });
 
   // 캐시된 세션 revoke 상태 즉시 반영 — 다른 기기에서 다음 요청에 401.

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -538,6 +538,9 @@ router.patch("/:id", async (req, res) => {
             : d.projectId ?? undefined,
       },
     });
+  }, {
+    // 명시적 timeout — viewer 가 수십명일 때 deleteMany + createMany 가 길어질 수 있어 8초.
+    timeout: 8_000,
   });
   await writeLog(u.id, "MEETING_UPDATE", updated.id);
 

--- a/server/src/routes/pin.ts
+++ b/server/src/routes/pin.ts
@@ -127,9 +127,13 @@ router.post("/reorder", async (req, res) => {
   // 내 것만 검증.
   const mine = await prisma.pin.findMany({ where: { userId: u.id, id: { in: ids } }, select: { id: true } });
   if (mine.length !== ids.length) return res.status(400).json({ error: "invalid ids" });
-  await prisma.$transaction(
-    ids.map((id, i) => prisma.pin.update({ where: { id }, data: { sortOrder: i } })),
-  );
+  // 배열 형태 → callback 형태로 변경. 배열 형태는 timeout 옵션을 받지 않으므로
+  // 100개 짜리 정렬에서 default 5초 timeout 에 걸릴 위험을 명시적으로 막는다.
+  await prisma.$transaction(async (tx) => {
+    for (let i = 0; i < ids.length; i++) {
+      await tx.pin.update({ where: { id: ids[i] }, data: { sortOrder: i } });
+    }
+  }, { timeout: 8_000 });
   res.json({ ok: true });
 });
 


### PR DESCRIPTION
## 증상
**request id 미들웨어 + $transaction 명시 timeout**

유지보수 작업을 진행합니다.

## 원인
## 1. Request ID 미들웨어
사용자 버그 리포트 ↔ 서버 로그 연결을 한 줄로 가능하게.

- 모든 요청에 <epoch36>-<rand36> 형태 ID 부여, 응답 헤더 X-Request-ID
- access log: "rid GET /api/x 200 12ms" — 한 줄에 ID 포함
- error log: console.error "[err:rid] ...", pushErrorEvent message 도 prefix
- 5xx 응답 body 에 { error, requestId } — 클라가 그대로 사용자에게 표시 가능
  → 사용자가 ID 만 우리에게 보내주면 서버 로그 즉시 검색

## 2. $transaction 명시 timeout
이전엔 모든 트랜잭션이 Prisma 기본 5초 timeout. signup 의 bcrypt 해싱 +
4-step 트랜잭션은 부하 상황에서 5초를 넘길 수 있어 의도치 않은 abort 발생 가능.

- auth.ts signup: 10초 (Serializable retry 여유)
- auth.ts password-reset/confirm: 8초 (4-step)
- meeting.ts update: 8초 (viewer deleteMany + createMany)
- pin.ts reorder: 8초 + 배열 형태 → callback 형태 변경 (배열은 timeout 미지원)
- admin.ts position reorder: 8초 + 동일 변경

응답 30초 타임아웃 안에 들어가도록 모두 10초 이하로 캡.

## 수정
**작업 항목 (커밋 단위)**
- reliability(wave5): request id 미들웨어 + $transaction 명시 timeout

**변경 대상 (5개 파일)**
- `server/src/index.ts`
- `server/src/routes/admin.ts`
- `server/src/routes/auth.ts`
- `server/src/routes/meeting.ts`
- `server/src/routes/pin.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #144** ↔ **이슈 #568** 로 연결됩니다.

Closes #568
