### PR TITLE
🔀 :: (#671) iOS 단독형 PWA 하단 네비바 아래 빈 공간 제거

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -118,9 +118,17 @@ html.hinest-shell-lock {
 }
 html.hinest-shell-lock body {
   position: fixed;
+  /*
+   * inset:0 (top/right/bottom/left = 0) 만으로 뷰포트 네 변에 고정한다.
+   * width/height:100% 를 함께 주면 안 된다 — top+bottom 과 height 가 동시에 지정되면
+   * 과제약(over-constrained)이라 CSS 가 bottom 을 무시하고 height 로 박스 높이를 정한다
+   * (CSS 2.1 §10.6.4). 그런데 iOS 단독형(standalone) PWA 는 fixed 요소의 height:100% 를
+   * 하단 safe-area(홈 인디케이터) 높이만큼 짧게 계산하는 사례가 있어, body 바닥이 화면
+   * 바닥에 닿지 못하고 in-flow 하단 네비바 아래로 회색 빈 공간이 드러난다.
+   * inset:0 만 쓰면 bottom:0 이 진짜 화면 바닥(safe-area 포함)에 고정돼 이 틈이 사라진다.
+   * 자식(#root → 루트 div)의 height:100% 는 이렇게 확정된 body 높이에 정상적으로 맞춰진다.
+   */
   inset: 0;
-  width: 100%;
-  height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
 }


### PR DESCRIPTION
## 증상
**iOS 단독형 PWA 하단 네비바 아래 빈 공간 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
홈 화면 앱(standalone)에서 하단 네비게이션 바가 화면 바닥에 닿지 못하고
바 아래로 회색 빈 공간이 드러나던 문제를 수정한다.

원인: 앱 셸 오버스크롤 잠금용 `html.hinest-shell-lock body` 규칙이
`position: fixed; inset: 0` 과 함께 `width: 100%; height: 100%` 를 같이
지정하고 있었다. top+bottom 과 height 가 동시에 주어지면 과제약(over-
constrained) 상태라 CSS 가 bottom 을 무시하고 height 로 박스 높이를 정한다
(CSS 2.1 §10.6.4). iOS standalone PWA 는 fixed 요소의 height:100% 를
하단 safe-area(홈 인디케이터) 높이만큼 짧게 계산하는 사례가 있어, body
바닥이 실제 화면 바닥에 닿지 못하고 in-flow 하단바 아래로 빈 공간이 보였다.

수정: 중복이면서 유해한 `width/height: 100%` 를 제거하고 `inset: 0` 만으로
네 변을 고정한다. `bottom: 0` 이 safe-area 를 포함한 진짜 화면 바닥에 박혀
틈이 사라지고, 자식(#root → 루트 div)의 height:100% 도 확정된 body 높이에
정상적으로 맞춰진다.

검증: 데스크톱 Chrome /preview 375x812 에서 body/#root/루트 div 모두
뷰포트(812)를 채우고 하단바가 바닥(812)에 flush — 일반 케이스 회귀 없음.
build EXIT 0. (Chrome 은 env(safe-area-inset-bottom) 를 0 으로 보고하므로
실제 기기 standalone 에서 최종 확인 필요.)

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): iOS 단독형 PWA 하단 네비바 아래 회색 빈 공간 제거

**변경 대상 (1개 파일)**
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #248** ↔ **이슈 #671** 로 연결됩니다.

Closes #671
