### PR TITLE
🔀 :: (#589) 메모를 독립 사이드바 메뉴(/memos)로 분리

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,7 @@ import {
   UserProfilePage,
   AdminPage,
   SuperAdminPage,
+  MemosPage,
 } from "./routes";
 
 /**
@@ -111,6 +112,7 @@ export default function App() {
           <Route path="meetings/:id" element={<MeetingDetailPage />} />
           <Route path="accounts" element={<ServiceAccountsPage />} />
           <Route path="snippets" element={<SnippetsPage />} />
+          <Route path="memos" element={<MemosPage />} />
           <Route path="users/:id" element={<UserProfilePage />} />
           <Route
             path="admin"

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -425,6 +425,7 @@ const COMM_NAV: NavItem[] = [
 
 const RESOURCE_NAV: NavItem[] = [
   { to: "/documents", label: "문서함", icon: DocsIcon },
+  { to: "/memos", label: "메모", icon: MemoIcon },
   { to: "/expense", label: "법인카드", icon: CardIcon },
   { to: "/accounts", label: "계정 관리", icon: KeyIcon },
   { to: "/snippets", label: "스니펫", icon: SnippetIcon },
@@ -1120,6 +1121,7 @@ function MegaIcon({ active }: I) { return svgBase(!!active, <><path d="M3 10v4a2
 function PeopleIcon({ active }: I) { return svgBase(!!active, <><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></>); }
 function OrgIcon({ active }: I) { return svgBase(!!active, <><rect x="8" y="3" width="8" height="6" rx="1" /><rect x="3" y="15" width="6" height="6" rx="1" /><rect x="15" y="15" width="6" height="6" rx="1" /><path d="M12 9v3M6 15v-3h12v3" /></>); }
 function DocsIcon({ active }: I) { return svgBase(!!active, <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M8 13h8M8 17h5" /></>); }
+function MemoIcon({ active }: I) { return svgBase(!!active, <><path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" /></>); }
 function ApprovalIcon({ active }: I) { return svgBase(!!active, <><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /><path d="m9 14 2 2 4-4" /></>); }
 function CardIcon({ active }: I) { return svgBase(!!active, <><rect x="3" y="6" width="18" height="13" rx="2" /><path d="M3 11h18M7 16h4" /></>); }
 function KeyIcon({ active }: I) { return svgBase(!!active, <><circle cx="7.5" cy="15.5" r="4.5" /><path d="m10.5 12.5 10-10M17 7l3 3M15.5 8.5l3 3" /></>); }

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -853,12 +853,6 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
               >
                 {folderUpload ? `업로드 중… ${folderUpload.done}/${folderUpload.total}` : "+ 폴더 업로드"}
               </button>
-              <button className="btn-ghost" onClick={() => setMemoTarget("new")}>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="inline-block mr-1">
-                  <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
-                </svg>
-                메모 작성
-              </button>
               <button className="btn-primary" onClick={() => { setModalErr(null); setCreating("doc"); }}>+ 문서 업로드</button>
             </>
           }

--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -1,0 +1,345 @@
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../api";
+import { useAuth } from "../auth";
+import PageHeader from "../components/PageHeader";
+import type { MemoDoc } from "../components/DocMemoModal";
+
+// DocMemoModal 은 TipTap(무거운 번들)을 포함 → 실제 열릴 때만 로드.
+const DocMemoModal = lazy(() => import("../components/DocMemoModal"));
+
+// ===== 타입 =====
+type DocScope = "ALL" | "TEAM" | "PRIVATE" | "CUSTOM";
+
+type Memo = {
+  id: string;
+  title: string;
+  content: any;
+  scope: DocScope;
+  scopeTeam?: string | null;
+  scopeUserIds?: string | null;
+  folderId?: string | null;
+  tags?: string | null;
+  authorId?: string;
+  author: { name: string; avatarColor: string; avatarUrl?: string | null };
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ScopeTab = "all" | "team" | "private";
+const SCOPE_TABS: { key: ScopeTab; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "team", label: "팀" },
+  { key: "private", label: "나만" },
+];
+
+const SCOPE_LABEL: Record<DocScope, string> = {
+  ALL: "전체 공개",
+  TEAM: "팀 공개",
+  PRIVATE: "나만 보기",
+  CUSTOM: "사용자지정",
+};
+
+// ===== TipTap JSON → 평문 추출 (미리보기용) =====
+function extractText(node: any, limit = 200): string {
+  if (!node) return "";
+  if (node.type === "text") return node.text ?? "";
+  if (!node.content) return "";
+  let result = "";
+  for (const child of node.content) {
+    result += extractText(child, limit);
+    if (result.length >= limit) break;
+  }
+  return result;
+}
+
+// ===== 날짜 포맷 =====
+function relativeDate(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "방금 전";
+  if (min < 60) return `${min}분 전`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}시간 전`;
+  const days = Math.floor(hr / 24);
+  if (days < 7) return `${days}일 전`;
+  return new Date(iso).toLocaleDateString("ko-KR", { month: "long", day: "numeric" });
+}
+
+// ===== 메모 카드 =====
+function MemoCard({ memo, onClick }: { memo: Memo; onClick: () => void }) {
+  const preview = extractText(memo.content);
+  const tags = (memo.tags ?? "").split(",").map((t) => t.trim()).filter(Boolean);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group w-full text-left rounded-2xl border border-ink-100 bg-white dark:bg-ink-900 dark:border-ink-800
+                 p-5 flex flex-col gap-3 hover:border-brand-300 hover:shadow-md transition-all duration-150
+                 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400"
+    >
+      {/* 스코프 배지 */}
+      {memo.scope !== "ALL" && (
+        <span className={`self-start text-[10px] font-bold px-1.5 py-[2px] rounded ${
+          memo.scope === "PRIVATE"
+            ? "bg-rose-50 text-rose-700 dark:bg-rose-900/30 dark:text-rose-400"
+            : memo.scope === "TEAM"
+            ? "bg-sky-50 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+            : "bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400"
+        }`}>
+          {SCOPE_LABEL[memo.scope]}{memo.scope === "TEAM" && memo.scopeTeam ? ` · ${memo.scopeTeam}` : ""}
+        </span>
+      )}
+
+      {/* 제목 */}
+      <h3 className="text-[14px] font-bold text-ink-900 dark:text-ink-50 line-clamp-2 group-hover:text-brand-700 dark:group-hover:text-brand-400 transition-colors">
+        {memo.title || "(제목 없음)"}
+      </h3>
+
+      {/* 본문 미리보기 */}
+      {preview && (
+        <p className="text-[12px] text-ink-500 dark:text-ink-400 line-clamp-3 leading-relaxed">
+          {preview}
+        </p>
+      )}
+
+      {/* 태그 */}
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {tags.slice(0, 4).map((t) => (
+            <span key={t} className="text-[10px] font-medium px-1.5 py-[1px] rounded bg-ink-100 dark:bg-ink-800 text-ink-500 dark:text-ink-400">
+              #{t}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* 하단 — 작성자 + 날짜 */}
+      <div className="flex items-center gap-2 mt-auto pt-1">
+        <div
+          className="w-5 h-5 rounded-full grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
+          style={{ background: memo.author.avatarUrl ? "transparent" : (memo.author.avatarColor ?? "#6B7280") }}
+        >
+          {memo.author.avatarUrl ? (
+            <img src={memo.author.avatarUrl} alt={memo.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async" />
+          ) : (
+            memo.author.name[0]
+          )}
+        </div>
+        <span className="text-[11px] text-ink-500 dark:text-ink-400 truncate flex-1">{memo.author.name}</span>
+        <span className="text-[11px] text-ink-400 dark:text-ink-500 flex-shrink-0">{relativeDate(memo.updatedAt)}</span>
+      </div>
+    </button>
+  );
+}
+
+// ===== 빈 상태 =====
+function EmptyState({ onNew }: { onNew: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 gap-5 text-center">
+      <div className="w-20 h-20 rounded-3xl bg-violet-50 dark:bg-violet-900/30 grid place-items-center">
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"
+          strokeLinecap="round" strokeLinejoin="round" className="text-violet-500">
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+        </svg>
+      </div>
+      <div>
+        <p className="text-[15px] font-bold text-ink-800 dark:text-ink-100">아직 메모가 없어요</p>
+        <p className="text-[13px] text-ink-400 mt-1">자유롭게 생각을 기록해 보세요.</p>
+      </div>
+      <button type="button" className="btn-primary" onClick={onNew}>
+        첫 메모 작성하기
+      </button>
+    </div>
+  );
+}
+
+// ===== 스켈레톤 카드 =====
+function SkeletonCard() {
+  return (
+    <div className="rounded-2xl border border-ink-100 dark:border-ink-800 bg-white dark:bg-ink-900 p-5 flex flex-col gap-3 animate-pulse">
+      <div className="h-3.5 bg-ink-100 dark:bg-ink-800 rounded w-3/4" />
+      <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-full" />
+      <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-5/6" />
+      <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-2/3" />
+      <div className="flex items-center gap-2 pt-2">
+        <div className="w-5 h-5 rounded-full bg-ink-100 dark:bg-ink-800" />
+        <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-16" />
+      </div>
+    </div>
+  );
+}
+
+// ===== 메인 페이지 =====
+export default function MemosPage() {
+  const { user } = useAuth();
+  const [memos, setMemos] = useState<Memo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [scopeTab, setScopeTab] = useState<ScopeTab>("all");
+  const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
+  const [memoTarget, setMemoTarget] = useState<Memo | "new" | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // q 디바운스 300ms
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(q), 300);
+    return () => clearTimeout(t);
+  }, [q]);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    const params = new URLSearchParams({ type: "memo" });
+    if (scopeTab === "team") params.set("scope", "team");
+    else if (scopeTab === "private") params.set("scope", "private");
+    if (debouncedQ) params.set("q", debouncedQ);
+    api<{ documents: Memo[] }>(`/api/documents?${params}`)
+      .then((r) => setMemos(r.documents))
+      .catch(() => setMemos([]))
+      .finally(() => setLoading(false));
+  }, [scopeTab, debouncedQ]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Cmd/Ctrl+K → 검색 포커스
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
+  const handleSaved = (saved: MemoDoc) => {
+    setMemoTarget(saved as unknown as Memo);
+    setMemos((prev) => {
+      const idx = prev.findIndex((m) => m.id === saved.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = { ...next[idx], ...saved };
+        return next;
+      }
+      return [saved as unknown as Memo, ...prev];
+    });
+  };
+
+  const handleDeleted = (id: string) => {
+    setMemoTarget(null);
+    setMemos((prev) => prev.filter((m) => m.id !== id));
+  };
+
+  const initialScope =
+    scopeTab === "team" ? "TEAM" : scopeTab === "private" ? "PRIVATE" : "ALL";
+
+  return (
+    <div className="flex flex-col gap-6 pb-16">
+      <PageHeader
+        eyebrow="자료"
+        title="메모"
+        description="생각과 아이디어를 자유롭게 기록합니다."
+        right={
+          <button type="button" className="btn-primary" onClick={() => setMemoTarget("new")}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+              strokeLinecap="round" strokeLinejoin="round" className="inline-block mr-1.5">
+              <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
+            </svg>
+            새 메모
+          </button>
+        }
+      />
+
+      {/* 검색 + 스코프 탭 */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* 스코프 탭 */}
+        <div className="flex items-center bg-ink-100 dark:bg-ink-800 rounded-xl p-1 gap-0.5">
+          {SCOPE_TABS.map((tab) => (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => setScopeTab(tab.key)}
+              className={`px-3 py-1.5 rounded-lg text-[12px] font-semibold transition-all ${
+                scopeTab === tab.key
+                  ? "bg-white dark:bg-ink-700 text-ink-900 dark:text-ink-50 shadow-sm"
+                  : "text-ink-500 dark:text-ink-400 hover:text-ink-700 dark:hover:text-ink-200"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* 검색 */}
+        <div className="relative flex-1 min-w-[180px] max-w-xs">
+          <svg className="absolute left-3 top-1/2 -translate-y-1/2 text-ink-400" width="13" height="13"
+            viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
+          </svg>
+          <input
+            ref={searchRef}
+            type="text"
+            placeholder="메모 검색…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            maxLength={80}
+            className="w-full pl-9 pr-3 py-2 text-[13px] rounded-xl border border-ink-200 dark:border-ink-700
+                       bg-white dark:bg-ink-900 text-ink-900 dark:text-ink-50 placeholder-ink-400
+                       focus:outline-none focus:ring-2 focus:ring-brand-400 focus:border-transparent"
+          />
+          {q && (
+            <button
+              type="button"
+              onClick={() => setQ("")}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-ink-400 hover:text-ink-600"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* 건수 */}
+        {!loading && (
+          <span className="text-[12px] text-ink-400 dark:text-ink-500 ml-auto">
+            {memos.length}개
+          </span>
+        )}
+      </div>
+
+      {/* 카드 그리드 */}
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => <SkeletonCard key={i} />)}
+        </div>
+      ) : memos.length === 0 ? (
+        <EmptyState onNew={() => setMemoTarget("new")} />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {memos.map((m) => (
+            <MemoCard key={m.id} memo={m} onClick={() => setMemoTarget(m)} />
+          ))}
+        </div>
+      )}
+
+      {/* 메모 편집/열람 모달 */}
+      {memoTarget !== null && (
+        <Suspense fallback={null}>
+          <DocMemoModal
+            doc={memoTarget === "new" ? null : (memoTarget as MemoDoc)}
+            initialScope={memoTarget === "new" ? initialScope : undefined}
+            projectId={null}
+            onClose={() => setMemoTarget(null)}
+            onSaved={handleSaved}
+            onDeleted={handleDeleted}
+          />
+        </Suspense>
+      )}
+    </div>
+  );
+}

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -26,6 +26,7 @@ export const loadSnippets = () => import("./pages/SnippetsPage");
 export const loadUserProfile = () => import("./pages/UserProfilePage");
 export const loadAdmin = () => import("./pages/AdminPage");
 export const loadSuperAdmin = () => import("./pages/SuperAdminPage");
+export const loadMemos = () => import("./pages/MemosPage");
 
 export const SchedulePage = lazy(loadSchedule);
 export const AttendancePage = lazy(loadAttendance);
@@ -45,6 +46,7 @@ export const SnippetsPage = lazy(loadSnippets);
 export const UserProfilePage = lazy(loadUserProfile);
 export const AdminPage = lazy(loadAdmin);
 export const SuperAdminPage = lazy(loadSuperAdmin);
+export const MemosPage = lazy(loadMemos);
 
 /** 사이드바 경로별 prefetch 함수 매핑 — hover/focus 시 호출해 청크 선로딩. */
 export const ROUTE_PREFETCH: Record<string, () => Promise<unknown>> = {
@@ -63,4 +65,5 @@ export const ROUTE_PREFETCH: Record<string, () => Promise<unknown>> = {
   "/meetings": loadMeetings,
   "/accounts": loadAccounts,
   "/snippets": loadSnippets,
+  "/memos": loadMemos,
 };

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -400,6 +400,8 @@ router.get("/", async (req, res) => {
   const q = rawQ.length > 128 ? rawQ.slice(0, 128) : rawQ;
   const scope = req.query.scope ? String(req.query.scope) : "all";
   const projectId = req.query.projectId ? String(req.query.projectId) : null;
+  // type=memo → content NOT NULL (TipTap JSON); type=file → 파일 문서만; 미지정 → 전체.
+  const docType = req.query.type ? String(req.query.type) : undefined;
 
   if (projectId) {
     // 프로젝트 문서 — 멤버십만 검증.
@@ -445,6 +447,9 @@ router.get("/", async (req, res) => {
   else if (scope === "private") ands.push({ scope: "PRIVATE", authorId: u.id });
   else if (scope === "custom") ands.push({ scope: "CUSTOM" });
   else if (scope === "public") ands.push({ scope: "ALL" });
+  // 타입 필터: memo=content 있는 것, file=파일 문서, 미지정=전체.
+  if (docType === "memo") ands.push({ content: { not: null } });
+  else if (docType === "file") ands.push({ content: null });
   // 상한 500 — 프로젝트 문서와 동일. 누적 워크스페이스에서 전체 결과 없이
   // 수십 MB 페이로드가 나오는 것을 방지. UX 는 폴더/검색으로 좁혀지므로 영향 없음.
   const docs = await prisma.document.findMany({


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary

- **사이드바에 메모 항목 추가** — 문서함 아래에 ✏️ 메모 메뉴 신설 (`/memos`)
- **MemosPage 신규** — 카드 그리드, 스코프 탭(전체/팀/나만), 실시간 검색, 스켈레톤 로딩, 빈 상태 안내
- **서버 API 확장** — `GET /api/documents?type=memo` 파라미터 지원 (content NOT NULL 필터)
- **DocumentsPage 정리** — PageHeader 에서 "메모 작성" 버튼 제거 (전용 페이지로 이동)

## Changes

| 파일 | 변경 |
|------|------|
| `server/src/routes/document.ts` | `type=memo` / `type=file` 쿼리 파라미터 추가 |
| `client/src/pages/MemosPage.tsx` | 신규 — 메모 목록 페이지 |
| `client/src/routes.ts` | `loadMemos`, `MemosPage` lazy export 및 ROUTE_PREFETCH 항목 추가 |
| `client/src/App.tsx` | `/memos` 라우트 등록 |
| `client/src/components/AppLayout.tsx` | `MemoIcon` + `RESOURCE_NAV` 항목 추가 |
| `client/src/pages/DocumentsPage.tsx` | PageHeader "메모 작성" 버튼 제거 |

## Test plan

- [ ] 사이드바 > 메모 클릭 → `/memos` 진입 확인
- [ ] 메모 목록 카드 렌더링 (제목, 본문 미리보기, 작성자, 날짜)
- [ ] 스코프 탭 전환 시 API 재조회 확인
- [ ] 검색어 입력 → 디바운스 후 필터링
- [ ] "새 메모" 버튼 → DocMemoModal 열림, 저장 시 카드 목록 업데이트
- [ ] 카드 클릭 → 기존 메모 열람·편집
- [ ] 삭제 후 목록에서 제거 확인
- [ ] 문서함에서 "메모 작성" 버튼이 사라졌는지 확인

Closes #589

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #589
