### PR TITLE
🔀 :: (#582) 구 Render 플랫폼 관련 주석 Fargate 기준으로 정정

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -110,7 +110,7 @@ function readCache<T>(path: string, maxAgeMs?: number): T | null {
  * 캐시된 값이 있으면 즉시 onCached 로 전달 → UI 가 바로 렌더.
  * 동시에 네트워크 요청을 쏴서 새 값이 오면 onFresh 로 재렌더.
  * 에러는 onError 로. 인증 만료 등 onError 가 처리해야 함.
- * Render Free 의 3~5초 콜드스타트를 최초 방문 이후 체감상 제거.
+ * Fargate 배포에서 최초 방문 이후 API 응답 체감 속도를 크게 단축.
  *
  * 반환 Promise 는 "네트워크 완료" 시 resolve. await 해도 되지만 보통 fire-and-forget.
  */

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -72,8 +72,7 @@ export default function ProjectPage() {
 
   // project 로딩이 끝나기 전에도 id 만 있으면 자식들이 fetch 를 시작하도록
   // 껍데기를 먼저 렌더한다. 이렇게 해야 /api/project/:id + events + webhook 3개가
-  // 직렬이 아니라 동시에 나간다 (Render 콜드스타트 + IAD↔SIN 왕복이 직렬로 쌓이면
-  // 체감 3~5초, 병렬이면 ~1초).
+  // 직렬이 아니라 동시에 나간다 (요청이 직렬로 쌓이면 체감 3~5초, 병렬이면 ~1초).
   if (err && !project) {
     return (
       <div className="text-center py-16 text-slate-400">

--- a/server/src/lib/dates.ts
+++ b/server/src/lib/dates.ts
@@ -1,11 +1,11 @@
 /**
  * 서버 시간대(KST) 전용 날짜 헬퍼.
  *
- * Render 컨테이너 기본 TZ 는 UTC 라서 `new Date().getDate()` 로 만든 "오늘" 문자열이
+ * 컨테이너 기본 TZ 는 UTC 라서 `new Date().getDate()` 로 만든 "오늘" 문자열이
  * 0~9시 KST 사이에는 전날 UTC 날짜를 내뱉음 → 출근/공지/관리자 리포트가 하루 밀리는 버그.
- * render.yaml 에 `TZ=Asia/Seoul` 를 넣어 근본 해결했지만,
+ * ECS 태스크 정의에 `TZ=Asia/Seoul` 환경변수를 넣어 근본 해결했지만,
  *   - 로컬 dev (.env 에 TZ 안 씀)
- *   - 다른 배포 환경에서 누락
+ *   - 컨테이너 환경 변경 시 TZ 누락 가능성
  * 같은 상황을 대비해 이 모듈은 Intl.DateTimeFormat 으로 명시적으로 서울을 고정.
  *
  * 모든 "오늘" 날짜 문자열(YYYY-MM-DD) 은 이 함수를 쓰는 걸 권장.

--- a/server/src/lib/storage.ts
+++ b/server/src/lib/storage.ts
@@ -21,7 +21,7 @@ import type { Readable } from "node:stream";
  *     → 전부 이관 끝난 뒤 (보통 1~2주) SUPABASE_* env 를 제거해 완전히 S3 전용.
  *  3) **둘 다 없을 시 (로컬 dev)**: `isStorageEnabled()` 가 false → upload 라우트가 디스크 경로로 fallback.
  *
- * 왜: Render Free 디스크는 재시작 시 휘발성이라 프로덕션에선 오브젝트 스토리지 필수.
+ * 왜: Fargate/컨테이너 로컬 디스크는 재시작 시 휘발성이라 프로덕션에선 오브젝트 스토리지 필수.
  * 서버 프록시 방식(= /uploads/:key 로 서버 거쳐서 다운로드) 은 CSP/인증/Content-Disposition
  * 방어선을 유지하기 위해 그대로 둠. 클라이언트가 직접 presigned URL 로 가는 구성은 다음 단계.
  */
@@ -35,7 +35,7 @@ const S3_ACCESS_KEY = process.env.AWS_ACCESS_KEY_ID?.trim();
 const S3_SECRET_KEY = process.env.AWS_SECRET_ACCESS_KEY?.trim();
 
 // S3 활성 조건: region + bucket 은 반드시. 자격증명은 2가지 경로 지원.
-//  1) 정적 키 (AWS_ACCESS_KEY_ID / SECRET) — Render 같은 외부 PaaS, 로컬 개발
+//  1) 정적 키 (AWS_ACCESS_KEY_ID / SECRET) — 로컬 개발, 외부 PaaS
 //  2) IAM 역할 (ECS Task Role, EC2 Instance Profile) — SDK 가 메타데이터 서비스에서 자동 회수
 // 2번은 환경변수가 없어도 되므로, 여기선 region+bucket 만 보고 S3 클라이언트를 생성.
 // 키가 있으면 명시 주입, 없으면 SDK default credential chain 에 맡김 (ECS → task role).

--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -13,7 +13,7 @@ import { isStorageEnabled, uploadFile } from "../lib/storage.js";
  *     기존 클라이언트 코드·DB 저장값이 그대로 유지됨. 실제 파일은 서버가 프록시해서 내려줌.
  *  3. 비활성화 시 (로컬 dev) → 과거와 동일하게 uploads/ 디렉터리에 파일 기록.
  *
- * Render Free 디스크는 재시작 시 날아가기 때문에 프로덕션은 반드시 Supabase 경로를 쓴다.
+ * Fargate/컨테이너 로컬 디스크는 재시작 시 휘발성이므로 프로덕션은 반드시 Supabase 경로를 쓴다.
  */
 
 const UPLOAD_DIR = path.resolve(process.cwd(), "uploads");


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary

- `client/src/api.ts`: `apiSWR` 헬퍼 주석의 "Render Free 콜드스타트" 언급 → Fargate 배포 기준으로 수정
- `client/src/pages/ProjectPage.tsx`: 병렬 fetch 설명 주석의 "Render 콜드스타트" 언급 제거
- `server/src/lib/storage.ts`: "Render Free 디스크 휘발성" 및 "Render 같은 외부 PaaS" 언급 → Fargate/컨테이너 기준으로 수정
- `server/src/lib/dates.ts`: "Render 컨테이너", "render.yaml" 언급 → ECS 태스크 정의 기준으로 수정
- `server/src/routes/upload.ts`: "Render Free 디스크" 언급 → 컨테이너 로컬 디스크 기준으로 수정

## Test plan

- [ ] 코드 동작 변경 없음 (주석만 수정)
- [ ] 빌드 정상 확인

Closes #582

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #582
