### PR TITLE
🔀 :: (#682) 로그인 직후 알림 권한 프롬프트 — iOS/macOS

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/app": "^8.1.0",
         "@capacitor/core": "^8.3.4",
         "@capacitor/keyboard": "^8.0.3",
+        "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
         "@simplewebauthn/browser": "^13.3.0",
@@ -454,6 +455,15 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.3.tgz",
       "integrity": "sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.2.0.tgz",
+      "integrity": "sha512-fvLY0w2w4MiX+DD4+Wv4DOwOLdzKZsMDwAcRv/Juudd+QbKbn69s6cM3xVqPwAiDqfnqsY4/S8xtQD6M73wY2A==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.4",
     "@capacitor/keyboard": "^8.0.3",
+    "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
     "@simplewebauthn/browser": "^13.3.0",

--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { api, clearApiCache } from "./api";
+import { requestNotifPermissionOnLogin } from "./lib/notifPermission";
 
 export type User = {
   id: string;
@@ -67,6 +68,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // 섬광처럼 보이는 것을 방지. logout 에서와 동일하게 세션 캐시를 싹 비움.
     clearApiCache();
     setUser(res.user);
+    // 로그인 직후 알림 권한 요청(iOS/macOS 등 설치형 앱). 라우팅을 막지 않도록 fire-and-forget.
+    void requestNotifPermissionOnLogin();
     // 호출부(LoginPage)가 superAdmin 여부로 진입 경로를 정할 수 있도록 사용자 객체를 반환.
     return res.user;
   }, []);
@@ -78,6 +81,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
     clearApiCache();
     setUser(res.user);
