### PR TITLE
🔀 :: (#593) Edge/Firefox 등에서 다운로드가 취소되던 문제 수정

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -4,6 +4,7 @@ import { api } from "../api";
 import { useAuth } from "../auth";
 import { useNotifications } from "../notifications";
 import { resolvePresence } from "../lib/presence";
+import { downloadFromUrl } from "../lib/download";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
 import { SnippetSlashMenu, type SnippetSlashHandle } from "./chat/SnippetSlashMenu";
 import {
@@ -1941,14 +1942,7 @@ function buildMessageActions(
       key: "download",
       label: "다운로드",
       icon: ActionIcons.download,
-      onSelect: () => {
-        const a = document.createElement("a");
-        a.href = m.fileUrl!;
-        a.download = m.fileName || "";
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-      },
+      onSelect: () => downloadFromUrl(m.fileUrl!, m.fileName || ""),
     });
   }
 

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -6,6 +6,7 @@ import { api } from "../../api";
 import { alertAsync } from "../ConfirmHost";
 import { parseCodeSegments } from "../../lib/codeDetect";
 import { copyToClipboard } from "../../lib/clipboard";
+import { downloadFromUrl } from "../../lib/download";
 import { useModalDismiss } from "../../lib/useModalDismiss";
 import { highlightCode } from "../../lib/syntaxHighlight";
 import { LangIcon } from "../../lib/langIcon";
