### PR TITLE
🔀 :: (#595) /memos 가 항상 0개로 보이던 문제 — API 경로 오타(복수형) 수정

### DIFF
--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -194,7 +194,7 @@ export default function MemosPage() {
     if (scopeTab === "team") params.set("scope", "team");
     else if (scopeTab === "private") params.set("scope", "private");
     if (debouncedQ) params.set("q", debouncedQ);
-    api<{ documents: Memo[] }>(`/api/documents?${params}`)
+    api<{ documents: Memo[] }>(`/api/document?${params}`)
       .then((r) => setMemos(r.documents))
       .catch(() => setMemos([]))
       .finally(() => setLoading(false));


### PR DESCRIPTION
## 증상
메모를 작성해도 `/memos` 에 안 올라오고 계속 "0개 / 아직 메모가 없어요" 로 보임.

## 원인
`MemosPage` 의 목록 조회가 **`/api/documents`(복수형)** 으로 GET 했는데, 서버 라우터는 **`/api/document`(단수형)** 에 마운트돼 있음 → Express 404 → `.catch()` 가 삼켜 `setMemos([])` → 항상 0개.

**메모는 정상 저장되고 있었음** — POST 는 단수형 `/api/document` 를 써서 DB 엔 잘 들어감. 목록 조회 URL 만 틀려 화면에 안 보였던 것.

> 직전 #170(문서함 파일 복구)과는 **별개 버그**. #170 은 서버 Json null 필터, 이건 클라 경로 오타.

## 수정
`/api/documents` → `/api/document` (DocumentsPage · DocMemoModal 과 동일 경로).

## Test plan (배포 후)
- [ ] /memos 에서 새 메모 작성 → 저장 후 목록에 즉시 노출
- [ ] 기존 메모들도 /memos 에 표시
- [ ] 전체/팀/나만 탭, 검색 정상

Closes #595
