### PR TITLE
🔀 :: (#585) 휴가 자기 결재 차단 [MEDIUM]

### DIFF
--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -146,6 +146,10 @@ router.patch("/leave/:id", async (req, res) => {
     include: { user: { select: { team: true } } },
   });
   if (!existing) return res.status(404).json({ error: "not found" });
+  // 본인 휴가를 직접 결재하는 것은 역할 무관 금지.
+  if (existing.userId === u.id) {
+    return res.status(403).json({ error: "본인의 휴가를 직접 심사할 수 없어요" });
+  }
   // MANAGER 는 자기 팀 휴가만 심사 가능.
   if (u.role === "MANAGER") {
     const me = await prisma.user.findUnique({ where: { id: u.id }, select: { team: true } });


### PR DESCRIPTION
## 증상
**휴가 자기 결재 차단 [MEDIUM]**

보안 취약점을 점검하고 보완합니다.

## 원인
MANAGER 가 본인 휴가를 직접 APPROVED 처리할 수 있었음.
팀 검사 이전에 `existing.userId === u.id` 를 먼저 확인해
역할 무관하게 자기 결재를 금지.

## 수정
**작업 항목 (커밋 단위)**
- security: 휴가 심사 자기 결재 차단 (MANAGER / ADMIN 공통)

**변경 대상 (1개 파일)**
- `server/src/routes/attendance.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #161** ↔ **이슈 #585** 로 연결됩니다.

Closes #585
