### PR TITLE
🔀 :: (#580) @types/* 패키지 devDependencies 이동 — Docker 이미지 bloat 제거

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,8 +14,6 @@
         "@prisma/client": "^5.22.0",
         "@simplewebauthn/server": "^13.3.0",
         "@supabase/supabase-js": "^2.104.0",
-        "@types/archiver": "^6.0.4",
-        "@types/compression": "^1.8.1",
         "archiver": "^7.0.1",
         "bcryptjs": "^2.4.3",
         "compression": "^1.8.1",
@@ -30,11 +28,12 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/archiver": "^6.0.4",
         "@types/bcryptjs": "^2.4.6",
+        "@types/compression": "^1.8.1",
         "@types/cookie-parser": "^1.4.7",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
-        "@types/express-rate-limit": "^5.1.3",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^22.8.4",
@@ -2386,6 +2385,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.4.tgz",
       "integrity": "sha512-ULdQpARQ3sz9WH4nb98mJDYA0ft2A8C4f4fovvUcFwINa1cgGjY36JCAYuP5YypRq4mco1lJp1/7jEMS2oR0Hg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/readdir-glob": "*"
@@ -2402,6 +2402,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -2412,6 +2413,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
       "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/express": "*",
@@ -2422,6 +2424,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2451,6 +2454,7 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2460,20 +2464,11 @@
         "@types/serve-static": "^1"
       }
     },
-    "node_modules/@types/express-rate-limit": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@types/express-rate-limit/-/express-rate-limit-5.1.3.tgz",
-      "integrity": "sha512-H+TYy3K53uPU2TqPGFYaiWc2xJV6+bIFkDd/Ma2/h67Pa6ARk9kWE0p/K9OH1Okm0et9Sfm66fmXoAxsH2PHXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
-      }
-    },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2486,6 +2481,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -2503,6 +2499,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime-types": {
@@ -2532,18 +2529,21 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/readdir-glob": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
       "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2553,6 +2553,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2562,6 +2563,7 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -2573,6 +2575,7 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",

--- a/server/package.json
+++ b/server/package.json
@@ -19,8 +19,6 @@
     "@prisma/client": "^5.22.0",
     "@simplewebauthn/server": "^13.3.0",
     "@supabase/supabase-js": "^2.104.0",
-    "@types/archiver": "^6.0.4",
-    "@types/compression": "^1.8.1",
     "archiver": "^7.0.1",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",
@@ -35,11 +33,12 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.4",
     "@types/bcryptjs": "^2.4.6",
+    "@types/compression": "^1.8.1",
     "@types/cookie-parser": "^1.4.7",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
-    "@types/express-rate-limit": "^5.1.3",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.8.4",

--- a/server/src/jobs/autoClockOut.ts
+++ b/server/src/jobs/autoClockOut.ts
@@ -15,8 +15,9 @@
  *  - KST(Asia/Seoul) 고정. 서버는 UTC 로 돌아도 OK — Intl.DateTimeFormat 으로 KST 계산.
  *
  * 스케일:
- *  - 현재 설계는 단일 인스턴스 가정(Render Starter 등). 멀티 인스턴스 배포로 가면
- *    advisory lock 또는 전용 cron 워커로 옮겨야 중복 실행이 안 남.
+ *  - 현재 설계는 단일 인스턴스 기준. Fargate 에서 멀티 태스크로 스케일아웃 시
+ *    updateMany WHERE checkOut IS NULL 조건 덕분에 중복 처리 없이 안전.
+ *    (같은 행을 여러 태스크가 동시에 업데이트해도 두 번째 이후는 0건 반환으로 멱등)
  */
 
 import { prisma } from "../lib/db.js";


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary

- `@types/archiver`, `@types/compression` → `dependencies` → `devDependencies`
- `@types/express-rate-limit` 제거 (v8 자체 타입 내장)
- `package-lock.json` 재생성 (`dev: true` 플래그 반영)
- `autoClockOut.ts` 주석 현행화 ("Render Starter" → Fargate 실제 멱등 설명)

## 문제

`@types/*` 패키지는 TypeScript 컴파일 시에만 필요한 타입 선언 파일.
프로덕션 런타임에서는 전혀 사용되지 않음.

하지만 `@types/archiver`와 `@types/compression`이 `dependencies` 에 잘못 등록되어:
1. Dockerfile Stage 1 (`npm ci --omit=dev`) 이 이 패키지들도 설치함
2. 프로덕션 이미지에 불필요한 파일 포함 → 이미지 크기 증가, 빌드 느려짐

## 영향

| 패키지 | 기존 | 변경 |
|--------|------|------|
| @types/archiver | dependencies | devDependencies |
| @types/compression | dependencies | devDependencies |
| @types/express-rate-limit | devDependencies | **제거** (v8 자체 타입) |

## Test plan

- [x] TypeScript 빌드 성공 (`tsc` 에러 없음)
- [x] `package-lock.json` 에 `@types/archiver`, `@types/compression` → `dev: true` 확인
- [x] Docker Stage 1 (`npm ci --omit=dev`) 에서 해당 패키지 설치 생략됨

Closes #580

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #580
