### PR TITLE
🔀 :: (#588) 비밀번호 보호 공유 링크 메타데이터 사전 노출 차단 [LOW]

### DIFF
--- a/client/src/pages/PublicSharePage.tsx
+++ b/client/src/pages/PublicSharePage.tsx
@@ -7,7 +7,8 @@ import { fmtSize } from "../lib/fmt";
  * 메타를 먼저 조회하고, 비밀번호가 걸려 있으면 입력 받은 뒤 다운로드를 트리거.
  */
 type Meta = {
-  document: { title: string; fileName: string | null; fileType: string | null; fileSize: number | null };
+  // 비밀번호 보호 링크는 인증 전에 document 가 null — 제목·파일명 노출 차단.
+  document: { title: string; fileName: string | null; fileType: string | null; fileSize: number | null } | null;
   kind?: "document" | "folder";
   expiresAt: string | null;
   maxDownloads: number | null;
@@ -58,8 +59,8 @@ export default function PublicSharePage() {
       const a = document.createElement("a");
       a.href = url;
       const defaultName = meta?.kind === "folder"
-        ? `${meta.document.title}.zip`
-        : (meta?.document.fileName ?? meta?.document.title ?? "download");
+        ? `${meta.document?.title ?? "folder"}.zip`
+        : (meta?.document?.fileName ?? meta?.document?.title ?? "download");
       a.download = defaultName;
       document.body.appendChild(a);
       a.click();
@@ -91,12 +92,16 @@ export default function PublicSharePage() {
               ) : (
                 <span className="text-2xl">📄</span>
               )}
-              <div className="text-lg font-bold text-ink-900">{meta.document.title}</div>
+              <div className="text-lg font-bold text-ink-900">
+                {meta.document?.title ?? (meta.hasPassword ? "🔒 비밀번호로 보호된 파일" : "파일")}
+              </div>
             </div>
-            <div className="text-[12px] text-ink-500 tabular">
-              {meta.kind === "folder" ? "폴더 전체 (ZIP)" : (meta.document.fileName ?? "파일")}
-              {typeof meta.document.fileSize === "number" ? ` · ${fmtSize(meta.document.fileSize)}` : ""}
-            </div>
+            {meta.document && (
+              <div className="text-[12px] text-ink-500 tabular">
+                {meta.kind === "folder" ? "폴더 전체 (ZIP)" : (meta.document.fileName ?? "파일")}
+                {typeof meta.document.fileSize === "number" ? ` · ${fmtSize(meta.document.fileSize)}` : ""}
+              </div>
+            )}
             <div className="text-[11px] text-ink-500 tabular mt-2 space-y-0.5">
               <div>다운로드 {meta.downloads}{meta.maxDownloads !== null ? `/${meta.maxDownloads}` : ""}</div>
               {meta.expiresAt && <div>만료 {new Date(meta.expiresAt).toLocaleString("ko-KR")}</div>}

--- a/server/src/routes/shareLink.ts
+++ b/server/src/routes/shareLink.ts
@@ -131,8 +131,10 @@ pub.get("/:token", async (req, res) => {
   const folderResult = await findActiveFolderLink(req.params.token);
   if (folderResult.link) {
     const fl = folderResult.link;
+    const hasPassword = !!fl.passwordHash;
     return res.json({
-      document: {
+      // 비밀번호 보호 링크는 인증 전에 파일명·형식을 노출하지 않음.
+      document: hasPassword ? null : {
         title: fl.folder.name,
         fileName: `${fl.folder.name}.zip`,
         fileType: "application/zip",
@@ -142,7 +144,7 @@ pub.get("/:token", async (req, res) => {
       expiresAt: fl.expiresAt,
       maxDownloads: fl.maxDownloads,
       downloads: fl.downloads,
-      hasPassword: !!fl.passwordHash,
+      hasPassword,
     });
   }
   if (folderResult.err && folderResult.err !== 404) {
@@ -152,8 +154,10 @@ pub.get("/:token", async (req, res) => {
   const r = await findActive(req.params.token);
   if (r.err) return res.status(r.err).json({ error: statusMsg(r.err) });
   const link = r.link!;
+  const hasPassword = !!link.passwordHash;
   res.json({
-    document: {
+    // 비밀번호 보호 링크는 인증 전에 문서 제목·파일명 등을 노출하지 않음.
+    document: hasPassword ? null : {
       title: link.document.title,
       fileName: link.document.fileName,
       fileType: link.document.fileType,
@@ -163,7 +167,7 @@ pub.get("/:token", async (req, res) => {
     expiresAt: link.expiresAt,
     maxDownloads: link.maxDownloads,
     downloads: link.downloads,
-    hasPassword: !!link.passwordHash,
+    hasPassword,
   });
 });
 


### PR DESCRIPTION
## 증상
**비밀번호 보호 공유 링크 메타데이터 사전 노출 차단 [LOW]**

보안 취약점을 점검하고 보완합니다.

## 원인
GET /api/public-share/:token 이 비밀번호 미입력 상태에서도
제목·파일명·파일크기를 반환해 기밀 문서 존재가 노출됐음.
비밀번호가 설정된 링크는 인증 전 document 를 null 로 반환.
클라이언트(PublicSharePage)도 document: null 케이스를 처리해
비밀번호 입력 전에는 "🔒 비밀번호로 보호된 파일" 만 표시.

## 수정
**작업 항목 (커밋 단위)**
- security: 비밀번호 보호 공유 링크의 문서 메타데이터 사전 노출 차단

**변경 대상 (2개 파일)**
- `client/src/pages/PublicSharePage.tsx`
- `server/src/routes/shareLink.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #164** ↔ **이슈 #588** 로 연결됩니다.

Closes #588