+    // 가입(=최초 로그인) 직후에도 동일하게 알림 권한 요청.
+    void requestNotifPermissionOnLogin();
   }, []);
 
   const logout = useCallback(async () => {

--- a/client/src/lib/notifPermission.ts
+++ b/client/src/lib/notifPermission.ts
@@ -1,0 +1,74 @@
+/**
+ * 로그인 직후 알림 권한을 요청한다 — iOS/Android(Capacitor) · macOS/Windows(Electron) 전용.
+ *
+ * 왜 "로그인 시점"인가:
+ *  - Apple/Google 모두 콜드 런치 즉시보다 맥락 있는 시점(로그인 후) 요청을 권장한다.
+ *    (App Store 심사에서도 권한 프롬프트 타이밍을 본다)
+ *  - 미리보기("둘러보기") 모드는 실제 로그인이 아니므로 요청하지 않는다.
+ *
+ * 플랫폼별 동작:
+ *  - iOS/Android (Capacitor): @capacitor/local-notifications 의 requestPermissions()
+ *    → OS 네이티브 "알림 허용" 시스템 프롬프트. 원격 푸시(APNs/FCM)·서버 연동 불필요.
+ *  - macOS/Windows (Electron): 렌더러의 Notification.requestPermission() 은 Electron 에선
+ *    프롬프트 없이 즉시 "granted" 라 소용이 없다. 대신 main 프로세스가 첫 알림을 실제로
+ *    post 하는 순간 OS 가 권한 프롬프트를 띄우므로, window.hinest.showNotification() 으로
+ *    환영 알림을 1회 발송해 프롬프트를 끌어낸다.
+ *  - 일반 웹: 자동 요청하지 않는다. 브라우저는 Notification.requestPermission() 호출 시
+ *    사용자 제스처(클릭) 컨텍스트를 요구하는데(특히 Safari/Firefox), 로그인은 비동기 콜백이라
+ *    제스처가 끊겨 무시된다. 웹은 기존대로 프로필 설정의 "데스크톱 알림 켜기" 버튼으로 요청한다.
+ *
+ * 한 번 물어보면(허용/거부 무관) 다시 묻지 않도록 localStorage 플래그로 가드한다.
+ * (요청이 예외로 실패하면 플래그를 세우지 않아 다음 로그인에서 재시도)
+ */
+import { isCapacitorNative, isDesktopApp } from "./platform";
+
+const ASKED_KEY = "hinest.notif.askedOnLogin";
+
+function isPreview(): boolean {
+  return typeof window !== "undefined" && (window as { __HINEST_PREVIEW__?: boolean }).__HINEST_PREVIEW__ === true;
+}
+
+function alreadyAsked(): boolean {
+  try {
+    return localStorage.getItem(ASKED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markAsked() {
+  try {
+    localStorage.setItem(ASKED_KEY, "1");
+  } catch {
+    /* localStorage 불가 환경 — 무시 */
+  }
+}
+
+/**
+ * 로그인/회원가입 성공 직후 호출한다. 흐름을 막지 않도록 fire-and-forget(void) 로 부른다.
+ * 설치형 앱(iOS/Android/데스크톱)에서만 1회 권한 프롬프트를 띄운다.
+ */
+export async function requestNotifPermissionOnLogin(): Promise<void> {
+  if (typeof window === "undefined") return;
+  if (isPreview()) return; // 데모(둘러보기) 모드에선 요청하지 않음
+  if (alreadyAsked()) return;
+
+  try {
+    if (isCapacitorNative()) {
+      // iOS/Android — 네이티브 로컬 알림 권한 (동적 import 로 웹/데스크톱 번들엔 미포함)
+      const { LocalNotifications } = await import("@capacitor/local-notifications");
+      await LocalNotifications.requestPermissions();
+      markAsked();
+    } else if (isDesktopApp()) {
+      // macOS/Windows (Electron) — 첫 알림 post 가 OS 권한 프롬프트를 띄운다
+      await window.hinest?.showNotification?.({
+        title: "HiNest",
+        body: "로그인되었습니다. 새 소식이 생기면 여기로 알려드릴게요.",
+      });
+      markAsked();
+    }
+    // 일반 웹은 위 주석대로 자동 요청하지 않음(프로필 토글로 처리).
+  } catch {
+    // 권한 요청 실패는 조용히 무시 — 앱 흐름을 막지 않는다 (플래그 미설정 → 다음 로그인 재시도)
+  }
+}


### PR DESCRIPTION
## 증상
**로그인 직후 알림 권한 프롬프트 — iOS/macOS**

새 기능을 추가합니다.

## 원인
설치형 앱에서 로그인/회원가입 성공 직후 OS 알림 권한 프롬프트가 뜨도록 추가.
기존엔 프로필 설정의 "데스크톱 알림 켜기"를 직접 눌러야만 요청돼, 앱 첫 실행 시
권한 프롬프트가 전혀 안 떴음.

- iOS/Android(Capacitor): @capacitor/local-notifications 추가 후
  requestPermissions() 호출 → 네이티브 "알림 허용" 시스템 프롬프트. APNs/서버 불필요.
- macOS/Windows(Electron): 렌더러 Notification.requestPermission() 은 Electron 에서
  프롬프트 없이 즉시 granted 라 무의미. 대신 첫 알림 post 가 OS 프롬프트를 띄우므로
  window.hinest.showNotification() 으로 환영 알림 1회 발송. (네이티브 코드 변경 없음)
- 웹: 자동 요청 제외. 브라우저가 requestPermission 에 사용자 제스처를 요구해
  비동기 로그인 콜백에선 무시되므로(특히 Safari/Firefox), 기존 프로필 토글에 위임.
- 미리보기(둘러보기) 모드 제외, localStorage 플래그로 디바이스당 1회만 요청.

iOS 빌드 시 `npm run cap:sync`(또는 cap:ios)가 LocalNotifications 팟을 설치한다.

## 수정
**작업 항목 (커밋 단위)**
- feat(notif): 로그인 직후 알림 권한 프롬프트 — iOS/macOS

**변경 대상 (4개 파일)**
- `client/package-lock.json`
- `client/package.json`
- `client/src/auth.tsx`
- `client/src/lib/notifPermission.ts`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #259** ↔ **이슈 #682** 로 연결됩니다.

Closes #682
