### PR TITLE
🔀 :: (#675) 급여명세서 응답 배열 방어로 크래시 방지

### DIFF
--- a/client/src/pages/PayrollPage.tsx
+++ b/client/src/pages/PayrollPage.tsx
@@ -39,7 +39,7 @@ export default function PayrollPage() {
     if (!isAdmin) return; // /employees 는 ADMIN 전용 — 직원은 호출하지 않음(403 방지).
     let alive = true;
     api<{ employees: EmployeeOption[] }>("/api/payslip/employees")
-      .then((r) => alive && setEmployees(r.employees))
+      .then((r) => alive && setEmployees(Array.isArray(r?.employees) ? r.employees : []))
       .catch(() => {});
     return () => { alive = false; };
   }, [isAdmin]);
@@ -53,7 +53,7 @@ export default function PayrollPage() {
     if (month) q.set("month", String(month));
     if (employeeId) q.set("employeeId", employeeId);
     api<{ payslips: Payslip[] }>(`/api/payslip?${q.toString()}`)
-      .then((r) => { if (alive) { setList(r.payslips); setLoading(false); } })
+      .then((r) => { if (alive) { setList(Array.isArray(r?.payslips) ? r.payslips : []); setLoading(false); } })
       .catch(() => { if (alive) setLoading(false); });
     return () => { alive = false; };
   }, [year, month, employeeId]);
@@ -64,7 +64,7 @@ export default function PayrollPage() {
     if (month) q.set("month", String(month));
     if (employeeId) q.set("employeeId", employeeId);
     api<{ payslips: Payslip[] }>(`/api/payslip?${q.toString()}`)
-      .then((r) => setList(r.payslips))
+      .then((r) => setList(Array.isArray(r?.payslips) ? r.payslips : []))
       .catch(() => {});
   }
 


### PR DESCRIPTION
## 증상
**급여명세서 응답 배열 방어로 크래시 방지**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
급여명세서 목록 응답이 배열을 담고 있지 않은 경우(예: 미리보기 데모의
빈 객체 {} 폴백) setList(undefined) 가 실행돼 렌더에서
`list.filter(...)` 가 "Cannot read properties of undefined" 로 터졌다.

세 곳(setEmployees · 최초 로드 setList · reload setList)에서 응답을
Array.isArray 로 방어해 항상 배열만 들어가게 한다. 데이터가 없으면
빈 표(graceful empty state)로 렌더된다.

운영 서버는 항상 { payslips: [...] } 를 주므로 운영 동작 변화는 없고,
공개 데모(/preview)의 급여명세서 진입 크래시가 해소된다.

## 수정
**작업 항목 (커밋 단위)**
- fix(payslip): 응답에 payslips/employees 배열이 없을 때 크래시 방지

**변경 대상 (1개 파일)**
- `client/src/pages/PayrollPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #252** ↔ **이슈 #675** 로 연결됩니다.

Closes #675
