### PR TITLE
🔀 :: (#629) 운영 콘솔 로고 — 원본 SVG 누끼 적용

### DIFF
--- a/client/public/admin-logo/dark.svg
+++ b/client/public/admin-logo/dark.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="116 118 746 226" width="746" height="226">
+<defs>
+  <linearGradient id="tile" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#5B8DFF"></stop>
+    <stop offset="55%" stop-color="#3B5CF0"></stop>
+    <stop offset="100%" stop-color="#1E4FD4"></stop>
+  </linearGradient>
+  <filter id="tshadow" x="-30%" y="-30%" width="160%" height="160%">
+    <feDropShadow dx="0" dy="9" stdDeviation="14" flood-color="#1E37B8" flood-opacity="0.55"></feDropShadow>
+  </filter>
+</defs>
+
+<rect x="130" y="136" width="188" height="188" rx="44" fill="url(#tile)" filter="url(#tshadow)"></rect>
+<rect x="130" y="136" width="188" height="188" rx="44" fill="none" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"></rect>
+
+<g transform="translate(224,227.62626262626262) scale(0.9494949494949495)">
+
+<polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="#FFFFFF"></polygon>
+<polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" opacity="0.4"></polygon>
+<polygon points="38,-33 58,-18 58,62 38,52" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="12,-33 38,-33 38,52 12,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="38,-33 58,-18 32,-18 12,-33" fill="#FFFFFF"></polygon>
+<polygon points="12,-33 38,-33 25,-47 0,-47" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="38,-33 58,-18 45,-33 25,-47" fill="#FFFFFF" opacity="0.55"></polygon>
+
+<rect x="-32" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="-32" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+</g>
+
+<text x="362" y="244.44" class="wm" font-family="&#39;Pretendard&#39;,&#39;Inter&#39;,sans-serif" font-weight="800" letter-spacing="-0.045em" font-size="104" fill="#FFFFFF">HiNest</text>
+
+<g>
+  <rect x="693.76" y="181" width="150" height="52" rx="26" fill="rgba(110,137,255,.18)" stroke="rgba(165,184,255,.45)" stroke-width="1.5"></rect>
+  <text x="768.76" y="216" class="badge" font-family="&#39;Pretendard&#39;,&#39;Inter&#39;,sans-serif" font-weight="700" font-size="26" fill="#A5B8FF" text-anchor="middle">ADMIN</text>
+</g>
+
+<text x="366" y="290.44" class="mono" font-family="&#39;JetBrains Mono&#39;,monospace" font-weight="500" font-size="30" letter-spacing="0.1em" fill="rgba(255,255,255,.6)">관리자 콘솔 · Admin Console</text>
+</svg>

--- a/client/public/admin-logo/light.svg
+++ b/client/public/admin-logo/light.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="116 118 746 226" width="746" height="226">
+<defs>
+  <linearGradient id="tile" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#5B8DFF"></stop>
+    <stop offset="55%" stop-color="#3B5CF0"></stop>
+    <stop offset="100%" stop-color="#1E4FD4"></stop>
+  </linearGradient>
+  <filter id="tshadow" x="-30%" y="-30%" width="160%" height="160%">
+    <feDropShadow dx="0" dy="9" stdDeviation="14" flood-color="#1E37B8" flood-opacity="0.32"></feDropShadow>
+  </filter>
+</defs>
+
+<rect x="130" y="136" width="188" height="188" rx="44" fill="url(#tile)" filter="url(#tshadow)"></rect>
+<rect x="130" y="136" width="188" height="188" rx="44" fill="none" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"></rect>
+
+<g transform="translate(224,227.62626262626262) scale(0.9494949494949495)">
+
+<polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="#FFFFFF"></polygon>
+<polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" opacity="0.4"></polygon>
+<polygon points="38,-33 58,-18 58,62 38,52" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="12,-33 38,-33 38,52 12,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="38,-33 58,-18 32,-18 12,-33" fill="#FFFFFF"></polygon>
+<polygon points="12,-33 38,-33 25,-47 0,-47" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="38,-33 58,-18 45,-33 25,-47" fill="#FFFFFF" opacity="0.55"></polygon>
+
+<rect x="-32" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="-32" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+</g>
+
+<text x="362" y="244.44" class="wm" font-family="&#39;Pretendard&#39;,&#39;Inter&#39;,sans-serif" font-weight="800" letter-spacing="-0.045em" font-size="104" fill="#0C1020">HiNest</text>
+
+<g>
+  <rect x="693.76" y="181" width="150" height="52" rx="26" fill="rgba(59,92,240,.10)" stroke="rgba(59,92,240,.30)" stroke-width="1.5"></rect>
+  <text x="768.76" y="216" class="badge" font-family="&#39;Pretendard&#39;,&#39;Inter&#39;,sans-serif" font-weight="700" font-size="26" fill="#1E37B8" text-anchor="middle">ADMIN</text>
+</g>
+
+<text x="366" y="290.44" class="mono" font-family="&#39;JetBrains Mono&#39;,monospace" font-weight="500" font-size="30" letter-spacing="0.1em" fill="#5A6072">관리자 콘솔 · Admin Console</text>
+</svg>

--- a/client/src/components/AdminLockup.tsx
+++ b/client/src/components/AdminLockup.tsx
@@ -3,70 +3,15 @@ import { useTheme } from "../theme";
 /**
  * AdminLockup — 운영(관리자) 콘솔 전용 로고.
  *
- * 디자이너 export(HiNest-Admin-라이트.svg / -다크.svg)를 컴포넌트화한 것.
- * 원본은 "그라데이션 둥근 타일 아이콘 + 흰 둥지 마크 + HiNest 워드마크 + ADMIN 배지
- * + '관리자 콘솔 · Admin Console' 서브타이틀" 의 가로형 락업이다.
+ * 디자이너가 준 원본 SVG(HiNest-Admin-라이트/다크)에서 바깥 배경(누끼)만 제거하고
+ * 로고 마크·워드마크·배지·서브타이틀 벡터는 원본 그대로 둔 파일을
+ * client/public/admin-logo/ 에 두고 <img> 로 렌더한다. viewBox 는 콘텐츠에 맞게
+ * 타이트하게 잘라(여백 제거) 작은 사이드바에서도 마크·글자가 보이도록 했다.
+ * 다크/라이트는 onDark(또는 테마)로 선택.
  *
- * 원본 대비 의도적으로 바꾼 점:
- *  - 바깥 배경 사각형(라이트 #F5F3EE / 다크 #0F1226) 제거 → 어느 표면에도 투명하게 얹힘.
- *  - 워드마크·배지·서브타이틀은 (스케일 시 글자가 뭉개지지 않도록) SVG 한 장으로 통째 축소하지 않고
- *    HTML 텍스트로 렌더. 타일 아이콘만 인라인 SVG. → 사이드바(작게)에서도 글자가 또렷.
- *  - gradient/filter id 는 페이지 내 충돌 방지를 위해 `ad-` 프리픽스.
- *
- * 타일 마크 좌표는 원본 폴리곤 그대로 보존(둥지 + 4개 파란 창).
+ * 주의: <img> 로 SVG 를 렌더하면 페이지 웹폰트(Pretendard)가 적용되지 않아
+ * 글자는 시스템 폰트로 폴백된다. (한글 서브타이틀은 원본도 폴백이었음)
  */
-
-function AdminTile({ size = 28, onDark }: { size?: number; onDark?: boolean }) {
-  // 원본 타일: x130 y136 w188 h188 rx44, 마크그룹 translate(224,227.626) scale(0.9495).
-  // 여기선 그림자 여유를 둔 220×220 정사각 viewBox 로 옮겨 담는다. 타일 TL=(16,16).
-  // 마크그룹 오프셋 = 원본(224-130, 227.626-136)=(94, 91.626) → (16+94, 16+91.626).
-  const shadowOpacity = onDark ? 0.55 : 0.3;
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 220 220"
-      xmlns="http://www.w3.org/2000/svg"
-      role="img"
-      aria-label="HiNest"
-      className="select-none flex-shrink-0"
-    >
-      <defs>
-        <linearGradient id="ad-tile" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#5B8DFF" />
-          <stop offset="55%" stopColor="#3B5CF0" />
-          <stop offset="100%" stopColor="#1E4FD4" />
-        </linearGradient>
-        <filter id="ad-tshadow" x="-30%" y="-30%" width="160%" height="160%">
-          <feDropShadow dx="0" dy="6" stdDeviation="9" floodColor="#1E37B8" floodOpacity={shadowOpacity} />
-        </filter>
-      </defs>
-
-      <rect x="16" y="16" width="188" height="188" rx="44" fill="url(#ad-tile)" filter="url(#ad-tshadow)" />
-      <rect x="16" y="16" width="188" height="188" rx="44" fill="none" stroke="#FFFFFF" strokeOpacity="0.18" strokeWidth="1.5" />
-
-      <g transform="translate(110,107.626) scale(0.9494949494949495)">
-        <polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="#FFFFFF" opacity="0.55" />
-        <polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="#FFFFFF" opacity="0.82" />
-        <polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="#FFFFFF" />
-        <polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="#FFFFFF" opacity="0.92" />
-        <polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="#FFFFFF" opacity="0.55" />
-        <polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" />
-        <polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" opacity="0.4" />
-        <polygon points="38,-33 58,-18 58,62 38,52" fill="#FFFFFF" opacity="0.55" />
-        <polygon points="12,-33 38,-33 38,52 12,52" fill="#FFFFFF" opacity="0.82" />
-        <polygon points="38,-33 58,-18 32,-18 12,-33" fill="#FFFFFF" />
-        <polygon points="12,-33 38,-33 25,-47 0,-47" fill="#FFFFFF" opacity="0.92" />
-        <polygon points="38,-33 58,-18 45,-33 25,-47" fill="#FFFFFF" opacity="0.55" />
-        <rect x="-32" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5" />
-        <rect x="-32" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5" />
-        <rect x="21" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5" />
-        <rect x="21" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5" />
-      </g>
-    </svg>
-  );
-}
-
 export default function AdminLockup({
   variant = "compact",
   onDark,
@@ -75,81 +20,18 @@ export default function AdminLockup({
   onDark?: boolean;
 }) {
   const { resolved } = useTheme();
-  // onDark: 항상 어두운 표면(운영 콘솔 사이드바)일 때 테마와 무관하게 밝은 톤 강제.
   const isDark = onDark ?? resolved === "dark";
+  const src = isDark ? "/admin-logo/dark.svg" : "/admin-logo/light.svg";
+  const height = variant === "full" ? 104 : 44;
 
-  const wordColor = isDark ? "#FFFFFF" : "#0C1020";
-  const badge = isDark
-    ? { bg: "rgba(110,137,255,.18)", border: "rgba(165,184,255,.45)", fg: "#A5B8FF" }
-    : { bg: "rgba(59,92,240,.10)", border: "rgba(59,92,240,.30)", fg: "#1E37B8" };
-  const subColor = isDark ? "rgba(255,255,255,.6)" : "#5A6072";
-  const wordFont = '"Pretendard Variable", Pretendard, -apple-system, sans-serif';
-  const monoFont = '"JetBrains Mono", ui-monospace, SFMono-Regular, monospace';
-
-  if (variant === "full") {
-    return (
-      <div className="flex items-center gap-4 select-none">
-        <AdminTile size={64} onDark={isDark} />
-        <div className="min-w-0">
-          <div className="flex items-center gap-3">
-            <span
-              style={{ fontFamily: wordFont, fontWeight: 800, fontSize: 40, letterSpacing: "-0.045em", color: wordColor, lineHeight: 1 }}
-            >
-              HiNest
-            </span>
-            <span
-              className="uppercase"
-              style={{
-                fontFamily: wordFont,
-                fontWeight: 700,
-                fontSize: 13,
-                letterSpacing: "0.06em",
-                color: badge.fg,
-                background: badge.bg,
-                border: `1.5px solid ${badge.border}`,
-                borderRadius: 999,
-                padding: "4px 12px",
-              }}
-            >
-              Admin
-            </span>
-          </div>
-          <div
-            className="mt-1.5"
-            style={{ fontFamily: monoFont, fontWeight: 500, fontSize: 13, letterSpacing: "0.08em", color: subColor }}
-          >
-            관리자 콘솔 · Admin Console
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // compact — 사이드바/모바일 헤더용. 타일 + HiNest + ADMIN 배지 한 줄.
   return (
-    <div className="flex items-center gap-2 select-none">
-      <AdminTile size={26} onDark={isDark} />
-      <span
-        style={{ fontFamily: wordFont, fontWeight: 800, fontSize: 17, letterSpacing: "-0.04em", color: wordColor, lineHeight: 1 }}
-      >
-        HiNest
-      </span>
-      <span
-        className="uppercase"
-        style={{
-          fontFamily: wordFont,
-          fontWeight: 700,
-          fontSize: 9.5,
-          letterSpacing: "0.06em",
-          color: badge.fg,
-          background: badge.bg,
-          border: `1px solid ${badge.border}`,
-          borderRadius: 999,
-          padding: "2px 7px",
-        }}
-      >
-        Admin
-      </span>
-    </div>
+    <img
+      src={src}
+      alt="HiNest Admin Console"
+      height={height}
+      style={{ height, width: "auto", maxWidth: "100%" }}
+      className="select-none flex-shrink-0"
+      draggable={false}
+    />
   );
 }


### PR DESCRIPTION
## 증상
**운영 콘솔 로고 — 원본 SVG 누끼 적용**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
디자이너 원본 SVG(라이트/다크)에서 바깥 배경(누끼)만 제거하고 로고 마크·
워드마크·ADMIN 배지·서브타이틀은 원본 그대로 둔 파일을 public/admin-logo/ 에
두고 <img> 로 렌더한다. viewBox 를 콘텐츠에 맞게 타이트하게 잘라 작은
사이드바에서도 마크·글자가 보이도록 했다. (기존 인라인 SVG 재현본 폐기)

## 수정
**작업 항목 (커밋 단위)**
- fix(console): 운영 콘솔 로고 — 원본 SVG 누끼 적용 (배경 제거·viewBox 타이트)

**변경 대상 (3개 파일)**
- `client/public/admin-logo/dark.svg`
- `client/public/admin-logo/light.svg`
- `client/src/components/AdminLockup.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #206** ↔ **이슈 #629** 로 연결됩니다.

Closes #629
