### PR TITLE
🔀 :: (#656) iOS 앱 셸 오버스크롤 잠금 — 상·하단 빈 공간 제거

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -476,6 +476,16 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     };
   }, [isMacDesktop]);
 
+  // 앱 셸 오버스크롤 잠금 — iOS 에서 문서 전체가 고무줄처럼 튕겨 상·하단에 빈 공간이
+  // 드러나는 걸 막는다(상단을 당기면 위, 하단바를 올리면 아래). styles.css 의
+  // .hinest-shell-lock 이 body 를 position:fixed 로 고정한다. 공개 페이지(로그인/약관)는
+  // 문서 스크롤이 필요하므로 AppLayout 이 마운트된 동안에만 <html> 에 클래스를 토글한다.
+  useEffect(() => {
+    const el = document.documentElement;
+    el.classList.add("hinest-shell-lock");
+    return () => el.classList.remove("hinest-shell-lock");
+  }, []);
+
   // 창모드에서만 신호등 버튼 여백 필요, 전체화면에선 숨어있으므로 여백 제거
   const showTitlebarSpace = isMacDesktop && !isFullscreen;
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -98,6 +98,32 @@ body {
     Inter, system-ui, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
   overscroll-behavior: none;
 }
+
+/*
+ * 앱 셸 오버스크롤 잠금 — iOS Safari/PWA 에서 문서 전체가 고무줄(rubber-band)처럼
+ * 튕기는 걸 막는다. body { overscroll-behavior: none } 만으론 부족한데, 특히 터치가
+ * 스크롤 불가능한 크롬(상단바/하단바) 위에서 시작되면 문서 자체가 위/아래로 늘어나며
+ * 빈 공간이 드러난다(상단을 당기면 위에 빈 공간, 하단바를 올리면 아래에 빈 공간).
+ * 그래서 body 를 position:fixed 로 물리적으로 고정해 문서가 아예 스크롤/바운스할 수
+ * 없게 만든다. 실제 스크롤은 내부의 <main class="overflow-y-auto"> 만 담당한다.
+ *
+ * 단, 이 잠금은 AppLayout(로그인 후 앱 셸)이 마운트된 동안에만 <html> 에 클래스를
+ * 토글해서 적용한다. 로그인/개인정보/약관 같은 공개 페이지는 문서 스크롤에 의존하므로
+ * 전역으로 걸면 안 된다.
+ */
+html.hinest-shell-lock {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+html.hinest-shell-lock body {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
 * { -webkit-tap-highlight-color: transparent; }
 .font-mono, code, pre, .tabular {
   font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, Monaco, monospace;


### PR DESCRIPTION
## 증상
**iOS 앱 셸 오버스크롤 잠금 — 상·하단 빈 공간 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
모바일(iOS Safari/PWA)에서 상단바를 아래로 당기면 위에, 하단 네비게이션 바를
위로 올리면 아래에 빈 공간이 드러나는 문제를 수정한다. 원인은 문서 전체가
고무줄(rubber-band)처럼 튕기는 것으로, 특히 터치가 스크롤 불가능한 크롬(상단바·
하단바) 위에서 시작될 때 발생한다. 기존 body { overscroll-behavior: none } 만으론
iOS 에서 이 바운스를 막지 못한다.

styles.css 에 .hinest-shell-lock 스코프 규칙을 추가해 <html> 에 클래스가 있을 때
body 를 position:fixed 로 물리적으로 고정, 문서가 아예 스크롤/바운스하지 못하게
한다. 실제 스크롤은 내부 <main class="overflow-y-auto"> 만 담당한다.

이 잠금은 로그인 후 앱 셸(AppLayout)이 마운트된 동안에만 적용해야 한다 —
로그인/개인정보/약관 등 공개 페이지는 문서 스크롤에 의존하므로 전역 적용은 금물.
그래서 AppLayoutInner 의 useEffect 에서 마운트 시 <html> 에 클래스를 추가하고
언마운트 시 제거한다.

## 수정
**작업 항목 (커밋 단위)**
- fix(client): iOS 앱 셸 오버스크롤(고무줄) 잠금으로 상·하단 빈 공간 제거

**변경 대상 (2개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #233** ↔ **이슈 #656** 로 연결됩니다.

Closes #656
