### PR TITLE
🔀 :: (#653) 총관리자 로그인 시 운영 콘솔로 자동 이동

### DIFF
--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -28,7 +28,7 @@ type Ctx = {
   user: User | null;
   impersonator: Impersonator | null;
   loading: boolean;
-  login: (email: string, password: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<User>;
   signup: (data: { inviteKey: string; email: string; name: string; password: string }) => Promise<void>;
   logout: () => Promise<void>;
   refresh: () => Promise<void>;
@@ -67,6 +67,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // 섬광처럼 보이는 것을 방지. logout 에서와 동일하게 세션 캐시를 싹 비움.
     clearApiCache();
     setUser(res.user);
+    // 호출부(LoginPage)가 superAdmin 여부로 진입 경로를 정할 수 있도록 사용자 객체를 반환.
+    return res.user;
   }, []);
 
   const signup = useCallback(async (d: { inviteKey: string; email: string; name: string; password: string }) => {

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -23,7 +23,8 @@ export default function LoginPage() {
   const [errCode, setErrCode] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  if (user) return <Navigate to="/" replace />;
+  // 총관리자(superAdmin)는 운영 콘솔로, 그 외 사용자는 회사 앱 홈으로.
+  if (user) return <Navigate to={user.superAdmin ? "/super-admin" : "/"} replace />;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -31,8 +32,8 @@ export default function LoginPage() {
     setErrCode(null);
     setLoading(true);
     try {
-      await login(email, password);
-      nav("/");
+      const u = await login(email, password);
+      nav(u.superAdmin ? "/super-admin" : "/");
     } catch (e: any) {
       setErr(e.message);
       // 서버가 ACCOUNT_LOCKED 같은 코드를 message JSON 에 포함하는 경우를 위해


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
- superAdmin 계정은 로그인 직후(및 로그인 상태로 `/login` 재진입 시) 회사 앱 홈(`/`) 대신 운영 콘솔(`/super-admin`)로 이동합니다.
- 이를 위해 `useAuth().login` 이 로그인한 `User` 를 반환하도록 바꿔, 호출부가 컨텍스트 갱신을 기다리지 않고 즉시 `superAdmin` 여부로 분기합니다.
- 일반 사용자 흐름은 그대로 `/` 입니다.

## 배경
닫은 PR #196 에서 **이 리다이렉트만** 떼어 현재 main 기준으로 재작성했습니다. #196 의 로고/콘솔 변경은 이미 머지된 BrandLockup·AdminLockup 작업(#229·#201)과 겹쳐 폐기했고, 그대로 머지하면 삭제된 `Logo` 컴포넌트로 되돌아가 빌드가 깨지는 상태였습니다.

## Commits
- `refactor(client)`: `login()` 이 `User` 를 반환
- `feat(client)`: 총관리자 → `/super-admin` 분기

## Test plan
- [ ] 일반 사용자 로그인 → `/` 진입
- [ ] superAdmin 로그인 → `/super-admin` 진입
- [ ] superAdmin 로그인 상태로 `/login` 직접 방문 → `/super-admin` 으로 리다이렉트
- [x] `tsc -b && vite build` 통과 (EXIT=0)

Closes #653

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #653
