### PR TITLE
🔀 :: (#605) 서비스 계정 URL 저장형 XSS 차단

### DIFF
--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -3,6 +3,7 @@ import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
+import { safeExternalUrl } from "../lib/safeUrl";
 
 /**
  * 서비스 계정 레지스트리 — 회사에서 쓰는 AWS/Vercel/GitHub/테스트 계정을 한 곳에 모으는 페이지.
@@ -741,9 +742,15 @@ function AccountCard({
             {a.url && (
               <div className="flex items-center gap-1.5 text-ink-700">
                 <span className="text-ink-400 w-14 flex-shrink-0">URL</span>
-                <a href={a.url} target="_blank" rel="noopener noreferrer" className="text-brand-600 hover:underline truncate">
-                  {a.url}
-                </a>
+                {/* href 는 http(s) 만 허용 — javascript:/data: 스킴 저장형 XSS 차단.
+                    안전하지 않으면 링크 대신 평문으로만 노출(텍스트는 React 가 escape). */}
+                {safeExternalUrl(a.url) ? (
+                  <a href={safeExternalUrl(a.url)!} target="_blank" rel="noopener noreferrer" className="text-brand-600 hover:underline truncate">
+                    {a.url}
+                  </a>
+                ) : (
+                  <span className="truncate text-ink-500" title={a.url}>{a.url}</span>
+                )}
               </div>
             )}
             <div className="flex items-center gap-1.5 text-ink-700">

--- a/server/src/routes/serviceAccount.ts
+++ b/server/src/routes/serviceAccount.ts
@@ -35,7 +35,10 @@ const baseSchema = z.object({
   serviceName: z.string().trim().min(1).max(80),
   category: z.enum(CATEGORIES).optional().default("OTHER"),
   loginId: z.string().trim().max(200).optional().nullable(),
-  url: z.string().trim().url().max(500).optional().nullable().or(z.literal("")),
+  // .url() 만으론 javascript:/data: 스킴이 통과한다(저장형 XSS). http(s) 만 허용하도록 refine.
+  url: z.string().trim().url().max(500)
+    .refine((u) => /^https?:\/\//i.test(u), { message: "http 또는 https URL 만 허용됩니다" })
+    .optional().nullable().or(z.literal("")),
   // 커스텀 로고 — 서버에 업로드된 /uploads/... 경로 (또는 외부 URL). 빈 문자열/ null 이면 자동 추측으로 되돌림.
   iconUrl: z.string().trim().max(500).optional().nullable().or(z.literal("")),
   iconShape: z.enum(["SQUIRCLE", "CIRCLE"]).optional(),


### PR DESCRIPTION
## 증상
**서비스 계정 URL 저장형 XSS 차단**

보안 취약점을 점검하고 보완합니다.

## 원인
z.string().url() 은 javascript:/data: 스킴을 통과시켜, 인증된 사용자가
scope:ALL 서비스 계정의 url 에 javascript: 페이로드를 저장하면 관리자가
링크를 클릭할 때 그 세션에서 스크립트가 실행되는 저장형 XSS 가 가능했다.

- 서버(serviceAccount.ts): url 스키마에 ^https?:// refine 추가 — 신규 저장 차단
- 클라(ServiceAccountsPage): href 렌더 전 safeExternalUrl 로 검증, 안전하지
  않으면 링크 대신 평문 표시 — 레거시 데이터까지 방어(이중 방어)

## 수정
**작업 항목 (커밋 단위)**
- fix(security): 서비스 계정 URL 저장형 XSS 차단 — http(s) 스킴만 허용

**변경 대상 (2개 파일)**
- `client/src/pages/ServiceAccountsPage.tsx`
- `server/src/routes/serviceAccount.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #181** ↔ **이슈 #605** 로 연결됩니다.

Closes #605
