### PR TITLE
🔀 :: (#659) 사내톡 런처 반응형 분기 — 데스크톱 FAB / 모바일 상단바

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1471,10 +1471,11 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
             <span className="flex-1 text-left">검색</span>
             <span className="kbd">⌘K</span>
           </button>
-          {/* 사내톡 런처 — 우하단 FAB 대신 상단바 벨 옆에 둔다. 클릭 시 전역 "chat:toggle"
-              이벤트로 ChatFab 패널을 토글한다(패널/리스너는 ChatFab 에 그대로 있음). */}
+          {/* 사내톡 런처 — 모바일(<md) 전용. 상단바 벨 옆에 두고 클릭 시 전역 "chat:toggle"
+              이벤트로 ChatFab 패널을 토글한다(패널/리스너는 ChatFab 에 그대로 있음).
+              데스크톱(md+)은 ChatFab 의 우하단 FAB 를 그대로 쓰므로 여기선 숨긴다. */}
           <button
-            className="btn-icon relative"
+            className="btn-icon relative md:hidden"
             onClick={() => window.dispatchEvent(new CustomEvent("chat:toggle"))}
             title="사내톡"
             aria-label={chatUnread > 0 ? `사내톡 · 안 읽은 메시지 ${chatUnread}건` : "사내톡"}

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -45,7 +45,7 @@ type ActiveRoomInfo = {
 
 export default function ChatFab() {
   const loc = useLocation();
-  const { chatUnread } = useNotifications();
+  const { chatUnread, ready } = useNotifications();
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   // 모바일(≤640px) 에서는 사내톡을 풀스크린 페이지처럼 띄움.
@@ -73,6 +73,23 @@ export default function ChatFab() {
       document.body.classList.remove("hinest-chat-fs");
     };
   }, [isMobile, open]);
+  // 새 채팅 알림이 들어올 때 파란 펄스(데스크톱 FAB 전용 연출).
+  // - 단순 새로고침/재오픈만으론 발동하지 않음 (localStorage 에 저장된 마지막으로 본 카운트와 비교).
+  // - 앱이 꺼진 사이 알림이 쌓였다면 켤 때 1회 발동.
+  const [pulsing, setPulsing] = useState(false);
+  useEffect(() => {
+    if (!ready) return; // 최초 서버 동기화 전엔 비교 무의미
+    const KEY = "hinest:lastSeenChatUnread";
+    const lastSeen = Number(localStorage.getItem(KEY) ?? "0");
+    if (chatUnread > lastSeen) {
+      setPulsing(true);
+      const t = setTimeout(() => setPulsing(false), 2800);
+      localStorage.setItem(KEY, String(chatUnread));
+      return () => clearTimeout(t);
+    }
+    // 내려갔거나 같을 땐 펄스 없이 최신 값으로만 동기화
+    localStorage.setItem(KEY, String(chatUnread));
+  }, [chatUnread, ready]);
   const [activeRoom, setActiveRoom] = useState<ActiveRoomInfo | null>(null);
   const [createReq, setCreateReq] = useState(0);
   // 외부에서 특정 방을 열어달라고 요청하면 여기에 담아 ChatMiniApp 으로 프롭 전달
@@ -117,6 +134,8 @@ export default function ChatFab() {
   useEffect(() => { if (!open) setActiveRoom(null); }, [open]);
 
   if (hidden) return null;
+
+  const toggle = () => setOpen((s) => { const n = !s; if (n) setMounted(true); return n; });
 
   return (
     <>
@@ -210,6 +229,68 @@ export default function ChatFab() {
             </Suspense>
           </div>
         </div>
+      )}
+
+      {/* ===== FAB — 데스크톱(md+) 전용 우하단 런처. 모바일(<md)은 상단바 벨 옆 버튼을 쓴다.
+           모바일 풀스크린 상태(≤640px)에선 헤더의 X로 닫으므로 그때도 숨김. ===== */}
+      {!(isMobile && open) && (
+      <button
+        type="button"
+        onClick={toggle}
+        title={open ? "사내톡 닫기" : "사내톡 열기"}
+        aria-label={chatUnread > 0 ? `사내톡 · 안 읽은 메시지 ${chatUnread}건` : "사내톡"}
+        aria-expanded={open}
+        className={`fixed z-40 hidden md:flex items-center justify-center active:scale-[.94]${pulsing ? " siri-pulse" : ""}`}
+        style={{
+          // notch/홈인디케이터 대응 — iPad/iPhone 세이프 에어리어 안쪽으로 당김.
+          // 데스크톱은 하단 네비 바가 없어 --hinest-bottomnav-h 가 0 이라 그대로 우하단.
+          right: "max(20px, env(safe-area-inset-right))",
+          bottom:
+            "calc(20px + env(safe-area-inset-bottom, 0px) + var(--hinest-bottomnav-h, 0px))",
+          width: 60, height: 60,
+          borderRadius: 999,
+          background: C.blue, color: "#fff",
+          border: 0, cursor: "pointer",
+          boxShadow:
+            "0 10px 24px rgba(49, 130, 246, .36), 0 2px 6px rgba(49, 130, 246, .20)",
+          transition:
+            "background .18s ease, transform .18s cubic-bezier(.22,.61,.36,1)",
+          transform: open ? "scale(.96)" : undefined,
+          fontFamily: FONT,
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.background = C.blueHover)}
+        onMouseLeave={(e) => (e.currentTarget.style.background = C.blue)}
+      >
+        {open ? (
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        ) : (
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+          </svg>
+        )}
+
+        {chatUnread > 0 && !open && (
+          <span
+            style={{
+              position: "absolute",
+              top: -2, right: -2,
+              minWidth: 22, height: 22, padding: "0 6px",
+              borderRadius: 999,
+              background: C.red, color: "#fff",
+              fontSize: 11, fontWeight: 700,
+              display: "grid", placeItems: "center",
+              boxShadow: `0 0 0 2px ${C.bg}`,
+              fontFamily: FONT,
+              letterSpacing: "-0.01em",
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {chatUnread > 99 ? "99+" : chatUnread}
+          </span>
+        )}
+      </button>
       )}
     </>
   );


### PR DESCRIPTION
## 증상
**사내톡 런처 반응형 분기 — 데스크톱 FAB / 모바일 상단바**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
앞서 FAB 를 전 화면에서 제거하고 상단바로 옮겼는데, 데스크톱에선 기존처럼 우하단
FAB 가 있어야 한다는 요청에 따라 FAB 를 되살린다. 단 데스크톱(md+) 전용으로 두어
모바일(<md)에선 상단바 벨 옆 버튼을 쓰도록 역할을 나눈다.

- FAB 버튼 className 에 `hidden md:flex` 를 붙여 md 미만에선 숨기고 md+ 에서만 표시.
  앱의 사이드바/하단바 전환선(768px)과 동일한 기준이라 런처가 한 화면에 하나만 뜬다.
- FAB 전용 연출이던 새 메시지 펄스(pulsing) 상태·효과와 로컬 toggle 헬퍼도 함께 복원.
- 데스크톱 패널 헤더의 닫기(X)는 그대로 유지(추가된 편의 기능, FAB 와 무관).

## 수정
**작업 항목 (커밋 단위)**
- refactor(client): 데스크톱 전용 우하단 사내톡 FAB 복원 (모바일은 상단바 사용)
- feat(client): 상단바 사내톡 버튼을 모바일(<md) 전용으로 제한

**변경 대상 (2개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatFab.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #236** ↔ **이슈 #659** 로 연결됩니다.

Closes #659
