### PR TITLE
🔀 :: (#611) 일정 조회 무제한 fetch 방어 — take 상한 추가

### DIFF
--- a/server/src/routes/schedule.ts
+++ b/server/src/routes/schedule.ts
@@ -99,6 +99,10 @@ router.get("/", async (req, res) => {
   const events = await prisma.event.findMany({
     where,
     orderBy: { startAt: "asc" },
+    // from/to 는 선택값 — 클라이언트(SchedulePage·DashboardPage)는 항상 보내지만,
+    // 인증된 사용자가 둘 다 생략하면 가시 범위의 전체 이벤트가 무제한으로 내려간다.
+    // document.ts 의 take:500 과 동일한 방어적 상한 — 실제 달력 윈도우는 한참 밑.
+    take: 2000,
     include: {
       author: { select: { name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
       project: { select: { id: true, name: true, color: true } },


### PR DESCRIPTION
## 증상
**일정 조회 무제한 fetch 방어 — take 상한 추가**

성능을 개선합니다.

## 원인
GET /schedule 의 event.findMany 에 take 가 없어, from/to 를 모두 생략한
요청(클라이언트는 항상 보내지만 인증 사용자가 직접 호출 가능)은 가시 범위의
전체 이벤트를 무제한으로 반환했다. document.ts 의 take:500 과 동일한 방어적
상한(2000)을 둬 실제 달력 윈도우는 영향 없이 비정상 페이로드만 차단한다.

## 수정
**작업 항목 (커밋 단위)**
- perf(server): 일정 조회 무제한 fetch 방어 — take 상한 추가

**변경 대상 (1개 파일)**
- `server/src/routes/schedule.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #187** ↔ **이슈 #611** 로 연결됩니다.

Closes #611
