### PR TITLE
🔀 :: (#575) 메모 모달 UX — Notion 스타일 대제목 구조

### DIFF
--- a/client/src/components/DocMemoModal.tsx
+++ b/client/src/components/DocMemoModal.tsx
@@ -3,10 +3,8 @@
  *
  * 레이아웃 전략:
  *   - createPortal(…, document.body) 로 DOM 트리 최상단에 붙임
- *     → overflow-y:auto / -webkit-overflow-scrolling:touch / transform 등 조상 요소의
- *       스태킹·컨테이닝 블록 문제를 완전히 우회.
- *   - top 오프셋은 <header> 요소의 getBoundingClientRect().bottom 을 실측해서 적용
- *     → macOS Electron 28px 드래그바, iOS safe-area, 임시/미리보기 배너 높이를 자동 반영.
+ *   - top 오프셋: <header> 실측으로 macOS 드래그바·safe-area·배너 자동 반영
+ *   - 디자인: Notion 스타일 — 대제목은 본문에, 헤더는 닫기+액션만
  */
 import { createPortal } from "react-dom";
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -58,7 +56,6 @@ const SCOPE_DESC: Record<DocScope, string> = {
   CUSTOM: "지정한 구성원만 열람",
 };
 
-/** <header> 요소의 뷰포트 하단 좌표를 실측해 반환. 없으면 48 px 폴백. */
 function measureHeaderBottom(): number {
   const h = document.querySelector("header");
   return h ? Math.round(h.getBoundingClientRect().bottom) : 48;
@@ -97,26 +94,15 @@ export default function DocMemoModal({
   const [err, setErr] = useState<string | null>(null);
 
   // ===== TopBar 하단 오프셋 실측 =====
-  // createPortal 로 body 에 붙은 fixed 패널의 top 값을 <header> 실측으로 결정.
-  // - 초기값: 렌더 시점에 동기 측정 (flash 없음)
-  // - useLayoutEffect: 마운트 직후 재측정 + ResizeObserver(배너 토글 등 동적 높이 변화)
   const [topOffset, setTopOffset] = useState<number>(measureHeaderBottom);
-
   useLayoutEffect(() => {
-    function measure() {
-      setTopOffset(measureHeaderBottom());
-    }
+    function measure() { setTopOffset(measureHeaderBottom()); }
     measure();
-
     const ro = typeof ResizeObserver !== "undefined" ? new ResizeObserver(measure) : null;
     const header = document.querySelector("header");
     if (ro && header) ro.observe(header);
     window.addEventListener("resize", measure);
-
-    return () => {
-      ro?.disconnect();
-      window.removeEventListener("resize", measure);
-    };
+    return () => { ro?.disconnect(); window.removeEventListener("resize", measure); };
   }, []);
 
   useEffect(() => {
@@ -134,9 +120,7 @@ export default function DocMemoModal({
         `/api/meeting/mentionable?visibility=ALL&q=${encodeURIComponent(q)}`
       );
       return r.users ?? [];
-    } catch {
-      return [];
-    }
+    } catch { return []; }
   }, []);
 
   const titleRef = useRef<HTMLInputElement>(null);
@@ -167,19 +151,12 @@ export default function DocMemoModal({
         folderId: doc?.folderId ?? initialFolderId ?? null,
         projectId: projectId ?? null,
       };
-
       let saved: MemoDoc;
       if (doc) {
-        const r = await api<{ document: MemoDoc }>(`/api/document/${doc.id}`, {
-          method: "PATCH",
-          json: body,
-        });
+        const r = await api<{ document: MemoDoc }>(`/api/document/${doc.id}`, { method: "PATCH", json: body });
         saved = r.document;
       } else {
-        const r = await api<{ document: MemoDoc }>("/api/document", {
-          method: "POST",
-          json: body,
-        });
+        const r = await api<{ document: MemoDoc }>("/api/document", { method: "POST", json: body });
         saved = r.document;
       }
       setEditMode(false);
@@ -208,102 +185,105 @@ export default function DocMemoModal({
     ? allUsers.filter((u) => u.name.includes(userSearch) || (u.team ?? "").includes(userSearch))
     : allUsers;
 
-  // ===== 렌더 — portal 로 body 에 직접 붙임 =====
+  const dateStr = doc
+    ? new Date(doc.updatedAt).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" })
+    : "";
+
   return createPortal(
     <>
-      {/* 메인 패널 — TopBar 바로 아래부터 화면 하단까지 */}
       <div
         className="fixed left-0 right-0 bottom-0 z-[60] flex flex-col bg-[color:var(--c-bg)]"
         style={{ top: topOffset }}
       >
-        {/* ===== 헤더 ===== */}
-        <div className="flex-shrink-0 flex items-center gap-2 px-4 h-12 border-b border-ink-150 bg-[color:var(--c-surface)]">
-          {/* 닫기 */}
-          <button onClick={onClose} className="btn-icon flex-shrink-0" aria-label="닫기" title="닫기">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          </button>
+        {/* ===== 헤더 — 닫기 + 경로 표시 + 우측 액션 ===== */}
+        <div className="flex-shrink-0 flex items-center justify-between gap-3 px-4 h-12 border-b border-ink-150 bg-[color:var(--c-surface)]">
+          {/* 왼쪽: 닫기 + 경로 */}
+          <div className="flex items-center gap-2 min-w-0">
+            <button
+              onClick={onClose}
+              className="btn-icon flex-shrink-0"
+              aria-label="닫기"
+              title="닫기 (Esc)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+            <div className="flex items-center gap-1.5 text-[12px] text-ink-400 min-w-0">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="flex-shrink-0">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" />
+              </svg>
+              <span className="truncate font-medium">
+                {editMode && !title ? "새 메모" : (title || "제목 없음")}
+              </span>
+            </div>
+          </div>
 
-          {/* 제목 */}
-          {editMode ? (
-            <input
-              ref={titleRef}
-              className="flex-1 min-w-0 text-[14px] font-bold bg-transparent border-none outline-none text-ink-900 placeholder:text-ink-400"
-              placeholder="메모 제목"
-              value={title}
-              onChange={(e) => { setTitle(e.target.value); if (err) setErr(null); }}
-              maxLength={200}
-              onKeyDown={(e) => { if (e.key === "Enter") e.preventDefault(); }}
-            />
-          ) : (
-            <h1 className="flex-1 min-w-0 text-[14px] font-bold text-ink-900 truncate">
-              {title || "제목 없음"}
-            </h1>
-          )}
-
-          {/* 공개 범위 — 편집 모드에서만 변경 가능, 프로젝트 문서는 고정 */}
-          {!projectId && (
-            <div className="relative flex-shrink-0">
-              <button
-                type="button"
-                disabled={!editMode}
-                onClick={() => editMode && setScopeOpen((o) => !o)}
-                className={`flex items-center gap-1 px-2.5 h-7 rounded-full text-[11px] font-bold border transition select-none ${
-                  scope === "PRIVATE" ? "bg-rose-50 border-rose-200 text-rose-700"
+          {/* 오른쪽: 공개 범위 + 액션 */}
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            {!projectId && (
+              <div className="relative">
+                <button
+                  type="button"
+                  disabled={!editMode}
+                  onClick={() => editMode && setScopeOpen((o) => !o)}
+                  className={`flex items-center gap-1 px-2.5 h-7 rounded-full text-[11px] font-bold border transition select-none ${
+                    scope === "PRIVATE" ? "bg-rose-50 border-rose-200 text-rose-700"
                     : scope === "TEAM" ? "bg-sky-50 border-sky-200 text-sky-700"
                     : scope === "CUSTOM" ? "bg-violet-50 border-violet-200 text-violet-700"
                     : "bg-emerald-50 border-emerald-200 text-emerald-700"
-                } ${editMode ? "cursor-pointer hover:opacity-80" : "cursor-default opacity-80"}`}
-              >
-                <ScopeIcon scope={scope} />
-                <span>{SCOPE_LABEL[scope]}</span>
-                {editMode && (
-                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-                    <path d="m6 9 6 6 6-6" />
-                  </svg>
+                  } ${editMode ? "cursor-pointer hover:opacity-80" : "cursor-default opacity-70"}`}
+                >
+                  <ScopeIcon scope={scope} />
+                  <span>{SCOPE_LABEL[scope]}</span>
+                  {editMode && (
+                    <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                      <path d="m6 9 6 6 6-6" />
+                    </svg>
+                  )}
+                </button>
+
+                {/* 범위 드롭다운 */}
+                {scopeOpen && (
+                  <div className="absolute right-0 top-full mt-1 w-[220px] bg-[color:var(--c-surface)] border border-ink-200 rounded-xl shadow-xl z-[70] overflow-hidden">
+                    {(["ALL", "TEAM", "PRIVATE", "CUSTOM"] as DocScope[]).map((s) => (
+                      <button
+                        key={s}
+                        type="button"
+                        onClick={() => { setScope(s); setScopeOpen(false); }}
+                        className={`w-full flex items-start gap-3 px-4 py-2.5 hover:bg-ink-50 transition text-left ${scope === s ? "bg-brand-50" : ""}`}
+                      >
+                        <ScopeIcon scope={s} className="mt-0.5 flex-shrink-0 text-ink-500" />
+                        <div>
+                          <div className={`text-[12px] font-bold ${scope === s ? "text-brand-700" : "text-ink-800"}`}>{SCOPE_LABEL[s]}</div>
+                          <div className="text-[11px] text-ink-500">{SCOPE_DESC[s]}</div>
+                        </div>
+                        {scope === s && (
+                          <svg className="ml-auto flex-shrink-0 text-brand-600" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                            <polyline points="20 6 9 17 4 12" />
+                          </svg>
+                        )}
+                      </button>
+                    ))}
+                  </div>
                 )}
-              </button>
+              </div>
+            )}
 
-              {/* 범위 드롭다운 — z-[70] 로 패널(z-60) 위에 */}
-              {scopeOpen && (
-                <div className="absolute right-0 top-full mt-1 w-[230px] bg-[color:var(--c-surface)] border border-ink-200 rounded-xl shadow-xl z-[70] overflow-hidden">
-                  {(["ALL", "TEAM", "PRIVATE", "CUSTOM"] as DocScope[]).map((s) => (
-                    <button
-                      key={s}
-                      type="button"
-                      onClick={() => { setScope(s); setScopeOpen(false); }}
-                      className={`w-full flex items-start gap-3 px-4 py-2.5 hover:bg-ink-50 transition text-left ${scope === s ? "bg-brand-50" : ""}`}
-                    >
-                      <ScopeIcon scope={s} className="mt-0.5 flex-shrink-0 text-ink-500" />
-                      <div>
-                        <div className={`text-[12px] font-bold ${scope === s ? "text-brand-700" : "text-ink-800"}`}>{SCOPE_LABEL[s]}</div>
-                        <div className="text-[11px] text-ink-500">{SCOPE_DESC[s]}</div>
-                      </div>
-                      {scope === s && (
-                        <svg className="ml-auto flex-shrink-0 text-brand-600" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-                          <polyline points="20 6 9 17 4 12" />
-                        </svg>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* 액션 버튼 */}
-          <div className="flex items-center gap-1.5 flex-shrink-0 ml-1">
             {editMode ? (
               <>
-                <button className="btn-ghost btn-sm" onClick={handleCancel} disabled={saving}>취소</button>
+                <button className="btn-ghost btn-sm" onClick={handleCancel} disabled={saving}>
+                  취소
+                </button>
                 <button className="btn-primary btn-sm" onClick={handleSave} disabled={saving}>
-                  {saving ? "저장 중…" : doc ? "저장" : "메모 만들기"}
+                  {saving ? "저장 중…" : doc ? "저장" : "만들기"}
                 </button>
               </>
             ) : (
               isMine && (
-                <button className="btn-ghost btn-sm" onClick={() => setEditMode(true)}>편집</button>
+                <button className="btn-ghost btn-sm" onClick={() => setEditMode(true)}>
+                  편집
+                </button>
               )
             )}
           </div>
@@ -311,15 +291,15 @@ export default function DocMemoModal({
 
         {/* 오류 띠 */}
         {err && (
-          <div className="flex-shrink-0 flex items-center gap-2 px-4 py-2 bg-rose-50 border-b border-rose-200 text-[12px] text-rose-700">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+          <div className="flex-shrink-0 flex items-center gap-2 px-5 py-2 bg-rose-50 border-b border-rose-200 text-[12px] text-rose-700">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
             {err}
           </div>
         )}
 
-        {/* CUSTOM scope — 열람자 선택 패널 */}
+        {/* CUSTOM 열람자 선택 패널 */}
         {editMode && scope === "CUSTOM" && (
-          <div className="flex-shrink-0 border-b border-ink-150 bg-violet-50/60 px-4 py-2 flex flex-wrap items-center gap-2">
+          <div className="flex-shrink-0 border-b border-ink-150 bg-violet-50/60 px-5 py-2 flex flex-wrap items-center gap-2">
             <span className="text-[11px] font-bold text-violet-700">열람 가능:</span>
             {scopeUserIds.map((uid) => {
               const u = allUsers.find((x) => x.id === uid);
@@ -341,22 +321,21 @@ export default function DocMemoModal({
                 <div className="absolute left-0 top-full mt-1 w-[200px] bg-white border border-ink-200 rounded-xl shadow-lg z-[70] max-h-[180px] overflow-y-auto">
                   {filteredUsers.filter((u) => !scopeUserIds.includes(u.id)).length === 0 ? (
                     <div className="px-3 py-2 text-[12px] text-ink-500">없음</div>
-                  ) : (
-                    filteredUsers.filter((u) => !scopeUserIds.includes(u.id)).map((u) => (
-                      <button key={u.id} type="button"
-                        onClick={() => { setScopeUserIds((p) => [...p, u.id]); setUserSearch(""); }}
-                        className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-ink-50 text-left"
-                      >
-                        <div className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
-                          style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
-                          {u.avatarUrl ? <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" /> : u.name[0]}
-                        </div>
-                        <span className="text-[12px] text-ink-800 font-semibold">{u.name}
-                          {u.team && <span className="text-ink-400 font-normal ml-1">· {u.team}</span>}
-                        </span>
-                      </button>
-                    ))
-                  )}
+                  ) : filteredUsers.filter((u) => !scopeUserIds.includes(u.id)).map((u) => (
+                    <button key={u.id} type="button"
+                      onClick={() => { setScopeUserIds((p) => [...p, u.id]); setUserSearch(""); }}
+                      className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-ink-50 text-left"
+                    >
+                      <div className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
+                        style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
+                        {u.avatarUrl ? <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" /> : u.name[0]}
+                      </div>
+                      <span className="text-[12px] text-ink-800 font-semibold">
+                        {u.name}
+                        {u.team && <span className="text-ink-400 font-normal ml-1">· {u.team}</span>}
+                      </span>
+                    </button>
+                  ))}
                 </div>
               )}
             </div>
@@ -365,63 +344,88 @@ export default function DocMemoModal({
 
         {/* ===== 본문 ===== */}
         <div className="flex-1 min-h-0 overflow-y-auto">
-          <div className="max-w-[860px] mx-auto px-5 md:px-10 py-5">
+          <div className="max-w-[740px] mx-auto px-6 md:px-10 pt-10 pb-16">
 
-            {/* 열람 모드 — 작성자 + 날짜 */}
+            {/* ── 대제목 ── */}
+            {editMode ? (
+              <input
+                ref={titleRef}
+                className="w-full text-[26px] md:text-[30px] font-extrabold text-ink-900 bg-transparent border-none outline-none placeholder:text-ink-300 leading-tight mb-3"
+                placeholder="제목 없음"
+                value={title}
+                onChange={(e) => { setTitle(e.target.value); if (err) setErr(null); }}
+                maxLength={200}
+                onKeyDown={(e) => { if (e.key === "Enter") e.preventDefault(); }}
+              />
+            ) : (
+              <h1 className="text-[26px] md:text-[30px] font-extrabold text-ink-900 leading-tight mb-3">
+                {title || <span className="text-ink-300">제목 없음</span>}
+              </h1>
+            )}
+
+            {/* ── 메타 (열람 모드) ── */}
             {!editMode && doc && (
-              <div className="flex items-center gap-2 mb-4 text-[11px] text-ink-400">
-                <div className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
-                  style={{ background: doc.author.avatarUrl ? "transparent" : (doc.author.avatarColor ?? "#6B7280") }}>
-                  {doc.author.avatarUrl ? <img src={doc.author.avatarUrl} alt={doc.author.name} className="w-full h-full object-cover" /> : doc.author.name[0]}
+              <div className="flex items-center gap-2 mb-4 text-[12px] text-ink-400">
+                <div
+                  className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
+                  style={{ background: doc.author.avatarUrl ? "transparent" : (doc.author.avatarColor ?? "#6B7280") }}
+                >
+                  {doc.author.avatarUrl
+                    ? <img src={doc.author.avatarUrl} alt={doc.author.name} className="w-full h-full object-cover" />
+                    : doc.author.name[0]
+                  }
                 </div>
                 <span className="font-semibold text-ink-600">{doc.author.name}</span>
-                <span>·</span>
-                <span>{new Date(doc.updatedAt).toLocaleDateString("ko-KR", { year: "numeric", month: "long", day: "numeric" })}</span>
+                <span className="text-ink-200">·</span>
+                <span>{dateStr}</span>
               </div>
             )}
 
-            {/* 태그 입력 (편집 모드) */}
-            {editMode && (
+            {/* ── 태그 ── */}
+            {editMode ? (
               <input
-                className="block w-full mb-3 bg-transparent text-[12px] text-ink-500 placeholder:text-ink-300 border-none outline-none"
-                placeholder="태그 입력 (쉼표로 구분, 예: 기획, 아이디어)"
+                className="block w-full text-[12px] text-ink-400 placeholder:text-ink-300 bg-transparent border-none outline-none mb-1"
+                placeholder="# 태그 입력 (쉼표로 구분, 예: 기획, 아이디어)"
                 value={tags}
                 onChange={(e) => setTags(e.target.value)}
                 maxLength={200}
               />
-            )}
-
-            {/* 태그 표시 (열람 모드) */}
-            {!editMode && (doc?.tags || tags) && (
-              <div className="flex flex-wrap gap-1 mb-4">
-                {(doc?.tags ?? tags).split(",").map((t) => t.trim()).filter(Boolean).map((t) => (
+            ) : (tags || doc?.tags) ? (
+              <div className="flex flex-wrap gap-1 mb-1">
+                {((doc?.tags ?? tags) || "").split(",").map((t) => t.trim()).filter(Boolean).map((t) => (
                   <span key={t} className="chip-gray text-[11px]">#{t}</span>
                 ))}
               </div>
-            )}
+            ) : null}
 
-            {/* TipTap 에디터 */}
+            {/* ── 구분선 ── */}
+            <div className="border-t border-ink-100 mt-4 mb-6" />
+
+            {/* ── TipTap 에디터 ── */}
             <Suspense fallback={
-              <div className="h-40 flex items-center justify-center text-[12px] text-ink-400">에디터 불러오는 중…</div>
+              <div className="py-12 flex items-center justify-center gap-2 text-[12px] text-ink-400">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="animate-spin">
+                  <path d="M21 12a9 9 0 1 1-6.2-8.6" />
+                </svg>
+                에디터 불러오는 중…
+              </div>
             }>
               <MeetingEditor
                 value={content}
                 onChange={editMode ? handleContentChange : undefined}
                 editable={editMode}
-                placeholder="여기에 메모를 작성하세요..."
+                placeholder="여기에 내용을 작성하세요…"
                 mentionFetcher={editMode ? mentionFetcher : undefined}
               />
             </Suspense>
+
           </div>
         </div>
       </div>
 
-      {/* 범위 드롭다운 외부 클릭 닫기 — z-[59] (패널 z-60 보다 아래, 나머지 페이지 위) */}
+      {/* 범위 드롭다운 외부 클릭 닫기 */}
       {scopeOpen && (
-        <div
-          className="fixed inset-0 z-[59]"
-          onClick={() => setScopeOpen(false)}
-        />
+        <div className="fixed inset-0 z-[59]" onClick={() => setScopeOpen(false)} />
       )}
     </>,
     document.body
@@ -430,22 +434,22 @@ export default function DocMemoModal({
 
 function ScopeIcon({ scope, className = "" }: { scope: DocScope; className?: string }) {
   if (scope === "PRIVATE") return (
-    <svg className={className} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg className={className} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <rect x="3" y="11" width="18" height="11" rx="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
     </svg>
   );
   if (scope === "TEAM") return (
-    <svg className={className} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg className={className} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
     </svg>
   );
   if (scope === "CUSTOM") return (
-    <svg className={className} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg className={className} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <circle cx="12" cy="12" r="10" /><polyline points="12 8 12 12 14 14" />
     </svg>
   );
   return (
-    <svg className={className} width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg className={className} width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <circle cx="12" cy="12" r="10" /><line x1="2" y1="12" x2="22" y2="12" /><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
     </svg>
   );


### PR DESCRIPTION
## 증상
**메모 모달 UX — Notion 스타일 대제목 구조**

유지보수 작업을 진행합니다.

## 원인
변경:
- 제목을 헤더 인라인(h-12)에서 본문 상단 큰 텍스트(26-30px, extrabold)로 이동
  → 열람/편집 모두 제목이 주인공이 되어 빈약해 보이지 않음
- 헤더는 '닫기 + 문서 경로 표시 + 공개범위 + 액션' 으로 단순화
- 열람 모드: 대제목 → 작성자·날짜 → 태그칩 → 구분선 → 본문 순서
- 편집 모드: 대제목 입력 → 태그 입력 → 구분선 → TipTap 에디터
- pt-10 pb-16 으로 충분한 상하 여백, max-w-740px
- 에디터 로딩 중 스피너 fallback (Suspense 내부)

## 수정
**작업 항목 (커밋 단위)**
- improve: 메모 모달 UX 개선 — Notion 스타일 대제목 + 메타 구조

**변경 대상 (1개 파일)**
- `client/src/components/DocMemoModal.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #151** ↔ **이슈 #575** 로 연결됩니다.

Closes #575
