### PR TITLE
🔀 :: (#601) 급여명세서 이메일 발송 — PDF 첨부

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,8 @@
         "@tiptap/starter-kit": "^3.22.4",
         "@tiptap/suggestion": "^3.22.4",
         "highlight.js": "^11.11.1",
+        "html2canvas": "^1.4.1",
+        "jspdf": "^2.5.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0",
@@ -287,6 +289,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1817,6 +1828,13 @@
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
@@ -1902,6 +1920,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -1937,6 +1967,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2013,6 +2052,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -2043,6 +2094,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/cfb": {
       "version": "1.2.2",
@@ -2121,6 +2192,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -2131,6 +2214,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -2183,6 +2275,13 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.339",
@@ -2420,6 +2519,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2524,6 +2636,30 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -2684,6 +2820,13 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3051,6 +3194,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3143,6 +3296,13 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -3174,6 +3334,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -3292,6 +3462,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -3326,6 +3506,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -3364,6 +3554,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -3518,6 +3717,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,8 @@
     "@tiptap/starter-kit": "^3.22.4",
     "@tiptap/suggestion": "^3.22.4",
     "highlight.js": "^11.11.1",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/client/src/components/PayslipPreview.tsx
+++ b/client/src/components/PayslipPreview.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useModalDismiss } from "../lib/useModalDismiss";
 import {
   type Payslip,
@@ -16,13 +17,27 @@ export default function PayslipPreview({
   payslip,
   onClose,
   onEdit,
+  onSend,
 }: {
   payslip: Payslip;
   onClose: () => void;
   onEdit?: () => void;
+  /** 관리자 전용 — 직원 계정 이메일로 PDF 발송. await 동안 버튼이 "발송 중…". */
+  onSend?: () => Promise<void> | void;
 }) {
   useModalDismiss(true, onClose);
+  const [sending, setSending] = useState(false);
   const p = payslip;
+
+  async function handleSend() {
+    if (!onSend || sending) return;
+    setSending(true);
+    try {
+      await onSend();
+    } finally {
+      setSending(false);
+    }
+  }
   const rows = Math.max(p.earnings.length, p.deductions.length);
   const att = attendanceEntries(p.attendance);
   const calc = p.calcRows ?? [];
@@ -42,6 +57,15 @@ export default function PayslipPreview({
             {onEdit && (
               <button className="btn-ghost text-[13px]" onClick={onEdit}>
                 수정
+              </button>
+            )}
+            {onSend && (
+              <button
+                className="btn-ghost text-[13px] text-brand-600 disabled:opacity-50"
+                onClick={handleSend}
+                disabled={sending}
+              >
+                {sending ? "발송 중…" : (p.sentAt ? "재발송" : "메일 발송")}
               </button>
             )}
             <button className="btn-ghost text-[13px]" onClick={() => openPayslipPrint(p)}>

--- a/client/src/lib/payslip.ts
+++ b/client/src/lib/payslip.ts
@@ -141,23 +141,38 @@ function esc(s: unknown): string {
     .replace(/>/g, "&gt;");
 }
 
-/**
- * 인쇄/PDF 저장용 standalone HTML 문서. 한국 임금명세서 양식을 충실히 렌더.
- * 브라우저 "대상: PDF 로 저장" 으로 PDF 화. 이메일 첨부(서버) 에서도 같은 마크업 재사용 가능.
- */
-export function payslipPrintHTML(p: Payslip): string {
+// 명세서 양식 CSS — 전부 .psheet 로 스코프. 일반 hex 색상 + 시스템 폰트만 사용해
+// html2canvas(PDF 변환) 가 modern color(oklch 등) 파싱에서 깨지지 않도록 한다.
+const SHEET_CSS = `
+.psheet, .psheet * { box-sizing: border-box; }
+.psheet { font-family: -apple-system, BlinkMacSystemFont, "Pretendard", "Apple SD Gothic Neo", "Segoe UI", sans-serif; color: #1F2937; background: #FFFFFF; padding: 24px; }
+.psheet .doc { max-width: 720px; margin: 0 auto; }
+.psheet h1 { font-size: 20px; text-align: center; margin: 0 0 4px; letter-spacing: -0.01em; }
+.psheet .sub { text-align: center; color: #6B7280; font-size: 12px; margin-bottom: 18px; }
+.psheet table { width: 100%; border-collapse: collapse; }
+.psheet .grid td, .psheet .grid th { border: 1px solid #C9CDD2; padding: 7px 10px; font-size: 12.5px; }
+.psheet .grid th { background: #EEF2F7; font-weight: 700; text-align: center; }
+.psheet .lbl { background: #F8FAFC; font-weight: 600; }
+.psheet .amt { text-align: right; }
+.psheet .c { text-align: center; }
+.psheet .mt { margin-top: 14px; }
+.psheet .total td { font-weight: 800; background: #EEF2F7; }
+.psheet .net { margin-top: 12px; border: 2px solid #4B5563; padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; border-radius: 4px; }
+.psheet .net .k { font-size: 14px; font-weight: 800; }
+.psheet .net .v { font-size: 20px; font-weight: 800; }
+.psheet .memo { margin-top: 18px; text-align: center; font-size: 13px; color: #374151; }
+.psheet .foot { margin-top: 22px; text-align: center; font-size: 13px; font-weight: 700; }
+`;
+
+/** 명세서 본문 마크업(.psheet 래퍼). <style> 없이 DOM 조각만. */
+function payslipSheetMarkup(p: Payslip): string {
   const rows = Math.max(p.earnings.length, p.deductions.length);
   const itemRows: string[] = [];
   for (let i = 0; i < rows; i++) {
     const e = p.earnings[i];
     const d = p.deductions[i];
     itemRows.push(
-      `<tr>
-        <td class="lbl">${e ? esc(e.label) : ""}</td>
-        <td class="amt">${e ? won(e.amount) : ""}</td>
-        <td class="lbl">${d ? esc(d.label) : ""}</td>
-        <td class="amt">${d ? won(d.amount) : ""}</td>
-      </tr>`,
+      `<tr><td class="lbl">${e ? esc(e.label) : ""}</td><td class="amt">${e ? won(e.amount) : ""}</td><td class="lbl">${d ? esc(d.label) : ""}</td><td class="amt">${d ? won(d.amount) : ""}</td></tr>`,
     );
   }
 
@@ -184,40 +199,10 @@ export function payslipPrintHTML(p: Payslip): string {
       </table>`
     : "";
 
-  return `<!doctype html>
-<html lang="ko">
-<head>
-<meta charset="utf-8" />
-<title>${esc(p.year)}년 ${esc(p.month)}월 임금명세서 - ${esc(p.employeeName)}</title>
-<style>
-  * { box-sizing: border-box; }
-  body { font-family: -apple-system, BlinkMacSystemFont, "Pretendard", "Apple SD Gothic Neo", "Segoe UI", sans-serif; color: #1F2937; margin: 0; padding: 28px; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-  .doc { max-width: 720px; margin: 0 auto; }
-  h1 { font-size: 20px; text-align: center; margin: 0 0 4px; letter-spacing: -0.01em; }
-  .sub { text-align: center; color: #6B7280; font-size: 12px; margin-bottom: 18px; }
-  table { width: 100%; border-collapse: collapse; }
-  .grid td, .grid th { border: 1px solid #C9CDD2; padding: 7px 10px; font-size: 12.5px; }
-  .grid th { background: #EEF2F7; font-weight: 700; text-align: center; }
-  .lbl { background: #F8FAFC; font-weight: 600; }
-  .amt { text-align: right; font-variant-numeric: tabular-nums; }
-  .c { text-align: center; }
-  .mt { margin-top: 14px; }
-  .info td { font-size: 12.5px; }
-  .total td { font-weight: 800; background: #EEF2F7; }
-  .net { margin-top: 12px; border: 2px solid #4B5563; padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; border-radius: 4px; }
-  .net .k { font-size: 14px; font-weight: 800; }
-  .net .v { font-size: 20px; font-weight: 800; font-variant-numeric: tabular-nums; }
-  .memo { margin-top: 18px; text-align: center; font-size: 13px; color: #374151; }
-  .foot { margin-top: 22px; text-align: center; font-size: 13px; font-weight: 700; }
-  @media print { body { padding: 12mm; } .doc { max-width: none; } }
-</style>
-</head>
-<body>
-  <div class="doc">
+  return `<div class="psheet"><div class="doc">
     <h1>${esc(p.year)}년 ${String(p.month).padStart(2, "0")}월분 임금명세서</h1>
     <div class="sub">${esc(p.companyName || DEFAULT_COMPANY)}</div>
-
-    <table class="grid info">
+    <table class="grid">
       <tr>
         <td class="lbl" style="width:18%">성명</td><td style="width:32%">${esc(p.employeeName)}</td>
         <td class="lbl" style="width:18%">생년월일(사번)</td><td style="width:32%">${esc(p.idNumber || "-")}</td>
@@ -231,7 +216,6 @@ export function payslipPrintHTML(p: Payslip): string {
         <td class="lbl">지급일</td><td>${esc(p.payDate || "-")}</td>
       </tr>
     </table>
-
     <table class="grid mt">
       <tr><th colspan="2">지급</th><th colspan="2">공제</th></tr>
       <tr>
@@ -244,21 +228,34 @@ export function payslipPrintHTML(p: Payslip): string {
         <td>공제액 계</td><td class="amt">${won(p.totalDeductions)}</td>
       </tr>
     </table>
-
-    <div class="net">
-      <span class="k">실수령액</span>
-      <span class="v">${won(p.netPay)}</span>
-    </div>
-
+    <div class="net"><span class="k">실수령액</span><span class="v">${won(p.netPay)}</span></div>
     ${attBlock}
     ${calcBlock}
-
     ${p.memo ? `<div class="memo">${esc(p.memo)}</div>` : ""}
     <div class="foot">${esc(p.companyName || DEFAULT_COMPANY)}</div>
-  </div>
-  <script>
-    window.onload = function () { setTimeout(function () { window.focus(); window.print(); }, 120); };
-  </script>
+  </div></div>`;
+}
+
+/** <style> + 본문 마크업. 오프스크린 컨테이너(PDF 변환) 에 그대로 주입 가능. */
+export function payslipInnerHTML(p: Payslip): string {
+  return `<style>${SHEET_CSS}</style>${payslipSheetMarkup(p)}`;
+}
+
+/**
+ * 인쇄/PDF 저장용 standalone HTML 문서. 한국 임금명세서 양식을 충실히 렌더.
+ * 브라우저 "대상: PDF 로 저장" 으로 PDF 화.
+ */
+export function payslipPrintHTML(p: Payslip): string {
+  return `<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<title>${esc(p.year)}년 ${esc(p.month)}월 임금명세서 - ${esc(p.employeeName)}</title>
+<style>html,body{margin:0;-webkit-print-color-adjust:exact;print-color-adjust:exact;}@media print{.psheet{padding:12mm;}.psheet .doc{max-width:none;}}</style>
+</head>
+<body>
+  ${payslipInnerHTML(p)}
+  <script>window.onload=function(){setTimeout(function(){window.focus();window.print();},120);};</script>
 </body>
 </html>`;
 }

--- a/client/src/lib/payslipPdf.ts
+++ b/client/src/lib/payslipPdf.ts
@@ -1,0 +1,78 @@
+/**
+ * 급여명세서 → PDF(base64) 변환 — 클라이언트 사이드.
+ *
+ * payslipInnerHTML(p) 로 만든 .psheet 마크업을 화면 밖 컨테이너에 주입하고,
+ * html2canvas 로 캔버스화 → jsPDF(A4) 에 이미지로 얹어 base64 로 돌려준다.
+ * 서버로 보내 SES 첨부 메일로 발송하는 데 쓴다.
+ *
+ * 왜 클라에서 PDF 를 만드나:
+ *   서버(Fargate)에 Chromium/한글 폰트를 올리지 않으려고. 미리보기와 동일한
+ *   payslipInnerHTML 을 그대로 재사용하므로 "화면 = PDF" 가 보장된다.
+ *
+ * 주의: html2canvas 는 oklch/CSS 변수 등 최신 색상 함수를 못 읽어 깨진다.
+ *   그래서 SHEET_CSS 는 전부 hex 색상 + 시스템 폰트만 쓴다(payslip.ts 참고).
+ *
+ * jspdf·html2canvas 는 무거우므로 동적 import — 이 함수를 호출할 때만 로드된다.
+ */
+import type { Payslip } from "./payslip";
+import { payslipInnerHTML } from "./payslip";
+
+/** 화면 밖 렌더 컨테이너 폭(px). .psheet .doc 의 max-width(720) + 좌우 여유. */
+const RENDER_WIDTH = 760;
+
+/**
+ * 명세서를 A4 PDF 로 만들어 순수 base64(데이터 URI 접두어 없음) 로 반환.
+ * 내용이 한 페이지를 넘으면 자동으로 페이지를 나눈다.
+ */
+export async function payslipToPdfBase64(p: Payslip): Promise<string> {
+  const [{ default: jsPDF }, { default: html2canvas }] = await Promise.all([
+    import("jspdf"),
+    import("html2canvas"),
+  ]);
+
+  // 화면 밖(왼쪽 -10000px)에 컨테이너를 띄워 캡처 — 사용자에겐 안 보인다.
+  const host = document.createElement("div");
+  host.style.cssText = `position:fixed;left:-10000px;top:0;width:${RENDER_WIDTH}px;background:#ffffff;z-index:-1;`;
+  host.innerHTML = payslipInnerHTML(p);
+  document.body.appendChild(host);
+
+  try {
+    const canvas = await html2canvas(host, {
+      scale: 2,
+      backgroundColor: "#ffffff",
+      useCORS: true,
+      logging: false,
+    });
+    if (!canvas.width || !canvas.height) {
+      throw new Error("명세서 캡처에 실패했어요");
+    }
+
+    const pdf = new jsPDF({ unit: "mm", format: "a4", orientation: "portrait" });
+    const pageW = pdf.internal.pageSize.getWidth(); // 210
+    const pageH = pdf.internal.pageSize.getHeight(); // 297
+    const imgW = pageW; // 가로 꽉 — .psheet 자체 패딩이 있어 가장자리에 붙지 않는다.
+    const imgH = (canvas.height * imgW) / canvas.width;
+    const imgData = canvas.toDataURL("image/jpeg", 0.92);
+
+    // 페이지 높이만큼 슬라이스 — 같은 이미지를 y 를 위로 밀며 페이지마다 얹는다.
+    let heightLeft = imgH;
+    let position = 0;
+    pdf.addImage(imgData, "JPEG", 0, position, imgW, imgH);
+    heightLeft -= pageH;
+    while (heightLeft > 0) {
+      pdf.addPage();
+      position -= pageH;
+      pdf.addImage(imgData, "JPEG", 0, position, imgW, imgH);
+      heightLeft -= pageH;
+    }
+
+    // output('datauristring') → "data:application/pdf;filename=...;base64,XXXX".
+    // 순수 base64 만 잘라낸다.
+    const dataUri = pdf.output("datauristring");
+    const marker = "base64,";
+    const at = dataUri.indexOf(marker);
+    return at >= 0 ? dataUri.slice(at + marker.length) : dataUri;
+  } finally {
+    document.body.removeChild(host);
+  }
+}

--- a/client/src/pages/PayrollPage.tsx
+++ b/client/src/pages/PayrollPage.tsx
@@ -4,8 +4,9 @@ import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import PayslipComposer from "../components/PayslipComposer";
 import PayslipPreview from "../components/PayslipPreview";
-import { confirmAsync } from "../components/ConfirmHost";
+import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import { type Payslip, type EmployeeOption, won } from "../lib/payslip";
+import { payslipToPdfBase64 } from "../lib/payslipPdf";
 
 const NOW = new Date();
 
@@ -30,6 +31,7 @@ export default function PayrollPage() {
   const [editTarget, setEditTarget] = useState<Payslip | null>(null);
   const [preview, setPreview] = useState<Payslip | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [sendingId, setSendingId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isAdmin) return; // /employees 는 ADMIN 전용 — 직원은 호출하지 않음(403 방지).
@@ -87,6 +89,40 @@ export default function PayrollPage() {
       setList((prev) => prev.filter((x) => x.id !== p.id));
     } finally {
       setBusyId(null);
+    }
+  }
+
+  // 명세서를 PDF 로 만들어 직원 계정 이메일로 발송. 클라에서 PDF 렌더 → 서버가 SES 첨부.
+  async function sendMail(p: Payslip) {
+    const to = p.employee?.email;
+    if (!to) {
+      await alertAsync({ title: "발송 불가", description: "직원 계정 이메일이 없어요." });
+      return;
+    }
+    const ok = await confirmAsync({
+      title: "급여명세서 메일 발송",
+      description: `${p.employeeName} (${to})에게 ${p.year}년 ${p.month}월 명세서를 PDF로 발송할까요?`,
+      confirmLabel: "발송",
+      cancelLabel: "취소",
+    });
+    if (!ok) return;
+    setSendingId(p.id);
+    try {
+      const pdfBase64 = await payslipToPdfBase64(p);
+      const r = await api<{ payslip: Payslip }>(`/api/payslip/${p.id}/send`, {
+        method: "POST",
+        json: { pdfBase64 },
+      });
+      setList((prev) => prev.map((x) => (x.id === p.id ? r.payslip : x)));
+      setPreview((prev) => (prev && prev.id === p.id ? r.payslip : prev));
+      await alertAsync({ title: "발송 완료", description: `${p.employeeName}님에게 메일을 보냈어요.` });
+    } catch (e: any) {
+      await alertAsync({
+        title: "발송 실패",
+        description: e?.data?.error || e?.message || "잠시 후 다시 시도해주세요.",
+      });
+    } finally {
+      setSendingId(null);
     }
   }
 
@@ -166,6 +202,13 @@ export default function PayrollPage() {
                     <>
                       <button className="text-[12px] text-ink-600 hover:underline ml-3" onClick={() => { setEditTarget(p); setComposing(true); }}>수정</button>
                       <button
+                        className="text-[12px] text-brand-600 hover:underline ml-3 disabled:opacity-50"
+                        onClick={() => sendMail(p)}
+                        disabled={sendingId === p.id}
+                      >
+                        {sendingId === p.id ? "발송 중…" : (p.sentAt ? "재발송" : "메일 발송")}
+                      </button>
+                      <button
                         className="text-[12px] text-rose-500 hover:underline ml-3 disabled:opacity-50"
                         onClick={() => remove(p)}
                         disabled={busyId === p.id}
@@ -197,6 +240,7 @@ export default function PayrollPage() {
           payslip={preview}
           onClose={() => setPreview(null)}
           onEdit={isAdmin ? () => { setEditTarget(preview); setPreview(null); setComposing(true); } : undefined}
+          onSend={isAdmin ? () => sendMail(preview) : undefined}
         />
       )}
     </div>

--- a/server/src/lib/email.ts
+++ b/server/src/lib/email.ts
@@ -1,4 +1,4 @@
-import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
+import { SESClient, SendEmailCommand, SendRawEmailCommand } from "@aws-sdk/client-ses";
 
 /**
  * 메일 발송 헬퍼 — AWS SES 사용.
@@ -64,6 +64,148 @@ export async function sendEmail(payload: EmailPayload): Promise<{ ok: boolean; m
     logFallback(payload, `SES error: ${e?.message ?? String(e)}`);
     return { ok: false, reason: e?.message ?? String(e) };
   }
+}
+
+export type EmailAttachment = {
+  /** ASCII 파일명 권장 — 비-ASCII 는 안전 문자로 치환된다. */
+  filename: string;
+  /** 순수 base64(데이터 URI 접두어 없음). */
+  contentBase64: string;
+  /** MIME 타입 — 기본 application/pdf. */
+  contentType?: string;
+};
+
+/**
+ * 첨부 포함 메일 발송 — SendRawEmailCommand 로 직접 MIME 을 만들어 보낸다.
+ * 첨부가 없으면 일반 sendEmail 경로로 위임(코드 중복 없음).
+ * sendEmail 과 동일하게 실패해도 throw 하지 않고 {ok:false}; 본문은 절대 로그 안 함.
+ */
+export async function sendEmailWithAttachment(
+  payload: EmailPayload & { attachments?: EmailAttachment[] },
+): Promise<{ ok: boolean; messageId?: string; reason?: string }> {
+  const attachments = payload.attachments ?? [];
+  if (attachments.length === 0) return sendEmail(payload);
+
+  if (!FROM) {
+    logFallback(payload, "SES_FROM_ADDRESS 미설정");
+    return { ok: false, reason: "SES_FROM_ADDRESS not configured" };
+  }
+  try {
+    const raw = buildRawMime(FROM, payload, attachments);
+    const cmd = new SendRawEmailCommand({
+      Destinations: [payload.to],
+      RawMessage: { Data: new TextEncoder().encode(raw) },
+    });
+    const r = await ses().send(cmd);
+    return { ok: true, messageId: r.MessageId };
+  } catch (e: any) {
+    logFallback(payload, `SES raw error: ${e?.message ?? String(e)}`);
+    return { ok: false, reason: e?.message ?? String(e) };
+  }
+}
+
+/* ===== MIME 빌더 (첨부 메일용) ===== */
+
+const CRLF = "\r\n";
+
+function b64(s: string): string {
+  return Buffer.from(s, "utf8").toString("base64");
+}
+
+/** base64 문자열을 76자마다 CRLF 로 접는다(RFC 2045). */
+function foldBase64(s: string): string {
+  const lines: string[] = [];
+  for (let i = 0; i < s.length; i += 76) lines.push(s.slice(i, i + 76));
+  return lines.join(CRLF);
+}
+
+/**
+ * 헤더용 UTF-8 인코딩(RFC 2047 encoded-word).
+ * 멀티바이트 경계가 안 깨지게 ~45바이트 이하로 쪼개 각각 =?UTF-8?B?..?= 로.
+ */
+function encodeHeaderUtf8(s: string): string {
+  // 순수 ASCII 면 그대로(가독성).
+  if (/^[\x20-\x7E]*$/.test(s)) return s;
+  const enc = new TextEncoder();
+  const chunks: string[] = [];
+  let cur = "";
+  let curBytes = 0;
+  for (const ch of s) {
+    const n = enc.encode(ch).length;
+    if (curBytes + n > 45 && cur) {
+      chunks.push(cur);
+      cur = "";
+      curBytes = 0;
+    }
+    cur += ch;
+    curBytes += n;
+  }
+  if (cur) chunks.push(cur);
+  return chunks.map((c) => `=?UTF-8?B?${b64(c)}?=`).join(`${CRLF} `);
+}
+
+/** 첨부 파일명 — ASCII 안전 문자만. 경로/따옴표/제어문자 제거, 비면 기본값. */
+function sanitizeFilename(name: string): string {
+  const cleaned = name
+    .replace(/[\\/:*?"<>|\r\n\t]+/g, "_")
+    .replace(/[^\x20-\x7E]+/g, "")
+    .trim();
+  return cleaned || "attachment.pdf";
+}
+
+function buildRawMime(
+  from: string,
+  payload: EmailPayload,
+  attachments: EmailAttachment[],
+): string {
+  const rand = () => `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+  const mixed = `mixed_${rand()}`;
+  const alt = `alt_${rand()}`;
+
+  const head = [
+    `From: ${from}`,
+    `To: ${payload.to}`,
+    `Subject: ${encodeHeaderUtf8(payload.subject)}`,
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/mixed; boundary="${mixed}"`,
+  ].join(CRLF);
+
+  // 본문 파트 — html 있으면 alternative(text+html), 없으면 text 단독.
+  // 한글 본문 안전하게 base64 인코딩.
+  let bodyPart: string;
+  if (payload.html) {
+    bodyPart =
+      `Content-Type: multipart/alternative; boundary="${alt}"${CRLF}${CRLF}` +
+      `--${alt}${CRLF}` +
+      `Content-Type: text/plain; charset=UTF-8${CRLF}` +
+      `Content-Transfer-Encoding: base64${CRLF}${CRLF}` +
+      `${foldBase64(b64(payload.text))}${CRLF}${CRLF}` +
+      `--${alt}${CRLF}` +
+      `Content-Type: text/html; charset=UTF-8${CRLF}` +
+      `Content-Transfer-Encoding: base64${CRLF}${CRLF}` +
+      `${foldBase64(b64(payload.html))}${CRLF}${CRLF}` +
+      `--${alt}--`;
+  } else {
+    bodyPart =
+      `Content-Type: text/plain; charset=UTF-8${CRLF}` +
+      `Content-Transfer-Encoding: base64${CRLF}${CRLF}` +
+      foldBase64(b64(payload.text));
+  }
+
+  const segments: string[] = [head, "", `--${mixed}`, bodyPart];
+  for (const att of attachments) {
+    const ct = att.contentType || "application/pdf";
+    const name = sanitizeFilename(att.filename);
+    segments.push(`--${mixed}`);
+    segments.push(
+      `Content-Type: ${ct}; name="${name}"${CRLF}` +
+        `Content-Disposition: attachment; filename="${name}"${CRLF}` +
+        `Content-Transfer-Encoding: base64${CRLF}${CRLF}` +
+        foldBase64(att.contentBase64),
+    );
+  }
+  segments.push(`--${mixed}--`);
+  return segments.join(CRLF);
 }
 
 /**

--- a/server/src/routes/payslip.ts
+++ b/server/src/routes/payslip.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { Prisma } from "@prisma/client";
 import { prisma } from "../lib/db.js";
 import { requireAuth, requireAdmin, writeLog } from "../lib/auth.js";
+import { sendEmailWithAttachment } from "../lib/email.js";
 
 /* ===== 급여(임금)명세서 =====
  * - 작성·수정·삭제·목록(전체)·발송: ADMIN 전용.
@@ -274,6 +275,80 @@ router.delete("/:id", requireAdmin, async (req, res) => {
   });
   await writeLog(u.id, "PAYSLIP_DELETE", exist.id);
   res.json({ ok: true });
+});
+
+/* ===== 메일 발송 (ADMIN) =====
+ * 클라이언트가 명세서를 PDF(base64)로 렌더해 보내면, 서버는 직원 계정 이메일로 첨부 발송.
+ * PDF 는 클라가 만든다(서버에 Chromium/폰트 안 올리려고). 서버는 매직바이트/크기만 검증.
+ * 발송 성공 시에만 sentAt/sentTo 기록 — 실패 시 502, 상태 안 바꿈.
+ */
+const PDF_MAX_BYTES = 6_000_000; // 디코드 후 6MB 상한(전역 JSON 2mb 제한과 별개 안전망).
+
+const sendSchema = z.object({
+  // base64 는 원본보다 ~33% 크다. 6MB PDF ≈ 8MB base64.
+  pdfBase64: z.string().min(1).max(8_000_000),
+});
+
+function escHtml(s: unknown): string {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+router.post("/:id/send", requireAdmin, async (req, res) => {
+  const u = (req as any).user;
+  const parsed = sendSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+
+  const p = await prisma.payslip.findFirst({
+    where: { id: req.params.id, deletedAt: null },
+    select: PAYSLIP_SELECT,
+  });
+  if (!p) return res.status(404).json({ error: "not found" });
+
+  const to = p.employee?.email;
+  if (!to) return res.status(400).json({ error: "직원 계정 이메일이 없어요" });
+
+  // base64 → 버퍼. PDF 매직바이트("%PDF-")와 크기 검증으로 엉뚱한 첨부 차단.
+  const pdf = Buffer.from(parsed.data.pdfBase64, "base64");
+  if (pdf.length === 0 || pdf.length > PDF_MAX_BYTES) {
+    return res.status(400).json({ error: "PDF 크기가 올바르지 않아요" });
+  }
+  if (pdf.subarray(0, 5).toString("latin1") !== "%PDF-") {
+    return res.status(400).json({ error: "PDF 형식이 아니에요" });
+  }
+
+  const company = p.companyName || "주식회사 하이비츠";
+  const subject = `[${company}] ${p.year}년 ${p.month}월 급여명세서`;
+  const filename = `payslip_${p.year}_${String(p.month).padStart(2, "0")}.pdf`;
+  const text =
+    `${p.employeeName}님, ${p.year}년 ${p.month}월 급여명세서를 첨부드립니다.\n\n` +
+    `본 메일은 발신 전용입니다.\n${company}`;
+  const html =
+    `<div style="font-family:sans-serif;font-size:14px;color:#1F2937;line-height:1.6">` +
+    `<p>${escHtml(p.employeeName)}님, ${p.year}년 ${p.month}월 급여명세서를 첨부드립니다.</p>` +
+    `<p style="color:#6B7280;font-size:12px">본 메일은 발신 전용입니다.<br/>${escHtml(company)}</p>` +
+    `</div>`;
+
+  const result = await sendEmailWithAttachment({
+    to,
+    subject,
+    text,
+    html,
+    attachments: [{ filename, contentBase64: parsed.data.pdfBase64, contentType: "application/pdf" }],
+  });
+  if (!result.ok) {
+    return res.status(502).json({ error: "메일 발송에 실패했어요", reason: result.reason });
+  }
+
+  const updated = await prisma.payslip.update({
+    where: { id: p.id },
+    data: { sentAt: new Date(), sentTo: to },
+    select: PAYSLIP_SELECT,
+  });
+  await writeLog(u.id, "PAYSLIP_SEND", p.id, `${p.year}-${p.month} ${p.employeeName}`);
+  res.json({ payslip: updated });
 });
 
 export default router;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
급여명세서 기능의 마지막 조각 — 작성한 명세서를 **직원 계정 이메일로 PDF 첨부 발송**합니다. (급여명세서 PR 4/4: #174 서버 CRUD · #175 관리자 페이지 · #176 직원 열람 · 본 PR 발송)

- **클라이언트 PDF 생성** (`client/src/lib/payslipPdf.ts`): 미리보기와 동일한 `payslipInnerHTML` 을 화면 밖 컨테이너에 렌더 → `html2canvas` → `jsPDF`(A4) → base64. 서버(Fargate)에 Chromium/한글 폰트를 올리지 않으려고 PDF 는 클라에서 만들고, 미리보기와 같은 마크업을 재사용해 **화면 = PDF** 를 보장합니다. `jspdf`·`html2canvas` 는 동적 import 라 발송할 때만 로드되는 별도 청크입니다(`PayrollPage` 청크 27.6 kB 그대로 유지).
- **서버 첨부 발송** (`server/src/lib/email.ts`): `SendRawEmailCommand` 기반 `sendEmailWithAttachment` 추가. `multipart/mixed` + `multipart/alternative` MIME 을 직접 생성(제목 RFC 2047 encoded-word, 본문·첨부 base64). 기존 `sendEmail` 의 "본문은 로그에 안 남긴다" 정책 그대로 유지.
- **발송 라우트** (`server/src/routes/payslip.ts`): `POST /:id/send` (ADMIN 전용). PDF 매직바이트(`%PDF-`)·크기 검증 후 **직원 계정 이메일**(DB 값, 클라가 지정 못 함)로 발송. 성공 시에만 `sentAt`/`sentTo` 기록 + `PAYSLIP_SEND` 감사로그, SES 실패 시 502.
- **발송 UI**: 목록(`PayrollPage`)과 미리보기(`PayslipPreview`)에 관리자 "메일 발송 / 재발송" 버튼. 확인 모달 → PDF 생성 → 발송 → 목록·미리보기 `sentAt` 동기화.

## 운영 사전 조건 (SES)
런타임 발송에 필요 — 코드 외 인프라 설정입니다:
1. `SES_FROM_ADDRESS` 를 verified identity 로 설정
2. SES **Production access** (샌드박스에선 verified 수신자만)
3. Task Role 에 **`ses:SendRawEmail`** 권한 (기존 `ses:SendEmail` 에 더해)

## 안전성 메모
- 발송 경로는 **개발 환경에서 실제 SES 호출로 검증하지 못했습니다**(SES 자격증명 없음). 그래서 MIME 빌더를 RFC 준수로 보수적으로 작성하고, 실패해도 throw 하지 않고 502 로 떨어지게 했습니다. `sentAt` 은 성공 응답일 때만 기록됩니다.
- PDF base64 는 전역 `express.json({ limit: "2mb" })` 가 1차 게이트입니다. 1페이지 명세서 JPEG(품질 0.92)는 보통 수백 KB라 충분하며, 라우트에도 디코드 후 6MB·매직바이트 검증을 둡니다.

## Test plan
- [x] `client`: `tsc -b` + `vite build` 통과 (jspdf/html2canvas 가 lazy 청크로 분리됨 확인)
- [x] `server`: `tsc -b` 통과
- [ ] (운영) SES Production access + `ses:SendRawEmail` 부여 후 실제 수신 확인 — Gmail/Outlook 에서 PDF 첨부 열림, 한글 제목·본문 정상
- [ ] (운영) 발송 후 목록/미리보기에 "발송됨" 뱃지 + 시각 표시 확인

Closes #601

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #601
