### PR TITLE
🔀 :: (#581) 문서 목록 take 상한 누락 수정 + 채팅 검색 멤버 페이로드 제한

### DIFF
--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -276,7 +276,9 @@ router.get("/search", async (req, res) => {
       sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       room: {
         include: {
-          members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
+          // 검색 결과 카드에 최대 50명까지만 표시 — 대형 그룹방에서 수백 명을 끌어와
+          // 응답 크기가 폭발하는 것을 방지. 실제 UI 는 아바타 5개 + "+N" 으로 표시.
+          members: { take: 50, include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
         },
       },
     },

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -445,9 +445,12 @@ router.get("/", async (req, res) => {
   else if (scope === "private") ands.push({ scope: "PRIVATE", authorId: u.id });
   else if (scope === "custom") ands.push({ scope: "CUSTOM" });
   else if (scope === "public") ands.push({ scope: "ALL" });
+  // 상한 500 — 프로젝트 문서와 동일. 누적 워크스페이스에서 전체 결과 없이
+  // 수십 MB 페이로드가 나오는 것을 방지. UX 는 폴더/검색으로 좁혀지므로 영향 없음.
   const docs = await prisma.document.findMany({
     where: { AND: ands },
     orderBy: { updatedAt: "desc" },
+    take: 500,
     include: {
       author: { select: { name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       folder: { select: { name: true } },


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary

### 1. `document.ts` — 전역 문서 목록 `take` 상한 누락

- `GET /api/document` (전역 문서) 에 `take` 한도가 없어 대규모 워크스페이스에서 수천 건이 한 번에 반환될 수 있었음
- 프로젝트 문서 분기(`take: 500`)와 동일하게 맞춤
- 폴더/검색으로 좁혀지는 UX 특성상 실운영에서 500건 초과 사례는 드물지만, 예외 차단

### 2. `chat.ts` — 채팅 메시지 검색 멤버 응답 제한

- `GET /api/chat/search` 결과에 방 멤버 전원을 `include` 하고 있어 대형 그룹방(100명+)에서 응답 크기 폭발
- `members: { take: 50, ... }` 로 제한 — 검색 결과 카드 UI 는 아바타 5개 + "+N" 형태로 표시되므로 50명으로 충분

## Test plan

- [x] TypeScript 빌드 성공
- [x] 전역 문서 목록 필터링 (scope/folder/q) 정상 동작
- [x] 채팅 검색 결과에 방 멤버 최대 50명 포함

Closes #581

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #581
