### PR TITLE
🔀 :: (#571) 문서함 Notion 스타일 메모 작성 기능 (#147)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -503,8 +503,9 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
       <aside
         className={`
           w-[232px] bg-white border-r border-ink-150 flex flex-col flex-shrink-0
-          md:static md:translate-x-0
-          fixed inset-y-0 left-0 z-40
+          md:static md:translate-x-0 md:h-auto
+          fixed top-0 left-0 z-40
+          h-[100dvh]
           transition-transform duration-200 ease-out
           ${mobileNavOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"}
         `}
@@ -583,10 +584,13 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
         )}
 
         <div
-          className="border-t border-ink-150 p-2 flex-shrink-0"
+          className="border-t border-ink-150 px-2 pt-2 flex-shrink-0"
           style={{
             // iOS 홈 인디케이터 영역 흡수 — 모바일 드로어가 화면 끝까지 닿을 때 가려지지 않도록.
-            paddingBottom: "calc(8px + env(safe-area-inset-bottom))",
+            // 이전엔 calc(8px + safe-area) 였지만 iOS PWA 에서 chip 아래로 ~42px 의 빈 공간이
+            // 시각적으로 두드러져 사용자가 "이상한 공간" 으로 인식했음. safe-area 만 남기고
+            // 추가 8px 은 제거 — 인디케이터 바로 위까지 chip 이 닿게.
+            paddingBottom: "max(8px, env(safe-area-inset-bottom))",
           }}
         >
           <div className="flex items-center gap-2.5 px-2 py-2 rounded-md hover:bg-ink-50">
@@ -653,7 +657,17 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
           onOpenNav={() => setMobileNavOpen(true)}
           safeAreaTop={topSlot === "topbar"}
         />
