### PR TITLE
🔀 :: (#625) 회사 가입 관리(플랫폼 콘솔) 페이지 디자인 개선

### DIFF
--- a/client/src/lib/previewMock.ts
+++ b/client/src/lib/previewMock.ts
@@ -1045,6 +1045,29 @@ function featureFlags() { return { flags: {} }; }
 function teams() { return { teams: DEMO_TEAMS }; }
 function navConfig() { return { items: [] }; }
 
+// 플랫폼 운영 콘솔(회사 가입 관리) 데모 데이터 — 상태별로 골고루 둬 재디자인을 미리 볼 수 있게.
+function demoCompanies(): any[] {
+  const now = Date.now();
+  const ago = (days: number) => new Date(now - days * 86400000).toISOString();
+  return [
+    { id: "co_efface",  name: "efface",    status: "PENDING",   contactName: "서지완", contactEmail: "xixn2@efface.dev",   contactPhone: "010-6286-0063", bizRegNo: "123-45-67890", createdAt: ago(0),   _count: { users: 0 } },
+    { id: "co_acme",    name: "Acme Corp", status: "PENDING",   contactName: "이지은", contactEmail: "ops@acme.io",        contactPhone: "010-1111-2222", bizRegNo: "777-11-00099", createdAt: ago(1),   _count: { users: 0 } },
+    { id: "co_hinest",  name: "HiNest",    status: "ACTIVE",    contactName: "김데모", contactEmail: "admin@hinest.app",   contactPhone: "02-1234-5678",  bizRegNo: "220-88-12345", createdAt: ago(120), approvedAt: ago(118), _count: { users: 24 } },
+    { id: "co_globex",  name: "Globex",    status: "SUSPENDED", contactName: "박준형", contactEmail: "it@globex.co.kr",                                   bizRegNo: "501-22-33445", createdAt: ago(60),  approvedAt: ago(55),  _count: { users: 8 } },
+    { id: "co_initech", name: "Initech",   status: "REJECTED",  contactName: "최민수", contactEmail: "biz@initech.com",   rejectedReason: "사업자 정보 확인 불가",                  createdAt: ago(30),  _count: { users: 0 } },
+  ];
+}
+function platformCompanies(p?: string) {
+  const m = (p ?? "").match(/[?&]status=([A-Z]+)/);
+  const all = demoCompanies();
+  return { companies: m ? all.filter((c) => c.status === m[1]) : all };
+}
+function platformSummary() {
+  const summary: Record<string, number> = { PENDING: 0, ACTIVE: 0, SUSPENDED: 0, REJECTED: 0 };
+  for (const c of demoCompanies()) summary[c.status]++;
+  return { summary };
+}
+
 /** 경로별 매처 — 위에서 아래로 검사하므로 **세부 경로 → 일반 경로** 순서. */
 const HANDLERS: { test: (p: string) => boolean; data: (p?: string) => any }[] = [
   /* === 본인 / 인증 === */
@@ -1053,6 +1076,10 @@ const HANDLERS: { test: (p: string) => boolean; data: (p?: string) => any }[] = 
   { test: (p) => p.startsWith("/api/version"),         data: () => ({ version: "preview" }) },
   // 미리보기에서 개발자 페이지 열람 허용 — step-up 게이트를 통과시킨다 (active=true).
   { test: (p) => p === "/api/auth/super-session",      data: () => ({ active: true, expiresAt: Date.now() + 60 * 60 * 1000 }) },
+
+  /* === 플랫폼 운영 (회사 가입 관리) — 세부(summary) 먼저 === */
+  { test: (p) => p.startsWith("/api/platform/companies/summary"), data: platformSummary },
+  { test: (p) => p.startsWith("/api/platform/companies"),         data: platformCompanies },
 
   /* === 사용자 / 디렉토리 === */
   { test: (p) => p.startsWith("/api/users/teams"),     data: teams },

--- a/client/src/pages/PlatformPage.tsx
+++ b/client/src/pages/PlatformPage.tsx
@@ -34,13 +34,13 @@ const STATUS_META: Record<Status, { label: string; color: string; bg: string }> 
   REJECTED: { label: "반려됨", color: "#6B7280", bg: "rgba(107,114,128,0.13)" },
 };
 
-const FILTERS: { key: Status | "ALL"; label: string }[] = [
-  { key: "PENDING", label: "승인 대기" },
-  { key: "ACTIVE", label: "운영중" },
-  { key: "SUSPENDED", label: "일시정지" },
-  { key: "REJECTED", label: "반려됨" },
-  { key: "ALL", label: "전체" },
-];
+// 회사명에서 결정적으로 모노그램 색을 뽑는다 — 같은 회사는 항상 같은 색.
+const MONO_COLORS = ["#3B5CF0", "#0EA5E9", "#8B5CF6", "#EC4899", "#F59E0B", "#10B981", "#EF4444", "#14B8A6"];
+function monoColor(name: string) {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (Math.imul(h, 31) + name.charCodeAt(i)) | 0;
+  return MONO_COLORS[Math.abs(h) % MONO_COLORS.length];
+}
 
 function fmtDate(iso: string) {
   try {
@@ -48,6 +48,28 @@ function fmtDate(iso: string) {
   } catch {
     return iso;
   }
+}
+
+function IconUser() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
+    </svg>
+  );
+}
+function IconCalendar() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="2" /><path d="M16 2v4M8 2v4M3 10h18" />
+    </svg>
+  );
+}
+function IconInbox() {
+  return (
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 12h-6l-2 3h-4l-2-3H2" /><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+    </svg>
+  );
 }
 
 export default function PlatformPage() {
@@ -65,8 +87,8 @@ export default function PlatformPage() {
         api<{ companies: Company[] }>(`/api/platform/companies${q}`),
         api<{ summary: Summary }>("/api/platform/companies/summary"),
       ]);
