### PR TITLE
🔀 :: (#636) ChatMessage(senderId, scheduledAt) 인덱스

### DIFF
--- a/server/prisma/migrations/20260601010000_chatmessage_sender_scheduled_index/migration.sql
+++ b/server/prisma/migrations/20260601010000_chatmessage_sender_scheduled_index/migration.sql
@@ -1,0 +1,11 @@
+-- 예약 메시지 목록 조회 성능 인덱스
+--
+-- chat.ts 의 GET /chat/scheduled 는 prisma.chatMessage.findMany({
+--   where: { senderId, scheduledAt: { gt: now }, deletedAt: null },
+--   orderBy: { scheduledAt: "asc" }
+-- }) 를 실행한다. ChatMessage 의 기존 인덱스는 (roomId, scheduledAt) ·
+-- (roomId, createdAt) · (companyId) 뿐이라, roomId 가 없는 이 쿼리는 (companyId)
+-- 로 떨어져 "회사 전체 메시지"(고볼륨 테이블) 를 스캔한 뒤 senderId/scheduledAt
+-- 필터를 적용했다. senderId 선두 복합 인덱스로 probe + 범위 스캔으로 전환한다.
+-- (senderId 는 회사에 1:1 종속이므로 companyId prefix 불필요 — 기존 roomId 패턴과 동일.)
+CREATE INDEX "ChatMessage_senderId_scheduledAt_idx" ON "ChatMessage"("senderId", "scheduledAt");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -741,6 +741,10 @@ model ChatMessage {
   // after-cursor 증분 폴링 — createdAt 역정렬·범위 조회가 핵심 경로
   @@index([roomId, createdAt])
   @@index([companyId])
+  // GET /chat/scheduled — where senderId + scheduledAt>now 조회. roomId 가 없어
+  // 기존 (roomId,*) 인덱스를 못 타고 (companyId) 로 떨어져 회사 전체 메시지를
+  // 스캔했다. senderId 는 회사에 종속되므로 companyId prefix 불필요.
+  @@index([senderId, scheduledAt])
 }
 
 model MessageReaction {


### PR DESCRIPTION
## 증상
**ChatMessage(senderId, scheduledAt) 인덱스**

성능을 개선합니다.

## 원인
GET /chat/scheduled 가 senderId + scheduledAt>now 로 조회하는데 roomId 가
없어 기존 (roomId,*) 인덱스를 못 타고 (companyId) 인덱스로 떨어져 회사 전체
메시지(고볼륨)를 스캔했다. senderId 선두 복합 인덱스로 전환.

마이그레이션은 컨테이너 기동 시 migrate deploy 로 자동 적용됨(기존 컨벤션).
DB 무접속 schema-to-schema diff 로 SQL 생성.

## 수정
**작업 항목 (커밋 단위)**
- perf(server): ChatMessage(senderId, scheduledAt) 인덱스 추가

**변경 대상 (2개 파일)**
- `server/prisma/migrations/20260601010000_chatmessage_sender_scheduled_index/migration.sql`
- `server/prisma/schema.prisma`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #213** ↔ **이슈 #636** 로 연결됩니다.

Closes #636
