### PR TITLE
🔀 :: (#624) 운영 콘솔 UI — macOS 신호등 영역 확보 + 브랜드 로고 적용

### DIFF
--- a/client/src/components/BrandLockup.tsx
+++ b/client/src/components/BrandLockup.tsx
@@ -15,9 +15,10 @@ import { useTheme } from "../theme";
  *
  * 마크 폴리곤 좌표는 원본 그대로 보존.
  */
-export default function BrandLockup({ height = 30 }: { height?: number }) {
+export default function BrandLockup({ height = 30, onDark }: { height?: number; onDark?: boolean }) {
   const { resolved } = useTheme();
-  const isDark = resolved === "dark";
+  // onDark: 항상 어두운 표면(예: 운영 콘솔 사이드바)에 얹힐 때 테마와 무관하게 밝은 워드마크 강제.
+  const isDark = onDark ?? resolved === "dark";
   const textColor = isDark ? "#FFFFFF" : "#0C1020";
   const dotColor = isDark ? "#A5B8FF" : "#3B5CF0";
 

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 
@@ -32,6 +33,18 @@ export default function ConsoleLayout() {
   const { user, logout } = useAuth();
   const nav = useNavigate();
 
+  // macOS 데스크톱 창모드에서 신호등(트래픽라이트) 버튼 영역 확보 (AppLayout 과 동일) — HiNest 로고 겹침 방지.
+  const isMacDesktop = !!window.hinest?.isDesktop && window.hinest?.platform === "darwin";
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  useEffect(() => {
+    if (!isMacDesktop || !window.hinest?.onFullscreenChange) return;
+    const off = window.hinest.onFullscreenChange((fs) => setIsFullscreen(fs));
+    return () => {
+      try { off?.(); } catch {}
+    };
+  }, [isMacDesktop]);
+  const showTitlebarSpace = isMacDesktop && !isFullscreen;
+
   // 회사 관리는 플랫폼 운영자뿐 아니라 개발자(superAdmin)에게도 노출 — 개발자는 최상위
   // 권한이므로 테넌트 가입 승인까지 직접 처리할 수 있어야 한다.
   const links: ConsoleLink[] = [
@@ -62,6 +75,16 @@ export default function ConsoleLayout() {
         className="hidden md:flex w-[252px] flex-col flex-shrink-0 bg-ink-900 text-white"
         style={{ paddingTop: "env(safe-area-inset-top)" }}
       >
+        {/* 신호등 버튼용 드래그 가능 여백 — macOS 창모드에서만 */}
+        {showTitlebarSpace && (
+          <div
+            style={{
+              height: 28,
+              // @ts-expect-error drag region
+              WebkitAppRegion: "drag",
+            }}
+          />
+        )}
         <div className="px-5 h-[52px] flex items-center gap-2 border-b border-white/10 flex-shrink-0">
           <span className="text-[15px] font-extrabold tracking-tight">HiNest</span>
           <span
@@ -130,6 +153,16 @@ export default function ConsoleLayout() {
 
       {/* ===== 모바일 상단바 + 본문 ===== */}
       <div className="flex-1 min-w-0 flex flex-col">
+        {showTitlebarSpace && (
+          <div
+            className="bg-ink-50"
+            style={{
+              height: 28,
+              // @ts-expect-error drag region
+              WebkitAppRegion: "drag",
+            }}
+          />
+        )}
         <header
           className="md:hidden bg-ink-900 text-white flex-shrink-0"
           style={{ paddingTop: "env(safe-area-inset-top)" }}

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
+import BrandLockup from "./BrandLockup";
 
 /**
  * 운영 콘솔 셸 — 총관리자(개발자)/플랫폼 운영자 전용. 회사 앱(AppLayout)과
@@ -86,7 +87,7 @@ export default function ConsoleLayout() {
           />
         )}
         <div className="px-5 h-[52px] flex items-center gap-2 border-b border-white/10 flex-shrink-0">
-          <span className="text-[15px] font-extrabold tracking-tight">HiNest</span>
+          <BrandLockup height={20} onDark />
           <span
             className="text-[10px] font-bold px-1.5 py-0.5 rounded-md uppercase tracking-wide"
             style={{ background: "var(--c-brand)", color: "#fff" }}
@@ -168,7 +169,7 @@ export default function ConsoleLayout() {
           style={{ paddingTop: "env(safe-area-inset-top)" }}
         >
           <div className="h-[48px] px-4 flex items-center gap-2">
-            <span className="text-[14px] font-extrabold tracking-tight">HiNest</span>
+            <BrandLockup height={18} onDark />
             <span className="text-[9.5px] font-bold px-1.5 py-0.5 rounded-md uppercase" style={{ background: "var(--c-brand)" }}>
               운영 콘솔
             </span>


### PR DESCRIPTION
## 증상
**운영 콘솔 UI — macOS 신호등 영역 확보 + 브랜드 로고 적용**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
데스크톱(Electron) macOS 창모드에서 hiddenInset 타이틀바 신호등 버튼이 운영 콘솔
(ConsoleLayout) 사이드바 상단 HiNest 로고와 겹쳤다. AppLayout 과 동일하게
showTitlebarSpace(isMacDesktop && !isFullscreen) 조건으로 사이드바·본문 상단에
28px 드래그 여백을 추가해 겹침 제거. 웹/비-macOS 에선 렌더 안 됨(동작 변화 없음).

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 운영 콘솔 사이드바 macOS 신호등 영역 확보 — HiNest 로고 겹침 수정
- fix(client): 운영 콘솔 헤더에 HiNest 브랜드 로고 적용 — 텍스트 → BrandLockup

**변경 대상 (2개 파일)**
- `client/src/components/BrandLockup.tsx`
- `client/src/components/ConsoleLayout.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #201** ↔ **이슈 #624** 로 연결됩니다.

Closes #624
