### PR TITLE
🔀 :: (#677) 하단 세이프라인(홈 인디케이터)을 콘텐츠가 뚫지 않고 뒤로 지나가게

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -826,10 +826,13 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
           <div
             className="max-w-[1400px] mx-auto px-4 md:px-8 pt-4 md:pt-6"
             style={{
-              // 하단 네비게이션 바가 이제 루트 플렉스의 in-flow 형제라 스크롤 영역이 바
-              // 위에서 끝난다(바가 본문을 덮지 않음). 바가 자체 높이+세이프에어리어를
-              // 차지하므로 본문은 마지막 콘텐츠 숨 쉴 여백만 주면 된다. 모바일·데스크톱 공통 24px.
-              paddingBottom: "24px",
+              // 본문 하단 여백 — 토큰(--hinest-main-pb)으로 분기(styles.css).
+              //  · 모바일(<md): in-flow 하단 바가 자체 높이+세이프에어리어를 차지하므로
+              //    스크롤 영역이 바 위에서 끝난다 → 본문은 숨 쉴 여백 24px 만(이중 여백 방지).
+              //  · md+(태블릿 등): 하단 바가 없어 콘텐츠가 화면 바닥까지 닿는다 → 끝까지
+              //    스크롤해도 마지막 콘텐츠가 홈 인디케이터(하단 세이프라인)에 가려지지 않게
+              //    max(24px, env(safe-area-inset-bottom)) 로 인디케이터 위에서 끝낸다.
+              paddingBottom: "var(--hinest-main-pb)",
               // 당겨서 새로고침 — 콘텐츠가 손가락을 따라 내려오는 촉각 피드백.
               transform: ptrOffset > 0 ? `translateY(${ptrOffset}px)` : undefined,
               transition: ptrPull > 0 ? "none" : "transform .25s cubic-bezier(.22,.61,.36,1)",

--- a/client/src/components/DocMemoModal.tsx
+++ b/client/src/components/DocMemoModal.tsx
@@ -288,7 +288,14 @@ export default function DocMemoModal({
 
         {/* ===== 본문 ===== */}
         <div className="flex-1 min-h-0 overflow-y-auto">
-          <div className="max-w-[740px] mx-auto px-6 md:px-10 pt-10 pb-16">
+          {/* 풀스크린 패널이 화면 바닥(bottom-0)까지 닿으므로, 끝까지 스크롤했을 때 마지막
+              콘텐츠가 iOS 홈 인디케이터(하단 세이프라인)에 가려지지 않게 safe-area 만큼 더
+              비운다. 기존 pb-16(4rem)을 하한으로 유지해 안전영역이 없는 기기(데스크톱 등)
+              에서도 동일한 여백을 보장. */}
+          <div
+            className="max-w-[740px] mx-auto px-6 md:px-10 pt-10"
+            style={{ paddingBottom: "max(4rem, calc(2rem + env(safe-area-inset-bottom)))" }}
+          >
 
             {/* ── 대제목 ── */}
             {editMode ? (

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -42,12 +42,25 @@
      데스크톱(md+)은 0 — 고정 사이드바를 쓰므로 하단 바가 없다. 모바일에서만 아래
      미디어쿼리로 켜진다. 이 값으로 ① 본문 하단 패딩 ② ChatFab 띄움 높이를 함께 맞춘다. */
   --hinest-bottomnav-h: 0px;
+
+  /* 본문(메인 스크롤 영역) 하단 패딩.
+     · md+ 기본값: 하단 바가 없어 콘텐츠가 직접 iOS 홈 인디케이터(safe-area-inset-bottom)를
+       비워야 한다. 태블릿 단독형 PWA 에서 페이지를 끝까지 스크롤하면 마지막 콘텐츠가
+       하단 세이프라인(노치/홈바)에 가려지던 문제 → max(24px, safe-area)로 항상 인디케이터
+       위에서 끝나고 그 아래(safe-area)는 콘텐츠가 뒤로 지나가게 한다.
+     · 모바일(<md)은 in-flow 하단 바가 safe-area 를 흡수하므로 본문엔 숨 쉴 여백(24px)만 —
+       아래 미디어쿼리에서 덮어쓴다(바 패딩과 이중 여백 방지). */
+  --hinest-main-pb: max(24px, env(safe-area-inset-bottom));
 }
 
 /* Tailwind md 브레이크포인트(768px) 미만 = 사이드바가 드로어로 접히는 구간.
    이때만 하단 탭 바가 뜨므로 높이를 부여한다. */
 @media (max-width: 767.98px) {
-  :root { --hinest-bottomnav-h: 56px; }
+  :root {
+    --hinest-bottomnav-h: 56px;
+    /* 모바일: 하단 바가 safe-area 를 책임지므로 본문은 24px 만(이중 여백 방지). */
+    --hinest-main-pb: 24px;
+  }
 }
 
 html.dark {


### PR DESCRIPTION
## 증상
**하단 세이프라인(홈 인디케이터)을 콘텐츠가 뚫지 않고 뒤로 지나가게**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
모바일(<md)은 in-flow 하단 바가 safe-area 를 흡수하지만, md+(태블릿 단독형 PWA
등)는 하단 바가 없어 본문이 화면 바닥까지 닿는다. 본문 하단 패딩이 고정 24px 라
페이지를 끝까지 스크롤하면 마지막 콘텐츠가 홈 인디케이터에 가려졌다.

--hinest-main-pb 토큰을 도입해 md+ 는 max(24px, env(safe-area-inset-bottom)),
모바일은 24px(바와 이중 여백 방지)로 분기. AppLayout 본문 paddingBottom 을 이
토큰으로 교체 → 인디케이터 위에서 콘텐츠가 끝나고 그 아래는 뒤로 지나가게.

## 수정
**작업 항목 (커밋 단위)**
- fix(layout): md+ 본문이 하단 세이프라인(홈 인디케이터)을 뚫지 않게 safe-area 확보
- fix(memo): 풀스크린 메모 패널 본문이 홈 인디케이터에 안 가리게 safe-area 하단 패딩

**변경 대상 (3개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/DocMemoModal.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #254** ↔ **이슈 #677** 로 연결됩니다.

Closes #677
