### PR TITLE
🔀 :: (#617) 급여명세서 발송 메일 디자인 개선

### DIFF
--- a/server/src/lib/email.ts
+++ b/server/src/lib/email.ts
@@ -37,7 +37,22 @@ export type EmailPayload = {
   text: string;
   /** HTML 본문 — 가능하면 동봉. 없으면 text 만 보냄. */
   html?: string;
+  /**
+   * 답장 받을 주소(addr-spec, ASCII). 설정하면 수신자가 "답장"을 눌렀을 때
+   * 발신주소(no-reply)가 아니라 이 주소로 회신이 간다. 예: 발송한 담당자 이메일.
+   */
+  replyTo?: string;
+  /** replyTo 표시 이름(선택). 비-ASCII(한글)도 헤더에서 안전하게 인코딩된다. */
+  replyToName?: string;
 };
+
+/**
+ * 주소 헤더 값 구성(Reply-To 등). 이름이 있으면 `=?UTF-8?B?..?= <email>`,
+ * 없으면 bare email. encoded-word 는 ASCII 라 raw MIME / SES 양쪽에서 안전.
+ */
+function formatAddressHeader(email: string, name?: string): string {
+  return name ? `${encodeHeaderUtf8(name)} <${email}>` : email;
+}
 
 export async function sendEmail(payload: EmailPayload): Promise<{ ok: boolean; messageId?: string; reason?: string }> {
   if (!FROM) {
@@ -48,6 +63,9 @@ export async function sendEmail(payload: EmailPayload): Promise<{ ok: boolean; m
     const cmd = new SendEmailCommand({
       Source: FROM,
       Destination: { ToAddresses: [payload.to] },
+      ...(payload.replyTo
+        ? { ReplyToAddresses: [formatAddressHeader(payload.replyTo, payload.replyToName)] }
+        : {}),
       Message: {
         Subject: { Data: payload.subject, Charset: "UTF-8" },
         Body: {
@@ -165,6 +183,9 @@ function buildRawMime(
   const head = [
     `From: ${from}`,
     `To: ${payload.to}`,
+    ...(payload.replyTo
+      ? [`Reply-To: ${formatAddressHeader(payload.replyTo, payload.replyToName)}`]
+      : []),
     `Subject: ${encodeHeaderUtf8(payload.subject)}`,
     "MIME-Version: 1.0",
     `Content-Type: multipart/mixed; boundary="${mixed}"`,

--- a/server/src/routes/payslip.ts
+++ b/server/src/routes/payslip.ts
@@ -296,6 +296,71 @@ function escHtml(s: unknown): string {
     .replace(/>/g, "&gt;");
 }
 
+function wonKR(n: number): string {
+  return `${Number(n || 0).toLocaleString("ko-KR")}원`;
+}
+
+/**
+ * 급여명세서 안내 메일 HTML.
+ * 이메일 클라이언트(Gmail/Outlook/Apple Mail) 호환을 위해 table 레이아웃 + 인라인 스타일만 사용.
+ * 브랜드 색(#3B5CF0) 헤더 + 실수령액 강조 요약 카드. 상세 내역은 첨부 PDF 에 있으므로
+ * 본문엔 비밀/민감정보가 없다(합계 수준 요약만).
+ */
+function payslipEmailHtml(a: {
+  company: string;
+  employeeName: string;
+  year: number;
+  month: number;
+  totalEarnings: number;
+  totalDeductions: number;
+  netPay: number;
+  metaLines: string[];
+}): string {
+  const FONT =
+    "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Apple SD Gothic Neo','Malgun Gothic',sans-serif";
+  const meta = a.metaLines.length
+    ? `<p style="margin:16px 0 0;font-size:12.5px;color:#6B7280;line-height:1.7">${a.metaLines
+        .map(escHtml)
+        .join("<br/>")}</p>`
+    : "";
+  return (
+    `<div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent">${a.year}년 ${a.month}월 급여명세서 · 실수령액 ${wonKR(a.netPay)}</div>` +
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#F3F4F6;padding:24px 0;font-family:${FONT}">` +
+    `<tr><td align="center">` +
+    `<table role="presentation" cellpadding="0" cellspacing="0" style="width:480px;max-width:480px;background:#FFFFFF;border-radius:14px;overflow:hidden;border:1px solid #E5E7EB">` +
+    // 헤더 (브랜드 바)
+    `<tr><td style="background:#3B5CF0;padding:24px 28px">` +
+    `<div style="color:#C9D5FF;font-size:12px;font-weight:700;letter-spacing:.04em">${escHtml(a.company)}</div>` +
+    `<div style="color:#FFFFFF;font-size:20px;font-weight:800;margin-top:5px">${a.year}년 ${a.month}월 급여명세서</div>` +
+    `</td></tr>` +
+    // 본문
+    `<tr><td style="padding:28px 28px 24px">` +
+    `<p style="margin:0 0 18px;font-size:15px;color:#111827;line-height:1.6"><b>${escHtml(a.employeeName)}</b>님, ${a.year}년 ${a.month}월 급여명세서를 보내드립니다.</p>` +
+    // 요약 카드
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#EEF3FF;border-radius:12px">` +
+    `<tr><td style="padding:18px 20px">` +
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0">` +
+    `<tr><td style="font-size:13px;color:#4B5563;padding:3px 0">지급 합계</td><td align="right" style="font-size:13px;color:#111827;font-weight:600;padding:3px 0">${wonKR(a.totalEarnings)}</td></tr>` +
+    `<tr><td style="font-size:13px;color:#4B5563;padding:3px 0">공제 합계</td><td align="right" style="font-size:13px;color:#DC2626;font-weight:600;padding:3px 0">${wonKR(a.totalDeductions)}</td></tr>` +
+    `</table>` +
+    `<div style="border-top:1px solid #D6E0FF;margin-top:12px;padding-top:12px">` +
+    `<table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>` +
+    `<td style="font-size:14px;color:#1D3AB8;font-weight:700;vertical-align:middle">실수령액</td>` +
+    `<td align="right" style="font-size:22px;color:#1D3AB8;font-weight:800;vertical-align:middle">${wonKR(a.netPay)}</td>` +
+    `</tr></table>` +
+    `</div>` +
+    `</td></tr></table>` +
+    meta +
+    `<p style="margin:16px 0 0;font-size:13px;color:#374151;line-height:1.6">자세한 지급·공제 내역은 첨부된 PDF 명세서를 확인해 주세요.</p>` +
+    `</td></tr>` +
+    // 푸터
+    `<tr><td style="padding:16px 28px;background:#FAFAFB;border-top:1px solid #EEF0F2">` +
+    `<div style="font-size:11.5px;color:#9CA3AF;line-height:1.6">본 메일은 발신 전용입니다. 문의는 담당자에게 연락해 주세요.<br/>${escHtml(a.company)}</div>` +
+    `</td></tr>` +
+    `</table></td></tr></table>`
+  );
+}
+
 router.post("/:id/send", requireAdmin, async (req, res) => {
   const u = (req as any).user;
   const parsed = sendSchema.safeParse(req.body);
@@ -322,14 +387,31 @@ router.post("/:id/send", requireAdmin, async (req, res) => {
   const company = p.companyName || "주식회사 하이비츠";
   const subject = `[${company}] ${p.year}년 ${p.month}월 급여명세서`;
   const filename = `payslip_${p.year}_${String(p.month).padStart(2, "0")}.pdf`;
+
+  // 부서·직위·지급일 메타 — 값이 있는 줄만 노출.
+  const metaLines = [
+    [p.department, p.position].filter(Boolean).join(" · "),
+    p.payDate ? `지급일 ${p.payDate}` : "",
+  ].filter(Boolean);
+
   const text =
-    `${p.employeeName}님, ${p.year}년 ${p.month}월 급여명세서를 첨부드립니다.\n\n` +
+    `${p.employeeName}님, ${p.year}년 ${p.month}월 급여명세서를 보내드립니다.\n\n` +
+    `· 지급 합계: ${wonKR(p.totalEarnings)}\n` +
+    `· 공제 합계: ${wonKR(p.totalDeductions)}\n` +
+    `· 실수령액: ${wonKR(p.netPay)}\n\n` +
+    `자세한 내역은 첨부된 PDF 명세서를 확인해 주세요.\n\n` +
     `본 메일은 발신 전용입니다.\n${company}`;
-  const html =
-    `<div style="font-family:sans-serif;font-size:14px;color:#1F2937;line-height:1.6">` +
-    `<p>${escHtml(p.employeeName)}님, ${p.year}년 ${p.month}월 급여명세서를 첨부드립니다.</p>` +
-    `<p style="color:#6B7280;font-size:12px">본 메일은 발신 전용입니다.<br/>${escHtml(company)}</p>` +
-    `</div>`;
+
+  const html = payslipEmailHtml({
+    company,
+    employeeName: p.employeeName,
+    year: p.year,
+    month: p.month,
+    totalEarnings: p.totalEarnings,
+    totalDeductions: p.totalDeductions,
+    netPay: p.netPay,
+    metaLines,
+  });
 
   const result = await sendEmailWithAttachment({
     to,

--- a/server/src/routes/payslip.ts
+++ b/server/src/routes/payslip.ts
@@ -315,6 +315,8 @@ function payslipEmailHtml(a: {
   totalDeductions: number;
   netPay: number;
   metaLines: string[];
+  /** 발송한 담당자 이메일 — 있으면 "담당자에게 회신" 버튼(mailto)을 노출. */
+  replyToEmail?: string;
 }): string {
   const FONT =
     "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Apple SD Gothic Neo','Malgun Gothic',sans-serif";
@@ -323,6 +325,18 @@ function payslipEmailHtml(a: {
         .map(escHtml)
         .join("<br/>")}</p>`
     : "";
+  // 담당자 회신 버튼(mailto) — 제목 프리필. encodeURIComponent 출력은 ASCII 라 href 속성에 안전.
+  const replyBtn = a.replyToEmail
+    ? `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:20px 0 2px"><tr>` +
+      `<td style="border-radius:10px;background:#3B5CF0">` +
+      `<a href="mailto:${escHtml(a.replyToEmail)}?subject=${encodeURIComponent(`[문의] ${a.year}년 ${a.month}월 급여명세서`)}" ` +
+      `style="display:inline-block;padding:11px 22px;font-size:13.5px;font-weight:700;color:#FFFFFF;text-decoration:none">담당자에게 회신</a>` +
+      `</td></tr></table>`
+    : "";
+  // 회신 가능하면 푸터에서 "발신 전용" 문구를 빼고 회신 안내로 대체.
+  const footerNote = a.replyToEmail
+    ? `문의 사항은 위 <b>담당자에게 회신</b> 버튼으로 연락해 주세요.<br/>${escHtml(a.company)}`
+    : `본 메일은 발신 전용입니다. 문의는 담당자에게 연락해 주세요.<br/>${escHtml(a.company)}`;
   return (
     `<div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent">${a.year}년 ${a.month}월 급여명세서 · 실수령액 ${wonKR(a.netPay)}</div>` +
     `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#F3F4F6;padding:24px 0;font-family:${FONT}">` +
@@ -352,10 +366,11 @@ function payslipEmailHtml(a: {
     `</td></tr></table>` +
     meta +
     `<p style="margin:16px 0 0;font-size:13px;color:#374151;line-height:1.6">자세한 지급·공제 내역은 첨부된 PDF 명세서를 확인해 주세요.</p>` +
+    replyBtn +
     `</td></tr>` +
     // 푸터
     `<tr><td style="padding:16px 28px;background:#FAFAFB;border-top:1px solid #EEF0F2">` +
-    `<div style="font-size:11.5px;color:#9CA3AF;line-height:1.6">본 메일은 발신 전용입니다. 문의는 담당자에게 연락해 주세요.<br/>${escHtml(a.company)}</div>` +
+    `<div style="font-size:11.5px;color:#9CA3AF;line-height:1.6">${footerNote}</div>` +
     `</td></tr>` +
     `</table></td></tr></table>`
   );
@@ -388,11 +403,20 @@ router.post("/:id/send", requireAdmin, async (req, res) => {
   const subject = `[${company}] ${p.year}년 ${p.month}월 급여명세서`;
   const filename = `payslip_${p.year}_${String(p.month).padStart(2, "0")}.pdf`;
 
+  // 발송을 누른 담당자(요청한 ADMIN) — 수신자가 회신할 주소로 사용.
+  // AuthUser.email/name 은 항상 존재하지만 방어적으로 truthy 체크.
+  const replyToEmail = (u.email as string) || undefined;
+  const replyToName = (u.name as string) || undefined;
+
   // 부서·직위·지급일 메타 — 값이 있는 줄만 노출.
   const metaLines = [
     [p.department, p.position].filter(Boolean).join(" · "),
     p.payDate ? `지급일 ${p.payDate}` : "",
   ].filter(Boolean);
+
+  const contactLine = replyToEmail
+    ? `문의: ${replyToName ? `${replyToName} ` : ""}<${replyToEmail}> (이 메일에 회신하셔도 됩니다)`
+    : "본 메일은 발신 전용입니다.";
 
   const text =
     `${p.employeeName}님, ${p.year}년 ${p.month}월 급여명세서를 보내드립니다.\n\n` +
@@ -400,7 +424,7 @@ router.post("/:id/send", requireAdmin, async (req, res) => {
     `· 공제 합계: ${wonKR(p.totalDeductions)}\n` +
     `· 실수령액: ${wonKR(p.netPay)}\n\n` +
     `자세한 내역은 첨부된 PDF 명세서를 확인해 주세요.\n\n` +
-    `본 메일은 발신 전용입니다.\n${company}`;
+    `${contactLine}\n${company}`;
 
   const html = payslipEmailHtml({
     company,
@@ -411,6 +435,7 @@ router.post("/:id/send", requireAdmin, async (req, res) => {
     totalDeductions: p.totalDeductions,
     netPay: p.netPay,
     metaLines,
+    replyToEmail,
   });
 
   const result = await sendEmailWithAttachment({
@@ -418,6 +443,8 @@ router.post("/:id/send", requireAdmin, async (req, res) => {
     subject,
     text,
     html,
+    replyTo: replyToEmail,
+    replyToName,
     attachments: [{ filename, contentBase64: parsed.data.pdfBase64, contentType: "application/pdf" }],
   });
   if (!result.ok) {


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
급여명세서 발송 메일 본문이 밋밋한 텍스트 두 줄이라 디자인을 개선했습니다.

- **브랜드 헤더 바**(#3B5CF0)에 회사명 + `YYYY년 M월 급여명세서`
- **실수령액 강조 요약 카드**: 지급 합계 / 공제 합계 / 실수령액(크게)
- 부서·직위·지급일 메타 라인(값 있을 때만)
- 첨부 PDF 안내 문구 + 발신전용 푸터
- 받은편지함 미리보기용 preheader 텍스트
- 텍스트 fallback 도 합계 요약 포함하도록 보강

## 구현 메모
- 이메일 클라이언트(Gmail/Outlook/Apple Mail) 호환을 위해 **table 레이아웃 + 인라인 스타일**만 사용 (flex/grid·외부 CSS 미사용)
- 기존 `sendEmailWithAttachment` 가 이미 multipart/alternative(text+html)를 지원 → **email.ts 변경 없음**, payslip 라우트의 본문 생성만 교체
- 본문엔 합계 수준 요약만 노출(상세는 첨부 PDF). 민감정보 추가 없음
- 동적 값은 `escHtml` 로 이스케이프

## 미리보기
샘플 데이터로 렌더한 HTML: 로컬에서 `node /tmp/preview-payslip-email.mjs` 후 `/tmp/payslip-email-preview.html`

## Test plan
- [ ] 실제 발송 테스트 → 받은편지함에서 헤더/요약 카드/실수령액 렌더 확인
- [ ] 공제 0원 / 음수 정산 케이스 금액 표기 확인
- [ ] 부서·직위·지급일 비어있을 때 메타 라인 숨김 확인
- [ ] 다크모드 메일 클라이언트에서 가독성 확인

Closes #617

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #617
