### PR TITLE
🔀 :: (#597) 문서함 긴 제목/파일명 깨짐

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1308,14 +1308,19 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                           </svg>
                         </div>
                       )}
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-1.5">
-                          <div className={`text-[13px] font-bold text-ink-900 ${d.content != null ? "hover:text-brand-700" : ""}`}>{d.title}</div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <div
+                            className={`text-[13px] font-bold text-ink-900 truncate max-w-[160px] sm:max-w-[280px] lg:max-w-[400px] ${d.content != null ? "hover:text-brand-700" : ""}`}
+                            title={d.title}
+                          >
+                            {d.title}
+                          </div>
                           {d.content != null && (
-                            <span className="text-[10px] font-bold px-1.5 py-[1px] rounded bg-violet-50 text-violet-700">메모</span>
+                            <span className="text-[10px] font-bold px-1.5 py-[1px] rounded bg-violet-50 text-violet-700 flex-shrink-0">메모</span>
                           )}
                           {d.scope && d.scope !== "ALL" && (
-                            <span className={`text-[10px] font-bold px-1.5 py-[1px] rounded ${
+                            <span className={`text-[10px] font-bold px-1.5 py-[1px] rounded flex-shrink-0 ${
                               d.scope === "PRIVATE" ? "bg-rose-50 text-rose-700"
                               : d.scope === "TEAM" ? "bg-sky-50 text-sky-700"
                               : "bg-violet-50 text-violet-700"
@@ -1347,8 +1352,10 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                         </span>
                       );
                       return (
-                        <a href={safe} target="_blank" rel="noreferrer" className="text-[12px] font-bold text-brand-600 hover:underline tabular">
-                          {d.fileName} <span className="text-ink-400">({humanSize(d.fileSize ?? 0)})</span>
+                        <a href={safe} target="_blank" rel="noreferrer" title={d.fileName ?? undefined}
+                          className="inline-flex items-center gap-1 max-w-[180px] sm:max-w-[260px] align-middle text-[12px] font-bold text-brand-600 hover:underline tabular">
+                          <span className="truncate">{d.fileName}</span>
+                          <span className="text-ink-400 flex-shrink-0">({humanSize(d.fileSize ?? 0)})</span>
                         </a>
                       );
                     })()}


### PR DESCRIPTION
## 증상
**문서함 긴 제목/파일명 깨짐**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
table.pro 는 table-layout:auto 라 제목/파일명에 truncate 가 없으면
긴 이름(예: '...-2026-05-28_14-34-18')이 컬럼을 무한정 넓혀 행이 깨져
보였음.

- 제목: truncate + 반응형 max-w, 메모/공개범위 배지는 flex-shrink-0 로 항상 노출
- 파일명 링크: inline-flex + truncate, 용량 표기는 flex-shrink-0 로 유지
- 둘 다 title 속성으로 풀네임 hover 툴팁 제공

## 수정
**작업 항목 (커밋 단위)**
- fix(document): 문서함 긴 제목/파일명이 레이아웃을 밀어 깨지던 문제

**변경 대상 (1개 파일)**
- `client/src/pages/DocumentsPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #173** ↔ **이슈 #597** 로 연결됩니다.

Closes #597
