### PR TITLE
🔀 :: (#663) 팀원 '내 프로필' 카드 모바일 텍스트 한 글자씩 쪼개짐 수정

### DIFF
--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -243,7 +243,10 @@ function MyProfileHero({
         className="absolute top-0 left-0 w-full h-[3px]"
         style={{ background: `linear-gradient(90deg, ${me.avatarColor ?? "#3D54C4"}, ${me.avatarColor ?? "#3D54C4"}80)` }}
       />
-      <div className="relative flex items-center gap-5 p-5">
+      {/* flex-wrap 필수 — 모바일 통계 줄(아래 w-full)이 같은 행에서 폭을 빼앗아 정보
+          컬럼이 0 으로 눌리면 이름·직급 텍스트가 한 글자씩 세로로 쪼개진다. wrap 으로
+          통계 줄을 다음 줄로 내린다. 데스크톱(md+)은 통계가 인라인이라 한 줄에 다 들어가 wrap 없음. */}
+      <div className="relative flex flex-wrap items-center gap-x-5 gap-y-3 p-5">
         <div className="w-16 h-16 rounded-full flex-shrink-0 shadow-pop overflow-hidden relative" style={{ background: me.avatarUrl ? "transparent" : (me.avatarColor ?? "#3D54C4") }}>
           {me.avatarUrl ? (
             <img src={me.avatarUrl} alt={me.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
@@ -277,7 +280,7 @@ function MyProfileHero({
             <div className="text-[22px] font-extrabold text-ink-900 tabular" style={{ letterSpacing: "-0.02em" }}>{teamCount}</div>
           </div>
         </div>
-        <div className="md:hidden w-full mt-2 flex items-center gap-3 text-[12px] text-ink-500">
+        <div className="md:hidden w-full flex items-center gap-3 text-[12px] text-ink-500">
           <span>동료 <b className="text-ink-900 tabular">{totalCount - 1}</b></span>
           <span className="text-ink-300">·</span>
           <span>팀 <b className="text-ink-900 tabular">{teamCount}</b></span>


### PR DESCRIPTION
## 증상
모바일 **팀원(Directory)** 화면 상단 **'내 프로필' 카드**에서 이름·직급·이메일이 **한 글자씩 세로로** 줄바꿈됐습니다 (예: `서`/`지`/`완`, `사`/`원`/`(Staff)`).

## 원인
카드 본문이 `flex items-center`(비-wrap) **한 행**인데, 그 안에 모바일 통계 줄(`md:hidden w-full`)이 **형제**로 들어가 있습니다. wrap 이 없어 통계 줄이 다음 줄로 못 내려가고 같은 행에서 **100% 폭을 요구** → 정보 컬럼(`flex-1`)이 한 글자 폭까지 짓눌렸습니다.

## 해결
부모에 **`flex-wrap`** 추가(+ `gap-x-5 gap-y-3`). 통계 줄이 다음 줄로 내려가 아바타+정보가 첫 줄을 정상 폭으로 차지합니다.

- 데스크톱(md+)은 통계가 인라인(`hidden md:flex`)이라 한 줄에 다 들어가 **wrap 이 일어나지 않음** → 레이아웃 변화 없음.
- 중복되던 `mt-2` 제거(이제 `gap-y-3` 가 줄 간격 담당).

## 테스트 플랜
- [ ] 모바일에서 '내 프로필' 카드 이름/직급/이메일이 한 줄로 정상 표시
- [ ] 통계(동료·팀)가 카드 둘째 줄에 인라인으로 표시
- [ ] 데스크톱에서 기존 좌(프로필)·우(동료/팀 큰 숫자) 레이아웃 회귀 없음

Closes #663
