### PR TITLE
🔀 :: (#668) 근태·급여 표 카드형 전환 (모바일 잘림 수정 2차)

### DIFF
--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -251,7 +251,7 @@ export default function AttendancePage() {
             />
           ) : (
             <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
-              <table className="w-full text-[13px] min-w-[480px]">
+              <table className="pro-cards w-full text-[13px] min-w-[480px]">
                 <thead className="bg-ink-25 text-ink-500 text-[11px] uppercase tracking-[0.06em]">
                   <tr>
                     <th className="text-left px-5 py-2.5 font-bold">일자</th>
@@ -272,20 +272,20 @@ export default function AttendancePage() {
                         className="border-t border-ink-100"
                         style={{ background: isToday ? "var(--c-brand-soft)" : undefined }}
                       >
-                        <td className="px-5 py-3">
+                        <td className="cell-primary px-5 py-3">
                           <div className="font-bold text-ink-900">{r.date.slice(5)}</div>
                           <div className="text-[10.5px] mt-0.5" style={{ color: isWeekend ? "var(--c-danger)" : "var(--c-text-3)" }}>
                             {dowLabel(dow)}
                             {isToday && <span className="ml-1 chip chip-brand !text-[9.5px] !py-0">오늘</span>}
                           </div>
                         </td>
-                        <td className="px-5 py-3 font-mono text-ink-800">
+                        <td data-label="출근" className="px-5 py-3 font-mono text-ink-800">
                           {r.checkIn ? formatHM(r.checkIn) : <span className="text-ink-400">—</span>}
                         </td>
-                        <td className="px-5 py-3 font-mono text-ink-800">
+                        <td data-label="퇴근" className="px-5 py-3 font-mono text-ink-800">
                           {r.checkOut ? formatHM(r.checkOut) : <span className="text-ink-400">—</span>}
                         </td>
-                        <td className="px-5 py-3 text-right">
+                        <td data-label="근무시간" className="px-5 py-3 text-right">
                           {r.checkIn && r.checkOut ? (
                             <span className="font-bold text-ink-900">{durationLabel(r.checkIn, r.checkOut)}</span>
                           ) : (
@@ -347,7 +347,7 @@ export default function AttendancePage() {
             />
           ) : (
             <div className="overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
-              <table className="w-full text-[13px] min-w-[720px]">
+              <table className="pro-cards w-full text-[13px] min-w-[720px]">
                 <thead className="bg-ink-25 text-ink-500 text-[11px] uppercase tracking-[0.06em]">
                   <tr>
                     <th className="text-left px-5 py-2.5 font-bold">이름</th>
@@ -361,24 +361,24 @@ export default function AttendancePage() {
                 <tbody>
                   {[...pendingForReviewer, ...handledForReviewer].map((l) => (
                     <tr key={l.id} className="border-t border-ink-100">
-                      <td className="px-5 py-3 font-bold text-ink-900">{l.user?.name}</td>
-                      <td className="px-5 py-3">
+                      <td className="cell-primary px-5 py-3 font-bold text-ink-900">{l.user?.name}</td>
+                      <td data-label="종류" className="px-5 py-3">
                         <span className="inline-flex items-center gap-1.5">
                           <LeaveTypeDot type={l.type} />
                           <span className="text-ink-800">{typeLabel(l.type)}</span>
                         </span>
                       </td>
-                      <td className="px-5 py-3 text-ink-700">
+                      <td data-label="기간" className="px-5 py-3 text-ink-700">
                         {formatRange(l.startDate, l.endDate)}
                         <span className="ml-1 text-[11px] text-ink-500">({dayDiff(l.startDate, l.endDate)}일)</span>
                       </td>
-                      <td className="px-5 py-3 text-ink-600 max-w-[240px] truncate" title={l.reason ?? ""}>
-                        {l.reason || <span className="text-ink-400">—</span>}
+                      <td data-label="사유" className="px-5 py-3 text-ink-600" title={l.reason ?? ""}>
+                        <span className="block truncate max-w-[240px]">{l.reason || <span className="text-ink-400">—</span>}</span>
                       </td>
-                      <td className="px-5 py-3">
+                      <td data-label="상태" className="px-5 py-3">
                         <StatusChip status={l.status} />
                       </td>
-                      <td className="px-5 py-3 text-right">
+                      <td className={`${l.status === "PENDING" ? "cell-actions" : "cell-hide-m"} px-5 py-3 text-right`}>
                         {l.status === "PENDING" && (
                           <div className="inline-flex gap-1.5">
                             <button

--- a/client/src/pages/PayrollPage.tsx
+++ b/client/src/pages/PayrollPage.tsx
@@ -254,7 +254,7 @@ export default function PayrollPage() {
       )}
 
       <div className="card p-0 overflow-hidden overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
-        <table className="w-full text-sm min-w-[760px]">
+        <table className="pro-cards w-full text-sm min-w-[760px]">
           <thead className="bg-slate-50 text-slate-500 text-xs">
             <tr>
               {isAdmin && (
@@ -281,17 +281,17 @@ export default function PayrollPage() {
           </thead>
           <tbody>
             {loading && (
-              <tr><td colSpan={isAdmin ? 8 : 7} className="px-4 py-10 text-center text-slate-400">불러오는 중…</td></tr>
+              <tr><td colSpan={isAdmin ? 8 : 7} className="cell-full px-4 py-10 text-center text-slate-400">불러오는 중…</td></tr>
             )}
             {!loading && list.length === 0 && (
-              <tr><td colSpan={isAdmin ? 8 : 7} className="px-4 py-10 text-center text-slate-400">
+              <tr><td colSpan={isAdmin ? 8 : 7} className="cell-full px-4 py-10 text-center text-slate-400">
                 {isAdmin ? "명세서가 없습니다. “+ 새 명세서”로 작성하세요." : "아직 발급된 급여명세서가 없어요."}
               </td></tr>
             )}
             {!loading && list.map((p) => (
               <tr key={p.id} className={`border-t border-slate-100 hover:bg-slate-50/50 ${isAdmin && selected.has(p.id) ? "bg-brand-50/40" : ""}`}>
                 {isAdmin && (
-                  <td className="px-4 py-3">
+                  <td data-label="선택" className="px-4 py-3">
                     <input
                       type="checkbox"
                       className="accent-brand-600 w-4 h-4 align-middle"
@@ -302,20 +302,20 @@ export default function PayrollPage() {
                     />
                   </td>
                 )}
-                <td className="px-4 py-3">
+                <td className="cell-primary px-4 py-3">
                   <div className="font-medium text-ink-900">{p.employeeName}</div>
                   {p.department && <div className="text-[11.5px] text-ink-500">{p.department}</div>}
                 </td>
-                <td className="px-4 py-3 tabular">{p.year}.{String(p.month).padStart(2, "0")}</td>
-                <td className="px-4 py-3 text-right tabular">{won(p.totalEarnings)}</td>
-                <td className="px-4 py-3 text-right tabular text-rose-600">{won(p.totalDeductions)}</td>
-                <td className="px-4 py-3 text-right font-bold tabular">{won(p.netPay)}</td>
-                <td className="px-4 py-3 text-center">
+                <td data-label="귀속" className="px-4 py-3 tabular">{p.year}.{String(p.month).padStart(2, "0")}</td>
+                <td data-label="지급액" className="px-4 py-3 text-right tabular">{won(p.totalEarnings)}</td>
+                <td data-label="공제액" className="px-4 py-3 text-right tabular text-rose-600">{won(p.totalDeductions)}</td>
+                <td data-label="실수령액" className="px-4 py-3 text-right font-bold tabular">{won(p.netPay)}</td>
+                <td data-label="발송" className="px-4 py-3 text-center">
                   {p.sentAt
                     ? <span className="chip bg-brand-100 text-brand-700" title={new Date(p.sentAt).toLocaleString("ko-KR")}>발송됨</span>
                     : <span className="chip bg-slate-100 text-slate-500">미발송</span>}
                 </td>
-                <td className="px-4 py-3 text-right whitespace-nowrap">
+                <td className="cell-actions px-4 py-3 text-right whitespace-nowrap">
                   <button className="text-[12px] text-brand-600 hover:underline" onClick={() => setPreview(p)}>보기</button>
                   {isAdmin && (
                     <>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -618,10 +618,14 @@ table.pro.pro-grid-fixed tbody td > div > select {
   /* 카드에선 제목 말줄임 폭 제한 해제 */
   table.pro-cards tbody td.cell-primary .cell-title { max-width: 100% !important; }
 
-  /* 액션 셀 — 카드 최하단으로, 전체폭·우측 정렬·상단 구분선 */
+  /* 액션 셀 — 카드 최하단으로, 전체폭·우측 정렬·상단 구분선.
+     버튼이 여러 개면 줄바꿈해 카드 폭을 넘기지 않게. */
   table.pro-cards tbody td.cell-actions {
     order: 100;
+    flex-wrap: wrap;
     justify-content: flex-end;
+    row-gap: 6px;
+    white-space: normal;
     padding-top: 10px !important;
     margin-top: 4px;
     border-top: 1px solid var(--c-border) !important;


### PR DESCRIPTION
## 증상
**근태·급여 표 카드형 전환 (모바일 잘림 수정 2차)**

유지보수 작업을 진행합니다.

## 원인
.pro-cards 의 .cell-actions 가 버튼을 한 줄에 강제로 두어
급여명세서처럼 액션이 3~4개인 행에서 카드 폭을 넘기는 문제가 있었다.
flex-wrap·row-gap·white-space:normal 을 추가해 버튼이 자연스럽게
다음 줄로 접히도록 한다. (열 간격은 기존 gap:14px 유지)

## 수정
**작업 항목 (커밋 단위)**
- style(mobile): 카드형 액션 셀 다중 버튼 줄바꿈 허용
- feat(mobile): 근태 페이지 표 2종 카드형 전환
- feat(mobile): 급여명세서 표 카드형 전환

**변경 대상 (3개 파일)**
- `client/src/pages/AttendancePage.tsx`
- `client/src/pages/PayrollPage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #245** ↔ **이슈 #668** 로 연결됩니다.

Closes #668
