### PR TITLE
🔀 :: (#599) 급여명세서 관리자 페이지 — 작성·수정·미리보기·PDF

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,6 +34,7 @@ import {
   AdminPage,
   SuperAdminPage,
   MemosPage,
+  PayrollPage,
 } from "./routes";
 
 /**
@@ -113,6 +114,14 @@ export default function App() {
           <Route path="accounts" element={<ServiceAccountsPage />} />
           <Route path="snippets" element={<SnippetsPage />} />
           <Route path="memos" element={<MemosPage />} />
+          <Route
+            path="payroll"
+            element={
+              <AdminOnly>
+                <PayrollPage />
+              </AdminOnly>
+            }
+          />
           <Route path="users/:id" element={<UserProfilePage />} />
           <Route
             path="admin"

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -552,6 +552,14 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
               >
                 {({ isActive }) => (<><ShieldIcon active={isActive} /><span>관리자</span></>)}
               </NavLink>
+              <NavLink
+                to="/payroll"
+                className={({ isActive }) => navClass(isActive)}
+                onMouseEnter={() => prefetchRoute("/payroll")}
+                onFocus={() => prefetchRoute("/payroll")}
+              >
+                {({ isActive }) => (<><PayrollIcon active={isActive} /><span>급여명세서</span></>)}
+              </NavLink>
               {user?.superAdmin && (
                 <NavLink
                   to="/super-admin"
@@ -1127,6 +1135,7 @@ function CardIcon({ active }: I) { return svgBase(!!active, <><rect x="3" y="6" 
 function KeyIcon({ active }: I) { return svgBase(!!active, <><circle cx="7.5" cy="15.5" r="4.5" /><path d="m10.5 12.5 10-10M17 7l3 3M15.5 8.5l3 3" /></>); }
 function SnippetIcon({ active }: I) { return svgBase(!!active, <><path d="m8 3-4 4 4 4M16 3l4 4-4 4" /><path d="M14 4 10 20" /></>); }
 function ShieldIcon({ active }: I) { return svgBase(!!active, <><path d="M12 3 4 6v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V6z" /><path d="m9 12 2 2 4-4" /></>); }
+function PayrollIcon({ active }: I) { return svgBase(!!active, <><path d="M4 4h16v16H4z" /><path d="M8 8h8M8 12h8M8 16h5" /></>); }
 function DevIcon({ active }: I) { return svgBase(!!active, <><polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" /></>); }
 function CrownIcon({ active }: I) { return svgBase(!!active, <><path d="M3 18h18" /><path d="M3 8l4 5 5-8 5 8 4-5v10H3z" /></>); }
 const _unused_swInv = swInv;

--- a/client/src/components/PayslipComposer.tsx
+++ b/client/src/components/PayslipComposer.tsx
@@ -1,0 +1,372 @@
+import { useMemo, useState } from "react";
+import { api } from "../api";
+import { useModalDismiss } from "../lib/useModalDismiss";
+import {
+  type Payslip,
+  type LineItem,
+  type EmployeeOption,
+  type Attendance,
+  type CalcRow,
+  blankEarnings,
+  blankDeductions,
+  sumAmount,
+  won,
+  DEFAULT_COMPANY,
+  DEFAULT_MEMO,
+} from "../lib/payslip";
+
+type AttForm = Record<keyof Attendance, string>;
+const EMPTY_ATT: AttForm = {
+  workDays: "",
+  totalHours: "",
+  overtimeHours: "",
+  nightHours: "",
+  holidayHours: "",
+  hourlyWage: "",
+  familyCount: "",
+};
+const ATT_FIELDS: { key: keyof Attendance; label: string; unit: string }[] = [
+  { key: "workDays", label: "근로일수", unit: "일" },
+  { key: "totalHours", label: "총 근로시간", unit: "시간" },
+  { key: "overtimeHours", label: "연장 근로시간", unit: "시간" },
+  { key: "nightHours", label: "야간 근로시간", unit: "시간" },
+  { key: "holidayHours", label: "휴일 근로시간", unit: "시간" },
+  { key: "hourlyWage", label: "통상시급", unit: "원" },
+  { key: "familyCount", label: "부양가족수", unit: "명" },
+];
+
+function attToForm(a?: Attendance | null): AttForm {
+  if (!a) return { ...EMPTY_ATT };
+  const out = { ...EMPTY_ATT };
+  for (const { key } of ATT_FIELDS) {
+    const v = a[key];
+    out[key] = v === undefined || v === null ? "" : String(v);
+  }
+  return out;
+}
+
+/**
+ * 급여명세서 작성·수정 모달 (ADMIN 전용 화면에서 사용).
+ * - 직원 선택 시 HR 정보 자동 채움(이름/부서/직위/입사일/생년월일).
+ * - 지급/공제 항목 행 추가·삭제, 합계·실수령액 실시간 계산.
+ * - 근태·계산방법은 선택 입력. 저장 시 서버가 합계를 재계산해 신뢰값 저장.
+ */
+export default function PayslipComposer({
+  initial,
+  employees,
+  defaultYear,
+  defaultMonth,
+  onClose,
+  onSaved,
+}: {
+  initial?: Payslip | null;
+  employees: EmployeeOption[];
+  defaultYear: number;
+  defaultMonth: number;
+  onClose: () => void;
+  onSaved: (p: Payslip) => void;
+}) {
+  const editing = !!initial;
+  const [employeeId, setEmployeeId] = useState(initial?.employeeId ?? "");
+  const [year, setYear] = useState(initial?.year ?? defaultYear);
+  const [month, setMonth] = useState(initial?.month ?? defaultMonth);
+  const [companyName, setCompanyName] = useState(initial?.companyName ?? DEFAULT_COMPANY);
+  const [employeeName, setEmployeeName] = useState(initial?.employeeName ?? "");
+  const [department, setDepartment] = useState(initial?.department ?? "");
+  const [position, setPosition] = useState(initial?.position ?? "");
+  const [joinDate, setJoinDate] = useState(initial?.joinDate ?? "");
+  const [payDate, setPayDate] = useState(initial?.payDate ?? "");
+  const [idNumber, setIdNumber] = useState(initial?.idNumber ?? "");
+  const [earnings, setEarnings] = useState<LineItem[]>(initial?.earnings ?? blankEarnings());
+  const [deductions, setDeductions] = useState<LineItem[]>(initial?.deductions ?? blankDeductions());
+  const [att, setAtt] = useState<AttForm>(attToForm(initial?.attendance));
+  const [calcRows, setCalcRows] = useState<CalcRow[]>(initial?.calcRows ?? []);
+  const [memo, setMemo] = useState(initial?.memo ?? DEFAULT_MEMO);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useModalDismiss(!saving, onClose);
+
+  const totalEarnings = useMemo(() => sumAmount(earnings), [earnings]);
+  const totalDeductions = useMemo(() => sumAmount(deductions), [deductions]);
+  const netPay = totalEarnings - totalDeductions;
+
+  function onPickEmployee(id: string) {
+    setEmployeeId(id);
+    const emp = employees.find((e) => e.id === id);
+    if (!emp) return;
+    // 신규 작성 시에만 인적사항 자동 채움. 수정 모드에선 기존 스냅샷 유지.
+    if (editing) return;
+    setEmployeeName(emp.name);
+    setDepartment(emp.department || emp.team || "");
+    setPosition(emp.position || "");
+    setJoinDate(emp.hireDate || "");
+    setIdNumber(emp.birthDate || "");
+  }
+
+  async function save() {
+    if (!employeeId) {
+      setErr("직원을 선택하세요");
+      return;
+    }
+    setSaving(true);
+    setErr(null);
+
+    const cleanItems = (items: LineItem[]) =>
+      items
+        .map((x) => ({ label: x.label.trim(), amount: Math.round(Number(x.amount) || 0) }))
+        .filter((x) => x.label.length > 0);
+
+    const attObj: Attendance = {};
+    let hasAtt = false;
+    for (const { key } of ATT_FIELDS) {
+      const raw = att[key].trim();
+      if (raw === "") continue;
+      const n = Number(raw);
+      if (Number.isNaN(n)) continue;
+      attObj[key] = n;
+      hasAtt = true;
+    }
+
+    const cleanCalc = calcRows
+      .map((c) => ({ item: c.item.trim(), formula: c.formula.trim(), amount: Math.round(Number(c.amount) || 0) }))
+      .filter((c) => c.item || c.formula);
+
+    const payload: Record<string, unknown> = {
+      employeeId,
+      year,
+      month,
+      companyName: companyName.trim() || undefined,
+      employeeName: employeeName.trim() || undefined,
+      department: department.trim() || null,
+      position: position.trim() || null,
+      joinDate: joinDate.trim() || null,
+      payDate: payDate.trim() || null,
+      idNumber: idNumber.trim() || null,
+      earnings: cleanItems(earnings),
+      deductions: cleanItems(deductions),
+      attendance: hasAtt ? attObj : null,
+      calcRows: cleanCalc.length ? cleanCalc : null,
+      memo: memo.trim() || null,
+    };
+
+    try {
+      const res = editing
+        ? await api<{ payslip: Payslip }>(`/api/payslip/${initial!.id}`, { method: "PATCH", json: payload })
+        : await api<{ payslip: Payslip }>(`/api/payslip`, { method: "POST", json: payload });
+      onSaved(res.payslip);
+    } catch (e: any) {
+      if (e?.status === 409 && e?.code === "DUPLICATE") {
+        setErr("이미 해당 직원의 그 달 명세서가 있어요. 목록에서 기존 명세서를 수정해주세요.");
+      } else {
+        setErr(e?.message ?? "저장에 실패했어요");
+      }
+      setSaving(false);
+    }
+  }
+
+  const years = Array.from({ length: 6 }, (_, i) => defaultYear - i + 1);
+
+  return (
+    <div className="fixed inset-0 bg-slate-900/45 grid place-items-center p-4 z-50" onClick={onClose}>
+      <div
+        className="card w-full max-w-3xl max-h-[92vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-bold">{editing ? "급여명세서 수정" : "새 급여명세서"}</h3>
+          <button className="btn-ghost text-[13px]" onClick={onClose} disabled={saving}>닫기</button>
+        </div>
+
+        {/* 기본 정보 */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="sm:col-span-1">
+            <label className="label">직원</label>
+            <select
+              className="input"
+              value={employeeId}
+              onChange={(e) => onPickEmployee(e.target.value)}
+              disabled={editing}
+            >
+              <option value="">선택…</option>
+              {employees.map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.name}{e.team ? ` · ${e.team}` : ""}
+                </option>
+              ))}
+            </select>
+            {editing && <p className="t-caption mt-1">직원·연월은 수정할 수 없어요</p>}
+          </div>
+          <div>
+            <label className="label">연도</label>
+            <select className="input" value={year} onChange={(e) => setYear(Number(e.target.value))} disabled={editing}>
+              {years.map((y) => <option key={y} value={y}>{y}년</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="label">월</label>
+            <select className="input" value={month} onChange={(e) => setMonth(Number(e.target.value))} disabled={editing}>
+              {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => <option key={m} value={m}>{m}월</option>)}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+          <Field label="성명" value={employeeName} onChange={setEmployeeName} max={60} />
+          <Field label="생년월일(사번)" value={idNumber} onChange={setIdNumber} max={40} />
+          <Field label="부서" value={department} onChange={setDepartment} max={60} />
+          <Field label="직위" value={position} onChange={setPosition} max={60} />
+          <Field label="입사일" value={joinDate} onChange={setJoinDate} max={40} placeholder="2025-01-01" />
+          <Field label="지급일" value={payDate} onChange={setPayDate} max={40} placeholder="2026-05-25" />
+          <div className="sm:col-span-2">
+            <Field label="회사명" value={companyName} onChange={setCompanyName} max={100} />
+          </div>
+        </div>
+
+        {/* 지급/공제 */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-5">
+          <ItemEditor title="지급 항목" accent="brand" items={earnings} setItems={setEarnings} total={totalEarnings} />
+          <ItemEditor title="공제 항목" accent="rose" items={deductions} setItems={setDeductions} total={totalDeductions} />
+        </div>
+
+        {/* 실수령액 */}
+        <div className="mt-4 flex items-center justify-between rounded-xl bg-ink-100 px-4 py-3">
+          <span className="text-[13px] font-bold text-ink-700">실수령액 (지급 − 공제)</span>
+          <span className={`text-[20px] font-extrabold tabular ${netPay < 0 ? "text-rose-600" : "text-ink-900"}`}>
+            {won(netPay)}
+          </span>
+        </div>
+
+        {/* 근태 (선택) */}
+        <details className="mt-5 group">
+          <summary className="cursor-pointer text-[13px] font-bold text-ink-700 select-none">근태 정보 (선택)</summary>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5 mt-3">
+            {ATT_FIELDS.map(({ key, label, unit }) => (
+              <div key={key}>
+                <label className="label text-[11px]">{label} ({unit})</label>
+                <input
+                  type="number"
+                  className="input"
+                  value={att[key]}
+                  onChange={(e) => setAtt((p) => ({ ...p, [key]: e.target.value }))}
+                />
+              </div>
+            ))}
+          </div>
+        </details>
+
+        {/* 계산방법 (선택) */}
+        <details className="mt-4">
+          <summary className="cursor-pointer text-[13px] font-bold text-ink-700 select-none">계산 방법 (선택)</summary>
+          <div className="space-y-2 mt-3">
+            {calcRows.map((c, i) => (
+              <div key={i} className="grid grid-cols-[1fr_1.5fr_1fr_auto] gap-2 items-center">
+                <input className="input" placeholder="항목" value={c.item} maxLength={60}
+                  onChange={(e) => setCalcRows((p) => p.map((x, j) => j === i ? { ...x, item: e.target.value } : x))} />
+                <input className="input" placeholder="산출식" value={c.formula} maxLength={300}
+                  onChange={(e) => setCalcRows((p) => p.map((x, j) => j === i ? { ...x, formula: e.target.value } : x))} />
+                <input className="input text-right" type="number" placeholder="금액" value={c.amount}
+                  onChange={(e) => setCalcRows((p) => p.map((x, j) => j === i ? { ...x, amount: Number(e.target.value) } : x))} />
+                <button type="button" className="text-rose-500 text-lg px-1" onClick={() => setCalcRows((p) => p.filter((_, j) => j !== i))} title="삭제">×</button>
+              </div>
+            ))}
+            <button type="button" className="btn-ghost text-[12px]" onClick={() => setCalcRows((p) => [...p, { item: "", formula: "", amount: 0 }])}>
+              + 계산 행 추가
+            </button>
+          </div>
+        </details>
+
+        {/* 메모 */}
+        <div className="mt-4">
+          <label className="label">하단 문구</label>
+          <input className="input" value={memo} maxLength={500} onChange={(e) => setMemo(e.target.value)} />
+        </div>
+
+        {err && <div className="mt-3 text-[12.5px] text-rose-600">{err}</div>}
+
+        <div className="flex justify-end gap-2 pt-4">
+          <button className="btn-ghost" onClick={onClose} disabled={saving}>취소</button>
+          <button className="btn-primary" onClick={save} disabled={saving || !employeeId}>
+            {saving ? "저장 중…" : editing ? "수정 저장" : "작성"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label, value, onChange, max, placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  max?: number;
+  placeholder?: string;
+}) {
+  return (
+    <div>
+      <label className="label">{label}</label>
+      <input
+        className="input"
+        value={value}
+        maxLength={max}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  );
+}
+
+function ItemEditor({
+  title, accent, items, setItems, total,
+}: {
+  title: string;
+  accent: "brand" | "rose";
+  items: LineItem[];
+  setItems: React.Dispatch<React.SetStateAction<LineItem[]>>;
+  total: number;
+}) {
+  const totalColor = accent === "rose" ? "text-rose-600" : "text-brand-700";
+  return (
+    <div className="border border-ink-150 rounded-xl p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[13px] font-bold text-ink-800">{title}</span>
+        <span className={`text-[13px] font-extrabold tabular ${totalColor}`}>{won(total)}</span>
+      </div>
+      <div className="space-y-1.5">
+        {items.map((it, i) => (
+          <div key={i} className="grid grid-cols-[1fr_1fr_auto] gap-1.5 items-center">
+            <input
+              className="input py-1.5 text-[12.5px]"
+              placeholder="항목명"
+              value={it.label}
+              maxLength={60}
+              onChange={(e) => setItems((p) => p.map((x, j) => (j === i ? { ...x, label: e.target.value } : x)))}
+            />
+            <input
+              className="input py-1.5 text-[12.5px] text-right"
+              type="number"
+              placeholder="0"
+              value={it.amount}
+              onChange={(e) => setItems((p) => p.map((x, j) => (j === i ? { ...x, amount: Number(e.target.value) } : x)))}
+            />
+            <button
+              type="button"
+              className="text-rose-500 text-lg px-1 leading-none"
+              onClick={() => setItems((p) => p.filter((_, j) => j !== i))}
+              title="삭제"
+            >×</button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        className="btn-ghost text-[12px] mt-2"
+        onClick={() => setItems((p) => [...p, { label: "", amount: 0 }])}
+      >
+        + 항목 추가
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/PayslipPreview.tsx
+++ b/client/src/components/PayslipPreview.tsx
@@ -1,0 +1,211 @@
+import { useModalDismiss } from "../lib/useModalDismiss";
+import {
+  type Payslip,
+  attendanceEntries,
+  won,
+  openPayslipPrint,
+  DEFAULT_COMPANY,
+} from "../lib/payslip";
+
+/**
+ * 급여명세서 미리보기(읽기 전용) 모달 — 회사 양식 그대로 렌더.
+ * 관리자/직원 공용. onEdit 가 있으면 "수정" 버튼 노출(관리자 전용).
+ * "PDF/인쇄" 는 동일 마크업의 standalone HTML 을 새 창에 띄워 브라우저 인쇄로 PDF 화.
+ */
+export default function PayslipPreview({
+  payslip,
+  onClose,
+  onEdit,
+}: {
+  payslip: Payslip;
+  onClose: () => void;
+  onEdit?: () => void;
+}) {
+  useModalDismiss(true, onClose);
+  const p = payslip;
+  const rows = Math.max(p.earnings.length, p.deductions.length);
+  const att = attendanceEntries(p.attendance);
+  const calc = p.calcRows ?? [];
+
+  return (
+    <div
+      className="fixed inset-0 bg-slate-900/50 grid place-items-center p-4 z-50"
+      onClick={onClose}
+    >
+      <div
+        className="card w-full max-w-2xl max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-bold">급여명세서 미리보기</h3>
+          <div className="flex items-center gap-2">
+            {onEdit && (
+              <button className="btn-ghost text-[13px]" onClick={onEdit}>
+                수정
+              </button>
+            )}
+            <button className="btn-ghost text-[13px]" onClick={() => openPayslipPrint(p)}>
+              PDF · 인쇄
+            </button>
+            <button className="btn-ghost text-[13px]" onClick={onClose}>
+              닫기
+            </button>
+          </div>
+        </div>
+
+        {/* 양식 본문 */}
+        <div className="border border-ink-200 rounded-xl p-5 bg-white text-ink-900">
+          <h2 className="text-center text-[17px] font-extrabold tracking-tight">
+            {p.year}년 {String(p.month).padStart(2, "0")}월분 임금명세서
+          </h2>
+          <div className="text-center text-[12px] text-ink-500 mb-4">
+            {p.companyName || DEFAULT_COMPANY}
+          </div>
+
+          {/* 인적사항 */}
+          <table className="w-full border-collapse text-[12.5px]">
+            <tbody>
+              <Row
+                cells={[
+                  ["성명", p.employeeName],
+                  ["생년월일(사번)", p.idNumber || "-"],
+                ]}
+              />
+              <Row
+                cells={[
+                  ["부서", p.department || "-"],
+                  ["직위", p.position || "-"],
+                ]}
+              />
+              <Row
+                cells={[
+                  ["입사일", p.joinDate || "-"],
+                  ["지급일", p.payDate || "-"],
+                ]}
+              />
+            </tbody>
+          </table>
+
+          {/* 지급/공제 */}
+          <table className="w-full border-collapse text-[12.5px] mt-3">
+            <thead>
+              <tr>
+                <th className="border border-ink-200 bg-ink-100 py-1.5" colSpan={2}>지급</th>
+                <th className="border border-ink-200 bg-ink-100 py-1.5" colSpan={2}>공제</th>
+              </tr>
+              <tr className="text-center">
+                <th className="border border-ink-200 bg-slate-50 py-1.5 font-semibold w-1/4">임금항목</th>
+                <th className="border border-ink-200 bg-slate-50 py-1.5 font-semibold w-1/4">지급금액</th>
+                <th className="border border-ink-200 bg-slate-50 py-1.5 font-semibold w-1/4">공제항목</th>
+                <th className="border border-ink-200 bg-slate-50 py-1.5 font-semibold w-1/4">공제금액</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: rows }).map((_, i) => {
+                const e = p.earnings[i];
+                const d = p.deductions[i];
+                return (
+                  <tr key={i}>
+                    <td className="border border-ink-200 bg-slate-50/60 px-2.5 py-1.5 font-medium">{e?.label ?? ""}</td>
+                    <td className="border border-ink-200 px-2.5 py-1.5 text-right tabular">{e ? won(e.amount) : ""}</td>
+                    <td className="border border-ink-200 bg-slate-50/60 px-2.5 py-1.5 font-medium">{d?.label ?? ""}</td>
+                    <td className="border border-ink-200 px-2.5 py-1.5 text-right tabular">{d ? won(d.amount) : ""}</td>
+                  </tr>
+                );
+              })}
+              <tr className="font-extrabold">
+                <td className="border border-ink-200 bg-ink-100 px-2.5 py-1.5">지급액 계</td>
+                <td className="border border-ink-200 bg-ink-100 px-2.5 py-1.5 text-right tabular">{won(p.totalEarnings)}</td>
+                <td className="border border-ink-200 bg-ink-100 px-2.5 py-1.5">공제액 계</td>
+                <td className="border border-ink-200 bg-ink-100 px-2.5 py-1.5 text-right tabular">{won(p.totalDeductions)}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          {/* 실수령액 */}
+          <div className="mt-3 flex items-center justify-between border-2 border-ink-600 rounded-lg px-4 py-3">
+            <span className="text-[14px] font-extrabold">실수령액</span>
+            <span className="text-[20px] font-extrabold tabular">{won(p.netPay)}</span>
+          </div>
+
+          {/* 근태 */}
+          {att.length > 0 && (
+            <table className="w-full border-collapse text-[12px] mt-3.5">
+              <thead>
+                <tr>
+                  <th className="border border-ink-200 bg-ink-100 py-1.5" colSpan={att.length}>근태 정보</th>
+                </tr>
+                <tr className="text-center">
+                  {att.map((a) => (
+                    <td key={a.label} className="border border-ink-200 bg-slate-50 py-1.5 font-semibold">{a.label}</td>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="text-center">
+                  {att.map((a) => (
+                    <td key={a.label} className="border border-ink-200 py-1.5 tabular">{a.value}</td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          )}
+
+          {/* 계산방법 */}
+          {calc.length > 0 && (
+            <table className="w-full border-collapse text-[12px] mt-3.5">
+              <thead>
+                <tr>
+                  <th className="border border-ink-200 bg-ink-100 py-1.5" colSpan={3}>계산 방법</th>
+                </tr>
+                <tr className="text-center">
+                  <td className="border border-ink-200 bg-slate-50 py-1.5 font-semibold w-[28%]">항목</td>
+                  <td className="border border-ink-200 bg-slate-50 py-1.5 font-semibold">산출식</td>
+                  <td className="border border-ink-200 bg-slate-50 py-1.5 font-semibold w-[24%]">금액</td>
+                </tr>
+              </thead>
+              <tbody>
+                {calc.map((c, i) => (
+                  <tr key={i}>
+                    <td className="border border-ink-200 bg-slate-50/60 px-2.5 py-1.5 font-medium">{c.item}</td>
+                    <td className="border border-ink-200 px-2.5 py-1.5">{c.formula}</td>
+                    <td className="border border-ink-200 px-2.5 py-1.5 text-right tabular">{won(c.amount)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          {p.memo && <div className="text-center text-[13px] text-ink-700 mt-4">{p.memo}</div>}
+          <div className="text-center text-[13px] font-bold mt-5">{p.companyName || DEFAULT_COMPANY}</div>
+        </div>
+
+        {p.sentAt && (
+          <div className="text-[11.5px] text-ink-500 mt-3 text-right">
+            발송됨 · {new Date(p.sentAt).toLocaleString("ko-KR")}
+            {p.sentTo ? ` · ${p.sentTo}` : ""}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** 인적사항 2열(라벨+값) 행. */
+function Row({ cells }: { cells: [string, string][] }) {
+  return (
+    <tr>
+      {cells.map(([k, v], i) => (
+        <Cell key={i} k={k} v={v} />
+      ))}
+    </tr>
+  );
+}
+function Cell({ k, v }: { k: string; v: string }) {
+  return (
+    <>
+      <td className="border border-ink-200 bg-slate-50 px-2.5 py-1.5 font-semibold w-[18%]">{k}</td>
+      <td className="border border-ink-200 px-2.5 py-1.5 w-[32%]">{v}</td>
+    </>
+  );
+}

--- a/client/src/lib/payslip.ts
+++ b/client/src/lib/payslip.ts
@@ -1,0 +1,277 @@
+/**
+ * 급여(임금)명세서 공용 타입·유틸.
+ *
+ * - 서버 모델(Payslip)과 1:1로 맞춘 클라 타입.
+ * - 합계 계산·금액 포맷·회사 양식 기본 항목(라벨만!) 상수.
+ * - 인쇄/PDF 용 standalone HTML 생성기 — 미리보기·발송에서 공용.
+ *
+ * 주의: 회사 양식의 "실제 급여액"은 절대 코드에 넣지 않는다. 항목 라벨 골격만 제공하고
+ * 금액은 항상 관리자가 입력한 값/서버 저장값을 쓴다.
+ */
+
+export type LineItem = { label: string; amount: number };
+
+export type Attendance = {
+  workDays?: number;
+  totalHours?: number;
+  overtimeHours?: number;
+  nightHours?: number;
+  holidayHours?: number;
+  hourlyWage?: number;
+  familyCount?: number;
+};
+
+export type CalcRow = { item: string; formula: string; amount: number };
+
+export type Payslip = {
+  id: string;
+  year: number;
+  month: number;
+  employeeId: string;
+  companyName: string;
+  employeeName: string;
+  department?: string | null;
+  position?: string | null;
+  joinDate?: string | null;
+  payDate?: string | null;
+  idNumber?: string | null;
+  earnings: LineItem[];
+  deductions: LineItem[];
+  attendance?: Attendance | null;
+  calcRows?: CalcRow[] | null;
+  memo?: string | null;
+  totalEarnings: number;
+  totalDeductions: number;
+  netPay: number;
+  sentAt?: string | null;
+  sentTo?: string | null;
+  createdById: string;
+  createdAt: string;
+  updatedAt: string;
+  employee?: {
+    id: string;
+    name: string;
+    email: string;
+    team?: string | null;
+    position?: string | null;
+  };
+};
+
+export type EmployeeOption = {
+  id: string;
+  name: string;
+  email: string;
+  position?: string | null;
+  team?: string | null;
+  department?: string | null;
+  employeeNo?: string | null;
+  hireDate?: string | null;
+  birthDate?: string | null;
+};
+
+export const DEFAULT_COMPANY = "주식회사 하이비츠";
+export const DEFAULT_MEMO = "귀하의 노고에 감사드립니다.";
+
+// 회사 양식 기본 지급/공제 항목 — 라벨(골격)만. 금액은 전부 0으로 시작.
+export const DEFAULT_EARNING_LABELS = [
+  "기본급",
+  "상여",
+  "직책수당",
+  "월차수당",
+  "식대",
+  "자가운전보조금",
+  "야간근로수당",
+  "연장근로수당",
+];
+export const DEFAULT_DEDUCTION_LABELS = [
+  "국민연금",
+  "건강보험",
+  "장기요양보험",
+  "고용보험",
+  "건강보험정산",
+  "장기요양보험정산",
+  "소득세",
+  "지방소득세",
+  "농특세",
+];
+
+export function blankEarnings(): LineItem[] {
+  return DEFAULT_EARNING_LABELS.map((label) => ({ label, amount: 0 }));
+}
+export function blankDeductions(): LineItem[] {
+  return DEFAULT_DEDUCTION_LABELS.map((label) => ({ label, amount: 0 }));
+}
+
+export function sumAmount(items: LineItem[] | undefined | null): number {
+  if (!items) return 0;
+  return items.reduce((s, x) => s + (Number(x.amount) || 0), 0);
+}
+
+/** 1,234,567원 */
+export function won(n: number | undefined | null): string {
+  return `${(Number(n) || 0).toLocaleString("ko-KR")}원`;
+}
+
+const ATTENDANCE_LABELS: { key: keyof Attendance; label: string; unit: string }[] = [
+  { key: "workDays", label: "근로일수", unit: "일" },
+  { key: "totalHours", label: "총 근로시간", unit: "시간" },
+  { key: "overtimeHours", label: "연장 근로시간", unit: "시간" },
+  { key: "nightHours", label: "야간 근로시간", unit: "시간" },
+  { key: "holidayHours", label: "휴일 근로시간", unit: "시간" },
+  { key: "hourlyWage", label: "통상시급", unit: "원" },
+  { key: "familyCount", label: "부양가족수", unit: "명" },
+];
+
+export function attendanceEntries(a?: Attendance | null): { label: string; value: string }[] {
+  if (!a) return [];
+  const out: { label: string; value: string }[] = [];
+  for (const { key, label, unit } of ATTENDANCE_LABELS) {
+    const v = a[key];
+    if (v === undefined || v === null || (typeof v === "number" && Number.isNaN(v))) continue;
+    const val = unit === "원" ? (Number(v) || 0).toLocaleString("ko-KR") : String(v);
+    out.push({ label, value: `${val}${unit}` });
+  }
+  return out;
+}
+
+function esc(s: unknown): string {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * 인쇄/PDF 저장용 standalone HTML 문서. 한국 임금명세서 양식을 충실히 렌더.
+ * 브라우저 "대상: PDF 로 저장" 으로 PDF 화. 이메일 첨부(서버) 에서도 같은 마크업 재사용 가능.
+ */
+export function payslipPrintHTML(p: Payslip): string {
+  const rows = Math.max(p.earnings.length, p.deductions.length);
+  const itemRows: string[] = [];
+  for (let i = 0; i < rows; i++) {
+    const e = p.earnings[i];
+    const d = p.deductions[i];
+    itemRows.push(
+      `<tr>
+        <td class="lbl">${e ? esc(e.label) : ""}</td>
+        <td class="amt">${e ? won(e.amount) : ""}</td>
+        <td class="lbl">${d ? esc(d.label) : ""}</td>
+        <td class="amt">${d ? won(d.amount) : ""}</td>
+      </tr>`,
+    );
+  }
+
+  const att = attendanceEntries(p.attendance);
+  const attBlock = att.length
+    ? `<table class="grid mt">
+        <tr><th colspan="${att.length}">근태 정보</th></tr>
+        <tr>${att.map((a) => `<td class="lbl c">${esc(a.label)}</td>`).join("")}</tr>
+        <tr>${att.map((a) => `<td class="amt c">${esc(a.value)}</td>`).join("")}</tr>
+      </table>`
+    : "";
+
+  const calc = p.calcRows ?? [];
+  const calcBlock = calc.length
+    ? `<table class="grid mt">
+        <tr><th colspan="3">계산 방법</th></tr>
+        <tr><td class="lbl c" style="width:28%">항목</td><td class="lbl c">산출식</td><td class="amt c" style="width:24%">금액</td></tr>
+        ${calc
+          .map(
+            (c) =>
+              `<tr><td class="lbl">${esc(c.item)}</td><td class="lbl">${esc(c.formula)}</td><td class="amt">${won(c.amount)}</td></tr>`,
+          )
+          .join("")}
+      </table>`
+    : "";
+
+  return `<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<title>${esc(p.year)}년 ${esc(p.month)}월 임금명세서 - ${esc(p.employeeName)}</title>
+<style>
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Pretendard", "Apple SD Gothic Neo", "Segoe UI", sans-serif; color: #1F2937; margin: 0; padding: 28px; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .doc { max-width: 720px; margin: 0 auto; }
+  h1 { font-size: 20px; text-align: center; margin: 0 0 4px; letter-spacing: -0.01em; }
+  .sub { text-align: center; color: #6B7280; font-size: 12px; margin-bottom: 18px; }
+  table { width: 100%; border-collapse: collapse; }
+  .grid td, .grid th { border: 1px solid #C9CDD2; padding: 7px 10px; font-size: 12.5px; }
+  .grid th { background: #EEF2F7; font-weight: 700; text-align: center; }
+  .lbl { background: #F8FAFC; font-weight: 600; }
+  .amt { text-align: right; font-variant-numeric: tabular-nums; }
+  .c { text-align: center; }
+  .mt { margin-top: 14px; }
+  .info td { font-size: 12.5px; }
+  .total td { font-weight: 800; background: #EEF2F7; }
+  .net { margin-top: 12px; border: 2px solid #4B5563; padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; border-radius: 4px; }
+  .net .k { font-size: 14px; font-weight: 800; }
+  .net .v { font-size: 20px; font-weight: 800; font-variant-numeric: tabular-nums; }
+  .memo { margin-top: 18px; text-align: center; font-size: 13px; color: #374151; }
+  .foot { margin-top: 22px; text-align: center; font-size: 13px; font-weight: 700; }
+  @media print { body { padding: 12mm; } .doc { max-width: none; } }
+</style>
+</head>
+<body>
+  <div class="doc">
+    <h1>${esc(p.year)}년 ${String(p.month).padStart(2, "0")}월분 임금명세서</h1>
+    <div class="sub">${esc(p.companyName || DEFAULT_COMPANY)}</div>
+
+    <table class="grid info">
+      <tr>
+        <td class="lbl" style="width:18%">성명</td><td style="width:32%">${esc(p.employeeName)}</td>
+        <td class="lbl" style="width:18%">생년월일(사번)</td><td style="width:32%">${esc(p.idNumber || "-")}</td>
+      </tr>
+      <tr>
+        <td class="lbl">부서</td><td>${esc(p.department || "-")}</td>
+        <td class="lbl">직위</td><td>${esc(p.position || "-")}</td>
+      </tr>
+      <tr>
+        <td class="lbl">입사일</td><td>${esc(p.joinDate || "-")}</td>
+        <td class="lbl">지급일</td><td>${esc(p.payDate || "-")}</td>
+      </tr>
+    </table>
+
+    <table class="grid mt">
+      <tr><th colspan="2">지급</th><th colspan="2">공제</th></tr>
+      <tr>
+        <td class="lbl c" style="width:25%">임금항목</td><td class="lbl c" style="width:25%">지급금액</td>
+        <td class="lbl c" style="width:25%">공제항목</td><td class="lbl c" style="width:25%">공제금액</td>
+      </tr>
+      ${itemRows.join("")}
+      <tr class="total">
+        <td>지급액 계</td><td class="amt">${won(p.totalEarnings)}</td>
+        <td>공제액 계</td><td class="amt">${won(p.totalDeductions)}</td>
+      </tr>
+    </table>
+
+    <div class="net">
+      <span class="k">실수령액</span>
+      <span class="v">${won(p.netPay)}</span>
+    </div>
+
+    ${attBlock}
+    ${calcBlock}
+
+    ${p.memo ? `<div class="memo">${esc(p.memo)}</div>` : ""}
+    <div class="foot">${esc(p.companyName || DEFAULT_COMPANY)}</div>
+  </div>
+  <script>
+    window.onload = function () { setTimeout(function () { window.focus(); window.print(); }, 120); };
+  </script>
+</body>
+</html>`;
+}
+
+/** 새 창에 인쇄용 HTML 을 띄우고 print() 호출 — 브라우저 PDF 저장으로 PDF 화. */
+export function openPayslipPrint(p: Payslip): void {
+  const w = window.open("", "_blank", "width=820,height=900");
+  if (!w) {
+    import("../components/ConfirmHost").then(({ alertAsync }) => {
+      alertAsync({ title: "팝업 차단", description: "팝업이 차단되었어요. 팝업 허용 후 다시 시도해주세요." });
+    });
+    return;
+  }
+  w.document.write(payslipPrintHTML(p));
+  w.document.close();
+}

--- a/client/src/pages/PayrollPage.tsx
+++ b/client/src/pages/PayrollPage.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from "react";
+import { api } from "../api";
+import PageHeader from "../components/PageHeader";
+import PayslipComposer from "../components/PayslipComposer";
+import PayslipPreview from "../components/PayslipPreview";
+import { confirmAsync } from "../components/ConfirmHost";
+import { type Payslip, type EmployeeOption, won } from "../lib/payslip";
+
+const NOW = new Date();
+
+/**
+ * 급여명세서 관리(ADMIN) 페이지.
+ * - 연/월/직원으로 명세서 목록 조회.
+ * - 작성·수정(PayslipComposer), 미리보기·PDF(PayslipPreview), 삭제.
+ * 라우트는 AdminOnly 로 보호되므로 이 페이지는 관리자 권한을 전제한다.
+ */
+export default function PayrollPage() {
+  const [employees, setEmployees] = useState<EmployeeOption[]>([]);
+  const [list, setList] = useState<Payslip[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [year, setYear] = useState(NOW.getFullYear());
+  const [month, setMonth] = useState<number | 0>(0); // 0 = 전체
+  const [employeeId, setEmployeeId] = useState("");
+
+  const [composing, setComposing] = useState(false);
+  const [editTarget, setEditTarget] = useState<Payslip | null>(null);
+  const [preview, setPreview] = useState<Payslip | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api<{ employees: EmployeeOption[] }>("/api/payslip/employees")
+      .then((r) => alive && setEmployees(r.employees))
+      .catch(() => {});
+    return () => { alive = false; };
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    const q = new URLSearchParams();
+    q.set("year", String(year));
+    if (month) q.set("month", String(month));
+    if (employeeId) q.set("employeeId", employeeId);
+    api<{ payslips: Payslip[] }>(`/api/payslip?${q.toString()}`)
+      .then((r) => { if (alive) { setList(r.payslips); setLoading(false); } })
+      .catch(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, [year, month, employeeId]);
+
+  function reload() {
+    const q = new URLSearchParams();
+    q.set("year", String(year));
+    if (month) q.set("month", String(month));
+    if (employeeId) q.set("employeeId", employeeId);
+    api<{ payslips: Payslip[] }>(`/api/payslip?${q.toString()}`)
+      .then((r) => setList(r.payslips))
+      .catch(() => {});
+  }
+
+  function onSaved(p: Payslip) {
+    setComposing(false);
+    setEditTarget(null);
+    // 현재 필터에 맞으면 목록 갱신.
+    reload();
+    // 방금 저장한 건 바로 미리보기로 띄워 결과 확인.
+    setPreview(p);
+  }
+
+  async function remove(p: Payslip) {
+    const ok = await confirmAsync({
+      title: "급여명세서 삭제",
+      description: `${p.employeeName} · ${p.year}년 ${p.month}월 명세서를 삭제할까요?`,
+      confirmLabel: "삭제",
+      cancelLabel: "취소",
+      tone: "danger",
+    });
+    if (!ok) return;
+    setBusyId(p.id);
+    try {
+      await api(`/api/payslip/${p.id}`, { method: "DELETE" });
+      setList((prev) => prev.filter((x) => x.id !== p.id));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const years = Array.from({ length: 6 }, (_, i) => NOW.getFullYear() - i + 1);
+
+  return (
+    <div>
+      <PageHeader
+        title="급여명세서"
+        description="직원별 임금명세서를 작성·발송하고 보관합니다."
+        right={
+          <button className="btn-primary" onClick={() => { setEditTarget(null); setComposing(true); }}>
+            + 새 명세서
+          </button>
+        }
+      />
+
+      {/* 필터 */}
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <select className="input w-auto" value={year} onChange={(e) => setYear(Number(e.target.value))}>
+          {years.map((y) => <option key={y} value={y}>{y}년</option>)}
+        </select>
+        <select className="input w-auto" value={month} onChange={(e) => setMonth(Number(e.target.value))}>
+          <option value={0}>전체 월</option>
+          {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => <option key={m} value={m}>{m}월</option>)}
+        </select>
+        <select className="input w-auto" value={employeeId} onChange={(e) => setEmployeeId(e.target.value)}>
+          <option value="">전체 직원</option>
+          {employees.map((e) => <option key={e.id} value={e.id}>{e.name}{e.team ? ` · ${e.team}` : ""}</option>)}
+        </select>
+      </div>
+
+      <div className="card p-0 overflow-hidden overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
+        <table className="w-full text-sm min-w-[760px]">
+          <thead className="bg-slate-50 text-slate-500 text-xs">
+            <tr>
+              <th className="text-left px-4 py-3">직원</th>
+              <th className="text-left px-4 py-3">귀속</th>
+              <th className="text-right px-4 py-3">지급액</th>
+              <th className="text-right px-4 py-3">공제액</th>
+              <th className="text-right px-4 py-3">실수령액</th>
+              <th className="text-center px-4 py-3">발송</th>
+              <th className="text-right px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && (
+              <tr><td colSpan={7} className="px-4 py-10 text-center text-slate-400">불러오는 중…</td></tr>
+            )}
+            {!loading && list.length === 0 && (
+              <tr><td colSpan={7} className="px-4 py-10 text-center text-slate-400">명세서가 없습니다. “+ 새 명세서”로 작성하세요.</td></tr>
+            )}
+            {!loading && list.map((p) => (
+              <tr key={p.id} className="border-t border-slate-100 hover:bg-slate-50/50">
+                <td className="px-4 py-3">
+                  <div className="font-medium text-ink-900">{p.employeeName}</div>
+                  {p.department && <div className="text-[11.5px] text-ink-500">{p.department}</div>}
+                </td>
+                <td className="px-4 py-3 tabular">{p.year}.{String(p.month).padStart(2, "0")}</td>
+                <td className="px-4 py-3 text-right tabular">{won(p.totalEarnings)}</td>
+                <td className="px-4 py-3 text-right tabular text-rose-600">{won(p.totalDeductions)}</td>
+                <td className="px-4 py-3 text-right font-bold tabular">{won(p.netPay)}</td>
+                <td className="px-4 py-3 text-center">
+                  {p.sentAt
+                    ? <span className="chip bg-brand-100 text-brand-700" title={new Date(p.sentAt).toLocaleString("ko-KR")}>발송됨</span>
+                    : <span className="chip bg-slate-100 text-slate-500">미발송</span>}
+                </td>
+                <td className="px-4 py-3 text-right whitespace-nowrap">
+                  <button className="text-[12px] text-brand-600 hover:underline" onClick={() => setPreview(p)}>보기</button>
+                  <button className="text-[12px] text-ink-600 hover:underline ml-3" onClick={() => { setEditTarget(p); setComposing(true); }}>수정</button>
+                  <button
+                    className="text-[12px] text-rose-500 hover:underline ml-3 disabled:opacity-50"
+                    onClick={() => remove(p)}
+                    disabled={busyId === p.id}
+                  >
+                    {busyId === p.id ? "삭제 중…" : "삭제"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {composing && (
+        <PayslipComposer
+          initial={editTarget}
+          employees={employees}
+          defaultYear={year}
+          defaultMonth={month || NOW.getMonth() + 1}
+          onClose={() => { setComposing(false); setEditTarget(null); }}
+          onSaved={onSaved}
+        />
+      )}
+
+      {preview && (
+        <PayslipPreview
+          payslip={preview}
+          onClose={() => setPreview(null)}
+          onEdit={() => { setEditTarget(preview); setPreview(null); setComposing(true); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -27,6 +27,7 @@ export const loadUserProfile = () => import("./pages/UserProfilePage");
 export const loadAdmin = () => import("./pages/AdminPage");
 export const loadSuperAdmin = () => import("./pages/SuperAdminPage");
 export const loadMemos = () => import("./pages/MemosPage");
+export const loadPayroll = () => import("./pages/PayrollPage");
 
 export const SchedulePage = lazy(loadSchedule);
 export const AttendancePage = lazy(loadAttendance);
@@ -47,6 +48,7 @@ export const UserProfilePage = lazy(loadUserProfile);
 export const AdminPage = lazy(loadAdmin);
 export const SuperAdminPage = lazy(loadSuperAdmin);
 export const MemosPage = lazy(loadMemos);
+export const PayrollPage = lazy(loadPayroll);
 
 /** 사이드바 경로별 prefetch 함수 매핑 — hover/focus 시 호출해 청크 선로딩. */
 export const ROUTE_PREFETCH: Record<string, () => Promise<unknown>> = {
@@ -66,4 +68,5 @@ export const ROUTE_PREFETCH: Record<string, () => Promise<unknown>> = {
   "/accounts": loadAccounts,
   "/snippets": loadSnippets,
   "/memos": loadMemos,
+  "/payroll": loadPayroll,
 };


### PR DESCRIPTION
## 증상
**급여명세서 관리자 페이지 — 작성·수정·미리보기·PDF**

새 기능을 추가합니다.

## 원인
- /payroll (ADMIN 전용): 연/월/직원 필터 목록 + 작성·수정·삭제.
- PayslipComposer: 직원 선택 시 HR 자동완성, 지급/공제 항목 행 편집, 합계·실수령액 실시간 계산, 근태·계산방법(선택).
- PayslipPreview: 회사 양식 그대로 렌더 + 브라우저 인쇄로 PDF 저장.
- lib/payslip: 공용 타입·합계·금액 포맷·인쇄용 HTML 생성기(발송에서 재사용 예정).
- 사이드바 "관리" 섹션에 메뉴 추가, 라우트 lazy + prefetch 등록.

## 수정
**작업 항목 (커밋 단위)**
- feat(payslip): 급여명세서 관리자 페이지 — 작성·수정·미리보기·PDF

**변경 대상 (7개 파일)**
- `client/src/App.tsx`
- `client/src/components/AppLayout.tsx`
- `client/src/components/PayslipComposer.tsx`
- `client/src/components/PayslipPreview.tsx`
- `client/src/lib/payslip.ts`
- `client/src/pages/PayrollPage.tsx`
- `client/src/routes.ts`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #175** ↔ **이슈 #599** 로 연결됩니다.

Closes #599
