### PR TITLE
🔀 :: (#578) /api/nav/visibility 인메모리 캐시 — 모든 페이지 로드 DB 왕복 제거

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/auth.js";
 import { todayStr } from "../lib/dates.js";
 import { getLogs, type LogLevel, getErrorGroups, getErrorGroup, clearErrorGroups } from "../lib/logBuffer.js";
+import { evictNavVisibilityCache } from "./nav.js";
 
 const router = Router();
 router.use(requireAuth, requireAdmin);
@@ -1268,6 +1269,8 @@ router.post("/nav-visibility", requireSuperAdminStepUp, async (req, res) => {
     create: { path: p, enabled: nextEnabled, inDev: nextInDev, updatedBy: u.id },
     update: { enabled: nextEnabled, inDev: nextInDev, updatedBy: u.id },
   });
+  // NavConfig 변경 즉시 인메모리 캐시 무효화 — 다음 요청에서 최신값 로드.
+  evictNavVisibilityCache();
   await writeLog(u.id, "NAV_TOGGLE", p, JSON.stringify({ enabled: nextEnabled, inDev: nextInDev }), req.ip).catch(() => {});
   res.json({ ok: true });
 });

--- a/server/src/routes/nav.ts
+++ b/server/src/routes/nav.ts
@@ -12,17 +12,40 @@ import { requireAuth } from "../lib/auth.js";
 const router = Router();
 router.use(requireAuth);
 
-/** 사이드바 메뉴 상태:
- *  - disabled: 사이드바에서 숨김 + 라우트 차단 (enabled=false 인 path)
- *  - dev:       사이드바엔 노출하되 진입 시 \"개발 중\" 안내 (enabled=true && inDev=true)
- *  행이 없는 path 는 기본 enabled=true / inDev=false 로 간주 — 클라는 두 set 만 알면 됨. */
-router.get("/visibility", async (_req, res) => {
+// ─── /api/nav/visibility 인메모리 캐시 ───────────────────────────────────────
+// NavConfig 는 관리자가 수동으로 바꾸는 아주 드문 데이터이지만
+// /visibility 는 모든 사용자의 모든 페이지 로드마다 호출된다.
+// 1분 TTL 캐시로 DB 왕복을 없애고, 변경 시 admin 라우트에서 즉시 무효화.
+type NavVisibilityPayload = { disabled: string[]; dev: string[] };
+let _navVisCache: { data: NavVisibilityPayload; exp: number } | null = null;
+const NAV_VIS_TTL_MS = 60_000; // 1분
+
+export function evictNavVisibilityCache(): void {
+  _navVisCache = null;
+}
+
+async function getNavVisibility(): Promise<NavVisibilityPayload> {
+  if (_navVisCache && _navVisCache.exp > Date.now()) return _navVisCache.data;
   const rows = await prisma.navConfig.findMany({
     select: { path: true, enabled: true, inDev: true },
   });
   const disabled = rows.filter((r) => !r.enabled).map((r) => r.path);
   const dev = rows.filter((r) => r.enabled && r.inDev).map((r) => r.path);
-  res.json({ disabled, dev });
+  const data = { disabled, dev };
+  _navVisCache = { data, exp: Date.now() + NAV_VIS_TTL_MS };
+  return data;
+}
+
+/** 사이드바 메뉴 상태:
+ *  - disabled: 사이드바에서 숨김 + 라우트 차단 (enabled=false 인 path)
+ *  - dev:       사이드바엔 노출하되 진입 시 "개발 중" 안내 (enabled=true && inDev=true)
+ *  행이 없는 path 는 기본 enabled=true / inDev=false 로 간주 — 클라는 두 set 만 알면 됨. */
+router.get("/visibility", async (_req, res) => {
+  const data = await getNavVisibility();
+  // 1분 private 캐시 + 30초 stale-while-revalidate — 캐시 미스 시 백그라운드 갱신.
+  // 어드민이 변경 시 evictNavVisibilityCache() 로 즉시 무효화되므로 1분 이상 지연 없음.
+  res.setHeader("Cache-Control", "private, max-age=60, stale-while-revalidate=30");
+  res.json(data);
 });
 
 function parseSince(v: unknown): Date | null {


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary

- `/api/nav/visibility` 에 **60초 인메모리 TTL 캐시** 추가
- `NavConfig` 는 관리자가 수동으로 드물게 바꾸지만, 이 엔드포인트는 **모든 사용자의 모든 페이지 로드**마다 호출됨
- 관리자가 nav 설정을 바꾸면 `evictNavVisibilityCache()` 로 즉시 무효화 (지연 없음)
- `Cache-Control: private, max-age=60, stale-while-revalidate=30` 응답 헤더 추가

## 변경된 파일

- `server/src/routes/nav.ts` — TTL 캐시 + eviction 함수
- `server/src/routes/admin.ts` — nav config 변경 시 캐시 즉시 무효화

## 패턴

`featureFlags.ts` 의 60s 캐시와 동일 패턴으로 일관성 유지.

## Test plan

- [x] TypeScript 빌드 성공
- [x] `/api/nav/visibility` 가 첫 요청 시 DB 쿼리, 이후 60초는 캐시 반환
- [x] Admin 이 nav config 변경 시 다음 요청에서 즉시 최신값 반환

Closes #578

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #578
