### PR TITLE
🔀 :: (#639) /uploads 테넌트 격리 — 신규 키 companyId 바인딩 (보안 MEDIUM)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -328,11 +328,36 @@ function applyUploadSecurityHeaders(
   }
 }
 
+/**
+ * 업로드 키의 회사 바인딩을 검사한다(테넌트 격리, 심층 방어).
+ * 신규 키는 `cmp_<companyId>__<...>` 형태로 업로더 회사를 박아 발급된다(upload.ts).
+ *  - 접두어가 없으면(legacy 키, 항상 숫자로 시작): 과거처럼 인증만으로 허용 — 하위호환.
+ *  - 접두어가 있으면: 인증 유저의 companyId 와 일치해야 통과. 슈퍼/플랫폼 관리자는 우회.
+ *  - 접두어는 있는데 파싱이 안 되면(우리가 만든 적 없는 형태) 거부(fail-closed).
+ */
+function canAccessUploadKey(
+  key: string,
+  user: { companyId?: string | null; superAdmin?: boolean; platformAdmin?: boolean } | undefined,
+): boolean {
+  if (!key.startsWith("cmp_")) return true; // legacy — 인증만으로 허용
+  if (user?.superAdmin || user?.platformAdmin) return true; // 크로스 테넌트 허용
+  const rest = key.slice(4);
+  const sep = rest.indexOf("__");
+  if (sep <= 0) return false; // cmp_ 접두어인데 companyId 파싱 불가 → 거부
+  const keyCompanyId = rest.slice(0, sep);
+  return !!user?.companyId && user.companyId === keyCompanyId;
+}
+
 app.use("/uploads", requireAuth, async (req, res) => {
   const name = req.path.replace(/^\/+/, "");
   // 경로 탈출 / 상대경로 차단
   if (!/^[A-Za-z0-9._-]+$/.test(name)) {
     return res.status(400).json({ error: "invalid filename" });
+  }
+  // 신규 키(cmp_<companyId>__...)는 다른 회사 유저의 접근을 차단. 존재 자체를 숨기려 404 로 응답
+  // (legacy 키·관리자는 통과). 스토리지 조회 전에 막아 불필요한 fetch·타이밍 노출도 차단.
+  if (!canAccessUploadKey(name, (req as any).user)) {
+    return res.status(404).json({ error: "not found" });
   }
   const forceDownload = req.query.download === "1" || req.query.download === "true";
   // ?name=<원본파일명> — 다운로드 대화상자에 표시할 이름. 서버 키는 해시라 보기 좋지 않음.

--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -97,7 +97,17 @@ async function storeAndRespond(req: any, res: any) {
   const originalName = fixName(f.originalname);
   const ext = safeExt(originalName);
   const id = crypto.randomBytes(12).toString("hex");
-  const key = `${Date.now()}-${id}${ext}`;
+  const base = `${Date.now()}-${id}${ext}`;
+  // 신규 키에 업로더의 companyId 를 `cmp_<companyId>__` 접두어로 박는다 — 다운로드 시
+  // 다른 회사 유저의 접근을 차단(테넌트 격리)하기 위함. 검사는 /uploads 핸들러
+  // (index.ts canAccessUploadKey)에서 한다.
+  // cuid companyId 는 [a-z0-9]+ 라 파일명 규칙(/^[A-Za-z0-9._-]+$/)·SAFE_UPLOAD_URL 을 그대로 통과.
+  // companyId 가 없거나(플랫폼 운영자) 형식이 어긋나면 접두어 없이 발급 → legacy(인증만) 동작.
+  const cid = (req as any).user?.companyId;
+  const key =
+    typeof cid === "string" && /^[A-Za-z0-9]+$/.test(cid)
+      ? `cmp_${cid}__${base}`
+      : base;
   const mime = String(f.mimetype || "application/octet-stream");
 
   try {


### PR DESCRIPTION
## 증상
**/uploads 테넌트 격리 — 신규 키 companyId 바인딩 (보안 MEDIUM)**

보안 취약점을 점검하고 보완합니다.

## 원인
기존 /uploads 다운로드는 "인증된 유저면 누구나" 였다. 키가 96비트 난수라
실질 추측은 어렵지만, 키가 노출되면 다른 회사 유저도 받을 수 있어 테넌트
격리가 헐거웠다(심층 방어 관점 MEDIUM).

신규 업로드 키를 `cmp_<companyId>__<ts>-<id><ext>` 로 발급하고(upload.ts),
다운로드 시 키에서 companyId 를 파싱해 인증 유저의 companyId 와 대조한다
(index.ts canAccessUploadKey). 불일치면 존재를 숨기려 404 로 응답하고,
스토리지 조회 전에 막아 불필요한 fetch·타이밍 노출도 차단한다.

호환성:
- legacy 키(접두어 없음, 항상 숫자로 시작)는 과거처럼 인증만으로 허용 →
  마이그레이션/백필 불필요. 기존 첨부 URL 전부 그대로 동작.
- 슈퍼/플랫폼 관리자는 우회(크로스 테넌트 설계 그대로).
- companyId 없는 업로더(플랫폼 운영자)는 접두어 없이 발급 → legacy 동작.
- cmp_ 접두어인데 파싱 불가한 키는 거부(fail-closed) — 우리가 만든 적 없는 형태.

키 형식 검증: cuid companyId 는 [a-z0-9]+ 라 `_` 포함 전부
다운로드 가드(/^[A-Za-z0-9._-]+$/)·SAFE_UPLOAD_URL(project·meeting·document
저장 검증)을 그대로 통과. 키를 split 하거나 타임스탬프를 파싱하는 소비자
없음(storage·document zip 모두 키를 불투명 문자열로 사용). 빌드 그린.

## 수정
**작업 항목 (커밋 단위)**
- fix(server): /uploads 테넌트 격리 — 신규 키에 companyId 바인딩 (보안 MEDIUM)

**변경 대상 (2개 파일)**
- `server/src/index.ts`
- `server/src/routes/upload.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #216** ↔ **이슈 #639** 로 연결됩니다.

Closes #639
