### PR TITLE
🔀 :: (#673) iOS PWA 하단바 떠보임 + 로그인 상단 safe-area 침범 수정

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -47,8 +47,15 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen flex flex-col" style={{ background: "var(--c-surface)" }}>
-      {/* 상단 — 로고만 살짝 */}
-      <header className="px-6 pt-8 pb-4 flex items-center">
+      {/* 상단 — 로고만 살짝.
+          iOS 단독형(standalone) PWA 는 status-bar 가 black-translucent 라 콘텐츠가
+          노치/상태바 아래까지 풀스크린으로 깔린다. pt-8(고정 28px) 만으론 로고가 상단
+          safe-area 를 침범하므로, env(safe-area-inset-top) 를 더해 노치 아래로 내린다.
+          데스크톱·브라우저는 inset=0 이라 기존 28px 그대로 유지된다. */}
+      <header
+        className="px-6 pb-4 flex items-center"
+        style={{ paddingTop: "calc(env(safe-area-inset-top) + 2rem)" }}
+      >
         <BrandLockup height={36} />
       </header>
 

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -115,6 +115,17 @@ html.hinest-shell-lock {
   height: 100%;
   overflow: hidden;
   overscroll-behavior: none;
+  /*
+   * 하단바 "떠 보임" 방지(2차 방어선) — 셸이 떠 있는 동안 캔버스/문서 배경을 네비바와
+   * 같은 surface 색으로 칠한다. inset:0 으로 body 를 화면 네 변에 고정해도, 일부 iOS
+   * 단독형(standalone) PWA 빌드는 하단에서 1~Npx 의 seam(이음새)을 남긴다. 그 틈으로
+   * 그동안 캔버스 배경(--c-bg: 라이트 #F5F6F8 / 다크 #0E1014)이 비쳤는데, 네비 surface
+   * 색(라이트 #FFFFFF / 다크 #171A20)과 달라 "하단바 밑에 빈 공간(떠 있음)" 으로 보였다.
+   * 배경을 surface 로 맞추면 seam 이 남아도 네비와 같은 색이라 시각적으로 사라진다.
+   * 셸 위(상단·콘텐츠)는 자식 요소가 모두 덮으므로 이 배경은 오직 seam 에서만 드러난다.
+   * (공개 페이지는 .hinest-shell-lock 이 안 붙으므로 기존 --c-bg 그대로.)
+   */
+  background: var(--c-surface);
 }
 html.hinest-shell-lock body {
   position: fixed;
@@ -131,6 +142,8 @@ html.hinest-shell-lock body {
   inset: 0;
   overflow: hidden;
   overscroll-behavior: none;
+  /* body 가 seam 의 직접 원인일 때를 위해 같은 surface 색으로 한 번 더 맞춘다. */
+  background: var(--c-surface);
 }
 
 /* 라우트 전환 페이드 — 셸(상단바·하단바)은 유지된 채 본문만 부드럽게 나타난다.


### PR DESCRIPTION
## 증상
**iOS PWA 하단바 떠보임 + 로그인 상단 safe-area 침범 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
실기기 iOS standalone PWA 에서 하단 네비바 아래로 빈 공간이 보여 바가
떠 있는 것처럼 보이는 문제. shell-lock 이 body 를 position:fixed; inset:0
으로 화면 네 변에 고정해도 일부 iOS 빌드는 하단에 1~Npx 의 seam(이음새)을
남기고, 그 틈으로 캔버스/문서 배경(--c-bg: 라이트 #F5F6F8 / 다크 #0E1014)이
비쳤다. 이 색이 네비 surface(라이트 #FFFFFF / 다크 #171A20)보다 어둡거나
탁해 "하단바 밑 빈 공간"으로 인식됐다.

구조(in-flow 네비 + env(safe-area-inset-bottom) 패딩 + inset:0 고정)는
이미 정상이므로, 2차 방어선으로 셸이 떠 있는 동안에만 html/body 배경을
네비와 같은 var(--c-surface) 로 칠한다. seam 이 남아도 네비와 동일 색이라
시각적으로 사라진다. 테마 변수를 쓰므로 라이트/다크 모두 자동 일치.
공개 페이지(로그인 등)는 .hinest-shell-lock 이 안 붙어 기존 --c-bg 유지.

검증: 미리보기에서 .hinest-shell-lock 적용 시 html·body 배경이
--c-bg(rgb 14,16,20) → --c-surface(rgb 23,26,32) 로 바뀌어 네비와 일치함 확인.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): iOS 단독형 PWA 하단 네비바 '떠 보임' 잔여 seam 제거
- fix(login): 로그인 페이지 로고 상단 safe-area 침범 수정

**변경 대상 (2개 파일)**
- `client/src/pages/LoginPage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #250** ↔ **이슈 #673** 로 연결됩니다.

Closes #673
