### PR TITLE
🔀 :: (#664) 회의록 상단 액션 버튼 모바일 콤팩트화

### DIFF
--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -244,12 +244,19 @@ export default function MeetingDetailPage() {
           h1, h2, h3 { page-break-after: avoid; }
           table, pre, blockquote { page-break-inside: avoid; }
         }
+        /* 모바일 헤더 액션바 콤팩트화 — 폰 화면에서 버튼 6개+타임스탬프가 빽빽하게 줄바꿈되는 걸 완화.
+           .btn-ghost(높이 36px)는 언레이어드라 Tailwind 유틸로 못 줄이므로 스코프 선택자(0,2,0)로 덮어쓴다.
+           아이콘 핀 버튼(btn-icon)이 32px이므로 텍스트 버튼도 32px로 맞춰 한 줄 높이를 통일한다. */
+        @media (max-width: 640px) {
+          .mtg-actions { gap: 6px; }
+          .mtg-actions .btn-ghost { height: 32px; padding: 0 10px; font-size: 12px; }
+        }
       `}</style>
       <div className="flex items-center justify-between gap-2 mb-3 flex-wrap no-print">
         <Link to="/meetings" className="text-[13px] text-slate-500 hover:text-brand-600 flex-shrink-0">
           ← 회의록 목록
         </Link>
-        <div className="flex items-center gap-2 flex-wrap justify-end">
+        <div className="mtg-actions flex items-center gap-2 flex-wrap justify-end">
           <button
             type="button"
             className="btn-ghost inline-flex items-center gap-1"
@@ -278,7 +285,7 @@ export default function MeetingDetailPage() {
           {canEdit && edit && (
             <>
               <span className="text-[11.5px] text-slate-400">
-                {saving ? "저장 중…" : lastSaved ? `저장됨 ${new Date(lastSaved).toLocaleTimeString("ko-KR")}` : ""}
+                {saving ? "저장 중…" : lastSaved ? `저장됨 ${new Date(lastSaved).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" })}` : ""}
               </span>
               <button className="btn-ghost" onClick={() => { setEdit(false); setSearchParams({}); }}>
                 미리보기


### PR DESCRIPTION
## 증상
**회의록 상단 액션 버튼 모바일 콤팩트화**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
폰 화면에서 회의록 상세 헤더의 액션바(링크 복사·핀·인쇄·히스토리·
편집/미리보기·삭제 + 저장 타임스탬프)가 빽빽하게 여러 줄로 줄바꿈되어
답답하게 보이던 문제를 완화한다.

- 액션 컨테이너에 .mtg-actions 클래스를 부여하고, ≤640px에서만 적용되는
  스코프 규칙을 컴포넌트 <style> 블록에 추가.
  · .btn-ghost 는 styles.css 상단의 언레이어드 규칙(높이 36px)이라
    Tailwind 사이징 유틸(h-8 등)로 덮을 수 없음 → 0,2,0 스코프 선택자로
    높이 32px / 패딩 0 10px / 폰트 12px 로 축소.
  · 아이콘 핀 버튼(btn-icon)이 이미 32px이므로 텍스트 버튼 높이를 맞춰
    한 줄 높이를 통일하고, 버튼 간 gap 도 8px→6px 로 좁힘.
- 저장 타임스탬프에서 초 단위 제거(toLocaleTimeString 옵션
  hour/minute 2-digit) → "저장됨 오후 7:27:16"처럼 길던 문자열을
  "저장됨 오후 07:27" 로 줄여 줄바꿈 압박 완화(데스크톱에도 동일 적용).

데스크톱(>640px) 레이아웃은 변경 없음.

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 회의록 상단 액션 버튼 모바일 콤팩트화

**변경 대상 (1개 파일)**
- `client/src/pages/MeetingDetailPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #241** ↔ **이슈 #664** 로 연결됩니다.

Closes #664