-      setCompanies(list.companies);
-      setSummary(sum.summary);
+      setCompanies(list.companies ?? []);
+      setSummary(sum.summary ?? { PENDING: 0, ACTIVE: 0, SUSPENDED: 0, REJECTED: 0 });
     } catch (e: any) {
       await alertAsync({ description: e?.message ?? "목록을 불러오지 못했어요" });
     } finally {
@@ -154,8 +176,8 @@ export default function PlatformPage() {
         description="가입 신청한 회사를 검토하고 승인·반려·정지할 수 있습니다."
       />
 
-      {/* 상태 요약 배지 */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+      {/* 상태별 KPI — 카드를 누르면 해당 상태로 필터. (기존엔 카드+칩이 같은 일을 중복했음) */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5 sm:gap-3 mb-5">
         {(Object.keys(STATUS_META) as Status[]).map((s) => {
           const meta = STATUS_META[s];
           const active = filter === s;
@@ -164,44 +186,77 @@ export default function PlatformPage() {
               key={s}
               type="button"
               onClick={() => setFilter(s)}
-              className="text-left rounded-2xl px-4 py-3 border transition"
+              aria-pressed={active}
+              className="text-left rounded-2xl px-4 py-3.5 border transition-all hover:-translate-y-px"
               style={{
                 background: active ? meta.bg : "var(--c-surface)",
-                borderColor: active ? "transparent" : "var(--c-border)",
-                boxShadow: active ? `inset 0 0 0 1.5px ${meta.color}` : "none",
+                borderColor: active ? meta.color : "var(--c-border)",
+                boxShadow: active ? `inset 0 0 0 1px ${meta.color}` : "none",
               }}
             >
-              <div className="text-[12px] font-bold" style={{ color: meta.color }}>{meta.label}</div>
-              <div className="text-[24px] font-extrabold text-ink-900 tabular mt-0.5">{summary[s]}</div>
+              <div className="flex items-center gap-1.5">
+                <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: meta.color }} />
+                <span className={`text-[12.5px] font-bold truncate ${active ? "" : "text-ink-500"}`} style={active ? { color: meta.color } : undefined}>{meta.label}</span>
+              </div>
+              <div className={`text-[26px] leading-none font-extrabold tabular mt-2 ${active ? "" : "text-ink-900"}`} style={active ? { color: meta.color } : undefined}>{summary[s]}</div>
             </button>
           );
         })}
       </div>
 
-      {/* 필터 탭 */}
-      <div className="flex items-center gap-1.5 mb-4 flex-wrap">
-        {FILTERS.map((f) => (
-          <button
-            key={f.key}
-            type="button"
-            onClick={() => setFilter(f.key)}
-            className="px-3.5 h-[34px] rounded-full text-[13px] font-bold transition"
-            style={
-              filter === f.key
-                ? { background: "var(--c-brand)", color: "#fff" }
-                : { background: "var(--c-surface-2, var(--c-surface))", color: "var(--c-text-2)", border: "1px solid var(--c-border)" }
-            }
-          >
-            {f.label}
-          </button>
-        ))}
+      {/* 목록 헤더: 현재 보기 라벨 + 개수 + 전체 토글 */}
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <h2 className="text-[14.5px] font-extrabold text-ink-800 flex items-center gap-1.5">
+          {filter === "ALL" ? "전체 회사" : STATUS_META[filter].label}
+          {!loading && <span className="text-ink-400 tabular font-bold">{companies.length}</span>}
+        </h2>
+        <button
+          type="button"
+          onClick={() => setFilter(filter === "ALL" ? "PENDING" : "ALL")}
+          aria-pressed={filter === "ALL"}
+          className="text-[12.5px] font-bold px-3.5 h-[32px] rounded-full transition"
+          style={
+            filter === "ALL"
+              ? { background: "var(--c-brand)", color: "#fff" }
+              : { background: "var(--c-surface)", color: "var(--c-text-2)", border: "1px solid var(--c-border)" }
+          }
+        >
+          전체 보기
+        </button>
       </div>
 
       {/* 목록 */}
       {loading ? (
-        <div className="py-16 text-center text-ink-400 text-[14px]">불러오는 중…</div>
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="rounded-2xl border p-4 sm:p-5 animate-pulse"
+              style={{ borderColor: "var(--c-border)", background: "var(--c-surface)" }}
+            >
+              <div className="flex items-start gap-3.5">
+                <div className="w-11 h-11 rounded-xl flex-shrink-0" style={{ background: "var(--c-border)" }} />
+                <div className="flex-1 space-y-2.5 pt-1">
+                  <div className="h-3.5 w-40 max-w-full rounded" style={{ background: "var(--c-border)" }} />
+                  <div className="h-3 w-64 max-w-full rounded" style={{ background: "var(--c-border)" }} />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
       ) : companies.length === 0 ? (
-        <div className="py-16 text-center text-ink-400 text-[14px]">해당 상태의 회사가 없습니다.</div>
+        <div
+          className="rounded-2xl border py-16 px-6 flex flex-col items-center text-center"
+          style={{ borderColor: "var(--c-border)", background: "var(--c-surface)" }}
+        >
+          <div className="w-12 h-12 rounded-full flex items-center justify-center mb-3 text-ink-300" style={{ background: "var(--c-surface-2, rgba(0,0,0,0.04))" }}>
+            <IconInbox />
+          </div>
+          <div className="text-[14px] font-bold text-ink-600">표시할 회사가 없어요</div>
+          <div className="text-[12.5px] text-ink-400 mt-1">
+            {filter === "ALL" ? "아직 가입 신청한 회사가 없습니다." : `'${STATUS_META[filter].label}' 상태의 회사가 없습니다.`}
+          </div>
+        </div>
       ) : (
         <div className="space-y-3">
           {companies.map((c) => {
@@ -210,47 +265,54 @@ export default function PlatformPage() {
             return (
               <div
                 key={c.id}
-                className="rounded-2xl border p-4 sm:p-5"
+                className="rounded-2xl border p-4 sm:p-5 transition hover:shadow-sm"
                 style={{ borderColor: "var(--c-border)", background: "var(--c-surface)" }}
               >
-                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-[16px] font-extrabold text-ink-900 truncate">{c.name}</span>
-                      <span
-                        className="text-[11px] font-bold px-2 py-0.5 rounded-full"
-                        style={{ color: meta.color, background: meta.bg }}
-                      >
-                        {meta.label}
-                      </span>
+                <div className="flex flex-col sm:flex-row sm:items-center gap-3.5 sm:gap-4">
+                  <div className="flex items-start gap-3.5 min-w-0 flex-1">
+                    <div className="avatar avatar-lg !rounded-xl flex-shrink-0" style={{ background: monoColor(c.name) }}>
+                      {c.name?.[0]?.toUpperCase() ?? "?"}
                     </div>
-                    <div className="text-[12.5px] text-ink-500 mt-1.5 space-y-0.5">
-                      <div>
-                        담당자 {c.contactName ?? "—"}
-                        {c.contactEmail ? ` · ${c.contactEmail}` : ""}
-                        {c.contactPhone ? ` · ${c.contactPhone}` : ""}
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-[16px] font-extrabold text-ink-900 truncate">{c.name}</span>
+                        <span
+                          className="text-[11px] font-bold px-2 py-0.5 rounded-full flex-shrink-0"
+                          style={{ color: meta.color, background: meta.bg }}
+                        >
+                          {meta.label}
+                        </span>
                       </div>
-                      <div>
-                        {c.bizRegNo ? `사업자 ${c.bizRegNo} · ` : ""}
-                        신청 {fmtDate(c.createdAt)}
-                        {typeof c._count?.users === "number" ? ` · 직원 ${c._count.users}명` : ""}
+                      <div className="mt-2 space-y-1 text-[12.5px] text-ink-500">
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <span className="text-ink-300 flex-shrink-0"><IconUser /></span>
+                          <span className="font-semibold text-ink-700">{c.contactName ?? "담당자 미상"}</span>
+                          {c.contactEmail && <><span className="text-ink-300">·</span><span className="truncate">{c.contactEmail}</span></>}
+                          {c.contactPhone && <><span className="text-ink-300">·</span><span>{c.contactPhone}</span></>}
+                        </div>
+                        <div className="flex items-center gap-1.5 flex-wrap">
+                          <span className="text-ink-300 flex-shrink-0"><IconCalendar /></span>
+                          <span>신청 {fmtDate(c.createdAt)}</span>
+                          {c.bizRegNo && <><span className="text-ink-300">·</span><span>사업자 {c.bizRegNo}</span></>}
+                          {typeof c._count?.users === "number" && <><span className="text-ink-300">·</span><span>직원 {c._count.users}명</span></>}
+                        </div>
+                        {c.status === "REJECTED" && c.rejectedReason && (
+                          <div className="font-medium" style={{ color: "var(--c-danger)" }}>반려 사유: {c.rejectedReason}</div>
+                        )}
                       </div>
-                      {c.status === "REJECTED" && c.rejectedReason && (
-                        <div style={{ color: "var(--c-danger)" }}>반려 사유: {c.rejectedReason}</div>
-                      )}
                     </div>
                   </div>
 
-                  <div className="flex items-center gap-2 flex-shrink-0">
+                  <div className="flex items-center gap-2 flex-shrink-0 pl-[58px] sm:pl-0">
                     {(c.status === "PENDING" || c.status === "SUSPENDED" || c.status === "REJECTED") && (
                       <button
                         type="button"
                         disabled={busy}
                         onClick={() => approve(c)}
-                        className="h-[36px] px-4 rounded-full text-[13px] font-bold text-white transition disabled:opacity-50"
+                        className="h-[36px] px-4 rounded-full text-[13px] font-bold text-white transition disabled:opacity-50 active:scale-95"
                         style={{ background: "var(--c-brand)" }}
                       >
-                        {c.status === "PENDING" ? "승인" : "재활성화"}
+                        {busy ? "처리중…" : c.status === "PENDING" ? "승인" : "재활성화"}
                       </button>
                     )}
                     {c.status === "PENDING" && (
@@ -258,7 +320,7 @@ export default function PlatformPage() {
                         type="button"
                         disabled={busy}
                         onClick={() => reject(c)}
-                        className="h-[36px] px-4 rounded-full text-[13px] font-bold transition disabled:opacity-50"
+                        className="h-[36px] px-4 rounded-full text-[13px] font-bold transition disabled:opacity-50 active:scale-95"
                         style={{ background: "var(--c-surface)", color: "var(--c-text-2)", border: "1px solid var(--c-border)" }}
                       >
                         반려
@@ -269,7 +331,7 @@ export default function PlatformPage() {
                         type="button"
                         disabled={busy}
                         onClick={() => suspend(c)}
-                        className="h-[36px] px-4 rounded-full text-[13px] font-bold transition disabled:opacity-50"
+                        className="h-[36px] px-4 rounded-full text-[13px] font-bold transition disabled:opacity-50 active:scale-95"
                         style={{ background: "var(--c-surface)", color: "var(--c-danger)", border: "1px solid color-mix(in srgb, var(--c-danger) 30%, transparent)" }}
                       >
                         일시정지


### PR DESCRIPTION
## 증상
**회사 가입 관리(플랫폼 콘솔) 페이지 디자인 개선**

새 기능을 추가합니다.

## 원인
개발자 운영 콘솔의 회사 가입 관리 화면을 정리한다. 상단 요약 지표와
회사 목록 카드/표 레이아웃을 다듬어 가독성과 정보 밀도를 개선했다.

## 수정
**작업 항목 (커밋 단위)**
- feat(client): 회사 가입 관리(플랫폼 콘솔) 페이지 디자인 개선
- chore(client): 플랫폼 콘솔 미리보기용 회사 목록/요약 데모 데이터 추가

**변경 대상 (2개 파일)**
- `client/src/lib/previewMock.ts`
- `client/src/pages/PlatformPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #202** ↔ **이슈 #625** 로 연결됩니다.

Closes #625
