### PR TITLE
🔀 :: (#632) 회사 앱 로고를 디자이너 원본 브랜드 락업(타일)으로 적용

### DIFF
--- a/client/public/brand-logo/dark.svg
+++ b/client/public/brand-logo/dark.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="116 118 716 236" width="716" height="236">
+<defs>
+  <linearGradient id="tile" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#5B8DFF"></stop>
+    <stop offset="55%" stop-color="#3B5CF0"></stop>
+    <stop offset="100%" stop-color="#1E4FD4"></stop>
+  </linearGradient>
+  <filter id="tshadow" x="-30%" y="-30%" width="160%" height="160%">
+    <feDropShadow dx="0" dy="9" stdDeviation="14" flood-color="#1E37B8" flood-opacity="0.55"></feDropShadow>
+  </filter>
+</defs>
+
+<rect x="130" y="136" width="188" height="188" rx="44" fill="url(#tile)" filter="url(#tshadow)"></rect>
+<rect x="130" y="136" width="188" height="188" rx="44" fill="none" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"></rect>
+
+<g transform="translate(224,227.62626262626262) scale(0.9494949494949495)">
+<polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="#FFFFFF"></polygon>
+<polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" opacity="0.4"></polygon>
+<polygon points="38,-33 58,-18 58,62 38,52" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="12,-33 38,-33 38,52 12,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="38,-33 58,-18 32,-18 12,-33" fill="#FFFFFF"></polygon>
+<polygon points="12,-33 38,-33 25,-47 0,-47" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="38,-33 58,-18 45,-33 25,-47" fill="#FFFFFF" opacity="0.55"></polygon>
+<rect x="-32" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="-32" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+</g>
+
+<text x="362" y="242.94" font-family="'Pretendard','Inter',-apple-system,'Apple SD Gothic Neo',sans-serif" font-weight="800" letter-spacing="-0.045em" font-size="104" fill="#FFFFFF">HiNest</text>
+<text x="366" y="291.94" font-family="'JetBrains Mono',ui-monospace,'SFMono-Regular',Menlo,monospace" font-weight="500" font-size="35" letter-spacing="0.1em" fill="rgba(255,255,255,.6)">Workplace Platform</text>
+</svg>

--- a/client/public/brand-logo/light.svg
+++ b/client/public/brand-logo/light.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="116 118 716 236" width="716" height="236">
+<defs>
+  <linearGradient id="tile" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#5B8DFF"></stop>
+    <stop offset="55%" stop-color="#3B5CF0"></stop>
+    <stop offset="100%" stop-color="#1E4FD4"></stop>
+  </linearGradient>
+  <filter id="tshadow" x="-30%" y="-30%" width="160%" height="160%">
+    <feDropShadow dx="0" dy="9" stdDeviation="14" flood-color="#1E37B8" flood-opacity="0.32"></feDropShadow>
+  </filter>
+</defs>
+
+<rect x="130" y="136" width="188" height="188" rx="44" fill="url(#tile)" filter="url(#tshadow)"></rect>
+<rect x="130" y="136" width="188" height="188" rx="44" fill="none" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"></rect>
+
+<g transform="translate(224,227.62626262626262) scale(0.9494949494949495)">
+<polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="#FFFFFF"></polygon>
+<polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF"></polygon>
+<polygon points="-12,10 12,5 12,24 -12,29" fill="#FFFFFF" opacity="0.4"></polygon>
+<polygon points="38,-33 58,-18 58,62 38,52" fill="#FFFFFF" opacity="0.55"></polygon>
+<polygon points="12,-33 38,-33 38,52 12,52" fill="#FFFFFF" opacity="0.82"></polygon>
+<polygon points="38,-33 58,-18 32,-18 12,-33" fill="#FFFFFF"></polygon>
+<polygon points="12,-33 38,-33 25,-47 0,-47" fill="#FFFFFF" opacity="0.92"></polygon>
+<polygon points="38,-33 58,-18 45,-33 25,-47" fill="#FFFFFF" opacity="0.55"></polygon>
+<rect x="-32" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="-32" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="-13" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+<rect x="21" y="15" width="11" height="11" fill="#3B5CF0" rx="1.5"></rect>
+</g>
+
+<text x="362" y="242.94" font-family="'Pretendard','Inter',-apple-system,'Apple SD Gothic Neo',sans-serif" font-weight="800" letter-spacing="-0.045em" font-size="104" fill="#0C1020">HiNest</text>
+<text x="366" y="291.94" font-family="'JetBrains Mono',ui-monospace,'SFMono-Regular',Menlo,monospace" font-weight="500" font-size="35" letter-spacing="0.1em" fill="#5A6072">Workplace Platform</text>
+</svg>

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -532,7 +532,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
             height: "calc(48px + env(safe-area-inset-top))",
           }}
         >
