### PR TITLE
🔀 :: (#626) 테넌트 경계 입력검증 — 외래 userId 동일 회사 강제

### DIFF
--- a/server/src/lib/tenantValidate.ts
+++ b/server/src/lib/tenantValidate.ts
@@ -1,0 +1,28 @@
+import { prisma } from "./db.js";
+
+/**
+ * body 로 들어온 userId 목록이 모두 "현재 테넌트(회사)" 소속 실제 사용자인지 검증.
+ *
+ * 왜 필요한가:
+ *   Prisma $extends 자동 스코프는 "쓰는 행"의 companyId 만 주입할 뿐, 사용자가 보낸
+ *   외래 userId(결재자·방 멤버·일정 대상자)가 같은 회사인지는 검사하지 않는다. 또한
+ *   nested create 와 SSE publish(userId, ...) 는 companyId 필터를 우회한다. 따라서 타
+ *   회사 userId 를 끼워 넣으면 ① 그 사용자에게 실시간 알림/메시지가 전달되거나
+ *   ② companyId 가 어긋난 고아 행(멤버십/결재 스텝)이 생겨 테넌트 경계가 깨진다.
+ *
+ * 어떻게 검증하나:
+ *   findMany 자체가 자동 스코프되어 현재 회사 사용자만 돌려준다 → 타 회사/미존재 id 는
+ *   결과에서 빠지므로 "고유 입력 개수 == 조회 결과 개수" 가 곧 "전원 같은 회사" 를 의미.
+ *   (입력은 내부에서 dedupe 하므로 호출부 중복 제거 여부와 무관하게 정확.)
+ *
+ * 반환: 비어 있거나 전원 같은 회사면 true, 하나라도 타 회사/미존재면 false.
+ */
+export async function allSameCompanyUsers(ids: string[]): Promise<boolean> {
+  const unique = Array.from(new Set(ids));
+  if (unique.length === 0) return true;
+  const found = await prisma.user.findMany({
+    where: { id: { in: unique } },
+    select: { id: true },
+  });
+  return found.length === unique.length;
+}

--- a/server/src/routes/approval.ts
+++ b/server/src/routes/approval.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { notify, notifyMany } from "../lib/notify.js";
+import { allSameCompanyUsers } from "../lib/tenantValidate.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -180,6 +181,8 @@ router.post("/:id/revise", async (req, res) => {
 
   const reviewers = Array.from(new Set(d.reviewerIds.filter((id) => id !== u.id)));
   if (!reviewers.length) return res.status(400).json({ error: "결재자를 1명 이상 선택해주세요" });
+  if (!(await allSameCompanyUsers(reviewers)))
+    return res.status(400).json({ error: "결재자 중 일부를 찾을 수 없어요." });
   let dataJson: string | null = null;
   if (d.data !== undefined && d.data !== null) {
     const serialized = JSON.stringify(d.data);
@@ -225,6 +228,8 @@ router.post("/", async (req, res) => {
 
   const reviewers = Array.from(new Set(d.reviewerIds.filter((id) => id !== u.id)));
   if (!reviewers.length) return res.status(400).json({ error: "결재자를 1명 이상 선택해주세요" });
+  if (!(await allSameCompanyUsers(reviewers)))
+    return res.status(400).json({ error: "결재자 중 일부를 찾을 수 없어요." });
 
   // d.data 는 z.any() 라 서버에서 다시 한 번 크기 제한. 결재 양식별 폼 JSON
   // (출장 지역/경비 등) 이 들어가는 자리라 수 KB 면 충분. 전역 json limit(2mb)

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/db.js";
 import { requireAuth, verifySuperToken, writeLog } from "../lib/auth.js";
 import { notifyMany } from "../lib/notify.js";
 import { publishMany } from "../lib/sse.js";
+import { allSameCompanyUsers } from "../lib/tenantValidate.js";
 
 /**
  * SSE 채팅 브로드캐스트.
@@ -165,6 +166,8 @@ router.post("/rooms", async (req, res) => {
 
   if (!d.name) return res.status(400).json({ error: "방 이름이 필요합니다" });
   const memberIds = Array.from(new Set([u.id, ...d.memberIds]));
+  if (!(await allSameCompanyUsers(memberIds)))
+    return res.status(400).json({ error: "멤버 중 일부를 찾을 수 없습니다" });
   const room = await prisma.chatRoom.create({
     data: {
       name: d.name,

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { generateWebhookToken } from "./webhook.js";
+import { allSameCompanyUsers } from "../lib/tenantValidate.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -61,6 +62,8 @@ router.post("/", async (req, res) => {
   const d = parsed.data;
   // 생성자는 OWNER 로 자동 포함. 중복 제거.
   const memberSet = new Set<string>([u.id, ...(d.memberIds ?? [])]);
+  if (!(await allSameCompanyUsers(Array.from(memberSet))))
+    return res.status(400).json({ error: "초대한 멤버 중 일부를 찾을 수 없어요." });
   const project = await prisma.project.create({
     data: {
       name: d.name,
@@ -663,6 +666,8 @@ router.post("/:id/member", async (req, res) => {
   if (targetRole === "OWNER" && !(me?.role === "OWNER" || u.role === "ADMIN")) {
     return res.status(403).json({ error: "OWNER 역할은 기존 OWNER 또는 시스템 관리자만 부여할 수 있어요" });
   }
+  if (!(await allSameCompanyUsers([body.data.userId])))
+    return res.status(400).json({ error: "추가하려는 멤버를 찾을 수 없어요." });
   const created = await prisma.projectMember.upsert({
     where: { projectId_userId: { projectId: req.params.id, userId: body.data.userId } },
     update: { role: targetRole },

--- a/server/src/routes/schedule.ts
+++ b/server/src/routes/schedule.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { notifyMany } from "../lib/notify.js";
+import { allSameCompanyUsers } from "../lib/tenantValidate.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -159,6 +160,8 @@ router.post("/", async (req, res) => {
   const me = await prisma.user.findUnique({ where: { id: u.id } });
 
   const targets = (d.targetUserIds ?? []).filter((id) => id && id !== u.id);
+  if (targets.length && !(await allSameCompanyUsers(targets)))
+    return res.status(400).json({ error: "대상자 중 일부를 찾을 수 없어요." });
 
   const ev = await prisma.event.create({
     data: {


### PR DESCRIPTION
## 증상
**테넌트 경계 입력검증 — 외래 userId 동일 회사 강제**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
결재자·채팅방 멤버·일정 대상자·프로젝트 멤버처럼 클라가 보낸 외래 userId 가
검증 없이 nested create / SSE publish(userId) 로 흘러 테넌트 경계를 넘던 문제.

Prisma 자동 스코프는 "쓰는 행"의 companyId 만 주입할 뿐 사용자가 지정한 외래
userId 가 같은 회사인지는 보지 않고, SSE 푸시는 companyId 필터를 우회한다. 따라서
타 회사 userId 를 끼워 넣으면 그 사용자에게 실시간 알림/메시지가 전달되거나
companyId 가 어긋난 고아 행(결재 스텝·방 멤버십)이 생긴다.

allSameCompanyUsers() 헬퍼(자동 스코프된 findMany 로 동일 회사만 통과)를 추가하고
- approval.ts: POST /, POST /:id/revise 의 reviewerIds
- chat.ts: 그룹/팀방 memberIds (DM 은 기존 findUnique 로 이미 검증)
- schedule.ts: TARGETED targetUserIds
- project.ts: 생성 시 memberIds, POST /:id/member 의 userId
에 동일 회사 검증을 추가. ownerUserId·assigneeIds 등은 이미 스코프된 조회로 보호됨.

## 수정
**작업 항목 (커밋 단위)**
- fix(server): 테넌트 경계 입력검증 — body 외래 userId 동일 회사 강제

**변경 대상 (5개 파일)**
- `server/src/lib/tenantValidate.ts`
- `server/src/routes/approval.ts`
- `server/src/routes/chat.ts`
- `server/src/routes/project.ts`
- `server/src/routes/schedule.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #203** ↔ **이슈 #626** 로 연결됩니다.

Closes #626
