### PR TITLE
🔀 :: (#669) 크롬 UI 네이티브 앱 감각 (선택·콜아웃·탭지연 제거)

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -125,6 +125,27 @@ html.hinest-shell-lock body {
   overscroll-behavior: none;
 }
 * { -webkit-tap-highlight-color: transparent; }
+
+/* 네이티브 앱 느낌 — 크롬(내비·상단바·버튼·탭·칩)은 길게 눌러도 텍스트가 잡히거나
+   iOS 콜아웃(복사·이미지 저장 메뉴)이 뜨지 않게 한다. 본문·표 값·입력·에디터는
+   복사할 수 있어야 하므로 손대지 않고, 혹시 아래 셀렉터에 걸려도 그 다음 규칙에서 복구. */
+nav, header, .btn, button, .tab, .tabs, .chip, .badge,
+[role="button"], [role="tab"], [role="tablist"] {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
+/* 탭 지연·더블탭 확대 없이 버튼·링크가 즉시 반응하도록(네이티브 탭 감각) */
+.btn, button, a, [role="button"], [role="tab"], .tab {
+  touch-action: manipulation;
+}
+/* 입력·편집 영역은 항상 선택/복사 가능 — 위 규칙(button 등)에 걸린 것도 되돌린다 */
+input, textarea, select, [contenteditable], [contenteditable] * {
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
+}
+
 .font-mono, code, pre, .tabular {
   font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, Monaco, monospace;
   font-feature-settings: "tnum" 1;


### PR DESCRIPTION
## 증상
**크롬 UI 네이티브 앱 감각 (선택·콜아웃·탭지연 제거)**

유지보수 작업을 진행합니다.

## 원인
모바일에서 웹이 아닌 실제 앱처럼 느껴지도록 UI 크롬을 다듬는다.
- 내비·상단바·버튼·탭·칩: user-select:none + -webkit-touch-callout:none
  → 길게 눌러도 라벨이 선택되거나 iOS 복사/이미지저장 메뉴가 뜨지 않음
- 버튼·링크·탭: touch-action:manipulation → 탭 지연·더블탭 확대 없이 즉시 반응
- input/textarea/select/contenteditable 은 명시적으로 선택·복사 복구
  → 본문·표 값·채팅·문서 내용 복사 기능은 그대로 유지

기존 네이티브 동작(오버스크롤 잠금·tap-highlight 제거·PWA 메타·
당겨서 새로고침·하단 네비·safe-area)은 이미 적용되어 있어 건드리지 않음.

## 수정
**작업 항목 (커밋 단위)**
- feat(mobile): 크롬 UI 네이티브 앱 감각 — 선택·콜아웃·탭지연 제거

**변경 대상 (1개 파일)**
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #246** ↔ **이슈 #669** 로 연결됩니다.

Closes #669
