### PR TITLE
🔀 :: (#620) 공유 링크 비밀번호 해시 rounds 12 로 통일

### DIFF
--- a/server/src/routes/folderShareLink.ts
+++ b/server/src/routes/folderShareLink.ts
@@ -66,7 +66,7 @@ authed.post("/", async (req, res) => {
       createdById: u.id,
       expiresAt: d.expiresAt ? new Date(d.expiresAt) : null,
       maxDownloads: d.maxDownloads ?? null,
-      passwordHash: d.password ? await bcrypt.hash(d.password, 10) : null,
+      passwordHash: d.password ? await bcrypt.hash(d.password, 12) : null,
     },
   });
   await writeLog(u.id, "FOLDER_SHARE_LINK_CREATE", link.id, folder.id);

--- a/server/src/routes/shareLink.ts
+++ b/server/src/routes/shareLink.ts
@@ -65,7 +65,7 @@ authed.post("/", async (req, res) => {
       createdById: u.id,
       expiresAt: d.expiresAt ? new Date(d.expiresAt) : null,
       maxDownloads: d.maxDownloads ?? null,
-      passwordHash: d.password ? await bcrypt.hash(d.password, 10) : null,
+      passwordHash: d.password ? await bcrypt.hash(d.password, 12) : null,
     },
   });
   await writeLog(u.id, "SHARE_LINK_CREATE", link.id, doc.id);


### PR DESCRIPTION
## 증상
**공유 링크 비밀번호 해시 rounds 12 로 통일**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
폴더 공유 링크 생성 시 비밀번호 해시 cost factor 를 10 에서 12 로 올린다.
rounds 12 는 현재 서버 사양에서 체감 지연 없이 무차별 대입 비용을 ~4배로
높여, 공유 링크가 유출돼도 비밀번호 복원을 어렵게 한다.

## 수정
**작업 항목 (커밋 단위)**
- fix(server): 폴더 공유 링크 비밀번호 해시 강도 상향 (bcrypt rounds 10→12)
- fix(server): 문서 공유 링크 비밀번호 해시 강도 상향 (bcrypt rounds 10→12)

**변경 대상 (2개 파일)**
- `server/src/routes/folderShareLink.ts`
- `server/src/routes/shareLink.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #197** ↔ **이슈 #620** 로 연결됩니다.

Closes #620
