### PR TITLE
🔀 :: (#661) 하단 네비바 아래 safe-area 라인(빈 strip) 제거

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -580,8 +580,13 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     <div
       className="flex flex-col bg-ink-50 overflow-hidden"
       style={{
-        // iOS Safari 의 동적 툴바를 고려한 동적 뷰포트 높이. h-screen(100vh) 은 iOS 에서 URL 바 영역만큼 잘려 보임.
-        height: "100dvh",
+        // 셸 잠금(.hinest-shell-lock)이 body 를 position:fixed; inset:0 으로 가시 뷰포트에
+        // 정확히 고정하므로, #root(height:100%) 를 거쳐 여기서도 100% 로 받으면 그 고정 박스에
+        // 픽셀 단위로 일치한다. 예전의 100dvh 는 body 고정 박스(ICB 기준)와 별개로 측정돼
+        // iOS 툴바 전환 구간에서 둘이 어긋나면 하단 네비 아래로 body 배경(--c-bg) 한 줄이
+        // 새어 보였다("safe line"). 100% 로 받아 그 틈을 없앤다. (잠금으로 문서가 스크롤·
+        // 바운스하지 않으므로 옛 100vh 의 iOS URL 바 잘림 문제는 발생하지 않는다.)
+        height: "100%",
       }}
     >
       <PreviewBanner safeAreaTop={topSlot === "preview"} />


### PR DESCRIPTION
## 증상
**하단 네비바 아래 safe-area 라인(빈 strip) 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
앱 셸 루트 컨테이너 높이를 100dvh → 100% 로 변경한다.

셸 잠금(.hinest-shell-lock)이 body 를 position:fixed; inset:0 으로 가시
뷰포트에 정확히 고정하는데, 루트는 100dvh 로 그와 별개로 측정돼 왔다. 두 값은
iOS 툴바 전환 구간에서 어긋날 수 있고, 100dvh 가 body 고정 박스보다 짧아지는
순간 하단 네비 아래로 body 배경(--c-bg) 한 줄이 새어 보였다("safe line").

루트를 #root(height:100%) 를 거쳐 100% 로 받으면 body 고정 박스에 픽셀 단위로
일치하므로 그 틈이 사라진다. 잠금으로 문서가 스크롤·바운스하지 않아 옛 100vh 의
iOS URL 바 잘림 문제도 재발하지 않는다.

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 하단 네비바 아래 safe-area 라인(빈 strip) 제거

**변경 대상 (1개 파일)**
- `client/src/components/AppLayout.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #238** ↔ **이슈 #661** 로 연결됩니다.

Closes #661
