### PR TITLE
🔀 :: (#627) 모바일 UI 최적화 — 회의록 통계카드·알림 드롭다운 잘림 수정

### DIFF
--- a/client/src/components/NotificationBell.tsx
+++ b/client/src/components/NotificationBell.tsx
@@ -63,7 +63,7 @@ export default function NotificationBell() {
         )}
       </button>
       {open && (
-        <div className="absolute right-0 top-full mt-2 w-[360px] panel shadow-pop z-50 p-0 overflow-hidden">
+        <div className="absolute right-0 top-full mt-2 w-[360px] max-w-[calc(100vw-1.5rem)] panel shadow-pop z-50 p-0 overflow-hidden">
           <div className="section-head">
             <div className="title">알림</div>
             <div className="flex items-center gap-1">

--- a/client/src/pages/MeetingsPage.tsx
+++ b/client/src/pages/MeetingsPage.tsx
@@ -395,16 +395,16 @@ function StatCard({
     violet: { bg: "rgba(124,58,237,0.10)", fg: "#7C3AED" },
   }[accent];
   return (
-    <div className="panel p-4 flex items-center gap-3">
+    <div className="panel p-3 sm:p-4 flex flex-col sm:flex-row items-start sm:items-center gap-1.5 sm:gap-3">
       <div
-        className="w-10 h-10 rounded-xl grid place-items-center flex-shrink-0"
+        className="w-9 h-9 sm:w-10 sm:h-10 rounded-xl grid place-items-center flex-shrink-0"
         style={{ background: a.bg, color: a.fg }}
       >
         {icon}
       </div>
-      <div className="min-w-0">
-        <div className="text-[11px] font-bold text-ink-500 uppercase tracking-[0.06em] truncate">{label}</div>
-        <div className="text-[19px] font-extrabold text-ink-900 mt-0.5 tabular-nums">{value}</div>
+      <div className="min-w-0 w-full">
+        <div className="text-[10.5px] sm:text-[11px] font-bold text-ink-500 uppercase tracking-[0.04em] leading-tight">{label}</div>
+        <div className="text-[18px] sm:text-[19px] font-extrabold text-ink-900 mt-0.5 tabular-nums">{value}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 증상
**모바일 UI 최적화 — 회의록 통계카드·알림 드롭다운 잘림 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- MeetingsPage StatCard: 좁은 화면에서 아이콘 위·텍스트 아래로 세로 배치
  전환하고 truncate 제거 → "이번 주 업데이트" 등 라벨 전체 노출
- NotificationBell 드롭다운: w-[360px] 에 max-w-[calc(100vw-1.5rem)] 추가
  → 360px 모바일에서 화면 밖으로 잘리던 문제 해결

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 모바일 UI — 회의록 통계카드 라벨 잘림·알림 드롭다운 뷰포트 넘침 수정

**변경 대상 (2개 파일)**
- `client/src/components/NotificationBell.tsx`
- `client/src/pages/MeetingsPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #204** ↔ **이슈 #627** 로 연결됩니다.

Closes #627
