### PR TITLE
🔀 :: (#683) iOS 원격 푸시(APNs) 연동

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/core": "^8.3.4",
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/local-notifications": "^8.2.0",
+        "@capacitor/push-notifications": "^8.1.1",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
         "@simplewebauthn/browser": "^13.3.0",
@@ -464,6 +465,15 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.2.0.tgz",
       "integrity": "sha512-fvLY0w2w4MiX+DD4+Wv4DOwOLdzKZsMDwAcRv/Juudd+QbKbn69s6cM3xVqPwAiDqfnqsY4/S8xtQD6M73wY2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/push-notifications": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/push-notifications/-/push-notifications-8.1.1.tgz",
+      "integrity": "sha512-WqzjPKIbYbARMN+GC0XMAJcxJpUUzqgzS/Ny8RODLrro38pQhm3GXYwX2Mwd+LZlLY39rGImkCkrKyQSNfuikA==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "@capacitor/core": "^8.3.4",
     "@capacitor/keyboard": "^8.0.3",
     "@capacitor/local-notifications": "^8.2.0",
+    "@capacitor/push-notifications": "^8.1.1",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
     "@simplewebauthn/browser": "^13.3.0",

--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { api, clearApiCache } from "./api";
 import { requestNotifPermissionOnLogin } from "./lib/notifPermission";
+import { setupIosPush, unregisterIosPush } from "./lib/pushNotifications";
 
 export type User = {
   id: string;
@@ -59,6 +60,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     refresh();
   }, [refresh]);
 
