### PR TITLE
🔀 :: (#607) 폴더 트리 탐색 풀스캔 제거 — Folder.parentId 인덱스

### DIFF
--- a/server/prisma/migrations/20260530010000_folder_parentid_index/migration.sql
+++ b/server/prisma/migrations/20260530010000_folder_parentid_index/migration.sql
@@ -1,0 +1,6 @@
+-- 폴더 트리 탐색 성능 인덱스
+--
+-- document.ts 의 collectFolderSubtree(BFS) 와 폴더 ZIP 다운로드 walk() 가
+-- prisma.folder.findMany({ where: { parentId } }) 를 트리 레벨/노드마다 호출한다.
+-- Folder 에는 @@index([projectId]) 만 있어 parentId 조회가 매번 풀스캔이었다.
+CREATE INDEX "Folder_parentId_idx" ON "Folder"("parentId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -737,6 +737,9 @@ model Folder {
   shareLinks FolderShareLink[]
 
   @@index([projectId])
+  // document.ts 의 폴더 서브트리 BFS(collectFolderSubtree) 와 ZIP walk() 가
+  // where:{parentId} 를 반복 조회한다. 인덱스가 없으면 트리 레벨마다 Folder 풀스캔.
+  @@index([parentId])
 }
 
 model Document {


### PR DESCRIPTION
## 증상
**폴더 트리 탐색 풀스캔 제거 — Folder.parentId 인덱스**

성능을 개선합니다.

## 원인
document.ts 의 collectFolderSubtree(BFS) 와 폴더 ZIP 다운로드 walk() 가
prisma.folder.findMany({ where: { parentId } }) 를 트리 레벨/노드마다 호출한다.
Folder 에는 @@index([projectId]) 만 있어 parentId 조회가 매번 풀스캔이었다.
@@index([parentId]) 추가로 자식 폴더 조회를 인덱스 probe 로 전환한다.

## 수정
**작업 항목 (커밋 단위)**
- perf(server): 폴더 트리 탐색 풀스캔 제거 — Folder.parentId 인덱스

**변경 대상 (2개 파일)**
- `server/prisma/migrations/20260530010000_folder_parentid_index/migration.sql`
- `server/prisma/schema.prisma`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #183** ↔ **이슈 #607** 로 연결됩니다.

Closes #607
