### PR TITLE
🔀 :: (#586) 프로젝트 문서 삭제 IDOR 차단 [MEDIUM]

### DIFF
--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -690,10 +690,14 @@ router.delete("/:id", async (req, res) => {
   if (!exist) return res.status(404).json({ error: "not found" });
   const isAuthor = exist.authorId === u.id;
   const isAdmin = u.role === "ADMIN";
+  // 프로젝트 문서함: 단순 멤버십만으로 타인 문서를 삭제할 수 없음.
+  // 작성자 본인 또는 전사 ADMIN / MANAGER 만 허용.
+  const isManagerOrAbove = u.role === "ADMIN" || u.role === "MANAGER";
   const isProjectMember = exist.projectId
     ? await assertProjectMember(u, exist.projectId)
     : false;
-  if (!isAuthor && !isAdmin && !isProjectMember)
+  const canDelete = isAuthor || isAdmin || (isProjectMember && isManagerOrAbove);
+  if (!canDelete)
     return res.status(403).json({ error: "forbidden" });
   await prisma.document.update({ where: { id: exist.id }, data: { deletedAt: new Date(), deletedById: (req as any).user?.id } });
   await writeLog(u.id, "DOC_DELETE", req.params.id);


### PR DESCRIPTION
## 증상
**프로젝트 문서 삭제 IDOR 차단 [MEDIUM]**

보안 취약점을 점검하고 보완합니다.

## 원인
프로젝트 멤버라면 누구나 다른 멤버의 문서를 삭제할 수 있었음.
삭제는 작성자 본인 또는 전사 ADMIN/MANAGER 로 제한.
일반 멤버(USER)는 본인 작성 문서만 삭제 가능.

## 수정
**작업 항목 (커밋 단위)**
- security: 프로젝트 문서 삭제 권한 강화 — 단순 멤버는 타인 문서 삭제 불가

**변경 대상 (1개 파일)**
- `server/src/routes/document.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #162** ↔ **이슈 #586** 로 연결됩니다.

Closes #586