+  // iOS 원격 푸시(APNs) 등록 — 로그인·회원가입뿐 아니라 세션 복원(앱 재실행) 시에도
+  // 토큰을 재등록하고 탭→이동 리스너를 다시 건다. setupIosPush 는 멱등이며 iOS 외엔 no-op.
+  // user.id 가 바뀔 때만(=로그인/계정전환) 1회 실행 — 매 리렌더마다 register() 가 불리지 않게.
+  useEffect(() => {
+    if (user?.id) void setupIosPush();
+  }, [user?.id]);
+
   const login = useCallback(async (email: string, password: string) => {
     const res = await api<{ user: User }>("/api/auth/login", {
       method: "POST",
@@ -96,6 +104,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       window.location.href = "/login";
       return;
     }
+    // iOS 푸시 토큰 해제 — 세션이 살아있을 때(로그아웃 API 호출 전) 보내야 401 이 안 난다. iOS 외엔 no-op.
+    await unregisterIosPush();
     await api("/api/auth/logout", { method: "POST" });
     setUser(null);
     // 다른 사용자가 로그인했을 때 이전 사용자의 프로젝트/캘린더가 깜빡 보이는 사고 방지.

--- a/client/src/lib/notifPermission.ts
+++ b/client/src/lib/notifPermission.ts
@@ -20,7 +20,7 @@
  * 한 번 물어보면(허용/거부 무관) 다시 묻지 않도록 localStorage 플래그로 가드한다.
  * (요청이 예외로 실패하면 플래그를 세우지 않아 다음 로그인에서 재시도)
  */
-import { isCapacitorNative, isDesktopApp } from "./platform";
+import { isCapacitorNative, isDesktopApp, nativePlatform } from "./platform";
 
 const ASKED_KEY = "hinest.notif.askedOnLogin";
 
@@ -55,7 +55,12 @@ export async function requestNotifPermissionOnLogin(): Promise<void> {
 
   try {
     if (isCapacitorNative()) {
-      // iOS/Android — 네이티브 로컬 알림 권한 (동적 import 로 웹/데스크톱 번들엔 미포함)
+      if (nativePlatform() === "ios") {
+        // iOS 는 원격 푸시(APNs) 경로가 권한 요청+토큰 등록을 모두 담당한다.
+        // (auth.tsx 의 user effect → setupIosPush). 여기선 중복 요청하지 않음.
+        return;
+      }
+      // Android — 네이티브 로컬 알림 권한 (원격 FCM 은 추후). 동적 import 로 웹/데스크톱 번들엔 미포함.
       const { LocalNotifications } = await import("@capacitor/local-notifications");
       await LocalNotifications.requestPermissions();
       markAsked();

--- a/client/src/lib/pushNotifications.ts
+++ b/client/src/lib/pushNotifications.ts
@@ -1,0 +1,113 @@
+/**
+ * iOS 원격 푸시(APNs) 등록·수신 — @capacitor/push-notifications.
+ *
+ * 흐름:
+ *  1) 로그인/세션복원 후 setupIosPush() 호출 (auth.tsx 의 user effect).
+ *  2) 권한 요청 — 이미 결정됐으면 OS 가 프롬프트 없이 기존 결정을 그대로 반환.
+ *  3) register() → OS 가 APNs 디바이스 토큰 발급 → 'registration' 이벤트.
+ *  4) 토큰을 POST /api/push/register 로 서버에 등록 → 서버가 알림 발생 시 이 토큰으로 APNs 발송.
+ *  5) 사용자가 알림을 탭 → 'pushNotificationActionPerformed' → payload 의 linkUrl 로 인앱 이동.
+ *  6) 로그아웃 시 unregisterIosPush() → POST /api/push/unregister 로 토큰 제거.
+ *
+ * iOS 네이티브에서만 동작. android/web/desktop 에선 전부 no-op.
+ * @capacitor/push-notifications 는 함수 안에서 동적 import — 웹/데스크톱 번들에 미포함.
+ */
+import { api } from "../api";
+import { isCapacitorNative, nativePlatform } from "./platform";
+
+let listenersReady = false;
+let lastToken: string | null = null;
+
+function isIos(): boolean {
+  return isCapacitorNative() && nativePlatform() === "ios";
+}
+
+/**
+ * 알림 탭 시 인앱 네비게이션 — desktopNotify 의 onclick 과 동일한 SPA 라우팅 규약을 따른다.
+ *  - /chat?...room=<id> : 우하단 사내톡 팝업 열고 해당 방으로 (chat:open / chat:open-room)
+ *  - 그 외 경로 : history.pushState + popstate 로 라우터 이동
+ */
+function navigateToInApp(url?: string) {
+  if (!url) return;
+  try {
+    const chatMatch = /^\/chat(?:\?|#).*?room=([^&]+)/.exec(url);
+    if (chatMatch) {
+      window.dispatchEvent(new CustomEvent("chat:open"));
+      window.dispatchEvent(new CustomEvent("chat:open-room", { detail: { roomId: chatMatch[1] } }));
+    } else if (url.startsWith("/chat")) {
+      window.dispatchEvent(new CustomEvent("chat:open"));
+    } else {
+      window.history.pushState({}, "", url);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
+  } catch {
+    /* 네비게이션 실패는 조용히 무시 */
+  }
+}
+
+/** 토큰 수신·탭 리스너를 1회만 등록(멱등). */
+async function ensureListeners() {
+  if (listenersReady) return;
+  const { PushNotifications } = await import("@capacitor/push-notifications");
+
+  // APNs 디바이스 토큰 발급 → 서버 등록. (실패해도 다음 로그인/부팅에서 재시도)
+  await PushNotifications.addListener("registration", (token) => {
+    lastToken = token.value;
+    void api("/api/push/register", {
+      method: "POST",
+      json: { token: token.value, platform: "ios" },
+    }).catch(() => {});
+  });
+
+  await PushNotifications.addListener("registrationError", (err) => {
+    console.warn("push registration error", err);
+  });
+
+  // 알림 탭 → linkUrl 로 이동. 커스텀 키(linkUrl)는 APNs payload 최상위에 실어 data 로 전달됨.
+  await PushNotifications.addListener("pushNotificationActionPerformed", (action) => {
+    const data = (action?.notification?.data ?? {}) as { linkUrl?: string };
+    navigateToInApp(data.linkUrl);
+  });
+
+  listenersReady = true;
+}
+
+/**
+ * iOS 원격 푸시 셋업 — 로그인 후/세션 복원 시 호출(멱등).
+ * 권한이 이미 결정됐으면 프롬프트 없이 통과하고, 허용 상태면 register() 로 토큰 발급을 유도한다.
+ */
+export async function setupIosPush(): Promise<void> {
+  if (!isIos()) return;
+  try {
+    const { PushNotifications } = await import("@capacitor/push-notifications");
+    await ensureListeners();
+
+    let perm = await PushNotifications.checkPermissions();
+    if (perm.receive === "prompt" || perm.receive === "prompt-with-rationale") {
+      perm = await PushNotifications.requestPermissions();
+    }
+    if (perm.receive !== "granted") return; // 거부됨 — 등록하지 않음
+
+    await PushNotifications.register(); // → 'registration' 이벤트 → 서버 등록
+  } catch (e) {
+    // 푸시 셋업 실패는 앱 흐름을 막지 않는다.
+    console.warn("setupIosPush failed", e);
+  }
+}
+
+/** 로그아웃 시 — 이 기기 토큰을 서버에서 제거해 더 이상 푸시가 가지 않게 한다. */
+export async function unregisterIosPush(): Promise<void> {
+  if (!isIos()) return;
+  try {
+    // 세션이 살아있을 때(=로그아웃 API 호출 전) 불려야 401 이 나지 않는다.
+    if (lastToken) {
+      await api("/api/push/unregister", { method: "POST", json: { token: lastToken } }).catch(() => {});
+    }
+    const { PushNotifications } = await import("@capacitor/push-notifications");
+    await PushNotifications.removeAllListeners();
+    listenersReady = false;
+    lastToken = null;
+  } catch {
+    /* 무시 */
+  }
+}

--- a/server/prisma/migrations/20260602000000_add_push_token/migration.sql
+++ b/server/prisma/migrations/20260602000000_add_push_token/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "PushToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "platform" TEXT NOT NULL DEFAULT 'ios',
+    "deviceId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+
+    CONSTRAINT "PushToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PushToken_token_key" ON "PushToken"("token");
+
+-- CreateIndex
+CREATE INDEX "PushToken_userId_idx" ON "PushToken"("userId");
+
+-- AddForeignKey
+ALTER TABLE "PushToken" ADD CONSTRAINT "PushToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -90,6 +90,7 @@ model User {
   approvalReviews         ApprovalStep[]         @relation("ApprovalReviewer")
   passkeys                Passkey[]
   desktopBios             DesktopBiometric[]
+  pushTokens              PushToken[]
   reactions               MessageReaction[]
   projects                ProjectMember[]
   projectsCreated         Project[]              @relation("ProjectCreator")
@@ -352,6 +353,21 @@ model DesktopBiometric {
   lastUsedAt DateTime?
 
   @@unique([userId, deviceId])
+  @@index([userId])
+}
+
+/// iOS/Android 원격 푸시(APNs/FCM) 기기 토큰. 로그인 후 네이티브에서 발급받아 등록.
+/// 한 기기(token)는 한 유저에게 귀속 — 재로그인 시 token 의 userId 가 갱신되도록 token 을 unique 로 둔다.
+model PushToken {
+  id         String    @id @default(cuid())
+  userId     String
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  token      String    @unique // APNs device token (hex). 기기당 고유.
+  platform   String    @default("ios") // ios | android (확장 대비)
+  deviceId   String? // 선택: 클라이언트가 보내는 기기 식별자
+  createdAt  DateTime  @default(now())
+  lastUsedAt DateTime?
+
   @@index([userId])
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,7 @@ import uploadRouter, { UPLOAD_DIR } from "./routes/upload.js";
 import { isStorageEnabled, downloadFile } from "./lib/storage.js";
 import fs from "node:fs";
 import notificationRouter from "./routes/notification.js";
+import pushRouter from "./routes/push.js";
 import searchRouter from "./routes/search.js";
 import documentRouter from "./routes/document.js";
 import approvalRouter from "./routes/approval.js";
@@ -275,6 +276,7 @@ app.use("/api/chat", chatRouter);
 app.use("/api/expense", expenseRouter);
 app.use("/api/upload", uploadLimiter, uploadRouter);
 app.use("/api/notification", notificationRouter);
+app.use("/api/push", pushRouter);
 app.use("/api/search", searchRouter);
 app.use("/api/document", documentRouter);
 // extras(templates/lines) 를 approval 보다 먼저 마운트 — approval 의 /:id 와 경로가 겹치는

--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -1,0 +1,217 @@
+import http2 from "node:http2";
+import { readFileSync } from "node:fs";
+import jwt from "jsonwebtoken";
+import { prisma } from "./db.js";
+
+/**
+ * APNs(Apple Push Notification service) 원격 푸시 발송 헬퍼.
+ *
+ * 의존성을 더 늘리지 않기 위해 Node 내장 http2 + 기존 jsonwebtoken(ES256) 만 사용한다.
+ * (apn/node-apn 같은 외부 패키지 불필요)
+ *
+ * 환경 변수:
+ *   APNS_KEY         필수 — .p8 키 내용(PEM) 또는 파일 경로.
+ *                    env 에 PEM 을 통째로 넣을 땐 줄바꿈이 "\n" 으로 이스케이프되어 들어오므로 복원한다.
+ *   APNS_KEY_ID      필수 — .p8 키의 Key ID (10자, 예: "ABC123DEFG")
+ *   APNS_TEAM_ID     필수 — Apple Developer Team ID (10자)
+ *   APNS_BUNDLE_ID   선택 — 앱 번들 ID. 기본 "com.hinest.app" (apns-topic 로 사용)
+ *   APNS_PRODUCTION  선택 — "1"/"true" 면 운영 게이트웨이, 아니면 샌드박스.
+ *
+ * 미설정 시: apnsEnabled() 가 false 를 반환하고 sendApnsToUser() 는 조용히 no-op.
+ * → 키가 없는 환경(로컬·개발)에서도 서버가 정상 동작하고, 알림 흐름을 막지 않는다.
+ *
+ * APNs 인증: 토큰 기반(JWT). iss=TeamID, kid=KeyID, ES256 서명.
+ * 토큰은 20~60분마다 갱신해야 하므로 ~50분 캐시한다.
+ */
+
+const KEY_RAW = process.env.APNS_KEY;
+const KEY_ID = process.env.APNS_KEY_ID;
+const TEAM_ID = process.env.APNS_TEAM_ID;
+const BUNDLE_ID = process.env.APNS_BUNDLE_ID || "com.hinest.app";
+const PRODUCTION = /^(1|true|yes)$/i.test(process.env.APNS_PRODUCTION || "");
+const HOST = PRODUCTION ? "https://api.push.apple.com" : "https://api.sandbox.push.apple.com";
+
+export function apnsEnabled(): boolean {
+  return Boolean(KEY_RAW && KEY_ID && TEAM_ID);
+}
+
+/** .p8 키를 PEM 문자열로 해석. env 에 직접 넣었으면 \n 복원, 아니면 파일 경로로 보고 읽는다. */
+let _key: string | null = null;
+function loadKey(): string {
+  if (_key) return _key;
+  const raw = (KEY_RAW || "").trim();
+  if (raw.includes("BEGIN PRIVATE KEY")) {
+    // env 에 PEM 을 통째로 넣은 경우 — 이스케이프된 줄바꿈 복원
+    _key = raw.replace(/\\n/g, "\n");
+  } else {
+    // 파일 경로로 간주
+    _key = readFileSync(raw, "utf8");
+  }
+  return _key;
+}
+
+/** APNs 인증 JWT (ES256). 50분 캐시. */
+let _token: { jwt: string; at: number } | null = null;
+function authToken(): string {
+  const now = Date.now();
+  if (_token && now - _token.at < 50 * 60 * 1000) return _token.jwt;
+  const signed = jwt.sign({ iss: TEAM_ID }, loadKey(), {
+    algorithm: "ES256",
+    keyid: KEY_ID,
+  });
+  _token = { jwt: signed, at: now };
+  return signed;
+}
+
+/** http2 세션 재사용 — 끊기거나 닫혔으면 새로 연결. */
+let _session: http2.ClientHttp2Session | null = null;
+function getSession(): http2.ClientHttp2Session {
+  if (_session && !_session.closed && !_session.destroyed) return _session;
+  const s = http2.connect(HOST);
+  // 에러 시 세션 핸들 비워 다음 호출에서 재연결되게 함. (리스너 미등록 시 throw 로 프로세스가 죽을 수 있음)
+  s.on("error", (e) => {
+    console.error("apns http2 session error", (e as Error)?.message || e);
+    if (_session === s) _session = null;
+  });
+  s.on("close", () => {
+    if (_session === s) _session = null;
+  });
+  _session = s;
+  return s;
+}
+
+export interface ApnsPayload {
+  title: string;
+  body?: string;
+  /** 앱 아이콘 배지 숫자. */
+  badge?: number;
+  /** 사운드. 기본 "default". */
+  sound?: string;
+  /** 탭 시 이동할 인앱 경로(클라이언트가 읽어 라우팅). */
+  linkUrl?: string;
+  /** 동일 스레드 묶음용 식별자(예: DM 방 id). */
+  threadId?: string;
+}
+
+interface SendResult {
+  token: string;
+  status: number;
+  /** APNs 가 준 실패 사유(JSON body 의 reason). 성공이면 undefined. */
+  reason?: string;
+}
+
+/** 단일 기기 토큰에 발송. http2 스트림 1건 = 요청 1건. */
+function sendOne(deviceToken: string, payload: ApnsPayload): Promise<SendResult> {
+  return new Promise((resolve) => {
+    const aps: Record<string, unknown> = {
+      alert: { title: payload.title, ...(payload.body ? { body: payload.body } : {}) },
+      sound: payload.sound || "default",
+    };
+    if (typeof payload.badge === "number") aps.badge = payload.badge;
+    const bodyObj: Record<string, unknown> = { aps };
+    if (payload.linkUrl) bodyObj.linkUrl = payload.linkUrl;
+    const body = Buffer.from(JSON.stringify(bodyObj));
+
+    let session: http2.ClientHttp2Session;
+    try {
+      session = getSession();
+    } catch (e) {
+      resolve({ token: deviceToken, status: 0, reason: (e as Error)?.message || "session error" });
+      return;
+    }
+
+    const headers: Record<string, string> = {
+      ":method": "POST",
+      ":path": `/3/device/${deviceToken}`,
+      authorization: `bearer ${authToken()}`,
+      "apns-topic": BUNDLE_ID,
+      "apns-push-type": "alert",
+      "apns-priority": "10",
+    };
+    if (payload.threadId) headers["apns-collapse-id"] = payload.threadId.slice(0, 64);
+
+    let req: http2.ClientHttp2Stream;
+    try {
+      req = session.request(headers);
+    } catch (e) {
+      resolve({ token: deviceToken, status: 0, reason: (e as Error)?.message || "request error" });
+      return;
+    }
+
+    let status = 0;
+    let raw = "";
+    req.on("response", (h) => {
+      status = Number(h[":status"]) || 0;
+    });
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+    req.on("end", () => {
+      let reason: string | undefined;
+      if (status !== 200 && raw) {
+        try {
+          reason = (JSON.parse(raw) as { reason?: string }).reason;
+        } catch {
+          /* 비-JSON 응답 무시 */
+        }
+      }
+      resolve({ token: deviceToken, status, reason });
+    });
+    req.on("error", (e) => {
+      resolve({ token: deviceToken, status: 0, reason: (e as Error)?.message || "stream error" });
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+/** 토큰이 영구 무효임을 뜻하는 응답 — 즉시 정리(prune)한다. */
+function isDeadToken(r: SendResult): boolean {
+  if (r.status === 410) return true; // Unregistered (마지막 비활성 시각 헤더 동반)
+  return r.reason === "BadDeviceToken" || r.reason === "Unregistered" || r.reason === "DeviceTokenNotForTopic";
+}
+
+/**
+ * 한 유저의 모든 iOS 기기로 푸시 발송.
+ * - 미설정/토큰 없음 → no-op.
+ * - 성공 토큰은 lastUsedAt 갱신, 죽은 토큰은 삭제.
+ * - 어떤 예외도 호출부(알림 생성 흐름)로 던지지 않는다.
+ */
+export async function sendApnsToUser(userId: string, payload: ApnsPayload): Promise<void> {
+  if (!apnsEnabled()) return;
+  try {
+    const tokens = await prisma.pushToken.findMany({
+      where: { userId, platform: "ios" },
+      select: { token: true },
+    });
+    if (!tokens.length) return;
+
+    const results = await Promise.all(tokens.map((t) => sendOne(t.token, payload)));
+
+    const dead = results.filter(isDeadToken).map((r) => r.token);
+    const ok = results.filter((r) => r.status === 200).map((r) => r.token);
+
+    if (dead.length) {
+      await prisma.pushToken.deleteMany({ where: { token: { in: dead } } });
+    }
+    if (ok.length) {
+      await prisma.pushToken.updateMany({
+        where: { token: { in: ok } },
+        data: { lastUsedAt: new Date() },
+      });
+    }
+
+    // 그 외 실패(예: 인증 오류·일시 장애)는 토큰을 지우지 않고 로그만 남긴다.
+    const other = results.filter((r) => r.status !== 200 && !isDeadToken(r));
+    if (other.length) {
+      console.error(
+        "apns send partial failure",
+        other.map((r) => ({ status: r.status, reason: r.reason })),
+      );
+    }
+  } catch (e) {
+    console.error("sendApnsToUser failed", (e as Error)?.message || e);
+  }
+}

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -1,5 +1,6 @@
 import { prisma } from "./db.js";
 import { publish } from "./sse.js";
+import { sendApnsToUser } from "./apns.js";
 
 export type NotifyType =
   | "NOTICE"
@@ -52,7 +53,11 @@ export async function notify(input: NotifyInput) {
     const d = map.get(input.userId);
     if (d && !d.allowed) return;
     const created = await prisma.notification.create({ data: input });
-    if (!d || d.allowPush) publish(input.userId, "notification", created);
+    if (!d || d.allowPush) {
+      publish(input.userId, "notification", created);
+      // 원격 푸시(iOS APNs) — fire-and-forget. 미설정/토큰없음이면 내부 no-op.
+      void sendApnsToUser(input.userId, { title: input.title, body: input.body, linkUrl: input.linkUrl });
+    }
   } catch (e) {
     console.error("notify failed", e);
   }
@@ -103,6 +108,8 @@ export async function notifyMany(inputs: NotifyInput[]) {
     for (const [uid, n] of picked) {
       if (pushFlag.get(`${uid}:${n.type as NotifyType}`) !== false) {
         publish(uid, "notification", n);
+        // 원격 푸시(iOS APNs) — fire-and-forget. 미설정/토큰없음이면 내부 no-op.
+        void sendApnsToUser(uid, { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined });
       }
     }
   } catch (e) {

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -1,0 +1,57 @@
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../lib/db.js";
+import { requireAuth } from "../lib/auth.js";
+
+/**
+ * 원격 푸시(APNs/FCM) 기기 토큰 등록·해제.
+ *
+ * 흐름:
+ *  - 로그인 후 클라이언트(@capacitor/push-notifications)가 OS 에서 디바이스 토큰을 발급받아
+ *    POST /api/push/register 로 보낸다.
+ *  - 로그아웃 시 POST /api/push/unregister 로 해당 기기 토큰을 지워 더 이상 푸시가 가지 않게 한다.
+ *
+ * token 은 schema 상 unique 다. 같은 기기를 다른 계정으로 재로그인하면 token 의 userId 를
+ * 새 유저로 갱신(upsert)해 이전 유저에게 푸시가 가지 않게 한다.
+ */
+
+const router = Router();
+router.use(requireAuth);
+
+const registerSchema = z.object({
+  token: z.string().min(8).max(512),
+  platform: z.enum(["ios", "android"]).default("ios"),
+  deviceId: z.string().max(256).optional(),
+});
+
+router.post("/register", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = registerSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const { token, platform, deviceId } = parsed.data;
+
+  await prisma.pushToken.upsert({
+    where: { token },
+    create: { userId: u.id, token, platform, deviceId: deviceId ?? null, lastUsedAt: new Date() },
+    update: { userId: u.id, platform, deviceId: deviceId ?? null, lastUsedAt: new Date() },
+  });
+
+  res.json({ ok: true });
+});
+
+const unregisterSchema = z.object({
+  token: z.string().min(8).max(512),
+});
+
+router.post("/unregister", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = unregisterSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+
+  // 본인 소유 토큰만 삭제 — 남의 토큰을 임의로 지우지 못하게 userId 로 스코프.
+  await prisma.pushToken.deleteMany({ where: { token: parsed.data.token, userId: u.id } });
+
+  res.json({ ok: true });
+});
+
+export default router;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## Summary
로그인 후 권한 프롬프트(PR #259)에 이어 **iOS 에 실제 푸시가 도착**하도록 APNs 원격 푸시를 붙였습니다.

- **서버**
  - `PushToken` 모델 + 마이그레이션(디바이스 토큰 저장, token unique)
  - `apns.ts` — Node 내장 `http2` + `jsonwebtoken`(ES256)로 APNs 전송. 외부 패키지 무의존.
  - `/api/push/register`·`/api/push/unregister` 라우트(requireAuth + zod)
  - `notify.ts` 의 SSE publish 와 동일 지점에서 `sendApnsToUser` 호출 — DND·카테고리 가드(allowPush) 그대로 적용
- **클라이언트**
  - `@capacitor/push-notifications` 추가
  - 로그인·세션복원 시 권한요청 → `register()` → 토큰을 `/api/push/register` 로 등록
  - 알림 탭 시 `linkUrl` 인앱 이동(기존 SSE 알림과 동일 라우팅 규약)
  - 로그아웃 시 토큰 해제
- **안전장치**: APNs env 미설정 시 `apnsEnabled()=false` 로 **graceful no-op** → 키 없는 환경에서도 기존 알림(SSE/데스크톱) 그대로 동작.

## 배포 전 필요한 운영 설정 (코드 외 — Apple 계정·Xcode 필요)
1. Apple Developer → **APNs Auth Key(.p8)** 발급 → `Key ID`, `Team ID` 확보
2. 서버 환경변수:
   - `APNS_KEY` (.p8 내용 또는 파일 경로), `APNS_KEY_ID`, `APNS_TEAM_ID`
   - `APNS_BUNDLE_ID` (기본 `com.hinest.app`), `APNS_PRODUCTION` (운영 배포 시 `1`)
3. 마이그레이션: 배포 파이프라인의 `prisma migrate deploy` 가 `20260602000000_add_push_token` 적용
4. Xcode: **Push Notifications** capability + **Background Modes → Remote notifications** 추가 후 `npx cap sync ios`

## Test plan
- [ ] env 미설정 상태에서 기존 알림 정상(no-op) 확인
- [ ] env 설정 후 iOS 실기기 로그인 → 권한 프롬프트 → 토큰 등록(`/api/push/register`) 확인
- [ ] 알림 발생 시 iOS 기기에 푸시 도착 확인
- [ ] 푸시 탭 → `linkUrl` 화면 이동 확인
- [ ] 로그아웃 → 토큰 삭제(`/api/push/unregister`) 확인

Closes #683

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #683
