### PR TITLE
🔀 :: (#606) 자동 퇴근 스케줄러 User 풀스캔 제거 — autoClockOutTime 인덱스

### DIFF
--- a/server/prisma/migrations/20260530000000_user_auto_clockout_index/migration.sql
+++ b/server/prisma/migrations/20260530000000_user_auto_clockout_index/migration.sql
@@ -1,0 +1,6 @@
+-- 자동 퇴근 스케줄러 성능 인덱스
+--
+-- jobs/autoClockOut.ts 의 tick() 이 매 60초 prisma.user.findMany({ where: { active, autoClockOutTime } })
+-- 를 실행하는데, User 에는 @unique(email) 외 인덱스가 없어 매 분 풀스캔(1440회/일)이 발생했다.
+-- autoClockOutTime 은 대부분 NULL 이라 인덱스 크기는 작고, 동등 조건이 인덱스 probe 로 떨어진다.
+CREATE INDEX "User_autoClockOutTime_idx" ON "User"("autoClockOutTime");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -106,6 +106,10 @@ model User {
   sessions                Session[]
   payslips                Payslip[]              @relation("PayslipEmployee")
   payslipsCreated         Payslip[]              @relation("PayslipCreatedBy")
+
+  // autoClockOut 스케줄러가 매 60초 where:{active, autoClockOutTime} 로 조회한다.
+  // 인덱스가 없으면 매 분 User 풀스캔(1440회/일). 대부분 null 이라 인덱스는 작게 유지된다.
+  @@index([autoClockOutTime])
 }
 
 /// 활성 로그인 세션 — JWT 만 쓸 땐 서버측 강제 로그아웃이 불가했음.


### PR DESCRIPTION
## 증상
**자동 퇴근 스케줄러 User 풀스캔 제거 — autoClockOutTime 인덱스**

성능을 개선합니다.

## 원인
jobs/autoClockOut.ts 의 tick() 이 매 60초 user.findMany({where:{active,
autoClockOutTime}}) 를 실행하는데 User 에 @unique(email) 외 인덱스가 없어
매 분 풀스캔(1440회/일)이 발생했다. 멀티 태스크면 그만큼 배가된다.

@@index([autoClockOutTime]) 추가 — 대부분 NULL 이라 인덱스는 작고 동등
조건이 probe 로 떨어진다.

## 수정
**작업 항목 (커밋 단위)**
- perf(server): 자동 퇴근 스케줄러 User 풀스캔 제거 — autoClockOutTime 인덱스

**변경 대상 (2개 파일)**
- `server/prisma/migrations/20260530000000_user_auto_clockout_index/migration.sql`
- `server/prisma/schema.prisma`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #182** ↔ **이슈 #606** 로 연결됩니다.

Closes #606
