### PR TITLE
🔀 :: (#642) 모바일 풀스크린 채팅이 미리보기 배너와 겹치는 문제 수정

### DIFF
--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -61,11 +61,17 @@ export default function ChatFab() {
     return () => mq.removeEventListener?.("change", update);
   }, []);
   // 모바일 풀스크린 상태에서 배경 스크롤 잠금.
+  // 동시에 body 에 마커 클래스를 달아, 미리보기 배너(sticky z-9999)가 풀스크린 채팅
+  // 헤더(z-40) 위로 그려져 닫기·새 채팅 버튼을 가리는 문제를 CSS 로 가린다(styles.css).
   useEffect(() => {
     if (!isMobile || !open) return;
     const prev = document.body.style.overflow;
     document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = prev; };
+    document.body.classList.add("hinest-chat-fs");
+    return () => {
+      document.body.style.overflow = prev;
+      document.body.classList.remove("hinest-chat-fs");
+    };
   }, [isMobile, open]);
   // 새 채팅 알림이 들어올 때 파란 펄스.
   // - 단순 새로고침/재오픈만으론 발동하지 않음 (localStorage 에 저장된 마지막으로 본 카운트와 비교).

--- a/client/src/components/PreviewBanner.tsx
+++ b/client/src/components/PreviewBanner.tsx
@@ -9,6 +9,7 @@ export default function PreviewBanner({ safeAreaTop = true }: { safeAreaTop?: bo
   if (!isPreviewMode()) return null;
   return (
     <div
+      className="hinest-preview-banner"
       style={{
         position: "sticky",
         top: 0,

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1022,3 +1022,14 @@ html.dark .nav-active svg { stroke: var(--c-brand-soft-fg); }
     grid-template-columns: 16px minmax(0, 2.2fr) 88px 1fr 150px 110px 56px;
   }
 }
+
+/* ============================================================ */
+/*   미리보기 배너 × 모바일 풀스크린 채팅 겹침 방지              */
+/*   미리보기 배너는 sticky z-9999 라, 풀스크린 채팅(fixed z-40) */
+/*   헤더 위로 그려져 닫기·새 채팅 버튼을 가린다. 풀스크린 채팅이 */
+/*   열린 동안(body.hinest-chat-fs)만 배너를 숨겨 충돌을 없앤다.  */
+/*   (배너는 미리보기 모드에서만 렌더되므로 운영에는 영향 없음)   */
+/* ============================================================ */
+body.hinest-chat-fs .hinest-preview-banner {
+  visibility: hidden;
+}


### PR DESCRIPTION
## 증상
**모바일 풀스크린 채팅이 미리보기 배너와 겹치는 문제 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
겹침 회피 CSS 가 배너를 정확히 타깃팅할 수 있도록 sticky 루트 div 에 안정적인 클래스명을 단다. 시각적 변화는 없음.

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 미리보기 배너에 hinest-preview-banner 클래스 부여
- fix(client): 모바일 풀스크린 채팅 동안 body 에 hinest-chat-fs 마커 부착
- fix(client): 풀스크린 채팅 중 미리보기 배너 숨김 규칙 추가

**변경 대상 (3개 파일)**
- `client/src/components/ChatFab.tsx`
- `client/src/components/PreviewBanner.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #219** ↔ **이슈 #642** 로 연결됩니다.

Closes #642