@@ -252,13 +253,7 @@ function ChatVideoPlayer({ src, fileName }: { src: string; fileName: string | nu
   const download = () => {
     const url = src + (src.includes("?") ? "&" : "?") + "download=1"
       + (fileName ? `&name=${encodeURIComponent(fileName)}` : "");
-    const a = document.createElement("a");
-    a.href = url;
-    a.rel = "noopener";
-    if (fileName) a.setAttribute("download", fileName);
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
+    downloadFromUrl(url, fileName ?? "");
     close();
   };
   const pip = async () => {

--- a/client/src/lib/download.ts
+++ b/client/src/lib/download.ts
@@ -1,0 +1,46 @@
+/**
+ * 크로스 브라우저 파일 다운로드 트리거.
+ *
+ * 왜 이 헬퍼가 필요한가 (= "크롬은 되는데 엣지는 안 됨" 의 원인):
+ *   기존 코드 곳곳이 `a.click()` 직후 **동기적으로** `a.remove()` / `URL.revokeObjectURL()`
+ *   를 호출했다. Chrome 은 click 시점에 다운로드를 즉시 가로채 처리해서 문제가 없지만,
+ *   Microsoft Edge·Firefox 의 다운로드 매니저는 엘리먼트/blob 을 **약간 늦게** 참조한다.
+ *   그 사이에 앵커가 제거되거나 objectURL 이 해제되면 다운로드가 **조용히 취소**된다.
+ *   → 같은 Chromium 이라도 Edge 에서만 다운로드가 안 되는 전형적 패턴.
+ *
+ * 해결:
+ *   - 제거/해제를 동기 블록이 아니라 다음 매크로태스크(setTimeout)로 미룬다.
+ *   - objectURL 은 다운로드가 시작될 충분한 시간을 준 뒤에만 해제한다.
+ *   - `target="_blank"` 를 쓰지 않는다. Content-Disposition: attachment 응답은 새 탭 없이도
+ *     현재 페이지를 navigate 시키지 않고 다운로드로 떨어진다. `_blank` 는 빈 탭·팝업 차단
+ *     문제만 만든다(특히 Edge).
+ */
+
+/**
+ * URL 을 파일로 다운로드.
+ * 동일 출처거나 서버가 `Content-Disposition: attachment` 를 주는 URL 에 사용.
+ *
+ * @param filename `download` 속성값. 빈 문자열이어도 동일 출처 다운로드를 강제하며,
+ *   이 경우 브라우저가 서버의 Content-Disposition 파일명으로 폴백한다.
+ */
+export function downloadFromUrl(href: string, filename = ""): void {
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  a.rel = "noopener";
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  // 동기 제거 금지 — 다음 틱에 정리해야 Edge/Firefox 가 다운로드를 취소하지 않음.
+  setTimeout(() => a.remove(), 0);
+}
+
+/**
+ * Blob 을 파일로 저장. objectURL 은 다운로드가 시작될 시간을 충분히 준 뒤 해제(메모리 누수 방지).
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const href = URL.createObjectURL(blob);
+  downloadFromUrl(href, filename);
+  // 즉시 revoke 하면 다운로드가 취소될 수 있어 넉넉히 지연 후 해제.
+  setTimeout(() => URL.revokeObjectURL(href), 60_000);
+}

--- a/client/src/lib/exportTable.ts
+++ b/client/src/lib/exportTable.ts
@@ -6,6 +6,8 @@
  * - PDF: 브라우저 `window.print()` 를 새 창으로 띄워 "PDF 로 저장" 옵션 제공.
  */
 
+import { downloadBlob } from "./download";
+
 // xlsx-js-style: xlsx(SheetJS CE) 의 drop-in 포크. 셀 스타일(채우기/테두리/폰트) 쓰기 지원.
 // 약 470KB — 관리자 페이지 외에선 거의 안 쓰므로 동적 import 로 초기 번들에서 제외.
 let _xlsxPromise: Promise<typeof import("xlsx-js-style")> | null = null;
@@ -128,14 +130,7 @@ export function downloadCSV<T>(filename: string, rows: T[], columns: TableColumn
   // UTF-8 BOM — Excel 이 utf-8 로 읽도록 힌트
   const csv = "\uFEFF" + header + "\r\n" + body;
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename.endsWith(".csv") ? filename : `${filename}.csv`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  setTimeout(() => URL.revokeObjectURL(url), 500);
+  downloadBlob(blob, filename.endsWith(".csv") ? filename : `${filename}.csv`);
 }
 
 /**

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -8,6 +8,7 @@ import ShareLinkModal from "../components/ShareLinkModal";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
 import type { MemoDoc } from "../components/DocMemoModal";
 import { safeUploadUrl } from "../lib/safeUrl";
+import { downloadFromUrl, downloadBlob } from "../lib/download";
 
 // DocMemoModal 은 TipTap(무거운 번들)을 포함 → 실제 열릴 때만 로드.
 const DocMemoModal = lazy(() => import("../components/DocMemoModal"));
@@ -719,7 +720,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     const url = new URL(d.fileUrl, window.location.origin);
     url.searchParams.set("download", "1");
     if (d.fileName) url.searchParams.set("name", d.fileName);
-    triggerDownload(url.toString());
+    downloadFromUrl(url.toString(), d.fileName ?? "");
   }
 
   // 폴더 전체 — 서버에서 ZIP 스트림으로 내려옴. 큰 폴더는 시간이 꽤 걸릴 수 있음.
@@ -746,29 +747,10 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       const cd = res.headers.get("Content-Disposition") || "";
       const mName = /filename\*=UTF-8''([^;]+)/i.exec(cd) || /filename="?([^";]+)"?/i.exec(cd);
       const fname = mName ? decodeURIComponent(mName[1]) : `${f.name}.zip`;
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = fname;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
+      downloadBlob(blob, fname);
     } catch (err: any) {
       await alertAsync({ title: "폴더 다운로드 실패", description: err?.message ?? String(err) });
     }
-  }
-
-  // 새 탭에서 열되 Content-Disposition: attachment 헤더 때문에 바로 다운로드로 떨어진다.
-  // target=_blank 로 열어야 현재 페이지가 navigate 되지 않음.
-  function triggerDownload(href: string) {
-    const a = document.createElement("a");
-    a.href = href;
-    a.target = "_blank";
-    a.rel = "noopener";
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
   }
 
   // ===== 문서 드래그앤드롭 이동 =====

--- a/client/src/pages/PublicSharePage.tsx
+++ b/client/src/pages/PublicSharePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { fmtSize } from "../lib/fmt";
+import { downloadBlob } from "../lib/download";
 
 /**
  * 외부 공유 링크 수신 페이지 — 로그인 없이 접근. 토큰을 URL 세그먼트로 받아
@@ -55,17 +56,10 @@ export default function PublicSharePage() {
         return;
       }
       const blob = await res.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
       const defaultName = meta?.kind === "folder"
         ? `${meta.document?.title ?? "folder"}.zip`
         : (meta?.document?.fileName ?? meta?.document?.title ?? "download");
-      a.download = defaultName;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, defaultName);
       // 다운로드 카운트가 올라갔을 테니 메타 새로 가져옴.
       const r2 = await fetch(`/api/public-share/${encodeURIComponent(token)}`);
       if (r2.ok) setMeta(await r2.json());


### PR DESCRIPTION
## 증상

Chrome 에서는 모든 다운로드가 정상인데 **Microsoft Edge 에서 파일이 받아지지 않음**(조용히 취소). Edge 외 Firefox/Safari 도 같은 위험.

## 원인

다운로드 트리거 코드가 `a.click()` **직후 동기적으로** `a.remove()` / `URL.revokeObjectURL()` 를 호출.

- Chrome: click 시점에 다운로드를 즉시 가로채 처리 → 동기 제거여도 OK
- **Edge·Firefox**: 다운로드 매니저가 엘리먼트/blob 을 약간 늦게 참조 → 그 사이 제거되면 **다운로드 취소**

일부 경로(`DocumentsPage`)는 불필요한 `target="_blank"` 까지 써서 Edge 에서 빈 탭/팝업 차단 문제도 유발.

> 참고: `api()` 가 상대경로 `fetch` 라 파일은 모두 **동일 출처**(cross-origin `download` 무시 이슈 아님). 서버 `/uploads` 의 `CSP: sandbox` 는 attachment 다운로드엔 영향 없어 그대로 둠.

## 수정

신규 `client/src/lib/download.ts` 공통 헬퍼로 일원화:
- 앵커 제거를 **다음 매크로태스크로 지연**(`setTimeout 0`)
- objectURL 은 **60초 후 해제**(다운로드 시작 시간 확보)
- `target="_blank"` 제거 — `Content-Disposition: attachment` 응답은 새 탭 없이 다운로드로 떨어짐
- 동일 출처 강제 다운로드 위해 `download` 속성 항상 설정(서버 파일명으로 폴백)

| 파일 | 변경 |
|---|---|
| `lib/download.ts` | 신규 — `downloadFromUrl` / `downloadBlob` |
| `pages/DocumentsPage.tsx` | 문서/폴더 ZIP 다운로드 → 헬퍼, `triggerDownload`(target=_blank) 제거 |
| `components/ChatMiniApp.tsx` | 채팅 첨부 다운로드 → 헬퍼 |
| `components/chat/MessageBubble.tsx` | 영상 다운로드 → 헬퍼 |
| `pages/PublicSharePage.tsx` | 공유 링크 다운로드 → 헬퍼 (동기 revoke 제거) |
| `lib/exportTable.ts` | CSV 내보내기 → 헬퍼 |

## Test plan (배포 후)

- [ ] **Edge**: 문서함 파일 다운로드 / 폴더 ZIP / 채팅 첨부·영상 / 공유 링크 / CSV 내보내기
- [ ] Chrome: 회귀 없음
- [ ] Firefox·Safari: 동일 동작
- [ ] 데스크톱(Electron): 동일 동작

Closes #593
