### PR TITLE
🔀 :: (#587) 생체인증 deviceId 서버 응답 노출 차단 [MEDIUM]

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -373,7 +373,9 @@ router.get("/desktop-biometric", requireAuth, async (req, res) => {
   const list = await prisma.desktopBiometric.findMany({
     where: { userId: u.id },
     orderBy: { createdAt: "desc" },
-    select: { id: true, deviceId: true, deviceName: true, createdAt: true, lastUsedAt: true },
+    // deviceId 는 반환하지 않음 — Electron 앱은 로컬 userData 에서 직접 읽으며
+    // 서버 응답을 통해 노출하면 세션 탈취 시 super step-up 우회에 악용될 수 있음.
+    select: { id: true, deviceName: true, createdAt: true, lastUsedAt: true },
   });
   res.json({ devices: list });
 });


### PR DESCRIPTION
## 증상
**생체인증 deviceId 서버 응답 노출 차단 [MEDIUM]**

보안 취약점을 점검하고 보완합니다.

## 원인
GET /auth/desktop-biometric 가 deviceId 를 반환해,
JWT 탈취 시 공격자가 deviceId 를 조회한 뒤 super step-up 을
비밀번호 없이 획득할 수 있는 공격 체인을 허용했음.
Electron 앱은 로컬 userData 에서 직접 deviceId 를 읽으므로
서버 응답에 포함하지 않아도 동작에 영향 없음.

## 수정
**작업 항목 (커밋 단위)**
- security: 생체인증 기기 목록 API 에서 deviceId 제거

**변경 대상 (1개 파일)**
- `server/src/routes/auth.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #163** ↔ **이슈 #587** 로 연결됩니다.

Closes #587
