### PR TITLE
🔀 :: (#583) 레거시 JWT(sid 없음) 세션 무효화 우회 차단 [HIGH]

### DIFF
--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -123,8 +123,12 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
   if (!token) return res.status(401).json({ error: "unauthorized" });
   try {
     const payload = jwt.verify(token, SECRET) as any;
-    // sessionId(sid) 클레임이 있는 토큰은 서버측 무효화 검사. 없는 레거시 토큰은 그대로 통과 (7일이면 만료).
-    if (payload.sid && (await isSessionRevoked(payload.sid))) {
+    // sid 없는 레거시 토큰은 서버측 세션 무효화(revokedAt) 를 적용할 수 없으므로 거부.
+    // 강제 로그아웃·계정 비활성화 즉시 차단이 보장되어야 하기 때문.
+    if (!payload.sid) {
+      return res.status(401).json({ error: "session expired", code: "LEGACY_TOKEN" });
+    }
+    if (await isSessionRevoked(payload.sid)) {
       return res.status(401).json({ error: "session revoked", code: "SESSION_REVOKED" });
     }
     const realUser = await getCachedUser(payload.id);


### PR DESCRIPTION
## 증상
**레거시 JWT(sid 없음) 세션 무효화 우회 차단 [HIGH]**

보안 취약점을 점검하고 보완합니다.

## 원인
`sid` 클레임이 없는 레거시 토큰은 서버 측 revokedAt 검사를 건너뛰어
강제 로그아웃·계정 비활성화가 즉시 반영되지 않는 취약점이 있었음.
레거시 토큰 수신 시 401 LEGACY_TOKEN 을 반환해 재로그인을 유도.

## 수정
**작업 항목 (커밋 단위)**
- security: sid 없는 레거시 JWT 를 거부해 세션 무효화 우회 차단

**변경 대상 (1개 파일)**
- `server/src/lib/auth.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #159** ↔ **이슈 #583** 로 연결됩니다.

Closes #583