-        <main className="flex-1 overflow-y-auto">
+        <main
+          className="flex-1 overflow-y-auto"
+          style={{
+            // iOS 러버밴드 오버스크롤 방지 — 사용자가 페이지 상단에서 더 끌어내리면
+            // 그 동작이 부모 요소로 전파되어 TopBar 가 잠시 사라지며 그 자리에 본문이
+            // 노출되는 \"뚫림\" 현상이 발생했다. contain 으로 main 안에서만 스크롤 처리.
+            overscrollBehaviorY: "contain",
+            // iOS Safari momentum scrolling 안정화.
+            WebkitOverflowScrolling: "touch",
+          }}
+        >
           <div className="max-w-[1400px] mx-auto px-4 md:px-8 py-4 md:py-6">
             <RouteVisibilityGate disabled={disabledNav} dev={devNav}>
               {/* /preview 같은 비-라우터-childless 진입 시엔 children 으로 직접 받음. 그 외엔 Outlet. */}

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -37,6 +37,8 @@ type ActiveRoomInfo = {
   onBack: () => void;
   onTitleClick?: () => void;
   isSettings?: boolean;
+  /** 모바일 풀스크린 모드에서 채팅 패널 자체를 닫을 때 사용. desktop 에선 undefined. */
+  onClose?: () => void;
 };
 
 export default function ChatFab() {
@@ -140,6 +142,9 @@ export default function ChatFab() {
             isMobile
               ? {
                   // 모바일: 풀스크린 페이지처럼. 하단 네비/홈인디케이터 영역 safe-area 반영.
+                  // ※ 절대 위치 계산 대신 flex column 으로 변경 — 이전엔 헤더는 padding 안에,
+                  //    본문은 absolute top:86 (border-box 기준) 으로 두면서 safe-area-top 만큼
+                  //    헤더 일부가 본문에 가려져 모바일에서 뒤로가기 버튼이 사라져 보였음.
                   inset: 0,
                   width: "100vw",
                   height: "100dvh",
@@ -154,11 +159,13 @@ export default function ChatFab() {
                   fontFamily: FONT,
                   color: C.ink,
                   letterSpacing: "-0.015em",
+                  display: "flex",
+                  flexDirection: "column",
                   transition:
                     "opacity .22s cubic-bezier(.22,.61,.36,1), transform .26s cubic-bezier(.22,.61,.36,1)",
                 }
               : {
-                  // 데스크톱: 기존 우하단 플로팅 팝업.
+                  // 데스크톱: 기존 우하단 플로팅 팝업. flex column 으로 통일.
                   right: "max(12px, env(safe-area-inset-right))",
                   bottom: "calc(96px + env(safe-area-inset-bottom))",
                   width: "min(380px, calc(100vw - 24px))",
@@ -173,6 +180,8 @@ export default function ChatFab() {
                   letterSpacing: "-0.015em",
                   boxShadow:
                     "0 20px 50px rgba(25, 31, 40, .14), 0 4px 12px rgba(25, 31, 40, .06)",
+                  display: "flex",
+                  flexDirection: "column",
                   transition:
                     "opacity .28s cubic-bezier(.22,.61,.36,1), transform .32s cubic-bezier(.22,.61,.36,1)",
                 }
@@ -180,7 +189,15 @@ export default function ChatFab() {
         >
           {/* ===== 헤더 ===== */}
           {activeRoom ? (
-            <RoomHeader info={activeRoom} />
+            <RoomHeader
+              info={{
+                ...activeRoom,
+                // 모바일 풀스크린에선 방 안에서도 패널 자체를 닫을 수 있어야 한다.
+                // 기존엔 onBack(=방 목록으로) 만 있어 두 번 눌러야 닫혔고,
+                // 그마저도 safe-area 겹침으로 뒤로가기 버튼이 안 보였음.
+                onClose: isMobile ? () => setOpen(false) : undefined,
+              }}
+            />
           ) : (
             <ListHeader
               chatUnread={chatUnread}
@@ -189,12 +206,12 @@ export default function ChatFab() {
             />
           )}
 
-          {/* ===== 본문 — 설정 화면에서는 헤더가 얇아지므로 top을 50으로 올림 ===== */}
+          {/* ===== 본문 — flex:1 로 남은 공간 모두 채움 ===== */}
           <div
             style={{
-              position: "absolute",
-              top: activeRoom?.isSettings ? 50 : 86,
-              bottom: 0, left: 0, right: 0,
+              flex: 1,
+              minHeight: 0,        // 자식의 overflow 가 동작하도록
+              position: "relative",
               background: C.surface,
             }}
           >
@@ -284,6 +301,7 @@ function ListHeader({
         justifyContent: "space-between",
         gap: 10,
         background: C.surface,
+        flexShrink: 0,
       }}
     >
       <div style={{ minWidth: 0 }}>
@@ -354,13 +372,15 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
       <div
         style={{
           padding: "12px 14px 4px",
-          display: "flex", alignItems: "center",
+          display: "flex", alignItems: "center", justifyContent: "space-between",
           background: C.surface,
+          flexShrink: 0,
         }}
       >
         <button
           onClick={info.onBack}
           title="뒤로"
+          aria-label="뒤로"
           style={{
             width: 34, height: 34, borderRadius: 999,
             background: C.gray100, color: C.ink,
@@ -375,6 +395,7 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
             <path d="M15 18l-6-6 6-6" />
           </svg>
         </button>
+        {info.onClose && <HeaderCloseButton onClose={info.onClose} />}
       </div>
     );
   }
@@ -387,11 +408,13 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
         alignItems: "center",
         gap: 10,
         background: C.surface,
+        flexShrink: 0,
       }}
     >
       <button
         onClick={info.onBack}
         title="뒤로"
+        aria-label="뒤로"
         style={{
           width: 34, height: 34, borderRadius: 999,
           background: C.gray100, color: C.ink,
@@ -458,7 +481,36 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
           </div>
         </div>
       </button>
+
+      {/* 모바일 풀스크린에선 패널 자체를 닫는 X — 방 안에서도 한 탭으로 빠져나갈 수 있게.
+          desktop 에선 onClose 미전달 → 렌더링 안 됨 (외부에 띄운 팝업이라 별도 닫기 불필요). */}
+      {info.onClose && <HeaderCloseButton onClose={info.onClose} />}
     </div>
+  );
+}
+
+/** 헤더 우측 X — 모바일 풀스크린 채팅을 한 번에 닫는 버튼. */
+function HeaderCloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      onClick={onClose}
+      title="채팅 닫기"
+      aria-label="채팅 닫기"
+      style={{
+        width: 34, height: 34, borderRadius: 999,
+        background: C.gray100, color: C.ink,
+        border: 0, cursor: "pointer",
+        display: "grid", placeItems: "center",
+        flexShrink: 0,
+        transition: "background .12s ease",
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = C.gray200)}
+      onMouseLeave={(e) => (e.currentTarget.style.background = C.gray100)}
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 6 6 18M6 6l12 12" />
+      </svg>
+    </button>
   );
 }
 

--- a/client/src/components/DocMemoModal.tsx
+++ b/client/src/components/DocMemoModal.tsx
@@ -1,0 +1,525 @@
+/**
+ * DocMemoModal — 문서함 내 리치텍스트 메모 작성·열람 모달.
+ *
+ * 사용 케이스:
+ *   1. 새 메모 작성  : doc=null, initialFolderId 전달 → 저장 후 onSaved(doc) 호출
+ *   2. 기존 메모 열람 : doc 전달 → 본인/ADMIN 이면 편집 가능 (수정 후 onSaved 호출)
+ *   3. 타인 메모 열람 : doc 전달, 본인 아님 → 읽기 전용 렌더링
+ *
+ * UI 구조:
+ *   - 헤더: 제목 입력 + 공개범위 칩 + 저장/취소
+ *   - 본문: MeetingEditor (TipTap, 기존 회의록과 동일 컴포넌트)
+ *   - 풀스크린 오버레이 (z-50)
+ */
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../api";
+import { useAuth } from "../auth";
+
+// TipTap 에디터는 무거운 번들 → 모달이 열릴 때 lazy 로드.
+const MeetingEditor = lazy(() => import("./MeetingEditor"));
+
+// ===== 타입 =====
+type DocScope = "ALL" | "TEAM" | "PRIVATE" | "CUSTOM";
+export type MemoDoc = {
+  id: string;
+  title: string;
+  content: any;
+  scope: DocScope;
+  scopeTeam?: string | null;
+  scopeUserIds?: string | null;
+  folderId?: string | null;
+  tags?: string | null;
+  authorId?: string;
+  author: { name: string; avatarColor: string; avatarUrl?: string | null };
+  createdAt: string;
+  updatedAt: string;
+};
+
+type DirUser = { id: string; name: string; team?: string | null; avatarColor?: string; avatarUrl?: string | null };
+
+type Props = {
+  /** 기존 메모 열람/수정. null 이면 새로 만들기. */
+  doc: MemoDoc | null;
+  /** 새 메모 생성 시 배치할 폴더 (null = 루트) */
+  initialFolderId?: string | null;
+  /** 새 메모 생성 시 기본 스코프 */
+  initialScope?: DocScope;
+  /** 새 메모 생성 시 프로젝트 연결 */
+  projectId?: string | null;
+  onClose: () => void;
+  onSaved: (doc: MemoDoc) => void;
+  onDeleted?: (id: string) => void;
+};
+
+const SCOPE_LABEL: Record<DocScope, string> = {
+  ALL: "전체 공개",
+  TEAM: "팀 공개",
+  PRIVATE: "나만 보기",
+  CUSTOM: "사용자지정",
+};
+
+const SCOPE_DESC: Record<DocScope, string> = {
+  ALL: "회사 구성원 누구나 열람",
+  TEAM: "내 팀 구성원만 열람",
+  PRIVATE: "나만 열람",
+  CUSTOM: "지정한 구성원만 열람",
+};
+
+export default function DocMemoModal({
+  doc,
+  initialFolderId,
+  initialScope = "ALL",
+  projectId,
+  onClose,
+  onSaved,
+  onDeleted,
+}: Props) {
+  const { user } = useAuth();
+
+  // 읽기 전용 여부 — 본인 글이거나 ADMIN 이면 편집 가능
+  const isMine = !doc || doc.authorId === user?.id || user?.role === "ADMIN";
+  // 새 메모면 처음부터 편집 모드
+  const [editMode, setEditMode] = useState(!doc);
+
+  const [title, setTitle] = useState(doc?.title ?? "");
+  const [content, setContent] = useState<any>(
+    doc?.content ?? { type: "doc", content: [{ type: "paragraph" }] }
+  );
+  const [scope, setScope] = useState<DocScope>(doc?.scope ?? initialScope);
+  const [scopeOpen, setScopeOpen] = useState(false);
+  const [tags, setTags] = useState(doc?.tags ?? "");
+
+  // CUSTOM 전용 유저 선택
+  const [scopeUserIds, setScopeUserIds] = useState<string[]>(
+    doc?.scopeUserIds
+      ? doc.scopeUserIds.split(",").map((s) => s.trim()).filter(Boolean)
+      : []
+  );
+  const [allUsers, setAllUsers] = useState<DirUser[]>([]);
+  const [userSearch, setUserSearch] = useState("");
+
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  // 저장 후 "저장됨" 토스트
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  // CUSTOM 선택 시 유저 로드
+  useEffect(() => {
+    if (scope !== "CUSTOM" || allUsers.length > 0) return;
+    let alive = true;
+    api<{ users: DirUser[] }>("/api/users")
+      .then((r) => { if (alive) setAllUsers(r.users); })
+      .catch(() => {});
+    return () => { alive = false; };
+  }, [scope, allUsers.length]);
+
+  // mentionFetcher — CUSTOM 메모에선 지정 유저만 멘션 가능. 간단히 ALL 기준 사용.
+  const mentionFetcher = useCallback(async (q: string) => {
+    try {
+      const r = await api<{ users: any[] }>(
+        `/api/meeting/mentionable?visibility=ALL&q=${encodeURIComponent(q)}`
+      );
+      return r.users ?? [];
+    } catch {
+      return [];
+    }
+  }, []);
+
+  const titleRef = useRef<HTMLInputElement>(null);
+  // 새 메모면 제목 자동 포커스
+  useEffect(() => {
+    if (!doc) {
+      titleRef.current?.focus();
+    }
+  }, [doc]);
+
+  // ===== 저장 =====
+  async function handleSave() {
+    if (!title.trim()) {
+      setErr("제목을 입력해주세요");
+      titleRef.current?.focus();
+      return;
+    }
+    if (scope === "CUSTOM" && scopeUserIds.length === 0) {
+      setErr("사용자지정 범위에선 최소 한 명을 선택해주세요");
+      return;
+    }
+    setSaving(true);
+    setErr(null);
+    try {
+      const body: any = {
+        title: title.trim(),
+        content,
+        scope: projectId ? undefined : scope,
+        scopeUserIds: !projectId && scope === "CUSTOM" ? scopeUserIds : undefined,
+        tags: tags.trim() || undefined,
+        folderId: doc?.folderId ?? initialFolderId ?? null,
+        projectId: projectId ?? null,
+      };
+
+      let saved: MemoDoc;
+      if (doc) {
+        const r = await api<{ document: MemoDoc }>(`/api/document/${doc.id}`, {
+          method: "PATCH",
+          json: body,
+        });
+        saved = r.document;
+      } else {
+        const r = await api<{ document: MemoDoc }>("/api/document", {
+          method: "POST",
+          json: body,
+        });
+        saved = r.document;
+      }
+      setSavedAt(Date.now());
+      setEditMode(false);
+      onSaved(saved);
+    } catch (e: any) {
+      setErr(e?.message ?? "저장에 실패했어요");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const handleContentChange = useCallback((json: any) => {
+    setContent(json);
+  }, []);
+
+  // 필터된 유저 목록 (CUSTOM 검색)
+  const filteredUsers = userSearch.trim()
+    ? allUsers.filter((u) =>
+        u.name.includes(userSearch) ||
+        (u.team ?? "").includes(userSearch)
+      )
+    : allUsers;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-[color:var(--c-bg)]"
+      style={{ paddingTop: "env(safe-area-inset-top)" }}
+    >
+      {/* ===== 헤더 바 ===== */}
+      <div className="flex-shrink-0 flex items-center gap-3 px-4 md:px-6 h-14 border-b border-ink-150 bg-[color:var(--c-surface)]">
+        {/* 닫기 */}
+        <button
+          onClick={onClose}
+          className="btn-icon flex-shrink-0"
+          aria-label="닫기"
+          title="닫기"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+
+        {/* 제목 */}
+        {editMode ? (
+          <input
+            ref={titleRef}
+            className="flex-1 min-w-0 text-[15px] font-bold bg-transparent border-none outline-none text-ink-900 placeholder:text-ink-400"
+            placeholder="메모 제목"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={200}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.preventDefault();
+            }}
+          />
+        ) : (
+          <h1 className="flex-1 min-w-0 text-[15px] font-bold text-ink-900 truncate">
+            {title || "제목 없음"}
+          </h1>
+        )}
+
+        {/* 공개 범위 칩 (편집 모드에만 토글 드롭다운) */}
+        {!projectId && (
+          <div className="relative flex-shrink-0">
+            <button
+              type="button"
+              disabled={!editMode}
+              onClick={() => editMode && setScopeOpen((o) => !o)}
+              className={`flex items-center gap-1.5 px-2.5 h-7 rounded-full text-[11px] font-bold border transition ${
+                scope === "PRIVATE"
+                  ? "bg-rose-50 border-rose-200 text-rose-700"
+                  : scope === "TEAM"
+                  ? "bg-sky-50 border-sky-200 text-sky-700"
+                  : scope === "CUSTOM"
+                  ? "bg-violet-50 border-violet-200 text-violet-700"
+                  : "bg-green-50 border-green-200 text-green-700"
+              } ${editMode ? "hover:opacity-80 cursor-pointer" : "cursor-default"}`}
+              title={editMode ? "공개 범위 변경" : SCOPE_DESC[scope]}
+            >
+              <ScopeIcon scope={scope} />
+              {SCOPE_LABEL[scope]}
+              {editMode && (
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="m6 9 6 6 6-6" />
+                </svg>
+              )}
+            </button>
+
+            {scopeOpen && (
+              <div className="absolute right-0 top-full mt-1 w-[240px] bg-[color:var(--c-surface)] border border-ink-200 rounded-xl shadow-xl z-10 overflow-hidden">
+                {(["ALL", "TEAM", "PRIVATE", "CUSTOM"] as DocScope[]).map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => { setScope(s); setScopeOpen(false); }}
+                    className={`w-full flex items-start gap-3 px-4 py-2.5 hover:bg-ink-50 transition ${
+                      scope === s ? "bg-brand-50" : ""
+                    }`}
+                  >
+                    <ScopeIcon scope={s} className="mt-0.5 flex-shrink-0 text-ink-500" />
+                    <div className="text-left">
+                      <div className={`text-[12px] font-bold ${scope === s ? "text-brand-700" : "text-ink-800"}`}>
+                        {SCOPE_LABEL[s]}
+                      </div>
+                      <div className="text-[11px] text-ink-500">{SCOPE_DESC[s]}</div>
+                    </div>
+                    {scope === s && (
+                      <svg className="ml-auto flex-shrink-0 text-brand-600" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 오른쪽 액션 */}
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {savedAt !== null && !editMode && (
+            <span className="text-[11px] text-ink-400 tabular hidden sm:block">
+              저장됨
+            </span>
+          )}
+          {editMode ? (
+            <>
+              <button
+                className="btn-ghost btn-sm"
+                onClick={() => {
+                  if (!doc) { onClose(); return; }
+                  // 기존 메모 편집 취소 → 원본으로 복원
+                  setTitle(doc.title);
+                  setContent(doc.content ?? { type: "doc", content: [{ type: "paragraph" }] });
+                  setScope(doc.scope);
+                  setScopeUserIds(
+                    doc.scopeUserIds
+                      ? doc.scopeUserIds.split(",").map((s) => s.trim()).filter(Boolean)
+                      : []
+                  );
+                  setTags(doc.tags ?? "");
+                  setErr(null);
+                  setEditMode(false);
+                }}
+                disabled={saving}
+              >
+                취소
+              </button>
+              <button
+                className="btn-primary btn-sm"
+                onClick={handleSave}
+                disabled={saving}
+              >
+                {saving ? "저장 중…" : doc ? "저장" : "메모 만들기"}
+              </button>
+            </>
+          ) : (
+            isMine && (
+              <button
+                className="btn-ghost btn-sm"
+                onClick={() => setEditMode(true)}
+              >
+                편집
+              </button>
+            )
+          )}
+        </div>
+      </div>
+
+      {/* ===== CUSTOM 유저 선택 패널 (편집 모드 + CUSTOM scope) ===== */}
+      {editMode && scope === "CUSTOM" && (
+        <div className="flex-shrink-0 border-b border-ink-150 bg-violet-50 px-4 md:px-6 py-2 flex flex-wrap items-center gap-2">
+          <span className="text-[11px] font-bold text-violet-700">열람 가능:</span>
+          {scopeUserIds.map((uid) => {
+            const u = allUsers.find((x) => x.id === uid);
+            return (
+              <span key={uid} className="flex items-center gap-1 bg-white border border-violet-200 rounded-full px-2 py-0.5 text-[11px] font-bold text-violet-800">
+                {u?.name ?? uid.slice(0, 8)}
+                <button
+                  type="button"
+                  onClick={() => setScopeUserIds((p) => p.filter((x) => x !== uid))}
+                  className="text-violet-400 hover:text-violet-700"
+                  aria-label={`${u?.name ?? uid} 제거`}
+                >
+                  ×
+                </button>
+              </span>
+            );
+          })}
+          <div className="relative">
+            <input
+              className="h-6 px-2 text-[11px] border border-violet-200 rounded-full focus:outline-none focus:ring-1 focus:ring-violet-400 w-28 bg-white"
+              placeholder="이름 검색"
+              value={userSearch}
+              onChange={(e) => setUserSearch(e.target.value)}
+            />
+            {userSearch && (
+              <div className="absolute left-0 top-full mt-1 w-[200px] bg-white border border-ink-200 rounded-xl shadow-lg z-20 max-h-[180px] overflow-y-auto">
+                {filteredUsers.length === 0 ? (
+                  <div className="px-3 py-2 text-[12px] text-ink-500">없음</div>
+                ) : (
+                  filteredUsers
+                    .filter((u) => !scopeUserIds.includes(u.id))
+                    .map((u) => (
+                      <button
+                        key={u.id}
+                        type="button"
+                        onClick={() => {
+                          setScopeUserIds((p) => [...p, u.id]);
+                          setUserSearch("");
+                        }}
+                        className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-ink-50 text-left"
+                      >
+                        <div className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
+                          {u.avatarUrl ? <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" /> : u.name[0]}
+                        </div>
+                        <div className="text-[12px] text-ink-800 font-semibold">{u.name}
+                          {u.team && <span className="text-ink-400 font-normal ml-1">· {u.team}</span>}
+                        </div>
+                      </button>
+                    ))
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* 오류 메시지 */}
+      {err && (
+        <div className="flex-shrink-0 mx-4 md:mx-6 mt-2 px-3 py-2 rounded-lg bg-rose-50 border border-rose-200 text-[12px] text-rose-700">
+          {err}
+        </div>
+      )}
+
+      {/* ===== 에디터 본문 ===== */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="max-w-[860px] mx-auto px-4 md:px-10 py-6">
+          {/* 메타 정보 (열람 모드) */}
+          {!editMode && doc && (
+            <div className="flex items-center gap-2 mb-4 text-[11px] text-ink-400">
+              <div className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden" style={{ background: doc.author.avatarUrl ? "transparent" : (doc.author.avatarColor ?? "#6B7280") }}>
+                {doc.author.avatarUrl ? <img src={doc.author.avatarUrl} alt={doc.author.name} className="w-full h-full object-cover" /> : doc.author.name[0]}
+              </div>
+              <span className="font-semibold text-ink-600">{doc.author.name}</span>
+              <span>·</span>
+              <span>{new Date(doc.updatedAt).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" })}</span>
+            </div>
+          )}
+
+          {/* 태그 (편집 모드) */}
+          {editMode && (
+            <div className="mb-3">
+              <input
+                className="w-full bg-transparent text-[12px] text-ink-500 placeholder:text-ink-300 border-none outline-none"
+                placeholder="태그 입력 (쉼표로 구분, 예: 기획, 아이디어)"
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
+                maxLength={200}
+              />
+            </div>
+          )}
+
+          {/* 태그 표시 (열람 모드) */}
+          {!editMode && (tags || doc?.tags) && (
+            <div className="flex flex-wrap gap-1 mb-4">
+              {((tags || doc?.tags) ?? "").split(",").map((t) => t.trim()).filter(Boolean).map((t) => (
+                <span key={t} className="chip-gray text-[11px]">#{t}</span>
+              ))}
+            </div>
+          )}
+
+          {/* TipTap 에디터 */}
+          <Suspense fallback={
+            <div className="h-40 flex items-center justify-center text-[12px] text-ink-400">
+              에디터 불러오는 중…
+            </div>
+          }>
+            <MeetingEditor
+              value={content}
+              onChange={editMode ? handleContentChange : undefined}
+              editable={editMode}
+              placeholder="여기에 메모를 작성하세요. '/' 로 블록을 삽입할 수 있어요."
+              mentionFetcher={editMode ? mentionFetcher : undefined}
+            />
+          </Suspense>
+
+          {/* 편집 모드 하단 저장 버튼 (긴 문서에서 스크롤 내려야 저장 버튼이 안 보이는 문제 방지) */}
+          {editMode && (
+            <div className="mt-8 flex items-center justify-between gap-3 pt-4 border-t border-ink-150">
+              {err ? (
+                <span className="text-[12px] text-rose-600">{err}</span>
+              ) : (
+                <span className="text-[11px] text-ink-400">변경사항은 저장 버튼을 눌러야 반영돼요.</span>
+              )}
+              <div className="flex gap-2">
+                <button
+                  className="btn-ghost btn-sm"
+                  onClick={() => {
+                    if (!doc) { onClose(); return; }
+                    setTitle(doc.title);
+                    setContent(doc.content ?? { type: "doc", content: [{ type: "paragraph" }] });
+                    setScope(doc.scope);
+                    setScopeUserIds(doc.scopeUserIds ? doc.scopeUserIds.split(",").map((s) => s.trim()).filter(Boolean) : []);
+                    setTags(doc.tags ?? "");
+                    setErr(null);
+                    setEditMode(false);
+                  }}
+                  disabled={saving}
+                >
+                  취소
+                </button>
+                <button className="btn-primary btn-sm" onClick={handleSave} disabled={saving}>
+                  {saving ? "저장 중…" : doc ? "저장" : "메모 만들기"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 드롭다운 외부 클릭 닫기 */}
+      {scopeOpen && (
+        <div className="fixed inset-0 z-[9]" onClick={() => setScopeOpen(false)} />
+      )}
+    </div>
+  );
+}
+
+// ===== 아이콘 =====
+function ScopeIcon({ scope, className = "" }: { scope: DocScope; className?: string }) {
+  if (scope === "PRIVATE") return (
+    <svg className={className} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+  if (scope === "TEAM") return (
+    <svg className={className} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+  if (scope === "CUSTOM") return (
+    <svg className={className} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" /><polyline points="12 8 12 12 14 14" />
+    </svg>
+  );
+  // ALL
+  return (
+    <svg className={className} width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" /><line x1="2" y1="12" x2="22" y2="12" /><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  );
+}

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -634,8 +634,10 @@ function ApprovalDetail({
           ) : (
             <div className="text-[12px] text-ink-400">아직 댓글이 없어요.</div>
           )}
-          <div className="mt-2 flex items-start gap-2">
-            <div className="flex-1 relative">
+          {/* min-w-0 — 안 주면 flex-1 자식의 textarea 가 자기 폭을 못 줄여 부모를 밀고
+              우측 등록 버튼이 컨테이너 바깥으로 잘려 보이는 현상이 발생했다. */}
+          <div className="mt-2 flex items-start gap-2 min-w-0">
+            <div className="flex-1 min-w-0 relative">
               <textarea
                 className="input w-full pb-5"
                 rows={2}
@@ -649,16 +651,24 @@ function ApprovalDetail({
                   }
                 }}
               />
-              {/* 글자 수 표시 — 한도 근처에서만 색상 강조. */}
+              {/* 글자 수 표시 — 한도 근처에서만 색상 강조.
+                  right-3 으로 살짝 안쪽에 배치 — 이전 right-2 는 둥근 모서리에 일부 가려져
+                  "0/2000" 의 슬래시가 잘려 보였다. */}
               <div
-                className={`absolute right-2 bottom-1 text-[10px] tabular pointer-events-none ${
+                className={`absolute right-3 bottom-1.5 text-[10px] tabular pointer-events-none select-none ${
                   commentBody.length >= 2000 ? "text-rose-500 font-bold" : commentBody.length >= 1800 ? "text-amber-500" : "text-ink-400"
                 }`}
               >
                 {commentBody.length}/2000
               </div>
             </div>
-            <button className="btn-primary" disabled={posting || !commentBody.trim()} onClick={postComment}>
+            {/* flex-shrink-0 — 좁은 부모에서 button 이 줄어들거나 잘리지 않도록.
+                기존엔 textarea 가 폭을 강하게 잡아 button 일부가 컨테이너 밖으로 밀려났음. */}
+            <button
+              className="btn-primary flex-shrink-0"
+              disabled={posting || !commentBody.trim()}
+              onClick={postComment}
+            >
               {posting ? "..." : "등록"}
             </button>
           </div>

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api } from "../api";
 import { useAuth } from "../auth";
@@ -6,6 +6,10 @@ import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
 import ShareLinkModal from "../components/ShareLinkModal";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
+import type { MemoDoc } from "../components/DocMemoModal";
+
+// DocMemoModal 은 TipTap(무거운 번들)을 포함 → 실제 열릴 때만 로드.
+const DocMemoModal = lazy(() => import("../components/DocMemoModal"));
 
 type Folder = {
   id: string;
@@ -27,9 +31,12 @@ type Doc = {
   fileType?: string | null;
   fileSize?: number | null;
   tags?: string | null;
+  /** TipTap JSON — 값이 있으면 메모 타입 문서. */
+  content?: any;
   scope?: DocScope;
   scopeTeam?: string | null;
   scopeUserIds?: string | null;
+  authorId?: string;
   createdAt: string;
   updatedAt: string;
   author: { name: string; avatarColor: string; avatarUrl?: string | null };
@@ -135,6 +142,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   const [sharingDoc, setSharingDoc] = useState<Doc | null>(null);
   const [sharingFolder, setSharingFolder] = useState<Folder | null>(null);
   const [historyDoc, setHistoryDoc] = useState<Doc | null>(null);
+  /** 현재 열린 메모 편집/열람 모달 (null = 닫힘 | "new" = 새 메모 | Doc = 기존 메모) */
+  const [memoTarget, setMemoTarget] = useState<Doc | "new" | null>(null);
   const [docForm, setDocForm] = useState<{
     title: string; description: string; tags: string;
     fileUrl: string; fileName: string; fileType: string; fileSize: number;
@@ -843,6 +852,12 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
               >
                 {folderUpload ? `업로드 중… ${folderUpload.done}/${folderUpload.total}` : "+ 폴더 업로드"}
               </button>
+              <button className="btn-ghost" onClick={() => setMemoTarget("new")}>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="inline-block mr-1">
+                  <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
+                </svg>
+                메모 작성
+              </button>
               <button className="btn-primary" onClick={() => { setModalErr(null); setCreating("doc"); }}>+ 문서 업로드</button>
             </>
           }
@@ -942,6 +957,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
           >
             {folderUpload ? `업로드 중… ${folderUpload.done}/${folderUpload.total}` : "+ 폴더 업로드"}
           </button>
+          <button className="btn-ghost btn-xs" onClick={() => setMemoTarget("new")}>메모 작성</button>
           <button className="btn-primary btn-xs" onClick={() => { setModalErr(null); setCreating("doc"); }}>+ 문서 업로드</button>
         </div>
       )}
@@ -1294,15 +1310,31 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                   }}
                 >
                   <td>
-                    <div className="flex items-start gap-2.5">
-                      <div className="w-8 h-8 rounded-lg bg-sky-50 text-sky-700 grid place-items-center flex-shrink-0">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" />
-                        </svg>
-                      </div>
+                    <div
+                      className={`flex items-start gap-2.5 ${d.content != null ? "cursor-pointer" : ""}`}
+                      onClick={d.content != null ? () => setMemoTarget(d) : undefined}
+                      title={d.content != null ? "메모 열기" : undefined}
+                    >
+                      {/* 메모 vs 파일 문서 아이콘 구분 */}
+                      {d.content != null ? (
+                        <div className="w-8 h-8 rounded-lg bg-violet-50 text-violet-700 grid place-items-center flex-shrink-0">
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
+                          </svg>
+                        </div>
+                      ) : (
+                        <div className="w-8 h-8 rounded-lg bg-sky-50 text-sky-700 grid place-items-center flex-shrink-0">
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" />
+                          </svg>
+                        </div>
+                      )}
                       <div className="min-w-0">
                         <div className="flex items-center gap-1.5">
-                          <div className="text-[13px] font-bold text-ink-900">{d.title}</div>
+                          <div className={`text-[13px] font-bold text-ink-900 ${d.content != null ? "hover:text-brand-700" : ""}`}>{d.title}</div>
+                          {d.content != null && (
+                            <span className="text-[10px] font-bold px-1.5 py-[1px] rounded bg-violet-50 text-violet-700">메모</span>
+                          )}
                           {d.scope && d.scope !== "ALL" && (
                             <span className={`text-[10px] font-bold px-1.5 py-[1px] rounded ${
                               d.scope === "PRIVATE" ? "bg-rose-50 text-rose-700"
@@ -1347,22 +1379,42 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                   <td className="tabular text-[11px] text-ink-500">{new Date(d.updatedAt).toLocaleDateString("ko-KR")}</td>
                   <td style={{ textAlign: "right" }}>
                     <div className="flex items-center justify-end gap-1">
-                      {d.fileUrl && (
-                        <button className="btn-icon" onClick={() => downloadDoc(d)} title="다운로드">
-                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></svg>
-                        </button>
+                      {/* 메모 타입 */}
+                      {d.content != null ? (
+                        <>
+                          <button className="btn-icon" onClick={() => setMemoTarget(d)} title="메모 열기">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                              <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
+                            </svg>
+                          </button>
+                          <button className="btn-icon" onClick={() => setHistoryDoc(d)} title="버전 히스토리">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8" /><path d="M3 3v5h5" /><path d="M12 7v5l3 2" /></svg>
+                          </button>
+                          <button className="btn-icon" onClick={() => deleteDoc(d)} title="삭제">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#DC2626" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+                          </button>
+                        </>
+                      ) : (
+                        /* 파일 문서 타입 */
+                        <>
+                          {d.fileUrl && (
+                            <button className="btn-icon" onClick={() => downloadDoc(d)} title="다운로드">
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></svg>
+                            </button>
+                          )}
+                          {d.fileUrl && (
+                            <button className="btn-icon" onClick={() => setSharingDoc(d)} title="외부 공유 링크">
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" /><path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4" /></svg>
+                            </button>
+                          )}
+                          <button className="btn-icon" onClick={() => setHistoryDoc(d)} title="버전 히스토리">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8" /><path d="M3 3v5h5" /><path d="M12 7v5l3 2" /></svg>
+                          </button>
+                          <button className="btn-icon" onClick={() => deleteDoc(d)} title="삭제">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#DC2626" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+                          </button>
+                        </>
                       )}
-                      {d.fileUrl && (
-                        <button className="btn-icon" onClick={() => setSharingDoc(d)} title="외부 공유 링크">
-                          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" /><path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4" /></svg>
-                        </button>
-                      )}
-                      <button className="btn-icon" onClick={() => setHistoryDoc(d)} title="버전 히스토리">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8" /><path d="M3 3v5h5" /><path d="M12 7v5l3 2" /></svg>
-                      </button>
-                      <button className="btn-icon" onClick={() => deleteDoc(d)} title="삭제">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#DC2626" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" /><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
-                      </button>
                     </div>
                   </td>
                 </tr>
@@ -1660,6 +1712,44 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
           onClose={() => setHistoryDoc(null)}
           onRestored={() => load()}
         />
+      )}
+
+      {/* ===== 메모 편집/열람 모달 ===== */}
+      {memoTarget !== null && (
+        <Suspense fallback={
+          <div className="fixed inset-0 z-50 grid place-items-center bg-[color:var(--c-bg)]">
+            <div className="text-[12px] text-ink-400">에디터 불러오는 중…</div>
+          </div>
+        }>
+          <DocMemoModal
+            doc={memoTarget === "new" ? null : (memoTarget as MemoDoc)}
+            initialFolderId={memoTarget === "new" ? (currentFolder === "root" ? null : currentFolder) : undefined}
+            initialScope={
+              memoTarget === "new"
+                ? (scopeTab === "team" ? "TEAM" : scopeTab === "private" ? "PRIVATE" : "ALL")
+                : undefined
+            }
+            projectId={activeProjectId ?? null}
+            onClose={() => setMemoTarget(null)}
+            onSaved={(saved) => {
+              setMemoTarget(saved as unknown as Doc);
+              // 목록 갱신 — 새 메모면 리스트에 추가, 수정이면 제자리 업데이트
+              setDocs((prev) => {
+                const idx = prev.findIndex((d) => d.id === saved.id);
+                if (idx >= 0) {
+                  const next = [...prev];
+                  next[idx] = { ...next[idx], ...saved };
+                  return next;
+                }
+                return [saved as unknown as Doc, ...prev];
+              });
+            }}
+            onDeleted={(id) => {
+              setMemoTarget(null);
+              setDocs((prev) => prev.filter((d) => d.id !== id));
+            }}
+          />
+        </Suspense>
       )}
     </div>
   );

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -85,6 +85,7 @@ html, body, #root {
 body {
   font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,
     Inter, system-ui, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+  overscroll-behavior: none;
 }
 * { -webkit-tap-highlight-color: transparent; }
 .font-mono, code, pre, .tabular {

--- a/server/prisma/migrations/20260527000000_add_doc_memo_content/migration.sql
+++ b/server/prisma/migrations/20260527000000_add_doc_memo_content/migration.sql
@@ -1,0 +1,7 @@
+-- 문서 메모 기능: Document 와 DocumentRevision 에 TipTap JSON 컨텐츠 컬럼 추가.
+-- content IS NULL  → 기존 파일/링크 문서 (하위 호환).
+-- content IS NOT NULL → 메모(리치텍스트) 타입 문서.
+
+ALTER TABLE "Document" ADD COLUMN "content" JSONB;
+
+ALTER TABLE "DocumentRevision" ADD COLUMN "content" JSONB;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -579,6 +579,8 @@ model DocumentRevision {
   fileName    String?
   fileType    String?
   fileSize    Int?
+  /// 메모(리치텍스트) 스냅샷 — 파일 문서 리비전에선 null.
+  content     Json?
   editorId    String
   editor      User     @relation(fields: [editorId], references: [id], onDelete: Cascade)
   createdAt   DateTime @default(now())
@@ -734,6 +736,8 @@ model Document {
   fileType     String?
   fileSize     Int?
   tags         String? // comma separated
+  /// TipTap JSON — null 이면 파일/링크 문서, 값이 있으면 메모(리치텍스트) 문서.
+  content      Json?
   authorId     String
   author       User                @relation("DocumentAuthor", fields: [authorId], references: [id], onDelete: Cascade)
   // 공개 범위 — ALL(전체) | TEAM(팀) | PRIVATE(개인) | CUSTOM(사용자지정)

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -348,6 +348,14 @@ router.delete("/folders/:id", async (req, res) => {
 });
 
 /* ===== 문서 ===== */
+// TipTap JSON 최대 크기 — 회의록(512KB) 과 동일 기준.
+// 이미지 다수 포함해도 통상 수백 KB 안. 너무 크면 Postgres JSONB 파싱/응답 비용 급등.
+const DOC_CONTENT_MAX = 512_000;
+
+function sizeOfJson(v: unknown): number {
+  try { return JSON.stringify(v ?? "").length; } catch { return Number.MAX_SAFE_INTEGER; }
+}
+
 const docSchema = z.object({
   title: z.string().min(1).max(200),
   description: z.string().max(2000).optional(),
@@ -359,6 +367,8 @@ const docSchema = z.object({
   fileSize: z.number().int().nonnegative().max(500_000_000).optional(),
   // 태그는 콤마로 구분된 문자열. UI에서 20개 이상 넣을 일 없음.
   tags: z.string().max(500).optional(),
+  /// TipTap JSON — 메모 타입 문서에만 사용. null/undefined 이면 파일 문서.
+  content: z.any().optional(),
   scope: z.enum(["ALL", "TEAM", "PRIVATE", "CUSTOM"]).optional(),
   scopeTeam: z.string().max(80).nullable().optional(),
   // scopeUserIds — folderCreateSchema 와 동일 기준 50명 상한.
@@ -449,6 +459,11 @@ router.post("/", async (req, res) => {
   const d = parsed.data;
   const projectId = d.projectId ?? null;
 
+  // 메모 content 크기 상한.
+  if (d.content !== undefined && d.content !== null && sizeOfJson(d.content) > DOC_CONTENT_MAX) {
+    return res.status(400).json({ error: "메모 내용이 너무 큽니다 (최대 512KB)" });
+  }
+
   if (projectId) {
     if (!(await assertProjectMember(u, projectId))) {
       return res.status(403).json({ error: "해당 프로젝트에 접근 권한이 없습니다" });
@@ -463,6 +478,7 @@ router.post("/", async (req, res) => {
         fileType: d.fileType,
         fileSize: d.fileSize,
         tags: d.tags,
+        content: d.content ?? null,
         authorId: u.id,
         scope: "ALL",
         scopeTeam: null,
@@ -489,6 +505,7 @@ router.post("/", async (req, res) => {
       fileType: d.fileType,
       fileSize: d.fileSize,
       tags: d.tags,
+      content: d.content ?? null,
       authorId: u.id,
       scope,
       scopeTeam,
@@ -538,6 +555,7 @@ router.patch("/:id", async (req, res) => {
     ...(d.description !== undefined && { description: d.description }),
     ...(d.folderId !== undefined && { folderId: d.folderId }),
     ...(d.tags !== undefined && { tags: d.tags }),
+    ...(d.content !== undefined && { content: d.content ?? null }),
   };
   if (touchesVisibility) {
     if (d.projectId !== undefined) {
@@ -565,11 +583,17 @@ router.patch("/:id", async (req, res) => {
     }
   }
 
-  // 변경 전 스냅샷을 DocumentRevision 에 남김 — title/description/fileUrl 의 실질 변경이
-  // 있을 때만 기록해 잡음을 줄인다. 폴더 이동·태그 변경만으로는 리비전을 찍지 않음.
+  // content 크기 상한.
+  if (d.content !== undefined && d.content !== null && sizeOfJson(d.content) > DOC_CONTENT_MAX) {
+    return res.status(400).json({ error: "메모 내용이 너무 큽니다 (최대 512KB)" });
+  }
+
+  // 변경 전 스냅샷을 DocumentRevision 에 남김 — title/description/fileUrl/content 의 실질
+  // 변경이 있을 때만 기록해 잡음을 줄인다. 폴더 이동·태그 변경만으로는 리비전을 찍지 않음.
   const contentChanged =
     (d.title !== undefined && d.title !== exist.title) ||
-    (d.description !== undefined && d.description !== exist.description);
+    (d.description !== undefined && d.description !== exist.description) ||
+    (d.content !== undefined && JSON.stringify(d.content) !== JSON.stringify((exist as any).content));
   if (contentChanged) {
     try {
       await prisma.documentRevision.create({
@@ -581,6 +605,7 @@ router.patch("/:id", async (req, res) => {
           fileName: exist.fileName,
           fileType: exist.fileType,
           fileSize: exist.fileSize,
+          content: (exist as any).content ?? null,
           editorId: u.id,
         },
       });


### PR DESCRIPTION
## 증상
**문서함 Notion 스타일 메모 작성 기능 (#147)**

새 기능을 추가합니다.

## 원인
4개 모바일/반응형 UI 버그를 한 번에 수정.

## 채팅 — 뒤로가기 없어 갇히는 문제 (ChatFab.tsx)
- 기존: 채팅 본문을 `position: absolute; top: 86` (border-box 기준) 으로 올렸는데
  부모에 `paddingTop: env(safe-area-inset-top)` (~47 px) 가 있어 absolute 는 padding 무시 →
  헤더(y=47~86) 와 본문(y=86~) 이 겹치지 않지만 뒤로가기 버튼이 notch 아래에 가려졌다.
- 수정: 외부 컨테이너를 **flex-column** 으로 전환, 헤더는 `flexShrink:0`, 본문은
  `flex:1; minHeight:0` — 절대 좌표 없이 자동으로 쌓임.
- 추가: 모바일 풀스크린에서 방 내부에서도 한 탭으로 패널 자체를 닫는 **× 버튼**
  (`HeaderCloseButton`) 을 RoomHeader 우측에 추가. onClose 미전달 시엔 렌더링 안 됨.

## iOS 오버스크롤 뚫림 (AppLayout.tsx + styles.css)
- `<main>` 에 `overscrollBehaviorY: contain` — 러버밴드가 부모로 전파돼
  TopBar 위로 본문이 잠시 보이는 현상 방지.
- `body { overscroll-behavior: none }` 으로 전역 fallback 추가.
- `WebkitOverflowScrolling: touch` 로 iOS Safari momentum scrolling 안정화.

## 사이드바 하단 빈 공간 (AppLayout.tsx)
- `fixed inset-y-0` → `fixed top-0 h-[100dvh] md:h-auto` 로 변경.
  inset-y-0 은 레이아웃 뷰포트(URL바 포함) 기준이라 동적 뷰포트보다 길어
  프로필 chip 아래로 ~42 px 의 빈 공간이 생겼다. 100dvh 로 동적 뷰포트에 맞춤.
- 프로필 chip 패딩: `calc(8px + safe-area)` → `max(8px, safe-area)` 로
  홈 인디케이터 없는 기기에서도 최소 8 px 확보하면서 notch 기기의 과도한 여백 제거.

## 결재 댓글 등록 버튼 클리핑 (ApprovalsPage.tsx)

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 채팅 뒤로가기 갇힘·iOS overscroll 뚫림·사이드바 빈 공간·결재 댓글 버튼 클리핑
- feat(docs): 문서함에 Notion 스타일 메모 작성 기능 추가
- merge: main 충돌 해결 (SAFE_UPLOAD_URL + doc memo content 공존)

**변경 대상 (9개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatFab.tsx`
- `client/src/components/DocMemoModal.tsx`
- `client/src/pages/ApprovalsPage.tsx`
- `client/src/pages/DocumentsPage.tsx`
- `client/src/styles.css`
- `server/prisma/migrations/20260527000000_add_doc_memo_content/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/routes/document.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #147** ↔ **이슈 #571** 로 연결됩니다.

Closes #571
