### PR TITLE
🔀 :: (#672) 네비 전환 시 셸 유지 + 상단바 버튼 확대

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 import { useTheme } from "../theme";
@@ -34,6 +34,15 @@ function prefetchRoute(to: string) {
     const fn = ROUTE_PREFETCH[to];
     if (fn) void fn();
   } catch {}
+}
+
+/**
+ * 페이지 청크 로딩 중 잠깐 보이는 본문 자리. 셸(상단바·하단바)은 그대로 유지되고
+ * 본문 영역 높이만 확보해 레이아웃 점프를 막는다. prefetch 덕에 대부분 즉시 교체돼
+ * 사실상 거의 안 보인다.
+ */
+function PageFallback() {
+  return <div className="min-h-[60vh]" aria-hidden />;
 }
 
 type NavItem = { to: string; label: string; icon: (p: { active?: boolean }) => JSX.Element; end?: boolean };
@@ -539,6 +548,7 @@ function usePullToRefresh() {
 function AppLayoutInner({ children }: { children?: React.ReactNode }) {
   const { user, logout, impersonator } = useAuth();
   const nav = useNavigate();
+  const { pathname } = useLocation();
   const { disabled: disabledNav, dev: devNav } = useNavStatus();
   const filterByVisibility = (items: NavItem[]) => items.filter((i) => !disabledNav.has(i.to));
   const isMacDesktop = !!window.hinest?.isDesktop && window.hinest?.platform === "darwin";
@@ -827,7 +837,15 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
           >
             <RouteVisibilityGate disabled={disabledNav} dev={devNav}>
               {/* /preview 같은 비-라우터-childless 진입 시엔 children 으로 직접 받음. 그 외엔 Outlet. */}
-              {children ?? <Outlet />}
+              {/* 페이지가 lazy 라, 셸까지 감싸던 상위 Suspense 가 fallback 을 띄우면 상단바·하단바가
+                  통째로 사라졌다 다시 나타났다. Suspense 를 본문(Outlet) 안쪽으로 내려 페이지 청크가
+                  로드되는 동안에도 셸은 유지하고 본문만 잠깐 비운다. key=pathname 으로 라우트가 바뀔
+                  때마다 가벼운 페이드를 다시 재생해 전환을 부드럽게 한다. */}
+              <Suspense fallback={<PageFallback />}>
+                <div key={pathname} className="route-fade">
+                  {children ?? <Outlet />}
+                </div>
+              </Suspense>
             </RouteVisibilityGate>
           </div>
         </main>
@@ -990,6 +1008,7 @@ function BottomNavTab({
       to={to}
       end={end}
       aria-label={ariaLabel}
+      onPointerDown={() => prefetchRoute(to)}
       onClick={() => prefetchRoute(to)}
       className={
         "relative flex-1 min-w-0 flex flex-col items-center justify-center gap-1 select-none " +

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1448,12 +1448,17 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
   return (
     <>
       <header
-        className="flex items-center justify-between px-3 md:px-6 border-b border-ink-150 bg-white flex-shrink-0"
+        className={
+          "flex items-center justify-between px-3 md:px-6 border-b border-ink-150 bg-white flex-shrink-0 " +
+          // 모바일 56px / 데스크톱 48px(기존 유지). 노치(safe-area-top)가 있으면 그만큼 더해
+          // 콘텐츠 영역 높이는 그대로 두고 상태바 밑으로 안 깔리게 한다.
+          (safeAreaTop
+            ? "min-h-[calc(56px+env(safe-area-inset-top))] md:min-h-[calc(48px+env(safe-area-inset-top))]"
+            : "min-h-[56px] md:min-h-[48px]")
+        }
         style={{
           // iOS 노치 흡수 — 헤더 자체가 첫 요소일 때만 (배너가 위에 있으면 배너가 처리).
           paddingTop: safeAreaTop ? "env(safe-area-inset-top)" : 0,
-          minHeight: 48,
-          height: safeAreaTop ? "calc(48px + env(safe-area-inset-top))" : 48,
           ...(draggable ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined),
         }}
       >
@@ -1475,8 +1480,8 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
               </svg>
             </button>
           )}
-          <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: "var(--c-brand)" }} />
-          <span className="text-ink-900 font-bold truncate">{label || "HiNest"}</span>
+          <span className="w-2 h-2 md:w-1.5 md:h-1.5 rounded-full flex-shrink-0" style={{ background: "var(--c-brand)" }} />
+          <span className="text-[17px] md:text-[13px] text-ink-900 font-bold truncate">{label || "HiNest"}</span>
         </div>
 
         <div
@@ -1498,12 +1503,12 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
               이벤트로 ChatFab 패널을 토글한다(패널/리스너는 ChatFab 에 그대로 있음).
               데스크톱(md+)은 ChatFab 의 우하단 FAB 를 그대로 쓰므로 여기선 숨긴다. */}
           <button
-            className="btn-icon relative md:hidden"
+            className="btn-icon relative md:hidden !w-[40px] !h-[40px]"
             onClick={() => window.dispatchEvent(new CustomEvent("chat:toggle"))}
             title="사내톡"
             aria-label={chatUnread > 0 ? `사내톡 · 안 읽은 메시지 ${chatUnread}건` : "사내톡"}
           >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
             </svg>
             {chatUnread > 0 && (

--- a/client/src/components/NotificationBell.tsx
+++ b/client/src/components/NotificationBell.tsx
@@ -32,7 +32,7 @@ export default function NotificationBell() {
   return (
     <div ref={ref} className="relative">
       <button
-        className="btn-icon relative"
+        className="btn-icon relative !w-[40px] !h-[40px] md:!w-8 md:!h-8"
         onClick={() => {
           // 모바일(<768px)에선 드롭다운 대신 전용 알림 페이지로 이동한다(작은 화면에서
           // 360px 팝업이 답답하고, 본문 위를 덮는 대신 한 화면 흐름이 자연스러움).
@@ -48,7 +48,7 @@ export default function NotificationBell() {
         }}
         title="알림"
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-[22px] h-[22px] md:w-4 md:h-4">
           <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
           <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
         </svg>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -132,6 +132,18 @@ html.hinest-shell-lock body {
   overflow: hidden;
   overscroll-behavior: none;
 }
+
+/* 라우트 전환 페이드 — 셸(상단바·하단바)은 유지된 채 본문만 부드럽게 나타난다.
+   key=pathname 으로 라우트가 바뀔 때마다 재생. 모션 최소화 설정이면 끈다. */
+@keyframes route-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.route-fade { animation: route-fade-in 0.18s ease-out both; }
+@media (prefers-reduced-motion: reduce) {
+  .route-fade { animation: none; }
+}
+
 * { -webkit-tap-highlight-color: transparent; }
 
 /* 네이티브 앱 느낌 — 크롬(내비·상단바·버튼·탭·칩)은 길게 눌러도 텍스트가 잡히거나


### PR DESCRIPTION
## 증상
**네비 전환 시 셸 유지 + 상단바 버튼 확대**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
페이지 컴포넌트가 모두 lazy() 라, 셸(AppLayout)보다 위에 있던 Suspense
경계가 라우트 이동마다 fallback 을 띄워 상단바·하단바까지 통째로 사라졌다
다시 나타났다. 모바일에서 탭을 옮길 때마다 화면 전체가 깜빡이던 원인.

- Suspense 경계를 본문(Outlet) 안쪽으로 내려, 페이지 청크가 로드되는
  동안에도 셸은 유지하고 본문 자리(PageFallback)만 잠깐 비운다.
- key=pathname + .route-fade 로 라우트가 바뀔 때마다 0.18s 페이드를 재생해
  전환을 부드럽게. prefers-reduced-motion 이면 끈다.
- 하단 탭은 onPointerDown 에서도 prefetch 해 터치 즉시 청크를 당겨와
  fallback 이 거의 안 보이게 한다.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 네비게이션 전환 시 셸 유지 — 본문만 부드럽게 교체
- feat(mobile): 상단바 페이지명·채팅·알림 버튼 확대 (데스크톱 유지)

**변경 대상 (3개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/NotificationBell.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #249** ↔ **이슈 #672** 로 연결됩니다.

Closes #672
