### PR TITLE
🔀 :: (#570) 채팅 갇힘·iOS 뚫림·사이드바 빈 공간·결재 댓글 버튼 (#146)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -503,8 +503,9 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
       <aside
         className={`
           w-[232px] bg-white border-r border-ink-150 flex flex-col flex-shrink-0
-          md:static md:translate-x-0
-          fixed inset-y-0 left-0 z-40
+          md:static md:translate-x-0 md:h-auto
+          fixed top-0 left-0 z-40
+          h-[100dvh]
           transition-transform duration-200 ease-out
           ${mobileNavOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"}
         `}
@@ -583,10 +584,13 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
         )}
 
         <div
-          className="border-t border-ink-150 p-2 flex-shrink-0"
+          className="border-t border-ink-150 px-2 pt-2 flex-shrink-0"
           style={{
             // iOS 홈 인디케이터 영역 흡수 — 모바일 드로어가 화면 끝까지 닿을 때 가려지지 않도록.
-            paddingBottom: "calc(8px + env(safe-area-inset-bottom))",
+            // 이전엔 calc(8px + safe-area) 였지만 iOS PWA 에서 chip 아래로 ~42px 의 빈 공간이
+            // 시각적으로 두드러져 사용자가 "이상한 공간" 으로 인식했음. safe-area 만 남기고
+            // 추가 8px 은 제거 — 인디케이터 바로 위까지 chip 이 닿게.
+            paddingBottom: "max(8px, env(safe-area-inset-bottom))",
           }}
         >
           <div className="flex items-center gap-2.5 px-2 py-2 rounded-md hover:bg-ink-50">
@@ -653,7 +657,17 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
           onOpenNav={() => setMobileNavOpen(true)}
           safeAreaTop={topSlot === "topbar"}
         />
