### PR TITLE
🔀 :: (#594) 문서함이 비고 메모 목록이 깨지던 문제 — Json? null 필터 throw 수정

### DIFF
--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import archiver from "archiver";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { downloadFile, isStorageEnabled } from "../lib/storage.js";
@@ -455,8 +456,12 @@ router.get("/", async (req, res) => {
   else if (scope === "custom") ands.push({ scope: "CUSTOM" });
   else if (scope === "public") ands.push({ scope: "ALL" });
   // 타입 필터: memo=content 있는 것, file=파일 문서, 미지정=전체.
-  if (docType === "memo") ands.push({ content: { not: null } });
-  else if (docType === "file") ands.push({ content: null });
+  // ⚠️ content 는 Json? 컬럼 — 리터럴 null 필터({ content: null })는 Prisma 가
+  //    클라이언트 검증 단계에서 throw 한다(런타임 500). 반드시 Prisma.AnyNull/DbNull/JsonNull
+  //    센티넬을 써야 한다. AnyNull = DB NULL 과 JSON null 둘 다 매칭 → "내용 없음(파일)" 을
+  //    가장 안전하게 표현. 메모는 그 여집합(실제 content 보유).
+  if (docType === "memo") ands.push({ NOT: { content: { equals: Prisma.AnyNull } } });
+  else if (docType === "file") ands.push({ content: { equals: Prisma.AnyNull } });
   // 상한 500 — 프로젝트 문서와 동일. 누적 워크스페이스에서 전체 결과 없이
   // 수십 MB 페이로드가 나오는 것을 방지. UX 는 폴더/검색으로 좁혀지므로 영향 없음.
   const docs = await prisma.document.findMany({


### PR DESCRIPTION
## 증상
**문서함이 비고 메모 목록이 깨지던 문제 — Json? null 필터 throw 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
증상: 문서함에서 기존 파일이 모두 사라지고, 메모도 저장/표시가 안 됨.

원인: Document.content 는 Json? 컬럼인데 type 필터에 리터럴 null 을 썼다.
  - type=file → { content: null }
  - type=memo → { content: { not: null } }
Prisma 는 Json 필드에 리터럴 null 필터를 허용하지 않고 **클라이언트 검증 단계에서
throw** 한다. 그래서 GET /api/documents?type=file 가 매 호출 500 → 문서함이 빈
목록으로 보였다(데이터는 그대로, 쿼리만 실패). 메모 목록도 동일 계열 문제로 어긋남.

확인: 로컬에서 Prisma 쿼리 구문 검증 결과
  { content: null }                         → 구문 오류(throw) ❌
  { content: { equals: Prisma.AnyNull } }   → 정상 ✅
  { NOT: { content: { equals: AnyNull } } } → 정상 ✅

수정: Prisma.AnyNull 센티넬 사용 (DB NULL + JSON null 모두 매칭).
  - type=file → { content: { equals: Prisma.AnyNull } }
  - type=memo → { NOT: { content: { equals: Prisma.AnyNull } } }

데이터 손실 없음 — 삭제된 문서 없고 쿼리만 복구됨.

## 수정
**작업 항목 (커밋 단위)**
- fix(document): 문서함 비고 + 메모 목록 깨짐 — Json? null 필터 throw 수정

**변경 대상 (1개 파일)**
- `server/src/routes/document.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #170** ↔ **이슈 #594** 로 연결됩니다.

Closes #594
