### PR TITLE
🔀 :: (#621) 웹훅 이벤트 폴링에 탭 가시성 정지 + 60초로 완화

### DIFF
--- a/client/src/components/ProjectWebhooks.tsx
+++ b/client/src/components/ProjectWebhooks.tsx
@@ -79,9 +79,18 @@ export default function ProjectWebhooks({ projectId }: { projectId: string }) {
     // 채널이 바뀌면 이전 이벤트 리스트를 즉시 비워 잠깐이라도 오인 표시되지 않게.
     setEvents([]);
     loadEvents(selected);
-    // 60초마다 새 이벤트 자동 조회
-    const t = setInterval(() => loadEvents(selected), 60_000);
-    return () => clearInterval(t);
+    // 비용 절감: 60초 주기 자동 조회 + 탭이 보이지 않으면 폴링 정지(다시 보이면 즉시 1회 조회 후 재개).
+    // 앱 전반의 폴링(알림·사내톡·결재 카운트)과 동일한 visibilitychange 패턴.
+    let id: number | null = null;
+    const start = () => { if (id === null) id = window.setInterval(() => loadEvents(selected), 60_000); };
+    const stop = () => { if (id !== null) { window.clearInterval(id); id = null; } };
+    if (document.visibilityState === "visible") start();
+    const onVis = () => {
+      if (document.visibilityState === "visible") { loadEvents(selected); start(); }
+      else stop();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => { stop(); document.removeEventListener("visibilitychange", onVis); };
     // eslint-disable-next-line
   }, [selected?.id]);
 

--- a/client/src/components/ProjectWebhooks.tsx
+++ b/client/src/components/ProjectWebhooks.tsx
@@ -61,7 +61,7 @@ export default function ProjectWebhooks({ projectId }: { projectId: string }) {
     // eslint-disable-next-line
   }, [projectId]);
 
-  // 채널을 빠르게 전환하거나 30초 주기 fetch 가 느린 네트워크에서 늦게 도착할 때,
+  // 채널을 빠르게 전환하거나 60초 주기 fetch 가 느린 네트워크에서 늦게 도착할 때,
   // 이전 요청 응답이 새 선택의 이벤트를 덮어쓰는 걸 막기 위한 토큰.
   const eventsTokenRef = useRef(0);
   async function loadEvents(ch: Channel) {
@@ -71,7 +71,7 @@ export default function ProjectWebhooks({ projectId }: { projectId: string }) {
       if (my !== eventsTokenRef.current) return;
       setEvents(r.events);
     } catch {
-      /* 30초마다 재시도되므로 일시적 오류는 조용히 넘어감 */
+      /* 60초마다 재시도되므로 일시적 오류는 조용히 넘어감 */
     }
   }
   useEffect(() => {
@@ -79,8 +79,8 @@ export default function ProjectWebhooks({ projectId }: { projectId: string }) {
     // 채널이 바뀌면 이전 이벤트 리스트를 즉시 비워 잠깐이라도 오인 표시되지 않게.
     setEvents([]);
     loadEvents(selected);
-    // 30초마다 새 이벤트 자동 조회
-    const t = setInterval(() => loadEvents(selected), 30_000);
+    // 60초마다 새 이벤트 자동 조회
+    const t = setInterval(() => loadEvents(selected), 60_000);
     return () => clearInterval(t);
     // eslint-disable-next-line
   }, [selected?.id]);


### PR DESCRIPTION
## 증상
**웹훅 이벤트 폴링에 탭 가시성 정지 + 60초로 완화**

성능을 개선합니다.

## 원인
프로젝트 웹훅 패널은 채널 선택 동안 30초마다 이벤트를 폴링했다. 서버 비용
절감을 위해 주기를 60초로 늘린다(관련 주석도 함께 갱신). 사용자가 체감하는
신선도 차이는 미미하면서 요청 수는 절반으로 준다.

## 수정
**작업 항목 (커밋 단위)**
- perf(client): 웹훅 이벤트 자동 조회 주기를 30초→60초로 완화
- perf(client): 탭이 숨겨지면 웹훅 폴링 정지 (visibilitychange)

**변경 대상 (1개 파일)**
- `client/src/components/ProjectWebhooks.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #198** ↔ **이슈 #621** 로 연결됩니다.

Closes #621
