### PR TITLE
🔀 :: (#667) 모바일 깨짐 수정 — 문서함·프로젝트·법인카드 (카드형 테이블)

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -925,9 +925,10 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
         </div>
       )}
 
-      {/* 임베드 모드용 미니 툴바 — 헤더가 없는 대신 우측 업로드 버튼을 여기 넣는다 */}
+      {/* 임베드 모드용 미니 툴바 — 헤더가 없는 대신 우측 업로드 버튼을 여기 넣는다.
+          모바일에선 버튼이 화면폭을 넘기므로 flex-wrap 으로 줄바꿈해 잘림 방지. */}
       {embedded && (
-        <div className="flex items-center justify-end gap-2 mb-3">
+        <div className="flex flex-wrap items-center justify-end gap-2 mb-3">
           <button className="btn-ghost btn-xs" onClick={openFolderModal}>+ 새 폴더</button>
           <button
             className="btn-ghost btn-xs"
@@ -943,7 +944,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
 
       {/* 공개 범위 탭 — 프로젝트 문서함에선 의미 없으므로 숨김. */}
       {!inProject && (
-        <div className="flex items-center gap-1 mb-3 border-b border-ink-150">
+        <div className="flex items-center gap-1 mb-3 border-b border-ink-150 overflow-x-auto no-scrollbar">
           {SCOPE_TABS.map((t) => {
             // 드래그로 스코프 이동 가능한 탭.
             //  - 폴더: ALL/TEAM/PRIVATE 로만. CUSTOM 은 대상 유저를 정해야 해서 폴더 드롭은 미지원.
@@ -1005,7 +1006,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                     }
                   }
                 }}
-                className={`px-3 h-9 text-[13px] font-bold border-b-2 transition ${
+                className={`inline-flex items-center justify-center flex-shrink-0 whitespace-nowrap px-3 h-9 text-[13px] font-bold border-b-2 transition ${
                   dragOverKey === tabKey ? "bg-brand-50 " : ""
                 }${
                   scopeTab === t.key
@@ -1257,7 +1258,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
         </div>
       ) : (
         <div className="panel p-0 overflow-hidden overflow-x-auto">
-          <table className="pro min-w-[760px]">
+          <table className="pro pro-cards min-w-[760px]">
             <thead>
               <tr>
                 <th>제목</th>
@@ -1288,7 +1289,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                     opacity: draggingDocId === d.id ? 0.5 : 1,
                   }}
                 >
-                  <td>
+                  <td className="cell-primary">
                     <div
                       className={`flex items-start gap-2.5 ${d.content != null ? "cursor-pointer" : ""}`}
                       onClick={d.content != null ? () => setMemoTarget(d) : undefined}
@@ -1311,7 +1312,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-1.5 min-w-0">
                           <div
-                            className={`text-[13px] font-bold text-ink-900 truncate max-w-[160px] sm:max-w-[280px] lg:max-w-[400px] ${d.content != null ? "hover:text-brand-700" : ""}`}
+                            className={`cell-title text-[13px] font-bold text-ink-900 truncate max-w-[160px] sm:max-w-[280px] lg:max-w-[400px] ${d.content != null ? "hover:text-brand-700" : ""}`}
                             title={d.title}
                           >
                             {d.title}
@@ -1334,14 +1335,14 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                       </div>
                     </div>
                   </td>
-                  <td>
-                    <div className="flex flex-wrap gap-1">
+                  <td data-label="태그" className={(d.tags ?? "").split(",").map((t) => t.trim()).filter(Boolean).length ? "" : "cell-hide-m"}>
+                    <div className="flex flex-wrap gap-1 justify-end">
                       {(d.tags ?? "").split(",").map((t) => t.trim()).filter(Boolean).map((t) => (
                         <span key={t} className="chip-gray">#{t}</span>
                       ))}
                     </div>
                   </td>
-                  <td>
+                  <td data-label="파일">
                     {(() => {
                       // 과거 데이터에 javascript:/외부 URL 이 남아있을 수 있어 렌더 직전에 한 번 더 검증.
                       const safe = safeUploadUrl(d.fileUrl);
@@ -1360,7 +1361,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                       );
                     })()}
                   </td>
-                  <td>
+                  <td data-label="작성자">
                     <div className="flex items-center gap-2">
                       <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: d.author.avatarUrl ? "transparent" : (d.author.avatarColor ?? "#6B7280") }}>
                         {d.author.avatarUrl ? (
@@ -1372,8 +1373,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                       <div className="text-[12px]">{d.author.name}</div>
                     </div>
                   </td>
-                  <td className="tabular text-[11px] text-ink-500">{new Date(d.updatedAt).toLocaleDateString("ko-KR")}</td>
-                  <td style={{ textAlign: "right" }}>
+                  <td data-label="수정" className="tabular text-[11px] text-ink-500">{new Date(d.updatedAt).toLocaleDateString("ko-KR")}</td>
+                  <td className="cell-actions" style={{ textAlign: "right" }}>
                     <div className="flex items-center justify-end gap-1">
                       {/* 메모 타입 */}
                       {d.content != null ? (

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -245,7 +245,7 @@ export default function ExpensePage() {
       </div>
 
       <div className="card p-0 overflow-hidden overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
-        <table className="w-full text-sm min-w-[720px]">
+        <table className="pro-cards w-full text-sm min-w-[720px]">
           <thead className="bg-slate-50 text-slate-500 text-xs">
             <tr>
               <th className="text-left px-4 py-3">사용일시</th>
@@ -262,14 +262,14 @@ export default function ExpensePage() {
           <tbody>
             {list.length === 0 && (
               <tr>
-                <td colSpan={9} className="px-4 py-10 text-center text-slate-400">
+                <td colSpan={9} className="cell-full px-4 py-10 text-center text-slate-400">
                   등록된 사용내역이 없습니다.
                 </td>
               </tr>
             )}
             {list.map((e) => (
               <tr key={e.id} className="border-t border-slate-100 hover:bg-slate-50/50">
-                <td className="px-4 py-3">
+                <td data-label="사용일시" className="px-4 py-3">
                   {new Date(e.usedAt).toLocaleString("ko-KR", {
                     month: "2-digit",
                     day: "2-digit",
@@ -277,14 +277,16 @@ export default function ExpensePage() {
                     minute: "2-digit",
                   })}
                 </td>
-                {scope === "all" && <td className="px-4 py-3">{e.user?.name}</td>}
-                <td className="px-4 py-3 font-medium">{e.merchant}</td>
-                <td className="px-4 py-3">
+                {scope === "all" && <td data-label="사용자" className="px-4 py-3">{e.user?.name}</td>}
+                <td className="cell-primary px-4 py-3 font-medium">{e.merchant}</td>
+                <td data-label="분류" className="px-4 py-3">
                   <span className="chip bg-slate-100 text-slate-700">{e.category}</span>
                 </td>
-                <td className="px-4 py-3 text-right font-semibold">{e.amount.toLocaleString()}원</td>
-                <td className="px-4 py-3 text-slate-500 max-w-[160px] truncate">{e.memo || "-"}</td>
-                <td className="px-4 py-3 text-center">
+                <td data-label="금액" className="px-4 py-3 text-right font-semibold">{e.amount.toLocaleString()}원</td>
+                <td data-label="메모" className="px-4 py-3 text-slate-500">
+                  <span className="block truncate max-w-[160px] md:max-w-[200px]">{e.memo || "-"}</span>
+                </td>
+                <td data-label="영수증" className="px-4 py-3 text-center">
                   {e.receiptUrl ? (
                     <button className="text-brand-600 text-xs underline" onClick={() => setPreview(e.receiptUrl!)}>
                       보기
@@ -293,10 +295,16 @@ export default function ExpensePage() {
                     <span className="text-slate-300 text-xs">-</span>
                   )}
                 </td>
-                <td className="px-4 py-3 text-center">
+                <td data-label="상태" className="px-4 py-3 text-center">
                   <StatusChip status={e.status} />
                 </td>
-                <td className="px-4 py-3 text-right">
+                <td
+                  className={`px-4 py-3 text-right ${
+                    (isReviewer && e.status === "PENDING" && scope === "all") || (e.userId === user?.id && e.status === "PENDING")
+                      ? "cell-actions"
+                      : "cell-hide-m"
+                  }`}
+                >
                   {isReviewer && e.status === "PENDING" && scope === "all" && (
                     <div className="inline-flex gap-1">
                       <button

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -549,6 +549,109 @@ table.pro.pro-grid-fixed tbody td > div > select {
 }
 
 /* ============================================================ */
+/*   모바일 카드형 테이블 — 옵트인 .pro-cards.                   */
+/*   ≤768px 에서 가로 스크롤 테이블 대신 행(tr)을 카드로,        */
+/*   셀(td)을 "라벨 : 값" 행으로 쌓아 앱처럼 보이게 한다.         */
+/*                                                              */
+/*   사용법: <table class="pro pro-cards"> + 각 <td data-label="컬럼"> */
+/*     · data-label  — 좌측에 표시할 라벨(없으면 라벨 생략)       */
+/*     · .cell-primary — 제목 셀: 전체폭 카드 헤더(라벨 없음)     */
+/*     · .cell-actions — 액션 셀: 전체폭 하단, 우측 정렬          */
+/*     · .cell-full    — 빈 상태 등 전체폭 가운데 정렬           */
+/*     · .cell-hide-m  — 모바일 카드에서 숨김(부차 정보)         */
+/* ============================================================ */
+@media (max-width: 768px) {
+  table.pro-cards { min-width: 0 !important; width: 100%; display: block; }
+  table.pro-cards thead { display: none; }
+  table.pro-cards tbody { display: block; }
+  table.pro-cards tbody tr {
+    display: flex;
+    flex-direction: column;
+    padding: 12px 14px;
+    margin: 0 0 10px;
+    border: 1px solid var(--c-border);
+    border-radius: 14px;
+    background: var(--c-surface);
+  }
+  table.pro-cards tbody tr:last-child { margin-bottom: 0; }
+  table.pro-cards tbody tr:hover td { background: transparent; }
+  table.pro-cards tbody td {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    min-width: 0;
+    padding: 5px 0 !important;
+    border: 0 !important;
+    font-size: 13px;
+  }
+  table.pro-cards tbody td::before {
+    content: attr(data-label);
+    flex-shrink: 0;
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--c-text-3);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  /* 라벨 없는 셀은 ::before 를 비워 공간을 차지하지 않게 */
+  table.pro-cards tbody td:not([data-label])::before,
+  table.pro-cards tbody td[data-label=""]::before { content: ""; }
+  /* 값은 우측으로 밀고 길면 말줄임 */
+  table.pro-cards tbody td > * { min-width: 0; margin-left: auto; }
+
+  /* 제목/헤더 셀 — 카드 최상단으로, 전체폭·좌측 정렬·하단 구분선.
+     직접 텍스트(예: 가맹점명)는 헤더처럼 강조. 내부에 자체 글꼴 클래스를
+     가진 셀(문서 제목 블록 등)은 그 클래스가 우선하므로 영향 없음. */
+  table.pro-cards tbody td.cell-primary {
+    order: -2;
+    display: block;
+    padding-bottom: 10px !important;
+    margin-bottom: 4px;
+    border-bottom: 1px solid var(--c-border) !important;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--c-text);
+  }
+  table.pro-cards tbody td.cell-primary::before { content: none; }
+  table.pro-cards tbody td.cell-primary > * { margin-left: 0; }
+  /* 카드에선 제목 말줄임 폭 제한 해제 */
+  table.pro-cards tbody td.cell-primary .cell-title { max-width: 100% !important; }
+
+  /* 액션 셀 — 카드 최하단으로, 전체폭·우측 정렬·상단 구분선 */
+  table.pro-cards tbody td.cell-actions {
+    order: 100;
+    justify-content: flex-end;
+    padding-top: 10px !important;
+    margin-top: 4px;
+    border-top: 1px solid var(--c-border) !important;
+  }
+  table.pro-cards tbody td.cell-actions::before { content: none; }
+  table.pro-cards tbody td.cell-actions > * { margin-left: 0; }
+
+  /* 빈 상태 등 전체폭 가운데 정렬 셀 */
+  table.pro-cards tbody td.cell-full { display: block; text-align: center; }
+  table.pro-cards tbody td.cell-full::before { content: none; }
+  table.pro-cards tbody td.cell-full > * { margin-left: 0; }
+
+  /* 모바일 카드에서 숨길 부차 셀 */
+  table.pro-cards tbody td.cell-hide-m { display: none; }
+
+  /* 카드 리스트를 감싼 패널/카드는 중첩 박스로 보이지 않게 테두리 제거 */
+  .panel:has(> table.pro-cards),
+  .card:has(> table.pro-cards) {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    overflow: visible;
+  }
+}
+
+/* 스크롤바 숨김 — 가로 스크롤 탭/칩 스트립을 앱처럼 깔끔하게 */
+.no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+.no-scrollbar::-webkit-scrollbar { display: none; }
+
+/* ============================================================ */
 /*                         HEADINGS                              */
 /* ============================================================ */
 .h-display { color: var(--c-text); font-weight: 700; font-size: 20px; line-height: 28px; letter-spacing: -0.02em; }


### PR DESCRIPTION
## 증상
**모바일 깨짐 수정 — 문서함·프로젝트·법인카드 (카드형 테이블)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
가로 스크롤로 내용이 잘리던 데이터 테이블을 모바일(≤768px)에서
행 단위 카드로 재배치하는 옵트인 CSS 유틸리티를 추가한다.

- thead 숨김 + tr→카드, td→"라벨 : 값" 행으로 전환
- data-label 로 각 셀 라벨 표시
- .cell-primary(헤더·최상단), .cell-actions(액션·최하단),
  .cell-full(빈 상태 중앙), .cell-hide-m(모바일 숨김) 보조 클래스
- flex-column + order 로 DOM 순서와 무관하게 헤더/액션 위치 고정
- :has() 로 감싼 panel/card 의 중첩 테두리 제거
- 가로 스크롤 스트립용 .no-scrollbar 유틸 추가

데스크톱(>768px)은 미디어쿼리 밖이라 기존 테이블 그대로 유지.

## 수정
**작업 항목 (커밋 단위)**
- style(client): 모바일 카드형 테이블 유틸리티(.pro-cards) 추가
- fix(client): 문서함·프로젝트 문서 탭 모바일 깨짐 수정
- fix(client): 법인카드 사용내역 테이블 모바일 깨짐 수정

**변경 대상 (3개 파일)**
- `client/src/pages/DocumentsPage.tsx`
- `client/src/pages/ExpensePage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #244** ↔ **이슈 #667** 로 연결됩니다.

Closes #667
