### PR TITLE
🔀 :: (#569) 그룹방 삭제 기능 + Windows 다운로드 안전성 개선

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -313,7 +313,16 @@ export default function ChatMiniApp({
         });
       }
     };
-    const onRoom = () => { loadRooms(); };
+    const onRoom = (ev: Event) => {
+      // 서버가 { kind: "deleted", roomId } 푸시 → 활성 방이 그거였으면 즉시 닫고,
+      // rooms 목록도 재조회. (그냥 loadRooms() 만 부르면 hover 상태에서 깜빡임)
+      const detail = (ev as CustomEvent).detail as { kind?: string; roomId?: string } | undefined;
+      if (detail?.kind === "deleted" && detail.roomId) {
+        if (activeId === detail.roomId) setActiveId(null);
+        setRooms((prev) => prev.filter((r) => r.id !== detail.roomId));
+      }
+      loadRooms();
+    };
     window.addEventListener("chat:sse-message", onMessage);
     window.addEventListener("chat:sse-update", onUpdate);
     window.addEventListener("chat:sse-room", onRoom);
@@ -612,9 +621,32 @@ export default function ChatMiniApp({
         <SettingsView
           room={active}
           meId={user?.id ?? ""}
+          isAdmin={user?.role === "ADMIN"}
           settings={roomSettings[active.id] ?? {}}
           onPatch={(p) => patchRoomSetting(active.id, p)}
           messages={messages}
+          onDeleteRoom={async () => {
+            // 그룹 생성자(또는 ADMIN) 만 가능 — 서버가 한 번 더 검증.
+            // 삭제 성공하면 onRoom SSE 가 도착하기 전에 클라가 먼저 정리.
+            const ok = await confirmAsync({
+              title: "그룹방 삭제",
+              description: `"${roomTitle(active, user?.id ?? "")}" 을(를) 삭제할까요?\n메시지와 첨부도 모두 사라지고, 되돌릴 수 없어요.`,
+              tone: "danger",
+              confirmLabel: "삭제",
+            });
+            if (!ok) return;
+            try {
+              await api(`/api/chat/rooms/${active.id}`, { method: "DELETE" });
+              setShowSettings(false);
+              setActiveId(null);
+              setRooms((prev) => prev.filter((r) => r.id !== active.id));
+            } catch (e: any) {
+              await alertAsync({
+                title: "삭제 실패",
+                description: e?.message ?? "잠시 후 다시 시도해 주세요",
+              });
+            }
+          }}
         />
       ) : active ? (
         <RoomView
@@ -1240,14 +1272,21 @@ function CreateGroupView({
 
 /* ======================= 채팅방 설정 ======================= */
 function SettingsView({
-  room, meId, settings, onPatch, messages,
+  room, meId, isAdmin, settings, onPatch, messages, onDeleteRoom,
 }: {
   room: Room;
   meId: string;
+  /** ADMIN 권한이면 어떤 그룹방이든 삭제 가능. */
+  isAdmin: boolean;
   settings: { nickname?: string; muted?: boolean };
   onPatch: (p: { nickname?: string; muted?: boolean }) => void;
   messages: Message[];
+  onDeleteRoom: () => void | Promise<void>;
 }) {
+  // 그룹/팀방 삭제 권한 — 생성자 본인 또는 ADMIN.
+  // DM 은 어떤 경우에도 삭제 불가 (서버에서도 거부).
+  const canDeleteRoom =
+    room.type !== "DIRECT" && (room.createdById === meId || isAdmin);
   const originalTitle = roomTitle(room, meId);
   const [draft, setDraft] = useState(settings.nickname ?? "");
   const [editing, setEditing] = useState(false);
@@ -1399,6 +1438,43 @@ function SettingsView({
       </button>
 
       <SharedMediaTabs messages={messages} />
+
+      {canDeleteRoom && (
+        <>
+          <SectionLabel>위험 구역</SectionLabel>
+          <button
+            type="button"
+            onClick={onDeleteRoom}
+            style={{
+              width: "100%",
+              padding: "12px 14px",
+              borderRadius: 12,
+              background: "color-mix(in srgb, var(--c-danger) 8%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--c-danger) 24%, transparent)",
+              color: "var(--c-danger)",
+              fontSize: 14, fontWeight: 700,
+              cursor: "pointer",
+              textAlign: "left",
+              display: "flex", alignItems: "center", gap: 10,
+              transition: "background .12s ease",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "color-mix(in srgb, var(--c-danger) 14%, transparent)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "color-mix(in srgb, var(--c-danger) 8%, transparent)")}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 6h18" />
+              <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+            </svg>
+            <div style={{ flex: 1 }}>
+              <div>그룹방 삭제</div>
+              <div style={{ fontSize: 11.5, fontWeight: 500, marginTop: 2, opacity: 0.85 }}>
+                메시지 · 첨부 · 멤버 정보가 모두 사라지고 되돌릴 수 없어요
+              </div>
+            </div>
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -9,6 +9,8 @@ export type Room = {
   id: string;
   name: string;
   type: "GROUP" | "DIRECT" | "TEAM";
+  /** 그룹/팀방 생성자 — DELETE 권한 판정. legacy row 는 null. */
+  createdById?: string | null;
   members: RoomMember[];
   messages: {
     content: string;

--- a/client/src/pages/DownloadPage.tsx
+++ b/client/src/pages/DownloadPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import Logo from "../components/Logo";
 
@@ -8,18 +8,21 @@ import Logo from "../components/Logo";
  * - Windows / macOS → 데스크톱 인스톨러 다운로드 링크
  * - iOS / Android   → PWA "홈 화면에 추가" 안내 (네이티브 앱 없이 웹앱으로 처리)
  *
- * 공개 페이지 — 로그인 없이 접근 가능. 사내 누구나 공유받고 바로 설치 흐름으로 갈 수 있도록.
+ * 공개 페이지 — 로그인 없이 접근 가능.
  *
- * 설치 파일 호스팅:
- *   현재는 GitHub Releases 에 올릴 예정이며, 아래 링크는 임시 플레이스홀더.
- *   실제 릴리스 레포가 확정되면 `DESKTOP_RELEASES_BASE` 만 바꾸면 된다.
+ * 다운로드 경로:
+ *   직접 GitHub Releases 링크 대신 자체 도메인 프록시(/api/download/*)를 사용한다.
+ *   이유:
+ *     1) Chrome/Edge Safe Browsing 의 평판은 도메인+파일명 조합 기반 — 자체
+ *        도메인의 일관된 경로로 배포하면 시간이 갈수록 \"안전하지 않은 파일\" 경고가
+ *        사라진다 (github.com 직링은 매번 새 평판).
+ *     2) 서버가 Content-Type / Content-Disposition / X-Content-Type-Options 를
+ *        명시 → 브라우저 MIME 추측 실패로 인한 다운로드 차단 방지.
  *
- * 다크 모드: html.dark 클래스 + CSS 변수(--c-bg / --c-surface / --c-text ...)로 자동 전환.
- *   → 배경/상단바에 var(--c-bg) 사용. 텍스트는 --c-text / --c-text-2 / --c-text-3.
+ *   백엔드 라우터: server/src/routes/desktopDownload.ts
  */
 
-const DESKTOP_RELEASES_BASE =
-  "https://github.com/Xixn2/HiNest-Desktop/releases/latest/download";
+const DESKTOP_DOWNLOAD_BASE = "/api/download";
 
 type OS = "win" | "mac" | "ios" | "android" | "other";
 
@@ -95,6 +98,102 @@ function IconAndroid() {
       <circle cx="9.6" cy="7.3" r="0.7" style={{ fill: "var(--c-surface-3)" }} />
       <circle cx="14.4" cy="7.3" r="0.7" style={{ fill: "var(--c-surface-3)" }} />
     </svg>
+  );
+}
+
+/**
+ * Windows 다운로드 차단/SmartScreen 우회 안내.
+ * 접힌 상태로 두고, 차단 경험한 사용자만 펼치도록.
+ *
+ * 사용자 시점에서 나타날 수 있는 막힘 단계:
+ *   (1) Chrome  "안전하지 않은 파일은 차단될 수 있습니다" / "위험 또는 안전하지 않은 다운로드"
+ *   (2) Windows SmartScreen "Windows의 PC 보호" 모달 (게시자: 알 수 없음)
+ *   (3) (드물게) Windows Defender 가 곧바로 격리 — 이건 우회 대신 신고 + 재배포 필요
+ *
+ * 각 단계의 사용자 친화적 우회 절차를 단계별로 분리해 보여준다.
+ */
+function WindowsBlockHelp() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ marginTop: 4 }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="text-[11.5px] font-semibold transition"
+        style={{
+          color: "var(--c-text-3)",
+          background: "transparent",
+          border: 0,
+          cursor: "pointer",
+          padding: "2px 0",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+        }}
+      >
+        <span aria-hidden style={{ transition: "transform .12s ease", display: "inline-block", transform: open ? "rotate(90deg)" : "rotate(0)" }}>›</span>
+        다운로드가 차단됐어요 / 안전하지 않은 파일이라고 떠요
+      </button>
+      {open && (
+        <div
+          className="text-[12px] leading-relaxed mt-2 p-3 rounded-lg"
+          style={{
+            background: "var(--c-surface-2)",
+            color: "var(--c-text-2)",
+            border: "1px solid var(--c-border)",
+          }}
+        >
+          <p style={{ marginBottom: 6 }}>
+            HiNest 데스크톱 앱은 아직 코드 서명 인증서를 받기 전이라, 처음 받을 때
+            브라우저나 Windows 가 한 번 확인을 요청해요. 단계별로:
+          </p>
+
+          <div style={{ marginTop: 8 }}>
+            <div style={{ fontWeight: 700, color: "var(--c-text)", marginBottom: 4 }}>
+              1) 브라우저(Chrome / Edge) 에서 차단 메시지가 떴을 때
+            </div>
+            <ul style={{ paddingLeft: 18, listStyle: "disc" }}>
+              <li>
+                다운로드 표시줄 또는 우측 상단 알림의 <b>점 3개(⋯) → "보관"</b>
+                (또는 "계속", "확인 후 다운로드") 을 누르세요.
+              </li>
+              <li>
+                Edge 라면 다운로드 탭 → 파일 옆 <b>⋯ → "보관" → "안전한 파일임"</b>.
+              </li>
+            </ul>
+          </div>
+
+          <div style={{ marginTop: 10 }}>
+            <div style={{ fontWeight: 700, color: "var(--c-text)", marginBottom: 4 }}>
+              2) 설치 파일을 열었을 때 "Windows의 PC 보호" 모달
+            </div>
+            <ul style={{ paddingLeft: 18, listStyle: "disc" }}>
+              <li><b>"추가 정보"</b> 글자 클릭 → 아래에 <b>"실행"</b> 버튼이 나타남.</li>
+              <li>설치 마법사가 정상 진행되면 끝.</li>
+            </ul>
+          </div>
+
+          <div style={{ marginTop: 10 }}>
+            <div style={{ fontWeight: 700, color: "var(--c-text)", marginBottom: 4 }}>
+              3) 그래도 안 되면
+            </div>
+            <ul style={{ paddingLeft: 18, listStyle: "disc" }}>
+              <li>회사 IT 정책으로 EXE 다운로드가 막혀있을 수 있어요. 관리자에게 문의해 주세요.</li>
+              <li>
+                일시 우회: <code>설정 → 개인정보 및 보안 → Windows 보안 → 앱 및
+                브라우저 컨트롤 → SmartScreen 평판 기반 보호 → 끔</code> (설치 후
+                다시 켤 것).
+              </li>
+            </ul>
+          </div>
+
+          <p style={{ marginTop: 10, color: "var(--c-text-3)", fontSize: 11 }}>
+            ※ HiNest 는 사내 도구로, 외부에 공개 배포되지 않습니다. 이 안내는 시간이
+            지나면(다운로드 평판이 쌓이면) 자연스럽게 사라집니다.
+          </p>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -256,8 +355,8 @@ export default function DownloadPage() {
           >
             <div className="space-y-2">
               <a
-                href={`${DESKTOP_RELEASES_BASE}/HiNest-Setup.exe`}
-                download
+                href={`${DESKTOP_DOWNLOAD_BASE}/windows`}
+                download="HiNest-Setup.exe"
                 rel="noopener"
                 className="btn-primary w-full"
               >
@@ -267,9 +366,9 @@ export default function DownloadPage() {
                 className="text-[11.5px] leading-relaxed"
                 style={{ color: "var(--c-text-3)" }}
               >
-                다운로드 후 설치 파일을 실행하세요. 첫 실행 시 SmartScreen 경고가 뜨면
-                "추가 정보 → 실행"을 눌러주세요.
+                다운로드 후 설치 파일을 실행하세요.
               </p>
+              <WindowsBlockHelp />
             </div>
           </Card>
 
@@ -284,16 +383,16 @@ export default function DownloadPage() {
             <div className="space-y-2">
               <div className="grid grid-cols-2 gap-2">
                 <a
-                  href={`${DESKTOP_RELEASES_BASE}/HiNest-arm64.dmg`}
-                  download
+                  href={`${DESKTOP_DOWNLOAD_BASE}/mac-arm64`}
+                  download="HiNest-arm64.dmg"
                   rel="noopener"
                   className="btn-primary"
                 >
                   Apple Silicon
                 </a>
                 <a
-                  href={`${DESKTOP_RELEASES_BASE}/HiNest-x64.dmg`}
-                  download
+                  href={`${DESKTOP_DOWNLOAD_BASE}/mac-x64`}
+                  download="HiNest-x64.dmg"
                   rel="noopener"
                   className="btn-ghost"
                 >

--- a/server/prisma/migrations/20260527044126_chatroom_created_by/migration.sql
+++ b/server/prisma/migrations/20260527044126_chatroom_created_by/migration.sql
@@ -1,0 +1,26 @@
+-- ChatRoom 에 createdById 추가 — 그룹방 삭제 권한 판정용.
+-- 1) 컬럼 추가 (NULL 허용 — legacy row 호환)
+ALTER TABLE "ChatRoom" ADD COLUMN "createdById" TEXT;
+
+-- 2) 인덱스 — "내가 만든 방" 조회 패턴
+CREATE INDEX "ChatRoom_createdById_idx" ON "ChatRoom"("createdById");
+
+-- 3) FK — User 삭제 시 방은 살리되 작성자 정보만 NULL
+ALTER TABLE "ChatRoom"
+  ADD CONSTRAINT "ChatRoom_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- 4) 기존 GROUP/TEAM 방 백필 — 가장 먼저 가입한(RoomMember.id 사전순 = 생성 순)
+--    멤버를 "추정 생성자" 로 설정. DIRECT 방은 두 명 모두 있으므로 의미 없음(스킵).
+--    legacy row 가 많지 않다면 NULL 로 둬도 무방 — UI 에서 ADMIN 만 삭제 가능.
+--    여기선 가능한 best-effort 로 채워 사용자 경험을 살려둠.
+UPDATE "ChatRoom" cr
+SET "createdById" = sub.user_id
+FROM (
+  SELECT DISTINCT ON ("roomId") "roomId", "userId" AS user_id
+  FROM "RoomMember"
+  ORDER BY "roomId", "id" ASC
+) sub
+WHERE cr.id = sub."roomId"
+  AND cr."createdById" IS NULL
+  AND cr.type IN ('GROUP', 'TEAM');

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -96,6 +96,7 @@ model User {
   meetingRevisions        MeetingRevision[]
   meetingAttachments      MeetingAttachment[]    @relation("MeetingAttachmentUploader")
   passwordResetTokens     PasswordResetToken[]
+  chatRoomsCreated        ChatRoom[]             @relation("ChatRoomCreator")
   documentRevisions       DocumentRevision[]
   shareLinksCreated       DocumentShareLink[]    @relation("ShareLinkCreator")
   folderShareLinksCreated FolderShareLink[]      @relation("FolderShareLinkCreator")
@@ -126,24 +127,24 @@ model Session {
 /// 팀/프로젝트 — 사이드바 "팀" 카테고리 아래에 자신이 참여중인 프로젝트가 표시됨.
 /// 멤버는 ProjectMember 로 연결, 생성자는 자동으로 OWNER 로 들어감.
 model Project {
-  id             String           @id @default(cuid())
-  name           String
-  description    String?
-  color          String           @default("#3B5CF0")
-  status         String           @default("ACTIVE") // ACTIVE | ARCHIVED
-  createdById    String
-  createdBy      User             @relation("ProjectCreator", fields: [createdById], references: [id], onDelete: Cascade)
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @updatedAt
-  members        ProjectMember[]
-  events         ProjectEvent[]
-  webhooks       WebhookChannel[]
-  meetings       Meeting[]
-  documents      Document[]
-  folders        Folder[]
-  qaItems        ProjectQaItem[]
+  id              String           @id @default(cuid())
+  name            String
+  description     String?
+  color           String           @default("#3B5CF0")
+  status          String           @default("ACTIVE") // ACTIVE | ARCHIVED
+  createdById     String
+  createdBy       User             @relation("ProjectCreator", fields: [createdById], references: [id], onDelete: Cascade)
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  members         ProjectMember[]
+  events          ProjectEvent[]
+  webhooks        WebhookChannel[]
+  meetings        Meeting[]
+  documents       Document[]
+  folders         Folder[]
+  qaItems         ProjectQaItem[]
   // 전사 캘린더(Event) 중 이 프로젝트 범위로 공유된 일정
-  scheduleEvents Event[]
+  scheduleEvents  Event[]
   serviceAccounts ServiceAccount[] @relation("ProjectServiceAccounts")
 }
 
@@ -587,12 +588,19 @@ model DocumentRevision {
 }
 
 model ChatRoom {
-  id        String        @id @default(cuid())
-  name      String
-  type      String        @default("GROUP") // GROUP | DIRECT | TEAM
-  createdAt DateTime      @default(now())
-  members   RoomMember[]
-  messages  ChatMessage[]
+  id          String        @id @default(cuid())
+  name        String
+  type        String        @default("GROUP") // GROUP | DIRECT | TEAM
+  // 그룹방을 만든 사람 — DELETE /rooms/:id 권한 판정에 사용.
+  // legacy row 는 null (그 경우 ADMIN 만 삭제 가능).
+  // 유저 삭제 시 방은 살아남아야 하므로 SetNull.
+  createdById String?
+  createdBy   User?         @relation("ChatRoomCreator", fields: [createdById], references: [id], onDelete: SetNull)
+  createdAt   DateTime      @default(now())
+  members     RoomMember[]
+  messages    ChatMessage[]
+
+  @@index([createdById])
 }
 
 model RoomMember {
@@ -814,20 +822,20 @@ model AuditLog {
 ///   SPECIFIC  선택된 개별 유저만 (viewers 릴레이션)
 /// 작성자는 무조건 조회·수정 가능. ADMIN 은 전역 열람.
 model Meeting {
-  id          String               @id @default(cuid())
+  id          String              @id @default(cuid())
   title       String
   /// TipTap JSON document. HTML 이 아닌 구조화된 노드 트리.
   content     Json
-  visibility  String               @default("ALL") // ALL | PROJECT | SPECIFIC
+  visibility  String              @default("ALL") // ALL | PROJECT | SPECIFIC
   projectId   String?
-  project     Project?             @relation(fields: [projectId], references: [id], onDelete: SetNull)
+  project     Project?            @relation(fields: [projectId], references: [id], onDelete: SetNull)
   authorId    String
-  author      User                 @relation("MeetingAuthor", fields: [authorId], references: [id], onDelete: Cascade)
+  author      User                @relation("MeetingAuthor", fields: [authorId], references: [id], onDelete: Cascade)
   viewers     MeetingViewer[]
   revisions   MeetingRevision[]
   attachments MeetingAttachment[]
-  createdAt   DateTime             @default(now())
-  updatedAt   DateTime             @updatedAt
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
   deletedAt   DateTime?
   deletedById String?
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -37,6 +37,7 @@ import snippetRouter from "./routes/snippet.js";
 import { shareLinkAuthedRouter, shareLinkPublicRouter } from "./routes/shareLink.js";
 import { folderShareLinkAuthedRouter } from "./routes/folderShareLink.js";
 import serviceAccountRouter from "./routes/serviceAccount.js";
+import desktopDownloadRouter from "./routes/desktopDownload.js";
 import path from "node:path";
 import mime from "mime-types";
 import { installConsoleHook, pushHttpLog, pushErrorEvent } from "./lib/logBuffer.js";
@@ -200,6 +201,10 @@ app.use("/api", rateLimitMiddleware);
 // 전역 API 레이트 리밋 — 라우트별 특수 limiter 는 그 뒤에 추가로 씌운다.
 // (login/upload 는 더 엄격한 limiter 가 먼저 적용됨)
 app.use("/api", apiLimiter);
+
+// 데스크톱 앱 다운로드 — 인증 불필요, GitHub Releases 스트리밍 프록시.
+// 자체 도메인으로 일관된 URL 을 제공해 브라우저 Safe Browsing 평판을 쌓는다.
+app.use("/api/download", desktopDownloadRouter);
 
 app.use("/api/auth", loginLimiter, authRouter);
 app.use("/api/me", meRouter);

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -148,6 +148,8 @@ router.post("/rooms", async (req, res) => {
       data: {
         name: `DM:${u.id}:${other}`,
         type: "DIRECT",
+        // DM 도 createdById 박아둠 — 통계/감사 목적 일관성. 삭제는 양쪽 모두 못 함(둘 다 보존 필요).
+        createdById: u.id,
         members: { create: [{ userId: u.id }, { userId: other }] },
       },
       include: {
@@ -167,6 +169,8 @@ router.post("/rooms", async (req, res) => {
     data: {
       name: d.name,
       type: d.type,
+      // 그룹/팀 방의 생성자 — DELETE /rooms/:id 권한 판정에 사용.
+      createdById: u.id,
       members: { create: memberIds.map((userId) => ({ userId })) },
     },
     include: {
@@ -177,6 +181,67 @@ router.post("/rooms", async (req, res) => {
   await writeLog(u.id, "ROOM_CREATE", room.id, `${d.type}:${d.name}`);
   broadcastToRoom(room.id, "chat:room", { kind: "create", roomId: room.id });
   res.json({ room });
+});
+
+/**
+ * 그룹방(또는 팀방) 삭제.
+ *
+ * 권한:
+ *   - 그룹 생성자(createdById === u.id)
+ *   - ADMIN
+ *   - 그 외는 403. (DM 은 누구도 삭제 불가 — 보존 정책)
+ *
+ * 동작:
+ *   - 트랜잭션으로 메시지·반응·읽음표시·멤버 cascade 제거 후 방 삭제
+ *     (Prisma onDelete: Cascade 가 schema 에 박혀있어 chatRoom.delete 한 번이면 자동 정리)
+ *   - 모든 멤버에게 chat:room { kind: "deleted" } 푸시 → 클라가 방 목록에서 즉시 제거
+ *
+ * 보존:
+ *   - 메시지 단순 soft-delete 가 아니라 방 통째로 제거 — 사용자가 "삭제" 의도로 누른 게
+ *     맞으니 message row 까지 hard delete. 감사 필요 시 AuditLog 에 ROOM_DELETE + 방
+ *     이름/멤버수만 남김.
+ */
+router.delete("/rooms/:id", async (req, res) => {
+  const u = (req as any).user;
+  const id = req.params.id;
+  const room = await prisma.chatRoom.findUnique({
+    where: { id },
+    select: { id: true, name: true, type: true, createdById: true, _count: { select: { members: true } } },
+  });
+  if (!room) return res.status(404).json({ error: "방을 찾을 수 없어요" });
+  // DM 은 양쪽 모두 보존 — 한쪽이 지우면 상대도 잃음. 안전상 거부.
+  if (room.type === "DIRECT") {
+    return res.status(403).json({ error: "1:1 대화는 삭제할 수 없어요" });
+  }
+  const isCreator = !!room.createdById && room.createdById === u.id;
+  const isAdmin = u.role === "ADMIN";
+  if (!isCreator && !isAdmin) {
+    // 메시지 통일 — "왜 안 되는지" 너무 자세히 알려주지 않음
+    // (그룹방 생성자/ADMIN 만 가능하다고 일관되게 안내).
+    return res.status(403).json({ error: "그룹 생성자 또는 관리자만 삭제할 수 있어요" });
+  }
+  // 삭제 직전, 멤버 ID 들을 받아 broadcast 용으로 보관 (cascade 후엔 못 읽음).
+  // RoomMember 까지 cascade 되니 broadcastToRoom 은 빈 set 을 받게 됨 → 사전 수집 필수.
+  const memberIds = (
+    await prisma.roomMember.findMany({ where: { roomId: id }, select: { userId: true } })
+  ).map((m) => m.userId);
+
+  // ChatRoom.delete → 스키마의 onDelete: Cascade 가 RoomMember/ChatMessage/MessageReaction
+  // 모두 자동 정리. 명시적 트랜잭션 불필요.
+  await prisma.chatRoom.delete({ where: { id } });
+  await writeLog(
+    u.id,
+    "ROOM_DELETE",
+    id,
+    `${room.type}:${room.name} members=${room._count.members} by=${isCreator ? "creator" : "admin"}`,
+    req.ip,
+  );
+
+  // SSE 푸시 — 클라가 사이드바/탭에서 즉시 방 제거 + 활성 채팅창 닫기.
+  // broadcastToRoom 은 roomId 기반인데 방은 이미 삭제됐으니, 멤버 개개인에게 직접 publishMany.
+  publishMany(memberIds, "chat:room", { kind: "deleted", roomId: id });
+
+  res.json({ ok: true });
 });
 
 /**

--- a/server/src/routes/desktopDownload.ts
+++ b/server/src/routes/desktopDownload.ts
@@ -1,0 +1,95 @@
+import { Router } from "express";
+
+/**
+ * 데스크톱 앱 다운로드 프록시.
+ *
+ * 왜 직접 GitHub Releases 링크를 두지 않는가:
+ *   1) Chrome / Edge 의 "Safe Browsing" 평판 시스템은 도메인+파일명 조합 기반.
+ *      github.com/.../releases/download/... 직접 링크는 매번 새 평판으로 시작.
+ *      자체 도메인(api.nest.hi-vits.com)에서 일관된 경로(/api/download/windows)로
+ *      배포하면 평판이 점진적으로 쌓여 \"이 파일은 일반적으로 다운로드되지 않습니다\"
+ *      경고가 시간이 지나면서 사라진다.
+ *   2) 명시적 Content-Type / Content-Disposition 으로 일부 브라우저의
+ *      MIME 추측 실패에 의한 다운로드 실패를 차단.
+ *   3) GitHub 의 release 자산 URL 이 바뀌어도 클라이언트는 그대로 사용 가능.
+ *
+ * 보안:
+ *   - 이 엔드포인트는 GET 만 받고 외부 GitHub Releases 의 정해진 자산만 스트림.
+ *     사용자 입력으로 fetch URL 이 정해지지 않으므로 SSRF 위험 없음.
+ *   - 인증 불필요 — 다운로드 페이지는 공개.
+ *
+ * 코드 서명:
+ *   궁극적인 해결은 EV Code Signing Cert (Windows) / Apple Developer ID (macOS) 로
+ *   서명하는 것. 그 전엔 SmartScreen 경고를 사용자가 \"추가 정보 → 실행\" 으로
+ *   넘기는 안내 UI 가 최선. README/DownloadPage 에 명시.
+ */
+
+const router = Router();
+
+const RELEASES_BASE = "https://github.com/Xixn2/HiNest-Desktop/releases/latest/download";
+
+// 화이트리스트된 자산만 프록시 가능. 키 = URL 경로, 값 = upstream 파일명.
+const ASSETS: Record<string, { upstream: string; filename: string; contentType: string }> = {
+  windows: {
+    upstream: "HiNest-Setup.exe",
+    filename: "HiNest-Setup.exe",
+    contentType: "application/octet-stream",
+  },
+  "mac-arm64": {
+    upstream: "HiNest-arm64.dmg",
+    filename: "HiNest-arm64.dmg",
+    contentType: "application/x-apple-diskimage",
+  },
+  "mac-x64": {
+    upstream: "HiNest-x64.dmg",
+    filename: "HiNest-x64.dmg",
+    contentType: "application/x-apple-diskimage",
+  },
+};
+
+router.get("/:asset", async (req, res) => {
+  const asset = ASSETS[req.params.asset];
+  if (!asset) return res.status(404).json({ error: "unknown asset" });
+
+  const upstreamUrl = `${RELEASES_BASE}/${asset.upstream}`;
+  try {
+    const r = await fetch(upstreamUrl, { redirect: "follow" });
+    if (!r.ok || !r.body) {
+      // 404 (해당 자산이 아직 안 올라온 릴리스) 또는 5xx — 그대로 패스.
+      return res.status(r.status === 404 ? 404 : 502).json({
+        error: r.status === 404 ? "아직 빌드되지 않은 파일입니다" : "다운로드 서버 오류",
+      });
+    }
+
+    // 명시적 다운로드 헤더 — 브라우저 MIME 추측 실패로 인한 \"안전하지 않은 파일\" 분류 차단.
+    res.setHeader("Content-Type", asset.contentType);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${asset.filename}"; filename*=UTF-8''${encodeURIComponent(asset.filename)}`,
+    );
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    // 업스트림에서 길이 알 수 있으면 그대로 전달 — 브라우저 진행률 바.
+    const len = r.headers.get("content-length");
+    if (len) res.setHeader("Content-Length", len);
+    // 브라우저 캐시 1시간 — 새 릴리스가 자주 안 나오므로 안전.
+    res.setHeader("Cache-Control", "public, max-age=3600");
+
+    // ETag 가 있으면 그대로 전달 — 브라우저가 304 활용 가능.
+    const etag = r.headers.get("etag");
+    if (etag) res.setHeader("ETag", etag);
+
+    // ReadableStream → Node.js Readable → res.
+    // Node 18+ 의 web stream interop 사용.
+    const { Readable } = await import("node:stream");
+    Readable.fromWeb(r.body as any).pipe(res);
+  } catch (e: any) {
+    console.error("[desktopDownload] proxy failed", upstreamUrl, e?.message ?? e);
+    if (!res.headersSent) {
+      res.status(502).json({ error: "다운로드 서버 오류" });
+    } else {
+      res.end();
+    }
+  }
+});
+
+export default router;


### PR DESCRIPTION
## 증상
**그룹방 삭제 기능 + Windows 다운로드 안전성 개선**

새 기능을 추가합니다.

## 원인
## 1. 그룹방 생성자가 그룹방 삭제 가능

이전엔 그룹방을 만든 후 삭제할 방법이 전혀 없어 운영 중 발생하는 잘못된 방
(테스트/실수/철수된 프로젝트) 이 무한히 누적됐다.

### 데이터 모델
- ChatRoom.createdById (nullable, User.id) 추가
- 마이그레이션 20260527044126_chatroom_created_by:
  CREATE INDEX + FK + 기존 GROUP/TEAM 방의 가장 먼저 가입한 멤버를
  "추정 생성자" 로 백필 (best-effort, NULL 도 허용)
- POST /api/chat/rooms 가 모든 신규 방에 createdById 기록 (DIRECT 포함)

### API
- DELETE /api/chat/rooms/:id
  - 권한: 그룹 생성자 본인 또는 ROLE=ADMIN
  - DIRECT 방은 항상 거부 (양쪽 보존 정책)
  - cascade 로 메시지/반응/멤버까지 자동 정리
  - 모든 멤버에게 SSE chat:room { kind: "deleted" } 푸시 → 사이드바 즉시 동기화
  - AuditLog ROOM_DELETE 남김 (방 이름 + 멤버 수 + creator/admin 구분)

### UI
- SettingsView (방 정보 화면) 하단에 "위험 구역" 섹션 추가
- 그룹/팀방 + (createdById === me OR ADMIN) 일 때만 노출
- 빨간 톤 + tone="danger" confirmAsync — 실수 클릭 방어
- 삭제 성공 시 SSE 도착 전에 클라가 먼저 정리해 즉시 사라짐

## 수정
**작업 항목 (커밋 단위)**
- feat(chat): 그룹방 삭제 기능 + Windows 다운로드 안전성 개선
- merge: main 충돌 해결 (passwordResetLimiter + desktopDownload 공존)

**변경 대상 (8개 파일)**
- `client/src/components/ChatMiniApp.tsx`
- `client/src/components/chat/types.ts`
- `client/src/pages/DownloadPage.tsx`
- `server/prisma/migrations/20260527044126_chatroom_created_by/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/index.ts`
- `server/src/routes/chat.ts`
- `server/src/routes/desktopDownload.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #145** ↔ **이슈 #569** 로 연결됩니다.

Closes #569
