### PR TITLE
🔀 :: (#604) 데스크톱 Touch ID 기기 목록이 개발자 콘솔 전체를 크래시시키던 문제

### DIFF
--- a/client/src/components/SuperStepUpGate.tsx
+++ b/client/src/components/SuperStepUpGate.tsx
@@ -502,7 +502,13 @@ function DesktopBiometricPanel({
                   )}
                 </div>
                 <div className="text-[10.5px] text-ink-400 tabular mt-0.5 truncate">
-                  ID {d.deviceId.slice(0, 8)}
+                  {/*
+                    서버는 보안상 deviceId 를 응답에서 제외한다(auth.ts: select 에 deviceId 없음
+                    — 세션 탈취 시 step-up 우회 악용 방지). 따라서 d.deviceId 는 항상 undefined 라
+                    여기서 .slice 하면 전체 게이트가 throw 했음. 감사 로그와 동일하게 행 id 앞 8자를
+                    식별자로 쓴다(서버: row.id.slice(0,8)).
+                  */}
+                  ID {d.id.slice(0, 8)}
                 </div>
               </div>
               <div className="text-[12px] text-ink-600 tabular">


### PR DESCRIPTION
## 증상
**데스크톱 Touch ID 기기 목록이 개발자 콘솔 전체를 크래시시키던 문제**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
서버는 보안상 /auth/desktop-biometric 응답에서 deviceId 를 제외한다(세션 탈취 시
step-up 우회 악용 방지 — auth.ts select 에 deviceId 없음). 그런데 클라이언트
DesktopBiometricPanel 은 d.deviceId.slice(0, 8) 로 항상 undefined 인 값을 slice 해
"Cannot read properties of undefined (reading 'slice')" 로 throw 했다.

이 패널은 게이트 인증 직후(nativeTouch=true, 데스크톱 앱) 상단에 렌더되어 탭 패널
바깥이라, 등록된 기기가 1개라도 있으면 개발자 콘솔 진입 시 화면 전체가 크래시했다.

식별자를 행 id 앞 8자(d.id.slice(0,8))로 교체 — 서버 감사 로그가 쓰는 식별자
(row.id.slice(0,8))와 동일하고 항상 존재한다.

참고: 같은 deviceId 제외로 enrolledHere(게이트)·"현재 기기" 배지도 항상 false 가
되는 기능 저하가 있으나, 크래시는 아니며 올바른 수정엔 서버측 isCurrent 플래그가
필요해 별도 처리.

## 수정
**작업 항목 (커밋 단위)**
- fix(superadmin): 데스크톱 Touch ID 기기 목록이 개발자 콘솔 전체를 크래시시키던 문제

**변경 대상 (1개 파일)**
- `client/src/components/SuperStepUpGate.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #180** ↔ **이슈 #604** 로 연결됩니다.

Closes #604
