### PR TITLE
🔀 :: (#618) 개발자(superAdmin) 회사 관리 접근 + 사이드바·뒤로가기 개선

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -77,7 +77,8 @@ function SuperOnly({ children }: { children: React.ReactNode }) {
 
 function PlatformOnly({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
-  if (!user?.platformAdmin) return <Navigate to="/" replace />;
+  // 개발자(superAdmin)도 회사 관리에 접근 가능 — 최상위 권한이므로 항상 허용.
+  if (!user?.platformAdmin && !user?.superAdmin) return <Navigate to="/" replace />;
   return <>{children}</>;
 }
 

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -32,8 +32,10 @@ export default function ConsoleLayout() {
   const { user, logout } = useAuth();
   const nav = useNavigate();
 
+  // 회사 관리는 플랫폼 운영자뿐 아니라 개발자(superAdmin)에게도 노출 — 개발자는 최상위
+  // 권한이므로 테넌트 가입 승인까지 직접 처리할 수 있어야 한다.
   const links: ConsoleLink[] = [
-    user?.platformAdmin && { to: "/platform", label: "회사 관리", desc: "테넌트 가입·승인·정지", icon: CompanyIcon },
+    (user?.platformAdmin || user?.superAdmin) && { to: "/platform", label: "회사 관리", desc: "테넌트 가입·승인·정지", icon: CompanyIcon },
     user?.superAdmin && { to: "/super-admin", label: "개발자 콘솔", desc: "로그·감사·시스템 설정", icon: TerminalIcon },
   ].filter(Boolean) as ConsoleLink[];
 
@@ -70,6 +72,20 @@ export default function ConsoleLayout() {
           </span>
         </div>
 
+        {hasCompany && (
+          <div className="px-2 pt-3 flex-shrink-0">
+            <button
+              onClick={() => nav("/")}
+              className="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-[12.5px] font-semibold text-white/75 bg-white/[0.06] hover:bg-white/[0.12] hover:text-white transition"
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="m12 19-7-7 7-7" /><path d="M19 12H5" />
+              </svg>
+              서비스로 돌아가기
+            </button>
+          </div>
+        )}
+
         <nav className="flex-1 overflow-y-auto px-2 py-3 space-y-1">
           {links.map((l) => (
             <NavLink key={l.to} to={l.to} className={({ isActive }) => itemClass(isActive)}>
@@ -92,17 +108,6 @@ export default function ConsoleLayout() {
           className="border-t border-white/10 px-2 py-2 flex-shrink-0 space-y-1"
           style={{ paddingBottom: "max(8px, env(safe-area-inset-bottom))" }}
         >
-          {hasCompany && (
-            <button
-              onClick={() => nav("/")}
-              className="w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-[12.5px] font-semibold text-white/60 hover:bg-white/[0.06] hover:text-white/90 transition"
-            >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="m12 19-7-7 7-7" /><path d="M19 12H5" />
-              </svg>
-              서비스로 돌아가기
-            </button>
-          )}
           <div className="flex items-center gap-2 px-3 py-2">
             <div
               className="avatar avatar-sm flex-shrink-0"

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -224,10 +224,15 @@ export function requireSuperAdmin(req: Request, res: Response, next: NextFunctio
   next();
 }
 
-/** 플랫폼 운영자 전용 — 회사 가입 승인 등 테넌트를 가로지르는 최상위 작업. */
+/**
+ * 플랫폼 운영(회사 가입 승인 등 테넌트를 가로지르는 최상위 작업) 접근 가드.
+ * 플랫폼 운영자(platformAdmin)뿐 아니라 개발자(superAdmin)도 허용한다 — 개발자는
+ * 최상위 권한이므로 회사 관리 콘솔을 항상 볼 수 있어야 한다. (스코프 우회는 라우터에서
+ * runUnscoped 로 명시 처리 — superAdmin 세션은 평소 자기 회사로 스코프되기 때문.)
+ */
 export function requirePlatformAdmin(req: Request, res: Response, next: NextFunction) {
   const u = (req as any).user as AuthUser | undefined;
-  if (!u || !u.platformAdmin) return res.status(403).json({ error: "forbidden" });
+  if (!u || (!u.platformAdmin && !u.superAdmin)) return res.status(403).json({ error: "forbidden" });
   next();
 }
 

--- a/server/src/routes/platform.ts
+++ b/server/src/routes/platform.ts
@@ -2,14 +2,18 @@ import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, requirePlatformAdmin, writeLog } from "../lib/auth.js";
+import { runUnscoped } from "../lib/tenant.js";
 
 /**
- * 플랫폼 운영자 전용 API — 회사(테넌트) 가입 승인 워크플로우.
- * 모든 라우트는 platformAdmin 만 접근 가능하며 테넌트를 가로질러 동작한다.
- * (회사 내부 admin/superAdmin 과 구분 — 그쪽은 /api/admin.)
+ * 플랫폼 운영 API — 회사(테넌트) 가입 승인 워크플로우.
+ * platformAdmin 또는 개발자(superAdmin)만 접근하며 테넌트를 가로질러 동작한다.
+ * (회사 내부 admin 과 구분 — 그쪽은 /api/admin.)
  */
 const router = Router();
-router.use(requireAuth, requirePlatformAdmin);
+// 이 라우트들은 본질적으로 전 회사를 가로지른다(목록·승인 등). platformAdmin 은 세션
+// 자체가 스코프 우회지만 superAdmin 은 평소 자기 회사로 스코프되므로, 이 구간만 명시적으로
+// 스코프를 해제해 모든 회사 데이터를 읽고 쓸 수 있게 한다.
+router.use(requireAuth, requirePlatformAdmin, (_req, _res, next) => runUnscoped(() => next()));
 
 const VALID_STATUS = ["PENDING", "ACTIVE", "SUSPENDED", "REJECTED"] as const;
 


### PR DESCRIPTION
## 증상
**개발자(superAdmin) 회사 관리 접근 + 사이드바·뒤로가기 개선**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
플랫폼 운영 API(/api/platform)가 platformAdmin 만 허용해, 개발자(superAdmin)
계정으로는 회사 가입 승인·관리에 접근조차 못 했다. superAdmin 은 최상위 권한이므로
회사 관리까지 직접 처리할 수 있어야 한다.

- requirePlatformAdmin 가드를 platformAdmin || superAdmin 허용으로 확장
- 플랫폼 라우트를 runUnscoped 로 감싸 전 회사 데이터를 읽고 쓰게 함.
  platformAdmin 은 세션 자체가 스코프 우회지만 superAdmin 은 평소 자기 회사로
  스코프되므로(전역 우회 시 일반 서비스 화면에서 타 회사 데이터 노출 위험),
  이 구간만 명시적으로 해제한다.

## 수정
**작업 항목 (커밋 단위)**
- fix(server): 개발자(superAdmin)도 회사 관리 API 접근 — 플랫폼 라우트 크로스테넌트
- fix(client): 운영 콘솔에 회사 관리 노출 + 뒤로가기 버튼 상단 배치

**변경 대상 (4개 파일)**
- `client/src/App.tsx`
- `client/src/components/ConsoleLayout.tsx`
- `server/src/lib/auth.ts`
- `server/src/routes/platform.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #194** ↔ **이슈 #618** 로 연결됩니다.

Closes #618
