### PR TITLE
🔀 :: (#665) 일정 추가 모달 모바일 키보드 가림 수정

### DIFF
--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -626,6 +626,34 @@ type EventForm = {
 
 type DirUser = { id: string; name: string; email: string; team?: string | null; avatarColor?: string; avatarUrl?: string | null; position?: string | null };
 
+/**
+ * iOS 키보드가 올라오면 visualViewport 만 키보드 높이만큼 줄어든다(레이아웃 뷰포트·100vh·100dvh 는 그대로).
+ * 그래서 화면 중앙 정렬 모달은 키보드가 뜨면 아래쪽(카테고리 칩·푸터의 저장 버튼)이 키보드와 iOS 입력
+ * 보조바에 가려진다. 오버레이를 visualViewport 영역(top/height)에 맞추고 패널을 그 안으로 캡(max-h-full)하면,
+ * 모달이 항상 키보드 위에 들어와 내부 스크롤만으로 모든 필드·푸터에 접근된다.
+ * visualViewport 미지원(구형) 환경에서는 전체 화면으로 폴백하므로 기존 동작과 동일.
+ */
+function useViewportInset(): { top: number; height: number | string } {
+  const read = (): { top: number; height: number | string } => {
+    const vv = typeof window !== "undefined" ? window.visualViewport : null;
+    return vv ? { top: vv.offsetTop, height: vv.height } : { top: 0, height: "100%" };
+  };
+  const [inset, setInset] = useState<{ top: number; height: number | string }>(read);
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const apply = () => setInset({ top: vv.offsetTop, height: vv.height });
+    apply();
+    vv.addEventListener("resize", apply);
+    vv.addEventListener("scroll", apply);
+    return () => {
+      vv.removeEventListener("resize", apply);
+      vv.removeEventListener("scroll", apply);
+    };
+  }, []);
+  return inset;
+}
+
 function EventModal({
   onClose,
   form,
@@ -679,10 +707,17 @@ function EventModal({
     );
   }, [directory, deferredSearch]);
 
+  // 키보드가 떠도 모달(카테고리 칩·저장 버튼)이 가려지지 않도록 오버레이를 visualViewport 영역에 맞춘다.
+  const viewport = useViewportInset();
+
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div
+      className="fixed inset-x-0 bg-ink-900/40 grid place-items-center p-4 z-50"
+      style={{ top: viewport.top, height: viewport.height }}
+      onClick={onClose}
+    >
       <div
-        className="panel w-full max-w-[640px] shadow-pop overflow-hidden max-h-[90vh] flex flex-col"
+        className="panel w-full max-w-[640px] shadow-pop overflow-hidden max-h-full flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {/* 헤더 */}


### PR DESCRIPTION
## 증상
**일정 추가 모달 모바일 키보드 가림 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
폰에서 '일정 추가' 모달의 제목·메모 입력란을 탭하면 iOS 키보드와 입력
보조바가 올라오면서 카테고리 칩과 푸터의 '일정 추가'(저장) 버튼이 가려져
선택·제출이 불가능하던 문제를 수정한다. (사용자 제보 스크린샷 — 일정 추가)

원인: 모달 오버레이가 화면(레이아웃 뷰포트) 중앙 정렬이라 키보드가 떠도
100vh/100dvh 는 줄지 않아 패널 하단이 키보드 뒤로 밀려난다.

- useViewportInset 훅 추가: window.visualViewport 의 offsetTop·height 를
  resize/scroll 로 추적. 키보드가 뜨면 줄어든 '보이는 영역'을 그대로 돌려준다.
- EventModal 오버레이를 inset-0 → inset-x-0 + style{top,height}=visualViewport
  로 바꿔 '중앙'이 키보드 위 가시 영역의 중앙이 되게 한다.
- 패널 max-h-[90vh] → max-h-full 로 변경해 오버레이(=가시 영역) 안으로 캡.
  헤더·푸터는 flex-shrink-0, 본문은 overflow-y-auto 라 모든 필드·저장 버튼이
  키보드 위에서 스크롤로 접근된다.

visualViewport 미지원 환경은 전체 화면 폴백(top 0 / height 100%)이라 기존
동작과 동일. 데스크톱은 오버레이=창 전체라 사실상 무변화(읽기 전용
DayDetailModal 은 입력란이 없어 손대지 않음).

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 일정 추가 모달 모바일 키보드 가림 수정

**변경 대상 (1개 파일)**
- `client/src/pages/SchedulePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #242** ↔ **이슈 #665** 로 연결됩니다.

Closes #665
