### PR TITLE
🔀 :: (#662) SW가 문서 요청을 강제 최신화 — iOS PWA 옛 번들 고착 해소

### DIFF
--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -10,7 +10,7 @@
  * 추후 오프라인 지원이 필요해지면 여기서부터 확장.
  */
 
-const VERSION = "v1";
+const VERSION = "v2";
 
 self.addEventListener("install", (event) => {
   // 새 SW 를 곧바로 활성화 (대기 단계 생략)
@@ -31,15 +31,23 @@ self.addEventListener("activate", (event) => {
 });
 
 self.addEventListener("fetch", (event) => {
+  const req = event.request;
+
+  // 문서(navigation) 요청은 HTTP 캐시를 우회(no-store)해 항상 최신 index.html 을 받는다.
+  // index.html 은 해시된 JS 청크를 가리키므로, HTML 만 최신이면 새 배포가 확실히 적용된다.
+  // 헤더가 must-revalidate 라도 iOS 단독형(standalone) PWA 는 캐시된 HTML·페이지 스냅샷을
+  // 붙들어 옛 번들을 계속 띄우는 사례가 있어, 문서 요청만큼은 강제로 네트워크에서 가져온다.
+  const isNavigate = req.mode === "navigate";
+
   // 네트워크 우선 — 항상 서버에 먼저 물어봄. 페이지 캐시로 오래된 코드가 박히는 걸 방지.
   // 실패했을 때만 캐시가 있으면 반환 (현재 캐시는 비어있으므로 사실상 no-op).
   event.respondWith(
     (async () => {
       try {
-        return await fetch(event.request);
+        return await fetch(req, isNavigate ? { cache: "no-store" } : undefined);
       } catch (err) {
         const cache = await caches.open(VERSION);
-        const cached = await cache.match(event.request);
+        const cached = await cache.match(req);
         if (cached) return cached;
         throw err;
       }


### PR DESCRIPTION
## 증상
홈화면에 설치한 **iOS 단독형(standalone) PWA** 에서, 새 배포(아이콘·레이아웃 변경)가 나가도 **옛 화면이 그대로** 보였습니다. 당겨서 새로고침을 해도 바뀌지 않음.

> 운영 헤더는 정상입니다: `index.html` → `max-age=0, must-revalidate`, 해시 자산 → `immutable`. 번들도 이미 라이브였습니다. **원인은 클라이언트(기기) 캐시.**

## 원인
서비스워커가 "네트워크 우선"이라지만 `fetch(req)` 는 HTTP 캐시 규약을 그대로 따릅니다. iOS 단독형 PWA 는 `must-revalidate` 헤더에도 **캐시된 `index.html`·페이지 스냅샷을 붙들어**, 옛 해시 JS 를 가리키는 HTML 을 계속 띄우는 사례가 있습니다.

## 해결
- **문서(navigation) 요청은 `fetch(req, { cache: "no-store" })`** 로 HTTP 캐시를 우회 → 항상 최신 `index.html` 수신. HTML 이 최신이면 그것이 가리키는 최신 해시 JS 가 로드되므로 새 배포가 확실히 적용됩니다. (해시 자산은 기존대로 네트워크 우선 — `immutable` 이라 캐시 적중해도 안전.)
- **`VERSION` v1→v2** 로 바이트 변경 → 옛 SW 를 물고 있던 클라이언트가 `reg.update()`(포그라운드 복귀·30분 폴링)로 새 SW 를 받으면 `skipWaiting` + `clients.claim` → `controllerchange` → 자동 새로고침(main.tsx) 경로로 **스스로 최신본으로 갱신**됩니다.

오프라인 동작 변화 없음(기존에도 캐시는 비어 있어 네트워크 실패 시 그대로 throw).

## 테스트 플랜
- [ ] 배포 후 iOS PWA를 한 번 포그라운드/리로드하면 새 SW로 교체되고 자동 새로고침되는지
- [ ] 이후 새 배포가 추가 조작 없이(앱 종료 없이) 반영되는지
- [ ] 데스크톱 브라우저에서 기존 동작 회귀 없는지(정상 로드/새로고침)

Closes #662
