### PR TITLE
🔀 :: (#655) 모바일 알림 — 드롭다운 대신 전용 페이지로 전환

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,6 +40,7 @@ import {
   MemosPage,
   PayrollPage,
   PlatformPage,
+  NotificationsPage,
 } from "./routes";
 
 /**
@@ -123,6 +124,8 @@ export default function App() {
           <Route index element={<DashboardPage />} />
           {/* 모바일 "전체" 메뉴 페이지 — 하단 바의 전체 탭이 여기로 온다(데스크톱은 사이드바). */}
           <Route path="menu" element={<MobileMenuPage />} />
+          {/* 전용 알림 페이지 — 모바일에서 벨을 누르면 드롭다운 대신 여기로 온다(데스크톱은 URL 직접 접근). */}
+          <Route path="notifications" element={<NotificationsPage />} />
           <Route path="schedule" element={<SchedulePage />} />
           <Route path="attendance" element={<AttendancePage />} />
           <Route path="journal" element={<JournalPage />} />

--- a/client/src/components/NotificationBell.tsx
+++ b/client/src/components/NotificationBell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useNotifications, type Notif } from "../notifications";
 import NotificationPrefsModal from "./NotificationPrefsModal";
+import { NotifRow, navigateToNotif } from "./notifShared";
 
 export default function NotificationBell() {
   const nav = useNavigate();
@@ -24,20 +25,7 @@ export default function NotificationBell() {
 
   async function handleClick(n: Notif) {
     if (!n.readAt) await markRead([n.id]);
-    if (n.linkUrl) {
-      // /chat 페이지가 제거됐으므로 chat 링크는 우하단 사내톡 팝업으로 돌림.
-      // 레거시 알림의 linkUrl 에 "/chat?room=<id>" 가 남아있을 수 있어 호환 처리.
-      const chatMatch = /^\/chat(?:\?|#).*?room=([^&]+)/.exec(n.linkUrl);
-      if (chatMatch) {
-        window.dispatchEvent(new CustomEvent("chat:open"));
-        window.dispatchEvent(new CustomEvent("chat:open-room", { detail: { roomId: chatMatch[1] } }));
-      } else if (n.linkUrl.startsWith("/chat")) {
-        // room 지정 없는 /chat 링크는 그냥 팝업만 연다
-        window.dispatchEvent(new CustomEvent("chat:open"));
-      } else {
-        nav(n.linkUrl);
-      }
-    }
+    navigateToNotif(n, nav);
     setOpen(false);
   }
 
@@ -109,67 +97,4 @@ export default function NotificationBell() {
       <NotificationPrefsModal open={prefsOpen} onClose={() => setPrefsOpen(false)} />
     </div>
   );
-}
-
-function NotifRow({ n, onClick }: { n: Notif; onClick: () => void }) {
-  const { icon, color } = typeVisuals(n.type);
-  const unread = !n.readAt;
-  return (
-    <button
-      onClick={onClick}
-      className="w-full text-left px-4 py-3 border-b border-ink-100 last:border-b-0 hover:bg-ink-25 flex items-start gap-3 relative"
-      style={unread ? { background: "color-mix(in srgb, var(--c-brand) 8%, transparent)" } : undefined}
-    >
-      {unread && (
-        <span
-          aria-hidden
-          style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 3, background: "var(--c-brand)" }}
-        />
-      )}
-      <div className={`w-8 h-8 rounded-lg grid place-items-center flex-shrink-0`} style={{ background: color + "20", color }}>
-        {icon}
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5">
-          {!n.readAt && <span className="w-1.5 h-1.5 rounded-full bg-brand-500 flex-shrink-0" />}
-          <div className="text-[13px] font-bold text-ink-900 truncate">{n.title}</div>
-        </div>
-        {n.body && <div className="text-[12px] text-ink-600 mt-0.5 line-clamp-2">{n.body}</div>}
-        <div className="text-[10px] text-ink-400 mt-1 tabular">{formatAgo(new Date(n.createdAt))}</div>
-      </div>
-    </button>
-  );
-}
-
-function typeVisuals(t: Notif["type"]) {
-  const S = (p: React.ReactNode) => (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">{p}</svg>
-  );
-  switch (t) {
-    case "NOTICE":
-      return { icon: S(<><path d="M3 10v4a2 2 0 0 0 2 2h2l8 5V3L7 8H5a2 2 0 0 0-2 2Z" /><path d="M19 8a5 5 0 0 1 0 8" /></>), color: "#DC2626" };
-    case "DM":
-      return { icon: S(<path d="M4 5h16v11H9l-4 4z" />), color: "#3B5CF0" };
-    case "APPROVAL_REQUEST":
-      return { icon: S(<><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /><path d="M8 13h8M8 17h5" /></>), color: "#D97706" };
-    case "APPROVAL_REVIEW":
-      return { icon: S(<><circle cx="12" cy="12" r="9" /><path d="m8 12 3 3 5-6" /></>), color: "#16A34A" };
-    case "MENTION":
-      return { icon: S(<><circle cx="12" cy="12" r="4" /><path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.9 7.93" /></>), color: "#0EA5E9" };
-    default:
-      return { icon: S(<><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" /><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" /></>), color: "#6B7280" };
-  }
-}
-
-function formatAgo(d: Date) {
-  const diff = Date.now() - d.getTime();
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return "방금";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}분 전`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}시간 전`;
-  const day = Math.floor(h / 24);
-  if (day < 7) return `${day}일 전`;
-  return d.toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" });
 }

--- a/client/src/components/NotificationBell.tsx
+++ b/client/src/components/NotificationBell.tsx
@@ -34,6 +34,14 @@ export default function NotificationBell() {
       <button
         className="btn-icon relative"
         onClick={() => {
+          // 모바일(<768px)에선 드롭다운 대신 전용 알림 페이지로 이동한다(작은 화면에서
+          // 360px 팝업이 답답하고, 본문 위를 덮는 대신 한 화면 흐름이 자연스러움).
+          // 브레이크포인트는 styles.css 의 하단 바/사이드바 전환(767.98px)과 일치시킨다.
+          // 데스크톱(md+)은 기존 드롭다운을 그대로 토글한다.
+          if (window.matchMedia("(max-width: 767.98px)").matches) {
+            nav("/notifications");
+            return;
+          }
           const willOpen = !open;
           setOpen(willOpen);
           if (willOpen) reload();

--- a/client/src/components/notifShared.tsx
+++ b/client/src/components/notifShared.tsx
@@ -1,0 +1,89 @@
+import type { Notif } from "../notifications";
+
+/**
+ * 알림 표시용 공유 헬퍼 — 벨 드롭다운(NotificationBell)과 전용 알림 페이지
+ * (NotificationsPage)가 동일한 행 UI·아이콘·이동 로직을 쓰도록 한곳에 모은다.
+ * 이전엔 NotificationBell 안에만 있어 페이지에서 재사용하려면 복붙해야 했다.
+ */
+
+/**
+ * 알림 클릭 시 이동 처리. 읽음 처리는 호출부에서 먼저 한 뒤 이 함수로 이동만 담당한다.
+ * /chat 페이지가 제거됐으므로 chat 링크는 우하단 사내톡 팝업으로 돌린다(레거시 알림의
+ * linkUrl 에 "/chat?room=<id>" 가 남아있을 수 있어 호환 처리).
+ */
+export function navigateToNotif(n: Notif, nav: (to: string) => void) {
+  if (!n.linkUrl) return;
+  const chatMatch = /^\/chat(?:\?|#).*?room=([^&]+)/.exec(n.linkUrl);
+  if (chatMatch) {
+    window.dispatchEvent(new CustomEvent("chat:open"));
+    window.dispatchEvent(new CustomEvent("chat:open-room", { detail: { roomId: chatMatch[1] } }));
+  } else if (n.linkUrl.startsWith("/chat")) {
+    // room 지정 없는 /chat 링크는 그냥 팝업만 연다
+    window.dispatchEvent(new CustomEvent("chat:open"));
+  } else {
+    nav(n.linkUrl);
+  }
+}
+
+export function NotifRow({ n, onClick }: { n: Notif; onClick: () => void }) {
+  const { icon, color } = typeVisuals(n.type);
+  const unread = !n.readAt;
+  return (
+    <button
+      onClick={onClick}
+      className="w-full text-left px-4 py-3 border-b border-ink-100 last:border-b-0 hover:bg-ink-25 flex items-start gap-3 relative"
+      style={unread ? { background: "color-mix(in srgb, var(--c-brand) 8%, transparent)" } : undefined}
+    >
+      {unread && (
+        <span
+          aria-hidden
+          style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 3, background: "var(--c-brand)" }}
+        />
+      )}
+      <div className={`w-8 h-8 rounded-lg grid place-items-center flex-shrink-0`} style={{ background: color + "20", color }}>
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          {!n.readAt && <span className="w-1.5 h-1.5 rounded-full bg-brand-500 flex-shrink-0" />}
+          <div className="text-[13px] font-bold text-ink-900 truncate">{n.title}</div>
+        </div>
+        {n.body && <div className="text-[12px] text-ink-600 mt-0.5 line-clamp-2">{n.body}</div>}
+        <div className="text-[10px] text-ink-400 mt-1 tabular">{formatAgo(new Date(n.createdAt))}</div>
+      </div>
+    </button>
+  );
+}
+
+function typeVisuals(t: Notif["type"]) {
+  const S = (p: React.ReactNode) => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">{p}</svg>
+  );
+  switch (t) {
+    case "NOTICE":
+      return { icon: S(<><path d="M3 10v4a2 2 0 0 0 2 2h2l8 5V3L7 8H5a2 2 0 0 0-2 2Z" /><path d="M19 8a5 5 0 0 1 0 8" /></>), color: "#DC2626" };
+    case "DM":
+      return { icon: S(<path d="M4 5h16v11H9l-4 4z" />), color: "#3B5CF0" };
+    case "APPROVAL_REQUEST":
+      return { icon: S(<><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" /><path d="M8 13h8M8 17h5" /></>), color: "#D97706" };
+    case "APPROVAL_REVIEW":
+      return { icon: S(<><circle cx="12" cy="12" r="9" /><path d="m8 12 3 3 5-6" /></>), color: "#16A34A" };
+    case "MENTION":
+      return { icon: S(<><circle cx="12" cy="12" r="4" /><path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-3.9 7.93" /></>), color: "#0EA5E9" };
+    default:
+      return { icon: S(<><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" /><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" /></>), color: "#6B7280" };
+  }
+}
+
+function formatAgo(d: Date) {
+  const diff = Date.now() - d.getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "방금";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}분 전`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}시간 전`;
+  const day = Math.floor(h / 24);
+  if (day < 7) return `${day}일 전`;
+  return d.toLocaleDateString("ko-KR", { month: "2-digit", day: "2-digit" });
+}

--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useNotifications, type Notif } from "../notifications";
+import { NotifRow, navigateToNotif } from "../components/notifShared";
+import NotificationPrefsModal from "../components/NotificationPrefsModal";
+
+/**
+ * 전용 알림 페이지 — 주로 모바일에서 진입한다(벨을 누르면 드롭다운 대신 이 페이지로 이동).
+ * 데스크톱은 벨 드롭다운을 그대로 쓰지만, URL(/notifications)로도 접근할 수 있게 라우트는
+ * 공통으로 둔다. 행 UI·이동 로직은 벨과 동일하게 notifShared 를 재사용한다.
+ */
+export default function NotificationsPage() {
+  const nav = useNavigate();
+  const { bellItems, unread, reload, markRead } = useNotifications();
+  const [tab, setTab] = useState<"all" | "unread">("all");
+  const [prefsOpen, setPrefsOpen] = useState(false);
+
+  // 페이지 진입 시 최신 알림으로 한 번 갱신(프로바이더의 주기 폴링과 별개로 즉시 동기화).
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const visible = tab === "unread" ? bellItems.filter((n) => !n.readAt) : bellItems;
+
+  async function handleClick(n: Notif) {
+    if (!n.readAt) await markRead([n.id]);
+    navigateToNotif(n, nav);
+  }
+
+  return (
+    <div className="max-w-[640px] mx-auto">
+      {/* 헤더 — 제목 + 미읽음 수, 우측에 모두 읽음 / 설정 */}
+      <div className="flex items-center gap-2 mb-4">
+        <h1 className="text-[20px] font-extrabold text-ink-900 tracking-tight">알림</h1>
+        {unread > 0 && (
+          <span className="min-w-[20px] h-[20px] px-1.5 rounded-full bg-danger text-white text-[11px] font-bold grid place-items-center tabular">
+            {unread > 99 ? "99+" : unread}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          {unread > 0 && (
+            <button
+              className="text-[12px] font-bold text-brand-600 hover:text-brand-700 px-2 py-1"
+              onClick={() => markRead(undefined, true)}
+            >
+              모두 읽음
+            </button>
+          )}
+          <button
+            className="btn-icon !w-8 !h-8"
+            title="알림 설정"
+            aria-label="알림 설정"
+            onClick={() => setPrefsOpen(true)}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* 탭 — 전체 / 안읽음 */}
+      <div className="tabs mb-3">
+        <button className={`tab ${tab === "all" ? "tab-active" : ""}`} onClick={() => setTab("all")}>전체</button>
+        <button className={`tab ${tab === "unread" ? "tab-active" : ""}`} onClick={() => setTab("unread")}>
+          안읽음 {unread > 0 && <span className="ml-0.5 text-danger tabular">{unread}</span>}
+        </button>
+      </div>
+
+      {/* 리스트 */}
+      <div className="panel overflow-hidden">
+        {visible.length === 0 ? (
+          <div className="py-16 text-center">
+            <div className="mx-auto w-11 h-11 rounded-xl bg-ink-100 grid place-items-center mb-2.5">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8E959E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+              </svg>
+            </div>
+            <div className="text-[13px] text-ink-500">
+              {tab === "unread" ? "안 읽은 알림이 없어요." : "알림이 없어요."}
+            </div>
+          </div>
+        ) : (
+          visible.map((n) => <NotifRow key={n.id} n={n} onClick={() => handleClick(n)} />)
+        )}
+      </div>
+
+      <NotificationPrefsModal open={prefsOpen} onClose={() => setPrefsOpen(false)} />
+    </div>
+  );
+}

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -29,6 +29,7 @@ export const loadSuperAdmin = () => import("./pages/SuperAdminPage");
 export const loadMemos = () => import("./pages/MemosPage");
 export const loadPayroll = () => import("./pages/PayrollPage");
 export const loadPlatform = () => import("./pages/PlatformPage");
+export const loadNotifications = () => import("./pages/NotificationsPage");
 
 export const SchedulePage = lazy(loadSchedule);
 export const AttendancePage = lazy(loadAttendance);
@@ -51,6 +52,7 @@ export const SuperAdminPage = lazy(loadSuperAdmin);
 export const MemosPage = lazy(loadMemos);
 export const PayrollPage = lazy(loadPayroll);
 export const PlatformPage = lazy(loadPlatform);
+export const NotificationsPage = lazy(loadNotifications);
 
 /** 사이드바 경로별 prefetch 함수 매핑 — hover/focus 시 호출해 청크 선로딩. */
 export const ROUTE_PREFETCH: Record<string, () => Promise<unknown>> = {


### PR DESCRIPTION
## 증상
**모바일 알림 — 드롭다운 대신 전용 페이지로 전환**

새 기능을 추가합니다.

## 원인
NotifRow·typeVisuals·formatAgo 와 chat 링크 호환 이동 로직이 NotificationBell
안에만 있어 다른 화면(곧 추가할 전용 알림 페이지)에서 재사용하려면 복붙해야 했다.

- components/notifShared.tsx 신설: NotifRow, navigateToNotif 공개 / typeVisuals,
  formatAgo 는 모듈 내부 구현 디테일로 유지
- handleClick 의 인라인 chat 링크 분기를 navigateToNotif(n, nav) 호출로 대체

동작 변화 없음(순수 리팩터). 빌드 통과.

## 수정
**작업 항목 (커밋 단위)**
- refactor(client): 알림 행·아이콘·이동 로직을 notifShared 모듈로 추출
- feat(client): 전용 알림 페이지(/notifications) 추가
- feat(client): 모바일에서 알림 벨을 누르면 전용 페이지로 이동

**변경 대상 (5개 파일)**
- `client/src/App.tsx`
- `client/src/components/NotificationBell.tsx`
- `client/src/components/notifShared.tsx`
- `client/src/pages/NotificationsPage.tsx`
- `client/src/routes.ts`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #232** ↔ **이슈 #655** 로 연결됩니다.

Closes #655
