### PR TITLE
🔀 :: (#609) 채팅 검색 상관 서브쿼리 제거 — roomId IN 으로 전환

### DIFF
--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -258,6 +258,11 @@ router.get("/search", async (req, res) => {
   if (!q) return res.json({ hits: [] });
 
   const now = new Date();
+  // roomId IN (...) 로 방 소속을 거른다. room.members.some 은 메시지 행마다 평가되는
+  // correlated subquery 라 (roomId, createdAt) 인덱스를 못 쓰고 풀스캔에 가깝다.
+  // 내가 속한 방 id 를 먼저 뽑아 IN 으로 넘기면 인덱스 probe 로 떨어진다(search.ts 와 동일 패턴).
+  const myRoomMems = await prisma.roomMember.findMany({ where: { userId: u.id }, select: { roomId: true } });
+  const myRoomIds = myRoomMems.map((m) => m.roomId);
   const raw = await prisma.chatMessage.findMany({
     where: {
       deletedAt: null,
@@ -268,7 +273,7 @@ router.get("/search", async (req, res) => {
         { scheduledAt: { lte: now } },
         { senderId: u.id },
       ],
-      room: { members: { some: { userId: u.id } } },
+      roomId: { in: myRoomIds.length ? myRoomIds : ["__none__"] },
     },
     orderBy: { createdAt: "desc" },
     take: 80,


### PR DESCRIPTION
## 증상
**채팅 검색 상관 서브쿼리 제거 — roomId IN 으로 전환**

성능을 개선합니다.

## 원인
GET /chat/search 의 where 가 room.members.some({userId}) 를 썼는데, 이는
ChatMessage 행마다 평가되는 correlated subquery 라 (roomId, createdAt) 인덱스를
활용하지 못했다. 내가 속한 방 id 를 먼저 조회해 roomId IN (...) 으로 넘기면
인덱스 probe 로 떨어진다. search.ts 의 통합검색이 이미 쓰는 패턴과 동일하게 통일.

## 수정
**작업 항목 (커밋 단위)**
- perf(server): 채팅 검색 상관 서브쿼리 제거 — roomId IN 으로 전환

**변경 대상 (1개 파일)**
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #185** ↔ **이슈 #609** 로 연결됩니다.

Closes #609