-          <BrandLockup height={28} />
+          <BrandLockup height={34} />
         </div>
 
         <nav className="flex-1 overflow-y-auto px-2 py-3 space-y-5">

--- a/client/src/components/BrandLockup.tsx
+++ b/client/src/components/BrandLockup.tsx
@@ -1,98 +1,32 @@
 import { useTheme } from "../theme";
 
 /**
- * BrandLockup — 새 HiNest 로고 (기하 마크 + "HiNest." 워드마크) 인라인 SVG.
+ * BrandLockup — 회사(사용자) 앱 브랜드 로고.
  *
- * 디자이너가 준 light/dark export(HiNest-logo-light.svg / -dark.svg)를 인라인화한 것.
- * 두 파일의 차이는 ① 배경 사각형 색 ② 워드마크 글자/점 색뿐이라, 한 컴포넌트에서
- * 테마(resolved)로 색만 전환한다.
+ * 디자이너가 준 원본 브랜드 SVG(HiNest-01-reference 라이트/다크)에서 export 미리보기
+ * 배경(누끼)만 제거하고 viewBox 를 콘텐츠에 맞게 타이트하게 잘라
+ * client/public/brand-logo/ 에 두고 <img> 로 렌더한다. 운영(관리자) 콘솔의
+ * AdminLockup 과 완전히 동일한 방식·동일한 타일 락업이라, 회사 앱과 운영 콘솔의
+ * 로고 톤(둥근 블루 타일 + 마크 + 워드마크)이 정확히 일치한다.
+ * 다크/라이트는 onDark(또는 테마)로 선택.
  *
- * export 원본 대비 의도적으로 바꾼 점:
- *  - 배경 사각형 제거 → 사이드바에 투명하게 얹힘 (원본의 bg rect 는 export 미리보기용)
- *  - 워드마크가 원본에선 미정의 `.wm` 클래스에 의존해 깨지므로 브랜드 폰트(Pretendard)로 렌더
- *    (원본 파일 desc 의 "outline the text before production" 지침을 코드 렌더로 대체)
- *  - gradient id 는 페이지 내 충돌 방지를 위해 `hn-` 프리픽스
- *
- * 마크 폴리곤 좌표는 원본 그대로 보존.
+ * 주의: <img> 로 SVG 를 렌더하면 페이지 웹폰트(Pretendard)가 적용되지 않아 워드마크는
+ * 시스템 산세리프로 폴백된다. (AdminLockup 과 동일한 절충 — SVG 안에 폰트 폴백을 박아둠)
  */
