### PR TITLE
🔀 :: (#574) Suspense fallback createPortal crash 수정

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,4 +1,3 @@
-import { createPortal } from "react-dom";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api } from "../api";
@@ -1726,16 +1725,12 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
         />
       )}
 
-      {/* ===== 메모 편집/열람 모달 — Suspense fallback 도 body 에 portal 해서 overflow/transform 계층 우회 ===== */}
+      {/* ===== 메모 편집/열람 모달 ===== */}
+      {/* fallback=null: DocMemoModal 이 createPortal(document.body) 를 사용하므로
+          Suspense fallback 에도 동일 컨테이너 portal 을 쓰면 React reconciler 가 crash.
+          초기 로드는 100ms 내외라 null 로 충분. */}
       {memoTarget !== null && (
-        <Suspense fallback={
-          createPortal(
-            <div className="fixed inset-0 z-[60] grid place-items-center bg-[color:var(--c-bg)]">
-              <div className="text-[12px] text-ink-400">에디터 불러오는 중…</div>
-            </div>,
-            document.body
-          )
-        }>
+        <Suspense fallback={null}>
           <DocMemoModal
             doc={memoTarget === "new" ? null : (memoTarget as MemoDoc)}
             initialFolderId={memoTarget === "new" ? (currentFolder === "root" ? null : currentFolder) : undefined}


### PR DESCRIPTION
## 증상
**Suspense fallback createPortal crash 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
DocMemoModal 이 createPortal(document.body) 를 반환하는 상태에서
Suspense fallback 에도 동일 컨테이너(document.body) 로의 portal 을 두면
React reconciler 가 fallback↔children 전환 시 같은 컨테이너를
두 개의 fiber 트리에서 동시에 관리하려다 invariant 위반으로 crash.

fallback=null 로 변경 (초기 로드 100ms 내외, null 이면 충분).

## 수정
**작업 항목 (커밋 단위)**
- fix: Suspense fallback 에서 createPortal 제거 — reconciler crash 수정

**변경 대상 (1개 파일)**
- `client/src/pages/DocumentsPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #150** ↔ **이슈 #574** 로 연결됩니다.

Closes #574
