### PR TITLE
🔀 :: (#608) 채팅 패널 지연 로딩 — 초기 번들에서 highlight.js 분리

### DIFF
--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, lazy, Suspense } from "react";
 import { useLocation } from "react-router-dom";
 import { useNotifications } from "../notifications";
-import ChatMiniApp from "./ChatMiniApp";
+// highlight.js(~92KB) 등 무거운 의존성을 끌고오므로 초기 번들에서 분리한다.
+// 채팅 패널은 사용자가 처음 열 때(mounted=true) 비로소 마운트되므로 lazy 로딩이 안전.
+const ChatMiniApp = lazy(() => import("./ChatMiniApp"));
 
 /**
  * 우하단 플로팅 채팅 버튼 — 토스(Toss) 스타일 팝업.
@@ -215,7 +217,9 @@ export default function ChatFab() {
               background: C.surface,
             }}
           >
-            <ChatMiniApp active={open} onActiveRoomChange={setActiveRoom} createGroupRequestId={createReq} openRoomRequest={openRoomReq} />
+            <Suspense fallback={null}>
+              <ChatMiniApp active={open} onActiveRoomChange={setActiveRoom} createGroupRequestId={createReq} openRoomRequest={openRoomReq} />
+            </Suspense>
           </div>
         </div>
       )}


### PR DESCRIPTION
## 증상
**채팅 패널 지연 로딩 — 초기 번들에서 highlight.js 분리**

성능을 개선합니다.

## 원인
ChatFab 가 ChatMiniApp 을 정적 import 하면서 highlight.js(~92KB) 의존성이
초기 진입 청크에 포함됐다. 채팅 패널은 사용자가 처음 열 때만 마운트되므로
React.lazy + Suspense 로 전환해 초기 진입 청크를 305KB → 214KB 로 줄였다.
ChatMiniApp(82KB)·highlight-vendor(92KB) 는 채팅 첫 오픈 시점에 로드된다.

## 수정
**작업 항목 (커밋 단위)**
- perf(client): 채팅 패널 지연 로딩 — 초기 번들에서 highlight.js 분리

**변경 대상 (1개 파일)**
- `client/src/components/ChatFab.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #184** ↔ **이슈 #608** 로 연결됩니다.

Closes #608
