### PR TITLE
🔀 :: (#196) 사이드바·콘솔 브랜드 로고 교체 + 총관리자 로그인 리다이렉트

### DIFF
--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -28,7 +28,7 @@ type Ctx = {
   user: User | null;
   impersonator: Impersonator | null;
   loading: boolean;
-  login: (email: string, password: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<User>;
   signup: (data: { inviteKey: string; email: string; name: string; password: string }) => Promise<void>;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
@@ -67,6 +67,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // 섬광처럼 보이는 것을 방지. logout 에서와 동일하게 세션 캐시를 싹 비움.
     clearApiCache();
     setUser(res.user);
+    return res.user;
   };
 
   const signup = async (d: { inviteKey: string; email: string; name: string; password: string }) => {

--- a/client/src/components/BrandLockup.tsx
+++ b/client/src/components/BrandLockup.tsx
@@ -21,10 +21,13 @@ export default function BrandLockup({
   height = 30,
   tone,
   subtitle = true,
+  admin = false,
 }: {
   height?: number;
   tone?: "light" | "dark";
   subtitle?: boolean;
+  /** 관리자 콘솔 변형 — 워드마크 옆 ADMIN 배지 + "관리자 콘솔" 서브. */
+  admin?: boolean;
 }) {
   const { resolved } = useTheme();
   const onDark = tone ? tone === "dark" : resolved === "dark";
@@ -36,8 +39,17 @@ export default function BrandLockup({
   const subSize = Math.max(7, Math.round(height * 0.2));
   const gap = Math.round(height * 0.34);
 
+  // 관리자 콘솔 변형 — 디자이너 admin export(HiNest-Admin-라이트/다크.svg)의
+  // ADMIN 배지 색·서브 문구를 tone 에 맞춰 재현. 작은 사이즈에서도 읽히도록
+  // 배지 글자는 비율 환산 + 최소 8px 하한.
+  const subText = admin ? "관리자 콘솔 · Admin Console" : "Workplace Platform";
+  const badgeFont = Math.max(8, Math.round(wordSize * 0.46));
+  const badge = onDark
+    ? { bg: "rgba(110,137,255,0.18)", border: "rgba(165,184,255,0.45)", text: "#A5B8FF" }
+    : { bg: "rgba(59,92,240,0.10)", border: "rgba(59,92,240,0.30)", text: "#1E37B8" };
+
   return (
-    <div className="inline-flex items-center select-none" style={{ gap }} aria-label="HiNest">
+    <div className="inline-flex items-center select-none" style={{ gap }} aria-label={admin ? "HiNest 관리자 콘솔" : "HiNest"}>
       {/* ── 블루 타일 + 흰 마크 (원본 좌표 보존, 상하좌우 여백만 크롭) ── */}
       <svg
         width={height}
@@ -82,31 +94,52 @@ export default function BrandLockup({
         </g>
       </svg>
 
-      {/* ── 워드마크 + 서브 (브랜드 폰트로 렌더) ── */}
+      {/* ── 워드마크 (+ ADMIN 배지) + 서브 (브랜드 폰트로 렌더) ── */}
       <span className="flex flex-col" style={{ lineHeight: 1 }}>
-        <span
-          style={{
-            fontFamily: '"Pretendard Variable", Pretendard, -apple-system, sans-serif',
-            fontWeight: 800,
-            fontSize: wordSize,
-            letterSpacing: "-0.03em",
-            color: textColor,
-          }}
-        >
-          HiNest
+        <span className="flex items-center" style={{ gap: Math.round(wordSize * 0.36) }}>
+          <span
+            style={{
+              fontFamily: '"Pretendard Variable", Pretendard, -apple-system, sans-serif',
+              fontWeight: 800,
+              fontSize: wordSize,
+              letterSpacing: "-0.03em",
+              color: textColor,
+            }}
+          >
+            HiNest
+          </span>
+          {admin && (
+            <span
+              style={{
+                fontFamily: '"Pretendard Variable", Pretendard, sans-serif',
+                fontWeight: 700,
+                fontSize: badgeFont,
+                letterSpacing: "0.06em",
+                color: badge.text,
+                background: badge.bg,
+                border: `1px solid ${badge.border}`,
+                borderRadius: 999,
+                padding: `${Math.max(1, Math.round(badgeFont * 0.34))}px ${Math.round(badgeFont * 0.72)}px`,
+                lineHeight: 1,
+                whiteSpace: "nowrap",
+              }}
+            >
+              ADMIN
+            </span>
+          )}
         </span>
         {subtitle && (
           <span
             style={{
               fontFamily: '"JetBrains Mono", "SF Mono", Menlo, monospace',
               fontSize: subSize,
-              letterSpacing: "0.12em",
+              letterSpacing: admin ? "0.06em" : "0.12em",
               color: subColor,
               marginTop: Math.round(height * 0.12),
               whiteSpace: "nowrap",
             }}
           >
-            Workplace Platform
+            {subText}
           </span>
         )}
       </span>

--- a/client/src/components/BrandLockup.tsx
+++ b/client/src/components/BrandLockup.tsx
@@ -1,97 +1,115 @@
 import { useTheme } from "../theme";
 
 /**
- * BrandLockup — 새 HiNest 로고 (기하 마크 + "HiNest." 워드마크) 인라인 SVG.
+ * BrandLockup — HiNest 로고 (블루 타일 마크 + "HiNest" 워드마크 + "Workplace Platform" 서브).
  *
- * 디자이너가 준 light/dark export(HiNest-logo-light.svg / -dark.svg)를 인라인화한 것.
- * 두 파일의 차이는 ① 배경 사각형 색 ② 워드마크 글자/점 색뿐이라, 한 컴포넌트에서
- * 테마(resolved)로 색만 전환한다.
+ * 디자이너가 준 light/dark export(HiNest-라이트.svg / HiNest-다크.svg)를 인라인화한 것.
+ * 두 파일의 차이는 ① 배경 사각형 색 ② 워드마크/서브 글자색뿐이라, 한 컴포넌트에서
+ * 색만 전환한다.
  *
  * export 원본 대비 의도적으로 바꾼 점:
- *  - 배경 사각형 제거 → 사이드바에 투명하게 얹힘 (원본의 bg rect 는 export 미리보기용)
- *  - 워드마크가 원본에선 미정의 `.wm` 클래스에 의존해 깨지므로 브랜드 폰트(Pretendard)로 렌더
- *    (원본 파일 desc 의 "outline the text before production" 지침을 코드 렌더로 대체)
- *  - gradient id 는 페이지 내 충돌 방지를 위해 `hn-` 프리픽스
+ *  - 배경 사각형 제거 → 사이드바에 투명하게 얹힘 (원본 bg rect 는 export 미리보기용)
+ *  - 워드마크/서브가 원본에선 미정의 `.wm`/`.mono` 클래스에 의존해 깨지므로 브랜드 폰트
+ *    (Pretendard / JetBrains Mono)로 HTML 텍스트로 렌더 — SVG <text> 폭 추정 없이 안전
+ *  - gradient/filter id 는 페이지 충돌 방지로 `hn-` 프리픽스
+ *  - 타일·마크 폴리곤 좌표는 원본 그대로 보존
  *
- * 마크 폴리곤 좌표는 원본 그대로 보존.
+ * tone: 색 강제. 콘솔처럼 테마와 무관하게 항상 어두운 표면 위에 얹힐 땐 tone="dark".
+ *       미지정 시 현재 테마(resolved)를 따른다.
  */
-export default function BrandLockup({ height = 30 }: { height?: number }) {
+export default function BrandLockup({
+  height = 30,
+  tone,
+  subtitle = true,
+}: {
+  height?: number;
+  tone?: "light" | "dark";
+  subtitle?: boolean;
+}) {
   const { resolved } = useTheme();
-  const isDark = resolved === "dark";
-  const textColor = isDark ? "#FFFFFF" : "#0C1020";
-  const dotColor = isDark ? "#A5B8FF" : "#3B5CF0";
+  const onDark = tone ? tone === "dark" : resolved === "dark";
+  const textColor = onDark ? "#FFFFFF" : "#0C1020";
+  const subColor = onDark ? "rgba(255,255,255,0.6)" : "#5A6072";
 
-  // 원본 viewBox 1080×320 에서 상하 여백만 잘라 헤더에 꽉 차게. 가로는 워드마크
-  // 클리핑 방지를 위해 그대로 유지.
-  const vbX = 0;
-  const vbY = 56;
-  const vbW = 1080;
-  const vbH = 236;
-  const width = (height * vbW) / vbH;
+  // 타일(188) 기준 비율을 원본(워드마크 104 / 서브 35 / 타일 188)에 맞춰 환산.
+  const wordSize = Math.round(height * 0.55);
+  const subSize = Math.max(7, Math.round(height * 0.2));
+  const gap = Math.round(height * 0.34);
 
   return (
-    <svg
-      width={width}
-      height={height}
-      viewBox={`${vbX} ${vbY} ${vbW} ${vbH}`}
-      xmlns="http://www.w3.org/2000/svg"
-      role="img"
-      aria-label="HiNest"
-      className="select-none"
-    >
-      <defs>
-        <linearGradient id="hn-bl1" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#4A7FFF" />
-          <stop offset="100%" stopColor="#1E4FD4" />
-        </linearGradient>
-        <linearGradient id="hn-bl2" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="#5B8DFF" />
-          <stop offset="100%" stopColor="#2A5DE8" />
-        </linearGradient>
-        <linearGradient id="hn-bl-light" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#8FB3FF" />
-          <stop offset="100%" stopColor="#5B8DFF" />
-        </linearGradient>
-        <linearGradient id="hn-bl-dark" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#2A5DE8" />
-          <stop offset="100%" stopColor="#1A3FB5" />
-        </linearGradient>
-      </defs>
-
-      {/* ── 기하 마크 (원본 좌표 보존) ── */}
-      <g transform="translate(40,40)">
-        <g transform="translate(120,120) scale(2.0)">
-          <polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="url(#hn-bl-dark)" />
-          <polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="url(#hn-bl2)" />
-          <polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="url(#hn-bl-light)" />
-          <polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="url(#hn-bl1)" />
-          <polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="url(#hn-bl-dark)" />
-          <polygon points="-12,10 12,5 12,24 -12,29" fill="url(#hn-bl-light)" />
-          <polygon points="-12,10 12,5 12,24 -12,29" fill="url(#hn-bl2)" opacity="0.55" />
-          <polygon points="38,-33 58,-18 58,62 38,52" fill="url(#hn-bl-dark)" />
-          <polygon points="12,-33 38,-33 38,52 12,52" fill="url(#hn-bl2)" />
-          <polygon points="38,-33 58,-18 32,-18 12,-33" fill="url(#hn-bl-light)" />
-          <polygon points="12,-33 38,-33 25,-47 0,-47" fill="url(#hn-bl1)" />
-          <polygon points="38,-33 58,-18 45,-33 25,-47" fill="url(#hn-bl-dark)" />
-          <rect x="-32" y="-13" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-          <rect x="-32" y="15" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-          <rect x="21" y="-13" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-          <rect x="21" y="15" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-        </g>
-      </g>
-
-      {/* ── 워드마크 (브랜드 폰트로 렌더) ── */}
-      <text
-        x="320"
-        y="220"
-        fontFamily='"Pretendard Variable", Pretendard, -apple-system, sans-serif'
-        fontWeight={800}
-        fontSize={196}
-        letterSpacing="-0.04em"
+    <div className="inline-flex items-center select-none" style={{ gap }} aria-label="HiNest">
+      {/* ── 블루 타일 + 흰 마크 (원본 좌표 보존, 상하좌우 여백만 크롭) ── */}
+      <svg
+        width={height}
+        height={height}
+        viewBox="112 122 224 224"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-hidden
+        style={{ flexShrink: 0 }}
       >
-        <tspan fill={textColor}>HiNest</tspan>
-        <tspan fill={dotColor}>.</tspan>
-      </text>
-    </svg>
+        <defs>
+          <linearGradient id="hn-tile" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#5B8DFF" />
+            <stop offset="55%" stopColor="#3B5CF0" />
+            <stop offset="100%" stopColor="#1E4FD4" />
+          </linearGradient>
+          <filter id="hn-tshadow" x="-30%" y="-30%" width="160%" height="160%">
+            <feDropShadow dx="0" dy="9" stdDeviation="14" floodColor="#1E37B8" floodOpacity="0.42" />
+          </filter>
+        </defs>
+
+        <rect x="130" y="136" width="188" height="188" rx="44" fill="url(#hn-tile)" filter="url(#hn-tshadow)" />
+        <rect x="130" y="136" width="188" height="188" rx="44" fill="none" stroke="#FFFFFF" strokeOpacity="0.18" strokeWidth="1.5" />
+
+        <g transform="translate(224,227.6262626) scale(0.94949494)">
+          <polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="#FFFFFF" opacity="0.55" />
+          <polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="#FFFFFF" opacity="0.82" />
+          <polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="#FFFFFF" />
+          <polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="#FFFFFF" opacity="0.92" />
+          <polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="#FFFFFF" opacity="0.55" />
+          <polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" />
+          <polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" opacity="0.4" />
+          <polygon points="38,-33 58,-18 58,62 38,52" fill="#FFFFFF" opacity="0.55" />
+          <polygon points="12,-33 38,-33 38,52 12,52" fill="#FFFFFF" opacity="0.82" />
+          <polygon points="38,-33 58,-18 32,-18 12,-33" fill="#FFFFFF" />
+          <polygon points="12,-33 38,-33 25,-47 0,-47" fill="#FFFFFF" opacity="0.92" />
+          <polygon points="38,-33 58,-18 45,-33 25,-47" fill="#FFFFFF" opacity="0.55" />
+          <rect x="-32" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5" />
+          <rect x="-32" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5" />
+          <rect x="21" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5" />
+          <rect x="21" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5" />
+        </g>
+      </svg>
+
+      {/* ── 워드마크 + 서브 (브랜드 폰트로 렌더) ── */}
+      <span className="flex flex-col" style={{ lineHeight: 1 }}>
+        <span
+          style={{
+            fontFamily: '"Pretendard Variable", Pretendard, -apple-system, sans-serif',
+            fontWeight: 800,
+            fontSize: wordSize,
+            letterSpacing: "-0.03em",
+            color: textColor,
+          }}
+        >
+          HiNest
+        </span>
+        {subtitle && (
+          <span
+            style={{
+              fontFamily: '"JetBrains Mono", "SF Mono", Menlo, monospace',
+              fontSize: subSize,
+              letterSpacing: "0.12em",
+              color: subColor,
+              marginTop: Math.round(height * 0.12),
+              whiteSpace: "nowrap",
+            }}
+          >
+            Workplace Platform
+          </span>
+        )}
+      </span>
+    </div>
   );
 }

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
+import BrandLockup from "./BrandLockup";
 
 /**
  * 운영 콘솔 셸 — 총관리자(개발자)/플랫폼 운영자 전용. 회사 앱(AppLayout)과
@@ -32,6 +34,20 @@ export default function ConsoleLayout() {
   const { user, logout } = useAuth();
   const nav = useNavigate();
 
+  // macOS Electron 창모드에선 신호등 버튼이 좌상단 콘텐츠를 침범한다 — AppLayout 과
+  // 동일하게 상단에 드래그 가능한 28px 여백을 두어 로고/본문이 가려지지 않게 한다.
+  // 전체화면에선 신호등이 숨으므로 여백 제거.
+  const isMacDesktop = !!window.hinest?.isDesktop && window.hinest?.platform === "darwin";
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  useEffect(() => {
+    if (!isMacDesktop || !window.hinest?.onFullscreenChange) return;
+    const off = window.hinest.onFullscreenChange((fs) => setIsFullscreen(fs));
+    return () => {
+      try { off?.(); } catch {}
+    };
+  }, [isMacDesktop]);
+  const showTitlebarSpace = isMacDesktop && !isFullscreen;
+
   // 회사 관리는 플랫폼 운영자뿐 아니라 개발자(superAdmin)에게도 노출 — 개발자는 최상위
   // 권한이므로 테넌트 가입 승인까지 직접 처리할 수 있어야 한다.
   const links: ConsoleLink[] = [
@@ -62,8 +78,18 @@ export default function ConsoleLayout() {
         className="hidden md:flex w-[252px] flex-col flex-shrink-0 bg-ink-900 text-white"
         style={{ paddingTop: "env(safe-area-inset-top)" }}
       >
+        {/* 신호등 영역용 드래그 가능 상단바 — 사이드바 배경과 통일 */}
+        {showTitlebarSpace && (
+          <div
+            style={{
+              height: 28,
+              // @ts-expect-error drag region
+              WebkitAppRegion: "drag",
+            }}
+          />
+        )}
         <div className="px-5 h-[52px] flex items-center gap-2 border-b border-white/10 flex-shrink-0">
-          <span className="text-[15px] font-extrabold tracking-tight">HiNest</span>
+          <BrandLockup tone="dark" height={24} subtitle={false} />
           <span
             className="text-[10px] font-bold px-1.5 py-0.5 rounded-md uppercase tracking-wide"
             style={{ background: "var(--c-brand)", color: "#fff" }}
@@ -130,12 +156,23 @@ export default function ConsoleLayout() {
 
       {/* ===== 모바일 상단바 + 본문 ===== */}
       <div className="flex-1 min-w-0 flex flex-col">
+        {/* 신호등 영역용 드래그 가능 상단바 — 본문 배경과 통일 */}
+        {showTitlebarSpace && (
+          <div
+            className="bg-ink-50 flex-shrink-0"
+            style={{
+              height: 28,
+              // @ts-expect-error drag region
+              WebkitAppRegion: "drag",
+            }}
+          />
+        )}
         <header
           className="md:hidden bg-ink-900 text-white flex-shrink-0"
           style={{ paddingTop: "env(safe-area-inset-top)" }}
         >
           <div className="h-[48px] px-4 flex items-center gap-2">
-            <span className="text-[14px] font-extrabold tracking-tight">HiNest</span>
+            <BrandLockup tone="dark" height={22} subtitle={false} />
             <span className="text-[9.5px] font-bold px-1.5 py-0.5 rounded-md uppercase" style={{ background: "var(--c-brand)" }}>
               운영 콘솔
             </span>

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -88,14 +88,8 @@ export default function ConsoleLayout() {
             }}
           />
         )}
-        <div className="px-5 h-[52px] flex items-center gap-2 border-b border-white/10 flex-shrink-0">
-          <BrandLockup tone="dark" height={24} subtitle={false} />
-          <span
-            className="text-[10px] font-bold px-1.5 py-0.5 rounded-md uppercase tracking-wide"
-            style={{ background: "var(--c-brand)", color: "#fff" }}
-          >
-            운영 콘솔
-          </span>
+        <div className="px-5 h-[52px] flex items-center border-b border-white/10 flex-shrink-0">
+          <BrandLockup tone="dark" admin height={28} />
         </div>
 
         {hasCompany && (
@@ -172,10 +166,7 @@ export default function ConsoleLayout() {
           style={{ paddingTop: "env(safe-area-inset-top)" }}
         >
           <div className="h-[48px] px-4 flex items-center gap-2">
-            <BrandLockup tone="dark" height={22} subtitle={false} />
-            <span className="text-[9.5px] font-bold px-1.5 py-0.5 rounded-md uppercase" style={{ background: "var(--c-brand)" }}>
-              운영 콘솔
-            </span>
+            <BrandLockup tone="dark" admin subtitle={false} height={24} />
             <div className="ml-auto flex items-center gap-1">
               {hasCompany && (
                 <button onClick={() => nav("/")} className="text-[12px] font-semibold text-white/70 hover:text-white px-2 py-1">

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -23,7 +23,8 @@ export default function LoginPage() {
   const [errCode, setErrCode] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  if (user) return <Navigate to="/" replace />;
+  // 총관리자(superAdmin)는 운영 콘솔(개발자 콘솔)로, 그 외는 회사 앱으로.
+  if (user) return <Navigate to={user.superAdmin ? "/super-admin" : "/"} replace />;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -31,8 +32,8 @@ export default function LoginPage() {
     setErrCode(null);
     setLoading(true);
     try {
-      await login(email, password);
-      nav("/");
+      const u = await login(email, password);
+      nav(u.superAdmin ? "/super-admin" : "/");
     } catch (e: any) {
       setErr(e.message);
       // 서버가 ACCOUNT_LOCKED 같은 코드를 message JSON 에 포함하는 경우를 위해


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- **사이드바 로고 교체** — 회사 앱(라이트)·운영 콘솔(다크) 사이드바 상단을 새 HiNest 브랜드 락업(블루 타일 마크 + HiNest 워드마크 + 서브)으로 교체. 디자이너 light/dark export 를 한 컴포넌트(`BrandLockup`)에서 tone 으로 전환.
- **콘솔 로고 ADMIN 변형** — 운영 콘솔 헤더는 워드마크 옆 `ADMIN` 배지 + "관리자 콘솔 · Admin Console" 서브를 쓰는 admin 변형 사용(데스크톱: 풀 락업 / 모바일: 배지만). 기존 수동 "운영 콘솔" 칩 제거.
- **콘솔 타이틀바 겹침 수정** — macOS Electron 창모드에서 신호등 버튼이 콘솔 로고를 침범하던 문제를, AppLayout 과 동일한 28px 드래그 가능 상단 여백을 ConsoleLayout 에 미러링해 해결(전체화면에선 제거).
- **총관리자 로그인 리다이렉트** — superAdmin 계정으로 로그인/세션 복원 시 회사 대시보드(`/`)가 아니라 운영 콘솔(`/super-admin`)로 바로 이동. `login()` 이 User 를 반환하도록 하여 LoginPage 에서 역할 기준으로 분기(콘솔의 "서비스로 돌아가기 → /" 동작은 그대로 유지).

## Changed files
- `client/src/components/BrandLockup.tsx` — `admin` 변형(ADMIN 배지 + 서브 문구/색) 추가
- `client/src/components/ConsoleLayout.tsx` — admin 락업 사용 + 28px 타이틀바 여백
- `client/src/auth.tsx` — `login()` 이 `Promise<User>` 반환
- `client/src/pages/LoginPage.tsx` — superAdmin → `/super-admin` 리다이렉트

## Test plan
- [ ] 로컬 타입체크 통과 (tsc --noEmit, exit 0)
- [ ] 라이트/다크 사이드바 로고 렌더 확인 (회사 앱 / 운영 콘솔)
- [ ] 콘솔 헤더 ADMIN 배지·서브 문구 확인 (데스크톱 풀 / 모바일 배지만)
- [ ] superAdmin 로그인 → `/super-admin` 도착 / 일반 계정 → `/` 도착
- [ ] 콘솔 "서비스로 돌아가기" → `/` 정상
- [ ] (데스크톱 앱) macOS 창모드에서 신호등이 로고를 가리지 않음 / 전체화면에서 여백 제거

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_
