### PR TITLE
🔀 :: (#674) 하단 네비바 높이 축소 (과하게 높던 범위 정리)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -959,7 +959,11 @@ function BottomNav({ items }: { items: NavItem[] }) {
         // 테마 변수로 칠해 다크 모드에서도 자연스럽게(이전엔 bg-white 고정이라 다크에서 깨졌음).
         background: "var(--c-surface)",
         borderTop: "1px solid var(--c-border)",
-        paddingBottom: "env(safe-area-inset-bottom)",
+        // 홈 인디케이터 회피용 하단 여백 — 단, 전체 safe-area(노치 기기 ~34px)를 그대로
+        // 비워두면 네비가 surface 색으로 칠해진 뒤(하단 seam 수정) 그 빈 영역까지 바의
+        // 일부로 보여 바가 과하게 높아 보인다. 인디케이터 클리어런스는 유지하되(>=~26px)
+        // 8px 만 덜어 빈 공간을 줄인다. safe-area 가 없는 기기(env=0)는 0 으로 떨어진다.
+        paddingBottom: "max(env(safe-area-inset-bottom) - 8px, 0px)",
         boxShadow: "0 -8px 24px rgba(20,22,27,0.06)",
       }}
       aria-label="주요 메뉴"
@@ -1015,7 +1019,9 @@ function BottomNavTab({
         "text-[10.5px] font-bold tracking-tight leading-none [&_svg]:w-[22px] [&_svg]:h-[22px]"
       }
       style={({ isActive }) => ({
-        height: 56,
+        // 탭 한 칸 높이 — iOS 기본 탭바(49pt)에 맞춰 50px. (이전 56px 은 살짝 높았다.)
+        // 터치 타깃은 셀 전체(flex-1 × 50px)라 Apple HIG 최소 44pt 이상 유지.
+        height: 50,
         color: isActive ? "var(--c-brand)" : "var(--c-text-3)",
       })}
     >


### PR DESCRIPTION
## 증상
**하단 네비바 높이 축소 (과하게 높던 범위 정리)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
직전 수정(하단 seam 을 surface 색으로 채움)으로 "떠 있는 빈 공간"은 사라졌으나,
safe-area 패딩(노치 기기 ~34px)까지 네비와 같은 색이 되면서 그 빈 영역이 바의
일부처럼 보여 바가 과하게 높아 보였다.

두 군데를 줄인다:
- 탭 한 칸 높이 56 → 50px (iOS 기본 탭바 49pt 에 맞춤). 터치 타깃은 셀 전체라
  Apple HIG 최소 44pt 이상 유지.
- 네비 paddingBottom 을 env(safe-area-inset-bottom) → max(env(...) - 8px, 0px)
  로 변경. 홈 인디케이터 클리어런스(노치 기기 26px)는 유지하되 빈 공간만 덜어낸다.
  safe-area 가 없는 기기는 0 으로 떨어져(음수 방지) 회귀 없음.

결과(노치 기기): 90px → 76px. 미리보기(/preview, env=0)에서 탭 50px·네비
paddingBottom 0px(음수 클램프 정상)·바닥 flush 확인.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 하단 네비바 높이 축소 — 과하게 높아 보이던 범위 정리

**변경 대상 (1개 파일)**
- `client/src/components/AppLayout.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #251** ↔ **이슈 #674** 로 연결됩니다.

Closes #674