-        <main className="flex-1 overflow-y-auto">
+        <main
+          className="flex-1 overflow-y-auto"
+          style={{
+            // iOS 러버밴드 오버스크롤 방지 — 사용자가 페이지 상단에서 더 끌어내리면
+            // 그 동작이 부모 요소로 전파되어 TopBar 가 잠시 사라지며 그 자리에 본문이
+            // 노출되는 \"뚫림\" 현상이 발생했다. contain 으로 main 안에서만 스크롤 처리.
+            overscrollBehaviorY: "contain",
+            // iOS Safari momentum scrolling 안정화.
+            WebkitOverflowScrolling: "touch",
+          }}
+        >
           <div className="max-w-[1400px] mx-auto px-4 md:px-8 py-4 md:py-6">
             <RouteVisibilityGate disabled={disabledNav} dev={devNav}>
               {/* /preview 같은 비-라우터-childless 진입 시엔 children 으로 직접 받음. 그 외엔 Outlet. */}

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -37,6 +37,8 @@ type ActiveRoomInfo = {
   onBack: () => void;
   onTitleClick?: () => void;
   isSettings?: boolean;
+  /** 모바일 풀스크린 모드에서 채팅 패널 자체를 닫을 때 사용. desktop 에선 undefined. */
+  onClose?: () => void;
 };
 
 export default function ChatFab() {
@@ -140,6 +142,9 @@ export default function ChatFab() {
             isMobile
               ? {
                   // 모바일: 풀스크린 페이지처럼. 하단 네비/홈인디케이터 영역 safe-area 반영.
+                  // ※ 절대 위치 계산 대신 flex column 으로 변경 — 이전엔 헤더는 padding 안에,
+                  //    본문은 absolute top:86 (border-box 기준) 으로 두면서 safe-area-top 만큼
+                  //    헤더 일부가 본문에 가려져 모바일에서 뒤로가기 버튼이 사라져 보였음.
                   inset: 0,
                   width: "100vw",
                   height: "100dvh",
@@ -154,11 +159,13 @@ export default function ChatFab() {
                   fontFamily: FONT,
                   color: C.ink,
                   letterSpacing: "-0.015em",
+                  display: "flex",
+                  flexDirection: "column",
                   transition:
                     "opacity .22s cubic-bezier(.22,.61,.36,1), transform .26s cubic-bezier(.22,.61,.36,1)",
                 }
               : {
-                  // 데스크톱: 기존 우하단 플로팅 팝업.
+                  // 데스크톱: 기존 우하단 플로팅 팝업. flex column 으로 통일.
                   right: "max(12px, env(safe-area-inset-right))",
                   bottom: "calc(96px + env(safe-area-inset-bottom))",
                   width: "min(380px, calc(100vw - 24px))",
@@ -173,6 +180,8 @@ export default function ChatFab() {
                   letterSpacing: "-0.015em",
                   boxShadow:
                     "0 20px 50px rgba(25, 31, 40, .14), 0 4px 12px rgba(25, 31, 40, .06)",
+                  display: "flex",
+                  flexDirection: "column",
                   transition:
                     "opacity .28s cubic-bezier(.22,.61,.36,1), transform .32s cubic-bezier(.22,.61,.36,1)",
                 }
@@ -180,7 +189,15 @@ export default function ChatFab() {
         >
           {/* ===== 헤더 ===== */}
           {activeRoom ? (
-            <RoomHeader info={activeRoom} />
+            <RoomHeader
+              info={{
+                ...activeRoom,
+                // 모바일 풀스크린에선 방 안에서도 패널 자체를 닫을 수 있어야 한다.
+                // 기존엔 onBack(=방 목록으로) 만 있어 두 번 눌러야 닫혔고,
+                // 그마저도 safe-area 겹침으로 뒤로가기 버튼이 안 보였음.
+                onClose: isMobile ? () => setOpen(false) : undefined,
+              }}
+            />
           ) : (
             <ListHeader
               chatUnread={chatUnread}
@@ -189,12 +206,12 @@ export default function ChatFab() {
             />
           )}
 
-          {/* ===== 본문 — 설정 화면에서는 헤더가 얇아지므로 top을 50으로 올림 ===== */}
+          {/* ===== 본문 — flex:1 로 남은 공간 모두 채움 ===== */}
           <div
             style={{
-              position: "absolute",
-              top: activeRoom?.isSettings ? 50 : 86,
-              bottom: 0, left: 0, right: 0,
+              flex: 1,
+              minHeight: 0,        // 자식의 overflow 가 동작하도록
+              position: "relative",
               background: C.surface,
             }}
           >
@@ -284,6 +301,7 @@ function ListHeader({
         justifyContent: "space-between",
         gap: 10,
         background: C.surface,
+        flexShrink: 0,
       }}
     >
       <div style={{ minWidth: 0 }}>
@@ -354,13 +372,15 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
       <div
         style={{
           padding: "12px 14px 4px",
-          display: "flex", alignItems: "center",
+          display: "flex", alignItems: "center", justifyContent: "space-between",
           background: C.surface,
+          flexShrink: 0,
         }}
       >
         <button
           onClick={info.onBack}
           title="뒤로"
+          aria-label="뒤로"
           style={{
             width: 34, height: 34, borderRadius: 999,
             background: C.gray100, color: C.ink,
@@ -375,6 +395,7 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
             <path d="M15 18l-6-6 6-6" />
           </svg>
         </button>
+        {info.onClose && <HeaderCloseButton onClose={info.onClose} />}
       </div>
     );
   }
@@ -387,11 +408,13 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
         alignItems: "center",
         gap: 10,
         background: C.surface,
+        flexShrink: 0,
       }}
     >
       <button
         onClick={info.onBack}
         title="뒤로"
+        aria-label="뒤로"
         style={{
           width: 34, height: 34, borderRadius: 999,
           background: C.gray100, color: C.ink,
@@ -458,7 +481,36 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
           </div>
         </div>
       </button>
+
+      {/* 모바일 풀스크린에선 패널 자체를 닫는 X — 방 안에서도 한 탭으로 빠져나갈 수 있게.
+          desktop 에선 onClose 미전달 → 렌더링 안 됨 (외부에 띄운 팝업이라 별도 닫기 불필요). */}
+      {info.onClose && <HeaderCloseButton onClose={info.onClose} />}
     </div>
+  );
+}
+
+/** 헤더 우측 X — 모바일 풀스크린 채팅을 한 번에 닫는 버튼. */
+function HeaderCloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      onClick={onClose}
+      title="채팅 닫기"
+      aria-label="채팅 닫기"
+      style={{
+        width: 34, height: 34, borderRadius: 999,
+        background: C.gray100, color: C.ink,
+        border: 0, cursor: "pointer",
+        display: "grid", placeItems: "center",
+        flexShrink: 0,
+        transition: "background .12s ease",
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = C.gray200)}
+      onMouseLeave={(e) => (e.currentTarget.style.background = C.gray100)}
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 6 6 18M6 6l12 12" />
+      </svg>
+    </button>
   );
 }
 

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -634,8 +634,10 @@ function ApprovalDetail({
           ) : (
             <div className="text-[12px] text-ink-400">아직 댓글이 없어요.</div>
           )}
-          <div className="mt-2 flex items-start gap-2">
-            <div className="flex-1 relative">
+          {/* min-w-0 — 안 주면 flex-1 자식의 textarea 가 자기 폭을 못 줄여 부모를 밀고
+              우측 등록 버튼이 컨테이너 바깥으로 잘려 보이는 현상이 발생했다. */}
+          <div className="mt-2 flex items-start gap-2 min-w-0">
+            <div className="flex-1 min-w-0 relative">
               <textarea
                 className="input w-full pb-5"
                 rows={2}
@@ -649,16 +651,24 @@ function ApprovalDetail({
                   }
                 }}
               />
-              {/* 글자 수 표시 — 한도 근처에서만 색상 강조. */}
+              {/* 글자 수 표시 — 한도 근처에서만 색상 강조.
+                  right-3 으로 살짝 안쪽에 배치 — 이전 right-2 는 둥근 모서리에 일부 가려져
+                  "0/2000" 의 슬래시가 잘려 보였다. */}
               <div
-                className={`absolute right-2 bottom-1 text-[10px] tabular pointer-events-none ${
+                className={`absolute right-3 bottom-1.5 text-[10px] tabular pointer-events-none select-none ${
                   commentBody.length >= 2000 ? "text-rose-500 font-bold" : commentBody.length >= 1800 ? "text-amber-500" : "text-ink-400"
                 }`}
               >
                 {commentBody.length}/2000
               </div>
             </div>
-            <button className="btn-primary" disabled={posting || !commentBody.trim()} onClick={postComment}>
+            {/* flex-shrink-0 — 좁은 부모에서 button 이 줄어들거나 잘리지 않도록.
+                기존엔 textarea 가 폭을 강하게 잡아 button 일부가 컨테이너 밖으로 밀려났음. */}
+            <button
+              className="btn-primary flex-shrink-0"
+              disabled={posting || !commentBody.trim()}
+              onClick={postComment}
+            >
               {posting ? "..." : "등록"}
             </button>
           </div>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -85,6 +85,7 @@ html, body, #root {
 body {
   font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,
     Inter, system-ui, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+  overscroll-behavior: none;
 }
 * { -webkit-tap-highlight-color: transparent; }
 .font-mono, code, pre, .tabular {


### PR DESCRIPTION
## 증상
**채팅 갇힘·iOS 뚫림·사이드바 빈 공간·결재 댓글 버튼 (#146)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
4개 모바일/반응형 UI 버그를 한 번에 수정.

## 채팅 — 뒤로가기 없어 갇히는 문제 (ChatFab.tsx)
- 기존: 채팅 본문을 `position: absolute; top: 86` (border-box 기준) 으로 올렸는데
  부모에 `paddingTop: env(safe-area-inset-top)` (~47 px) 가 있어 absolute 는 padding 무시 →
  헤더(y=47~86) 와 본문(y=86~) 이 겹치지 않지만 뒤로가기 버튼이 notch 아래에 가려졌다.
- 수정: 외부 컨테이너를 **flex-column** 으로 전환, 헤더는 `flexShrink:0`, 본문은
  `flex:1; minHeight:0` — 절대 좌표 없이 자동으로 쌓임.
- 추가: 모바일 풀스크린에서 방 내부에서도 한 탭으로 패널 자체를 닫는 **× 버튼**
  (`HeaderCloseButton`) 을 RoomHeader 우측에 추가. onClose 미전달 시엔 렌더링 안 됨.

## iOS 오버스크롤 뚫림 (AppLayout.tsx + styles.css)
- `<main>` 에 `overscrollBehaviorY: contain` — 러버밴드가 부모로 전파돼
  TopBar 위로 본문이 잠시 보이는 현상 방지.
- `body { overscroll-behavior: none }` 으로 전역 fallback 추가.
- `WebkitOverflowScrolling: touch` 로 iOS Safari momentum scrolling 안정화.

## 사이드바 하단 빈 공간 (AppLayout.tsx)
- `fixed inset-y-0` → `fixed top-0 h-[100dvh] md:h-auto` 로 변경.
  inset-y-0 은 레이아웃 뷰포트(URL바 포함) 기준이라 동적 뷰포트보다 길어
  프로필 chip 아래로 ~42 px 의 빈 공간이 생겼다. 100dvh 로 동적 뷰포트에 맞춤.
- 프로필 chip 패딩: `calc(8px + safe-area)` → `max(8px, safe-area)` 로
  홈 인디케이터 없는 기기에서도 최소 8 px 확보하면서 notch 기기의 과도한 여백 제거.

## 결재 댓글 등록 버튼 클리핑 (ApprovalsPage.tsx)

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 채팅 뒤로가기 갇힘·iOS overscroll 뚫림·사이드바 빈 공간·결재 댓글 버튼 클리핑

**변경 대상 (4개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatFab.tsx`
- `client/src/pages/ApprovalsPage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #146** ↔ **이슈 #570** 로 연결됩니다.

Closes #570
