### PR TITLE
🔀 :: (#591) 메모 생성/수정 시 에러 페이지 + 메모가 문서함에 남는 문제

### DIFF
--- a/client/src/components/DocMemoModal.tsx
+++ b/client/src/components/DocMemoModal.tsx
@@ -25,7 +25,7 @@ export type MemoDoc = {
   folderId?: string | null;
   tags?: string | null;
   authorId?: string;
-  author: { name: string; avatarColor: string; avatarUrl?: string | null };
+  author?: { name: string; avatarColor: string; avatarUrl?: string | null };
   createdAt: string;
   updatedAt: string;
 };
@@ -273,14 +273,14 @@ export default function DocMemoModal({
               <div className="flex items-center gap-2 mb-4 text-[12px] text-ink-400">
                 <div
                   className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
-                  style={{ background: doc.author.avatarUrl ? "transparent" : (doc.author.avatarColor ?? "#6B7280") }}
+                  style={{ background: doc.author?.avatarUrl ? "transparent" : (doc.author?.avatarColor ?? "#6B7280") }}
                 >
-                  {doc.author.avatarUrl
+                  {doc.author?.avatarUrl
                     ? <img src={doc.author.avatarUrl} alt={doc.author.name} className="w-full h-full object-cover" />
-                    : doc.author.name[0]
+                    : (doc.author?.name?.[0] ?? "?")
                   }
                 </div>
-                <span className="font-semibold text-ink-600">{doc.author.name}</span>
+                <span className="font-semibold text-ink-600">{doc.author?.name ?? "알 수 없음"}</span>
                 <span className="text-ink-200">·</span>
                 <span>{dateStr}</span>
                 {!projectId && (

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -176,10 +176,12 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   async function load(aliveRef?: { current: boolean }) {
     // 프로젝트 선택 시엔 projectId 필터. scope 필터는 프로젝트 내에선 의미 없음(멤버십이 권한).
     const pid = activeProjectId;
+    // 전역 문서함은 파일 문서만 — 메모는 별도 /memos 페이지로 분리됨.
+    // 프로젝트 문서함은 메모·파일 모두 표시(프로젝트 메모는 프로젝트에 귀속).
     const qs = (extra: string) =>
       pid
         ? `projectId=${encodeURIComponent(pid)}&${extra}`
-        : `scope=${scopeTab}&${extra}`;
+        : `scope=${scopeTab}&type=file&${extra}`;
     try {
       const [f, d] = await Promise.all([
         api<{ folders: Folder[] }>(

--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -20,7 +20,7 @@ type Memo = {
   folderId?: string | null;
   tags?: string | null;
   authorId?: string;
-  author: { name: string; avatarColor: string; avatarUrl?: string | null };
+  author?: { name: string; avatarColor: string; avatarUrl?: string | null };
   createdAt: string;
   updatedAt: string;
 };
@@ -118,15 +118,15 @@ function MemoCard({ memo, onClick }: { memo: Memo; onClick: () => void }) {
       <div className="flex items-center gap-2 mt-auto pt-1">
         <div
           className="w-5 h-5 rounded-full grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
-          style={{ background: memo.author.avatarUrl ? "transparent" : (memo.author.avatarColor ?? "#6B7280") }}
+          style={{ background: memo.author?.avatarUrl ? "transparent" : (memo.author?.avatarColor ?? "#6B7280") }}
         >
-          {memo.author.avatarUrl ? (
+          {memo.author?.avatarUrl ? (
             <img src={memo.author.avatarUrl} alt={memo.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async" />
           ) : (
-            memo.author.name[0]
+            memo.author?.name?.[0] ?? "?"
           )}
         </div>
-        <span className="text-[11px] text-ink-500 dark:text-ink-400 truncate flex-1">{memo.author.name}</span>
+        <span className="text-[11px] text-ink-500 dark:text-ink-400 truncate flex-1">{memo.author?.name ?? "알 수 없음"}</span>
         <span className="text-[11px] text-ink-400 dark:text-ink-500 flex-shrink-0">{relativeDate(memo.updatedAt)}</span>
       </div>
     </button>

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -380,6 +380,13 @@ const docSchema = z.object({
   projectId: z.string().max(64).nullable().optional(),
 });
 
+// 생성/수정 응답에 작성자·폴더를 함께 실어 보낸다 — 목록 조회(GET)와 동일한 형태.
+// 이게 없으면 클라이언트(메모 카드·뷰어)가 author 를 읽다가 크래시.
+const DOC_RELATIONS = {
+  author: { select: { name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
+  folder: { select: { name: true } },
+} as const;
+
 function visibilityWhere(u: { id: string; team: string | null; role: string }) {
   if (u.role === "ADMIN") return {};
   const ors: any[] = [
@@ -497,6 +504,7 @@ router.post("/", async (req, res) => {
         scopeUserIds: null,
         projectId,
       },
+      include: DOC_RELATIONS,
     });
     await writeLog(u.id, "DOC_CREATE", doc.id, d.title);
     return res.json({ document: doc });
@@ -523,6 +531,7 @@ router.post("/", async (req, res) => {
       scopeTeam,
       scopeUserIds,
     },
+    include: DOC_RELATIONS,
   });
   await writeLog(u.id, "DOC_CREATE", doc.id, d.title);
   res.json({ document: doc });
@@ -624,7 +633,11 @@ router.patch("/:id", async (req, res) => {
     } catch {}
   }
 
-  const doc = await prisma.document.update({ where: { id: exist.id }, data: updateData });
+  const doc = await prisma.document.update({
+    where: { id: exist.id },
+    data: updateData,
+    include: DOC_RELATIONS,
+  });
   await writeLog(u.id, "DOC_UPDATE", doc.id);
   res.json({ document: doc });
 });


### PR DESCRIPTION
## 증상

1. 메모를 작성하고 저장하면 **에러 페이지**("이 페이지를 표시하는 중 문제가 발생했어요")가 뜸
2. 생성한 메모가 **/memos 에 안 보이고 문서함(문서함)에만** 남음

## 원인

`POST` / `PATCH /api/document` 가 `prisma.document.create()` / `update()` 결과를 **`author` 관계 없이** 그대로 반환했음. 클라이언트의 메모 카드(`MemosPage`)와 뷰어(`DocMemoModal`)가 `author.name`/`author.avatarUrl` 을 읽다가 크래시 → ErrorBoundary 노출.

메모는 정상 저장되므로 `author` 를 포함하는 목록 조회(GET)를 쓰는 **문서함에는 보였지만**, 방금 생성한 객체로 즉시 렌더하는 **/memos 는 깨졌음.**

## 수정

| 파일 | 변경 |
|------|------|
| `server/src/routes/document.ts` | 생성/수정 응답에 `author`·`folder` `include` (`DOC_RELATIONS`) 추가 — 목록 조회와 동일한 형태 |
| `client/src/pages/DocumentsPage.tsx` | 전역 문서함은 `type=file` 로 조회 → 메모 제외, 메모는 `/memos` 로 일원화 (프로젝트 문서함은 메모·파일 모두 유지) |
| `client/src/pages/MemosPage.tsx`, `DocMemoModal.tsx` | `author` 접근을 옵셔널 체이닝으로 방어 — 관계 누락 시에도 크래시 대신 "알 수 없음" 표기 |

## Test plan

- [ ] /memos 에서 새 메모 작성 → 저장 → 에러 없이 카드 목록에 즉시 추가
- [ ] 저장 직후 뷰어(읽기 모드)에서 작성자·날짜·공개범위 정상 표시
- [ ] 문서함(전역)에는 메모가 더 이상 보이지 않음 (파일 문서만)
- [ ] 프로젝트 문서함에서는 메모·파일 모두 보임
- [ ] 기존 메모 편집 → 저장 시에도 정상

Closes #591
