### PR TITLE
🔀 :: (#637) 미사용 xlsx 의존성 제거 (보안 HIGH 해소)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -34,7 +34,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0",
-        "xlsx": "^0.18.5",
         "xlsx-js-style": "^1.2.0"
       },
       "devDependencies": {
@@ -2616,15 +2615,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4949,27 +4939,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/xlsx-js-style": {

--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",
-    "xlsx": "^0.18.5",
     "xlsx-js-style": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 증상
**미사용 xlsx 의존성 제거 (보안 HIGH 해소)**

보안 취약점을 점검하고 보완합니다.

## 원인
코드는 xlsx-js-style(드롭인 포크)만 동적 import 하고 직접 xlsx 를 쓰는 곳이 없다. 죽은 직접 의존성이 ReDoS(HIGH)·Prototype Pollution 권고만 남기고 있어 manifest 에서 제거한다. (xlsx-js-style 은 별도 트리라 유지)

## 수정
**작업 항목 (커밋 단위)**
- chore(client): package.json 에서 미사용 xlsx 직접 의존성 제거
- chore(client): package-lock 에서 xlsx 트리 정리

**변경 대상 (2개 파일)**
- `client/package-lock.json`
- `client/package.json`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #214** ↔ **이슈 #637** 로 연결됩니다.

Closes #637
