### PR TITLE
🔀 :: (#635) 프로젝트 목록 조회 take:500 상한

### DIFF
--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -23,6 +23,9 @@ router.get("/", async (req, res) => {
     include: {
       _count: { select: { members: true } },
     },
+    // 형제 엔드포인트(document/approval)와 동일하게 상한 — ADMIN 의 all=1 전체 조회가
+    // 대규모 조직에서 무한정 커지는 것을 방지(사이드바 "팀" 목록은 그 이상 필요 없음).
+    take: 500,
   });
   res.json({ projects: list });
 });


### PR DESCRIPTION
## 증상
**프로젝트 목록 조회 take:500 상한**

성능을 개선합니다.

## 원인
GET /projects 의 findMany 가 ADMIN all=1 전체 조회 시 상한이 없어
대규모 조직에서 무한정 커질 수 있었음. 형제 엔드포인트(document·approval)와
동일하게 take:500 캡을 적용해 사이드바 "팀" 목록 응답 크기를 제한.
사용자 화면(팀 목록)은 그 이상 필요하지 않음.

## 수정
**작업 항목 (커밋 단위)**
- perf(server): 프로젝트 목록 조회에 take:500 상한 추가

**변경 대상 (1개 파일)**
- `server/src/routes/project.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #212** ↔ **이슈 #635** 로 연결됩니다.

Closes #635
