### PR TITLE
🔀 :: (#584) 결재 scope=all IDOR 차단 — ADMIN 전용 강제 [HIGH]

### DIFF
--- a/server/src/routes/approval.ts
+++ b/server/src/routes/approval.ts
@@ -68,13 +68,20 @@ router.get("/counts", async (req, res) => {
 
 router.get("/", async (req, res) => {
   const u = (req as any).user;
-  const scope = String(req.query.scope ?? "mine"); // mine | pending | all
+  const scope = String(req.query.scope ?? "mine"); // mine | pending | all(admin only)
   const where: any = {};
-  if (scope === "mine") where.requesterId = u.id;
-  else if (scope === "pending") {
+
+  if (scope === "all") {
+    // 전체 목록은 ADMIN 전용. 일반 사용자가 ?scope=all 로 요청 시 강제 403.
+    if (u.role !== "ADMIN") return res.status(403).json({ error: "forbidden" });
+    // where = {} — 전체 조회 (ADMIN 의도된 동작)
+  } else if (scope === "pending") {
     // 내가 리뷰어이고, 아직 대기중이며 내 순번이 돌아온 것
     where.steps = { some: { reviewerId: u.id, status: "PENDING" } };
     where.status = "PENDING";
+  } else {
+    // "mine" 또는 미지원 scope → 안전하게 본인 것만 반환
+    where.requesterId = u.id;
   }
   const list = await prisma.approval.findMany({
     where,


### PR DESCRIPTION
## 증상
**결재 scope=all IDOR 차단 — ADMIN 전용 강제 [HIGH]**

보안 취약점을 점검하고 보완합니다.

## 원인
?scope=all 은 where = {} 로 시스템 전체 결재를 반환했으나
ADMIN 권한 검사가 없었음. ADMIN 이 아닌 사용자의 scope=all 요청에
403 을 반환하고, 알 수 없는 scope 는 mine 으로 폴백하도록 수정.

## 수정
**작업 항목 (커밋 단위)**
- security: 결재 목록 scope=all 이 ADMIN 외 일반 사용자에게도 노출되는 IDOR 차단

**변경 대상 (1개 파일)**
- `server/src/routes/approval.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #160** ↔ **이슈 #584** 로 연결됩니다.

Closes #584