-export default function BrandLockup({ height = 30, onDark }: { height?: number; onDark?: boolean }) {
+export default function BrandLockup({ height = 34, onDark }: { height?: number; onDark?: boolean }) {
   const { resolved } = useTheme();
-  // onDark: 항상 어두운 표면(예: 운영 콘솔 사이드바)에 얹힐 때 테마와 무관하게 밝은 워드마크 강제.
+  // onDark: 항상 어두운 표면에 얹힐 때 테마와 무관하게 다크 변형 강제.
   const isDark = onDark ?? resolved === "dark";
-  const textColor = isDark ? "#FFFFFF" : "#0C1020";
-  const dotColor = isDark ? "#A5B8FF" : "#3B5CF0";
-
-  // 원본 viewBox 1080×320 에서 상하 여백만 잘라 헤더에 꽉 차게. 가로는 워드마크
-  // 클리핑 방지를 위해 그대로 유지.
-  const vbX = 0;
-  const vbY = 56;
-  const vbW = 1080;
-  const vbH = 236;
-  const width = (height * vbW) / vbH;
+  const src = isDark ? "/brand-logo/dark.svg" : "/brand-logo/light.svg";
 
   return (
-    <svg
-      width={width}
+    <img
+      src={src}
+      alt="HiNest"
       height={height}
-      viewBox={`${vbX} ${vbY} ${vbW} ${vbH}`}
-      xmlns="http://www.w3.org/2000/svg"
-      role="img"
-      aria-label="HiNest"
-      className="select-none"
-    >
-      <defs>
-        <linearGradient id="hn-bl1" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#4A7FFF" />
-          <stop offset="100%" stopColor="#1E4FD4" />
-        </linearGradient>
-        <linearGradient id="hn-bl2" x1="0%" y1="0%" x2="0%" y2="100%">
-          <stop offset="0%" stopColor="#5B8DFF" />
-          <stop offset="100%" stopColor="#2A5DE8" />
-        </linearGradient>
-        <linearGradient id="hn-bl-light" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#8FB3FF" />
-          <stop offset="100%" stopColor="#5B8DFF" />
-        </linearGradient>
-        <linearGradient id="hn-bl-dark" x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#2A5DE8" />
-          <stop offset="100%" stopColor="#1A3FB5" />
-        </linearGradient>
-      </defs>
-
-      {/* ── 기하 마크 (원본 좌표 보존) ── */}
-      <g transform="translate(40,40)">
-        <g transform="translate(120,120) scale(2.0)">
-          <polygon points="-58,-18 -38,-33 -38,52 -58,62" fill="url(#hn-bl-dark)" />
-          <polygon points="-38,-33 -12,-33 -12,52 -38,52" fill="url(#hn-bl2)" />
-          <polygon points="-58,-18 -38,-33 -12,-33 -32,-18" fill="url(#hn-bl-light)" />
-          <polygon points="-38,-33 -25,-47 0,-47 -12,-33" fill="url(#hn-bl1)" />
-          <polygon points="-32,-18 -12,-33 0,-47 -20,-33" fill="url(#hn-bl-dark)" />
-          <polygon points="-12,10 12,5 12,24 -12,29" fill="url(#hn-bl-light)" />
-          <polygon points="-12,10 12,5 12,24 -12,29" fill="url(#hn-bl2)" opacity="0.55" />
-          <polygon points="38,-33 58,-18 58,62 38,52" fill="url(#hn-bl-dark)" />
-          <polygon points="12,-33 38,-33 38,52 12,52" fill="url(#hn-bl2)" />
-          <polygon points="38,-33 58,-18 32,-18 12,-33" fill="url(#hn-bl-light)" />
-          <polygon points="12,-33 38,-33 25,-47 0,-47" fill="url(#hn-bl1)" />
-          <polygon points="38,-33 58,-18 45,-33 25,-47" fill="url(#hn-bl-dark)" />
-          <rect x="-32" y="-13" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-          <rect x="-32" y="15" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-          <rect x="21" y="-13" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-          <rect x="21" y="15" width="11" height="11" fill="#FFFFFF" rx="1.5" />
-        </g>
-      </g>
-
-      {/* ── 워드마크 (브랜드 폰트로 렌더) ── */}
-      <text
-        x="320"
-        y="220"
-        fontFamily='"Pretendard Variable", Pretendard, -apple-system, sans-serif'
-        fontWeight={800}
-        fontSize={196}
-        letterSpacing="-0.04em"
-      >
-        <tspan fill={textColor}>HiNest</tspan>
-        <tspan fill={dotColor}>.</tspan>
-      </text>
-    </svg>
+      style={{ height, width: "auto", maxWidth: "100%" }}
+      className="select-none flex-shrink-0"
+      draggable={false}
+    />
   );
 }

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -48,7 +48,7 @@ export default function LoginPage() {
     <div className="min-h-screen flex flex-col" style={{ background: "var(--c-surface)" }}>
       {/* 상단 — 로고만 살짝 */}
       <header className="px-6 pt-8 pb-4 flex items-center">
-        <BrandLockup height={28} />
+        <BrandLockup height={36} />
       </header>
 
       {/* 본문 — 중앙 정렬, 한 단 */}


### PR DESCRIPTION
## 증상
**회사 앱 로고를 디자이너 원본 브랜드 락업(타일)으로 적용**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
운영(관리자) 콘솔은 디자이너 원본 SVG(AdminLockup)로 로고가 적용돼 있었지만
회사(사용자) 앱은 인라인 SVG 재현본(BrandLockup)이라 둥근 블루 타일이 없어
두 영역의 로고 톤이 어긋났다.

디자이너 원본 브랜드 SVG(HiNest-01-reference 라이트/다크)에서 export 미리보기
배경만 누끼 처리하고 viewBox 를 콘텐츠에 맞게 타이트하게 잘라
client/public/brand-logo/{light,dark}.svg 로 두고, BrandLockup 을 AdminLockup
과 동일한 <img> 렌더 방식으로 교체했다. (<img> SVG 는 웹폰트가 안 먹으므로
워드마크 폰트 폴백을 SVG 안에 박아 시스템 산세리프로 렌더 — AdminLockup 과 동일)

- 사이드바(AppLayout) 로고 높이 28→34, 로그인(LoginPage) 28→36
- 라이트/다크 · 사이드바/로그인 4개 상태 미리보기 검증 완료

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 회사 앱 로고를 디자이너 원본 브랜드 락업(타일)으로 교체

**변경 대상 (5개 파일)**
- `client/public/brand-logo/dark.svg`
- `client/public/brand-logo/light.svg`
- `client/src/components/AppLayout.tsx`
- `client/src/components/BrandLockup.tsx`
- `client/src/pages/LoginPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #209** ↔ **이슈 #632** 로 연결됩니다.

Closes #632
