### PR TITLE
🔀 :: (#686) 아바타/업로드 이미지 로드 (imgSrc + /uploads ?token=)

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -39,6 +39,26 @@ export function apiFetch(path: string, init: RequestInit = {}): Promise<Response
   });
 }
 
+/**
+ * <img>/<video> 처럼 헤더를 못 싣는 태그의 src 변환 — 주로 /uploads 이미지(아바타·첨부).
+ *
+ * 두 가지를 해결한다:
+ *  1) 상대경로(/uploads/..)를 절대 URL 로 — 네이티브 WebView(origin https://localhost)에선
+ *     상대경로가 자기 origin 으로 새서 안 닿으므로 apiUrl 로 API 오리진을 붙인다.
+ *  2) 네이티브면 ?token=<jwt> 를 덧붙인다 — /uploads 는 requireAuth 인데 <img> 는 헤더를
+ *     못 싣고 네이티브 쿠키는 ITP 에 막히므로, 쿼리 토큰으로 인증한다(서버가 허용·로그 마스킹).
+ *
+ * 절대 URL(http/https)·data:·blob: 은 그대로 통과. 웹/데스크톱은 토큰이 없어 기존과 동일.
+ */
+export function imgSrc(url?: string | null): string | undefined {
+  if (!url) return undefined;
+  if (/^(https?:|data:|blob:)/i.test(url)) return url;
+  const abs = apiUrl(url);
+  const t = getAuthToken(); // 네이티브에서만 값이 있음
+  if (!t) return abs;
+  return abs + (abs.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(t);
+}
+
 export async function api<T = any>(
   path: string,
   init: RequestInit & { json?: any } = {}

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -2,7 +2,7 @@ import { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 import { useTheme } from "../theme";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import BrandLockup from "./BrandLockup";
 import NotificationBell from "./NotificationBell";
 import SearchModal from "./SearchModal";
@@ -784,7 +784,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
             <NavLink to="/profile" className="flex items-center gap-2.5 flex-1 min-w-0" title="프로필">
               {user?.avatarUrl ? (
                 <img
-                  src={user.avatarUrl}
+                  src={imgSrc(user.avatarUrl)}
                   alt={user.name ?? ""}
                   className="avatar avatar-sm object-cover" loading="lazy" decoding="async"/>
               ) : (
@@ -1178,7 +1178,7 @@ export function MobileMenuPage() {
       >
         {user?.avatarUrl ? (
           <img
-            src={user.avatarUrl}
+            src={imgSrc(user.avatarUrl)}
             alt={user.name ?? ""}
             className="rounded-full object-cover flex-shrink-0"
             style={{ width: 46, height: 46 }}

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1117,9 +1117,9 @@ function BottomNavTab({
         "text-[10.5px] font-bold tracking-tight leading-none [&_svg]:w-[22px] [&_svg]:h-[22px]"
       }
       style={({ isActive }) => ({
-        // 탭 한 칸 높이 — 56→50 도 높다는 피드백에 따라 Apple HIG 최소치 44px 로 더 낮춤.
-        // 터치 타깃은 셀 전체(flex-1 × 44px)라 HIG 최소 44pt 를 정확히 만족한다.
-        height: 44,
+        // 탭 한 칸 높이. 56→50→44(HIG 최소)로 낮췄다가 "조금 더 높게" 피드백에 +5 = 49px.
+        // 터치 타깃은 셀 전체(flex-1 × 49px)라 HIG 최소 44pt 를 여유 있게 만족한다.
+        height: 49,
         color: isActive ? "var(--c-brand)" : "var(--c-text-3)",
       })}
     >

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, lazy, Suspense } from "react";
 import { useLocation } from "react-router-dom";
 import { useNotifications } from "../notifications";
+import { imgSrc } from "../api";
 // highlight.js(~92KB) 등 무거운 의존성을 끌고오므로 초기 번들에서 분리한다.
 // 채팅 패널은 사용자가 처음 열 때(mounted=true) 비로소 마운트되므로 lazy 로딩이 안전.
 const ChatMiniApp = lazy(() => import("./ChatMiniApp"));
@@ -472,7 +473,7 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
           }}
         >
           {info.imageUrl ? (
-            <img src={info.imageUrl} alt={info.title} style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
+            <img src={imgSrc(info.imageUrl)} alt={info.title} style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
           ) : (
             <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center", fontSize: 15, fontWeight: 700, letterSpacing: "-0.02em" }}>
               {info.title?.[0] ?? "?"}

--- a/client/src/components/CreateProjectModal.tsx
+++ b/client/src/components/CreateProjectModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 
 type UserLite = {
   id: string;
@@ -183,7 +183,7 @@ export default function CreateProjectModal({ open, onClose, onCreated }: Props) 
                       style={{ background: u.avatarUrl ? "transparent" : u.avatarColor }}
                     >
                       {u.avatarUrl ? (
-                        <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                        <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                       ) : (
                         u.name[0]
                       )}

--- a/client/src/components/DocMemoModal.tsx
+++ b/client/src/components/DocMemoModal.tsx
@@ -8,7 +8,7 @@
  */
 import { createPortal } from "react-dom";
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync } from "./ConfirmHost";
 
@@ -322,7 +322,7 @@ export default function DocMemoModal({
                   style={{ background: doc.author?.avatarUrl ? "transparent" : (doc.author?.avatarColor ?? "#6B7280") }}
                 >
                   {doc.author?.avatarUrl
-                    ? <img src={doc.author.avatarUrl} alt={doc.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async" />
+                    ? <img src={imgSrc(doc.author.avatarUrl)} alt={doc.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async" />
                     : (doc.author?.name?.[0] ?? "?")
                   }
                 </div>
@@ -428,7 +428,7 @@ export default function DocMemoModal({
                             >
                               <div className="w-5 h-5 rounded grid place-items-center text-white text-[9px] font-bold flex-shrink-0 overflow-hidden"
                                 style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
-                                {u.avatarUrl ? <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async" /> : u.name[0]}
+                                {u.avatarUrl ? <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async" /> : u.name[0]}
                               </div>
                               <span className="text-[12px] text-ink-800 font-semibold">
                                 {u.name}

--- a/client/src/components/MentionList.tsx
+++ b/client/src/components/MentionList.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { imgSrc } from "../api";
 
 export type MentionUser = {
   id: string;
@@ -76,7 +77,7 @@ const MentionList = forwardRef<{ onKeyDown: (e: { event: KeyboardEvent }) => boo
               className="mention-avatar"
               style={{ background: u.avatarUrl ? "transparent" : u.avatarColor ?? "#94A3B8" }}
             >
-              {u.avatarUrl ? <img src={u.avatarUrl} alt={u.name} loading="lazy" decoding="async"/> : u.name[0]}
+              {u.avatarUrl ? <img src={imgSrc(u.avatarUrl)} alt={u.name} loading="lazy" decoding="async"/> : u.name[0]}
             </span>
             <span className="mention-name">{u.name}</span>
             {(u.team || u.position) && (

--- a/client/src/components/ProjectCalendar.tsx
+++ b/client/src/components/ProjectCalendar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { api, apiSWR } from "../api";
+import { api, apiSWR , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import DateTimePicker from "./DateTimePicker";
 import { confirmAsync, alertAsync } from "./ConfirmHost";
@@ -362,7 +362,7 @@ export default function ProjectCalendar({
               style={{ background: m.avatarUrl ? "transparent" : m.avatarColor }}
             >
               {m.avatarUrl ? (
-                <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                <img src={imgSrc(m.avatarUrl)} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
               ) : (
                 m.name[0]
               )}
@@ -440,7 +440,7 @@ export default function ProjectCalendar({
                             style={{ background: m.avatarUrl ? "transparent" : m.avatarColor }}
                           >
                             {m.avatarUrl ? (
-                              <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                              <img src={imgSrc(m.avatarUrl)} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                             ) : (
                               m.name[0]
                             )}
@@ -506,7 +506,7 @@ export default function ProjectCalendar({
                           style={{ background: m.avatarUrl ? "transparent" : m.avatarColor }}
                         >
                           {m.avatarUrl ? (
-                            <img src={m.avatarUrl} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                            <img src={imgSrc(m.avatarUrl)} alt={m.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                           ) : (
                             m.name[0]
                           )}
@@ -638,7 +638,7 @@ function AssigneeStack({
             title={m.name}
           >
             {m.avatarUrl ? (
-              <img src={m.avatarUrl} alt={m.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
+              <img src={imgSrc(m.avatarUrl)} alt={m.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
             ) : (
               m.name[0]
             )}

--- a/client/src/components/ProjectQaList.tsx
+++ b/client/src/components/ProjectQaList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { api, apiSWR, apiFetch } from "../api";
+import { api, apiSWR, apiFetch , imgSrc} from "../api";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
 import DatePicker from "./DatePicker";
 import { safeAttachmentUrl } from "../lib/safeUrl";
@@ -886,7 +886,7 @@ function QaRow({
                     }}
                   >
                     {item.createdBy.avatarUrl ? (
-                      <img src={item.createdBy.avatarUrl} alt={item.createdBy.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
+                      <img src={imgSrc(item.createdBy.avatarUrl)} alt={item.createdBy.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
                     ) : (
                       item.createdBy.name[0]
                     )}
@@ -1025,7 +1025,7 @@ function QaRow({
               }}
             >
               {item.assignee.avatarUrl ? (
-                <img src={item.assignee.avatarUrl} alt={item.assignee.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
+                <img src={imgSrc(item.assignee.avatarUrl)} alt={item.assignee.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
               ) : (
                 item.assignee.name[0]
               )}
@@ -1288,7 +1288,7 @@ function AssigneeSelect({
             }}
           >
             {current.avatarUrl ? (
-              <img src={current.avatarUrl} alt={current.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
+              <img src={imgSrc(current.avatarUrl)} alt={current.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} loading="lazy" decoding="async"/>
             ) : (
               current.name[0]
             )}

--- a/client/src/components/ProjectSettingsModal.tsx
+++ b/client/src/components/ProjectSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { api, invalidateCache } from "../api";
+import { api, invalidateCache , imgSrc} from "../api";
 import { confirmAsync } from "./ConfirmHost";
 
 type Role = "OWNER" | "MANAGER" | "MEMBER";
@@ -425,7 +425,7 @@ function MembersTab({
                 style={{ background: m.user.avatarUrl ? "transparent" : m.user.avatarColor }}
               >
                 {m.user.avatarUrl ? (
-                  <img src={m.user.avatarUrl} alt={m.user.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                  <img src={imgSrc(m.user.avatarUrl)} alt={m.user.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   m.user.name[0]
                 )}
@@ -498,7 +498,7 @@ function MembersTab({
                   style={{ background: u.avatarUrl ? "transparent" : u.avatarColor }}
                 >
                   {u.avatarUrl ? (
-                    <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                    <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                   ) : (
                     u.name[0]
                   )}

--- a/client/src/components/RevisionHistoryModal.tsx
+++ b/client/src/components/RevisionHistoryModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { confirmAsync, alertAsync } from "./ConfirmHost";
 import { fmtSize } from "../lib/fmt";
 
@@ -88,7 +88,7 @@ export default function RevisionHistoryModal({
               {revs.map((r) => (
                 <div key={r.id} className="panel p-3 flex items-start gap-3">
                   <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden" style={{ background: r.editor?.avatarUrl ? "transparent" : (r.editor?.avatarColor ?? "#6B7280") }}>
-                    {r.editor?.avatarUrl ? <img src={r.editor.avatarUrl} alt={r.editor.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : (r.editor?.name[0] ?? "?")}
+                    {r.editor?.avatarUrl ? <img src={imgSrc(r.editor.avatarUrl)} alt={r.editor.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : (r.editor?.name[0] ?? "?")}
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="text-[12px] font-bold text-ink-900">

--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { alertAsync } from "./ConfirmHost";
 
 type Results = {
@@ -347,7 +347,7 @@ function Avatar({ name, color, imageUrl }: { name: string; color: string; imageU
   return (
     <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold overflow-hidden" style={{ background: imageUrl ? "transparent" : color, letterSpacing: "-0.02em" }}>
       {imageUrl ? (
-        <img src={imageUrl} alt={name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+        <img src={imgSrc(imageUrl)} alt={name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
       ) : (
         name?.[0] ?? "?"
       )}

--- a/client/src/components/chat/theme.tsx
+++ b/client/src/components/chat/theme.tsx
@@ -3,6 +3,7 @@
  * ChatMiniApp 분할 과정에서 중복 유틸을 모아둠.
  */
 import type { Room } from "./types";
+import { imgSrc } from "../../api";
 
 /**
  * 채팅 팔레트 — 모두 CSS 변수 매핑으로 라이트/다크 자동 전환.
@@ -213,7 +214,7 @@ export function Avatar({
       >
         {imageUrl ? (
           <img
-            src={imageUrl}
+            src={imgSrc(imageUrl)}
             alt={name}
             style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} loading="lazy" decoding="async"/>
         ) : (

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import PageHeader from "../components/PageHeader";
 import { downloadCSV, downloadXLSX, openPrintable, parseSheet, type TableColumn } from "../lib/exportTable";
 import DatePicker from "../components/DatePicker";
@@ -1573,7 +1573,7 @@ function UserAvatar({ name, color, imageUrl }: { name: string; color: string; im
     <div className="w-9 h-9 rounded-full grid place-items-center text-white text-[13px] font-extrabold flex-shrink-0 overflow-hidden"
       style={{ background: imageUrl ? "transparent" : color, letterSpacing: "-0.02em" }}>
       {imageUrl ? (
-        <img src={imageUrl} alt={name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+        <img src={imgSrc(imageUrl)} alt={name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
       ) : (
         name?.[0] ?? "?"
       )}

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import DateTimePicker from "../components/DateTimePicker";
@@ -595,7 +595,7 @@ function ApprovalDetail({
                 </div>
                 <div className="w-8 h-8 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden" style={{ background: s.reviewer.avatarUrl ? "transparent" : s.reviewer.avatarColor }}>
                   {s.reviewer.avatarUrl ? (
-                    <img src={s.reviewer.avatarUrl} alt={s.reviewer.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                    <img src={imgSrc(s.reviewer.avatarUrl)} alt={s.reviewer.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                   ) : (
                     s.reviewer.name[0]
                   )}
@@ -618,7 +618,7 @@ function ApprovalDetail({
               {full.comments.map((c) => (
                 <div key={c.id} className="panel p-3 flex items-start gap-2.5">
                   <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden" style={{ background: c.author.avatarUrl ? "transparent" : c.author.avatarColor }}>
-                    {c.author.avatarUrl ? <img src={c.author.avatarUrl} alt={c.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : c.author.name[0]}
+                    {c.author.avatarUrl ? <img src={imgSrc(c.author.avatarUrl)} alt={c.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : c.author.name[0]}
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-baseline gap-1.5 flex-wrap">
@@ -1014,7 +1014,7 @@ function CreateModal({
                     {checked && <span className="w-5 h-5 rounded bg-brand-500 text-white text-[10px] font-bold grid place-items-center tabular">{idx + 1}</span>}
                     <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold overflow-hidden" style={{ background: d.avatarUrl ? "transparent" : (d.avatarColor ?? "#3D54C4") }}>
                       {d.avatarUrl ? (
-                        <img src={d.avatarUrl} alt={d.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                        <img src={imgSrc(d.avatarUrl)} alt={d.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                       ) : (
                         d.name[0]
                       )}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import InstallAppBanner from "../components/InstallAppBanner";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
@@ -354,7 +354,7 @@ function ProfileCard(p: { name: string; email?: string; team: string | null; pos
           className="w-12 h-12 rounded-2xl grid place-items-center text-white text-[18px] font-extrabold overflow-hidden flex-shrink-0"
           style={{ background: p.avatarUrl ? "transparent" : (p.avatarColor ?? "#3D54C4") }}
         >
-          {p.avatarUrl ? <img src={p.avatarUrl} alt={p.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : initial}
+          {p.avatarUrl ? <img src={imgSrc(p.avatarUrl)} alt={p.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/> : initial}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 flex-wrap">

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -1,5 +1,5 @@
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
-import { api, apiSWR } from "../api";
+import { api, apiSWR , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
@@ -249,7 +249,7 @@ function MyProfileHero({
       <div className="relative flex flex-wrap items-center gap-x-5 gap-y-3 p-5">
         <div className="w-16 h-16 rounded-full flex-shrink-0 shadow-pop overflow-hidden relative" style={{ background: me.avatarUrl ? "transparent" : (me.avatarColor ?? "#3D54C4") }}>
           {me.avatarUrl ? (
-            <img src={me.avatarUrl} alt={me.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
+            <img src={imgSrc(me.avatarUrl)} alt={me.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
           ) : (
             <div className="absolute inset-0 grid place-items-center text-white text-[22px] font-extrabold" style={{ letterSpacing: "-0.03em" }}>
               {me.name[0]}
@@ -313,7 +313,7 @@ function GridCard({
           <div className="relative w-12 h-12 flex-shrink-0">
             <div className="absolute inset-0 rounded-full overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3D54C4") }}>
               {u.avatarUrl ? (
-                <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
+                <img src={imgSrc(u.avatarUrl)} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
               ) : (
                 <div className="absolute inset-0 grid place-items-center text-white text-[16px] font-extrabold" style={{ letterSpacing: "-0.02em" }}>
                   {u.name[0]}
@@ -393,7 +393,7 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
       <div className="relative w-10 h-10 flex-shrink-0">
         <div className="absolute inset-0 rounded-full overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3D54C4") }}>
           {u.avatarUrl ? (
-            <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
+            <img src={imgSrc(u.avatarUrl)} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
           ) : (
             <div className="absolute inset-0 grid place-items-center text-white text-[13px] font-extrabold" style={{ letterSpacing: "-0.02em" }}>
               {u.name[0]}

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { api, apiFetch } from "../api";
+import { api, apiFetch , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
@@ -1365,7 +1365,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                     <div className="flex items-center gap-2">
                       <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: d.author.avatarUrl ? "transparent" : (d.author.avatarColor ?? "#6B7280") }}>
                         {d.author.avatarUrl ? (
-                          <img src={d.author.avatarUrl} alt={d.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                          <img src={imgSrc(d.author.avatarUrl)} alt={d.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                         ) : (
                           d.author.name[0]
                         )}
@@ -1504,7 +1504,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                             />
                             <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
                               {u.avatarUrl ? (
-                                <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                                <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                               ) : (
                                 u.name[0]
                               )}
@@ -1656,7 +1656,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                             />
                             <div className="w-6 h-6 rounded grid place-items-center text-white text-[10px] font-bold overflow-hidden" style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#6B7280") }}>
                               {u.avatarUrl ? (
-                                <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                                <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                               ) : (
                                 u.name[0]
                               )}

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { api, apiSWR } from "../api";
+import { api, apiSWR , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
@@ -316,7 +316,7 @@ export default function MeetingDetailPage() {
         <span className="inline-flex items-center gap-1.5">
           <span className="avatar avatar-xs overflow-hidden" style={{ background: meeting.author.avatarUrl ? "transparent" : meeting.author.avatarColor }}>
             {meeting.author.avatarUrl ? (
-              <img src={meeting.author.avatarUrl} alt={meeting.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+              <img src={imgSrc(meeting.author.avatarUrl)} alt={meeting.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
             ) : (
               meeting.author.name[0]
             )}
@@ -490,7 +490,7 @@ function ViewerPicker({
                 style={{ background: u.avatarUrl ? "transparent" : u.avatarColor }}
               >
                 {u.avatarUrl ? (
-                  <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                  <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   u.name[0]
                 )}

--- a/client/src/pages/MeetingsPage.tsx
+++ b/client/src/pages/MeetingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { api, apiSWR, invalidateCache } from "../api";
+import { api, apiSWR, invalidateCache , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { alertAsync } from "../components/ConfirmHost";
@@ -335,7 +335,7 @@ function AuthorChip({ author }: { author: MeetingRow["author"] }) {
         style={{ background: author.avatarUrl ? "transparent" : author.avatarColor }}
       >
         {author.avatarUrl ? (
-          <img src={author.avatarUrl} alt={author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+          <img src={imgSrc(author.avatarUrl)} alt={author.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
         ) : (
           (author.name[0] ?? "?")
         )}

--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import type { MemoDoc } from "../components/DocMemoModal";
@@ -121,7 +121,7 @@ function MemoCard({ memo, onClick }: { memo: Memo; onClick: () => void }) {
           style={{ background: memo.author?.avatarUrl ? "transparent" : (memo.author?.avatarColor ?? "#6B7280") }}
         >
           {memo.author?.avatarUrl ? (
-            <img src={memo.author.avatarUrl} alt={memo.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async" />
+            <img src={imgSrc(memo.author.avatarUrl)} alt={memo.author.name} className="w-full h-full object-cover" loading="lazy" decoding="async" />
           ) : (
             memo.author?.name?.[0] ?? "?"
           )}

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { alertAsync } from "../components/ConfirmHost";
@@ -508,7 +508,7 @@ function UserAvatar({ u, size }: { u: DirUser; size: number }) {
       style={{ width: size, height: size, background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3D54C4") }}
     >
       {u.avatarUrl ? (
-        <img src={u.avatarUrl} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
+        <img src={imgSrc(u.avatarUrl)} alt={u.name} className="absolute inset-0 w-full h-full object-cover" loading="lazy" decoding="async"/>
       ) : (
         <div
           className="absolute inset-0 grid place-items-center text-white font-extrabold"

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { api, invalidateCache, clearApiCache, apiFetch } from "../api";
+import { api, invalidateCache, clearApiCache, apiFetch , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { useTheme, type ThemeMode } from "../theme";
@@ -168,7 +168,7 @@ export default function ProfilePage() {
             <div className="flex items-center gap-3">
               {avatarUrl ? (
                 <img
-                  src={avatarUrl}
+                  src={imgSrc(avatarUrl)}
                   alt={name}
                   className="w-16 h-16 rounded-full object-cover border border-ink-150" loading="lazy" decoding="async"/>
               ) : (
@@ -216,7 +216,7 @@ export default function ProfilePage() {
                 <div className="flex items-center gap-3">
                   {avatarUrl ? (
                     <img
-                      src={avatarUrl}
+                      src={imgSrc(avatarUrl)}
                       alt="프로필"
                       className="w-14 h-14 rounded-full object-cover border border-ink-150" loading="lazy" decoding="async"/>
                   ) : (

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { apiSWR } from "../api";
+import { apiSWR , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import ProjectCalendar from "../components/ProjectCalendar";
@@ -192,7 +192,7 @@ export default function ProjectPage() {
                   title={m.user.name}
                 >
                   {m.user.avatarUrl ? (
-                    <img src={m.user.avatarUrl} alt={m.user.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                    <img src={imgSrc(m.user.avatarUrl)} alt={m.user.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                   ) : (
                     m.user.name[0]
                   )}

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -1,5 +1,5 @@
 import { useDeferredValue, useEffect, useMemo, useState } from "react";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { getHoliday } from "../lib/holidays";
@@ -898,7 +898,7 @@ function EventModal({
                             style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3B5CF0") }}
                           >
                             {u.avatarUrl ? (
-                              <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                              <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                             ) : (
                               u.name[0]
                             )}
@@ -955,7 +955,7 @@ function EventModal({
                             style={{ background: u.avatarUrl ? "transparent" : (u.avatarColor ?? "#3B5CF0") }}
                           >
                             {u.avatarUrl ? (
-                              <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                              <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                             ) : (
                               u.name[0]
                             )}

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { api, apiFetch } from "../api";
+import { api, apiFetch , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
@@ -762,7 +762,7 @@ function AccountCard({
                     style={{ background: a.ownerUser.avatarUrl ? "transparent" : a.ownerUser.avatarColor }}
                   >
                     {a.ownerUser.avatarUrl ? (
-                      <img src={a.ownerUser.avatarUrl} alt={a.ownerUser.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                      <img src={imgSrc(a.ownerUser.avatarUrl)} alt={a.ownerUser.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                     ) : (
                       a.ownerUser.name[0]
                     )}

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -1,6 +1,6 @@
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, Route, Routes, useNavigate, useSearchParams } from "react-router-dom";
-import { api } from "../api";
+import { api , imgSrc} from "../api";
 import { safeUploadUrl } from "../lib/safeUrl";
 import { useTheme } from "../theme";
 import SuperStepUpGate from "../components/SuperStepUpGate";
@@ -839,7 +839,7 @@ function ChatAuditPanel() {
                         <div className="w-7 h-7 rounded-full grid place-items-center text-white text-[11px] font-bold flex-shrink-0 overflow-hidden"
                           style={{ background: m.sender.avatarUrl ? "transparent" : m.sender.avatarColor }}>
                           {m.sender.avatarUrl ? (
-                            <img src={m.sender.avatarUrl} alt={m.sender.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                            <img src={imgSrc(m.sender.avatarUrl)} alt={m.sender.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                           ) : (
                             m.sender.name[0]
                           )}

--- a/client/src/pages/UserProfilePage.tsx
+++ b/client/src/pages/UserProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { api, apiSWR } from "../api";
+import { api, apiSWR , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { alertAsync } from "../components/ConfirmHost";
@@ -144,7 +144,7 @@ export default function UserProfilePage() {
                 }}
               >
                 {u.avatarUrl ? (
-                  <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                  <img src={imgSrc(u.avatarUrl)} alt={u.name} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   initial
                 )}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -350,7 +350,17 @@ function canAccessUploadKey(
   return !!user?.companyId && user.companyId === keyCompanyId;
 }
 
-app.use("/uploads", requireAuth, async (req, res) => {
+// <img> 태그는 Authorization 헤더를 못 싣고, 네이티브 앱(Capacitor)은 쿠키도 cross-site ITP 에
+// 막혀 /uploads 이미지를 인증할 방법이 없다. 그래서 ?token=<jwt> 쿼리로 세션 토큰을 받아(헤더/쿠키가
+// 없을 때만 보강) requireAuth 가 인식하게 한다. 접근 로그는 token 쿼리값을 마스킹한다(SENSITIVE_QS_KEYS).
+function uploadsQueryToken(req: express.Request, _res: express.Response, next: express.NextFunction) {
+  if (!req.headers.authorization && typeof req.query.token === "string" && req.query.token) {
+    req.headers.authorization = `Bearer ${req.query.token}`;
+  }
+  next();
+}
+
+app.use("/uploads", uploadsQueryToken, requireAuth, async (req, res) => {
   const name = req.path.replace(/^\/+/, "");
   // 경로 탈출 / 상대경로 차단
   if (!/^[A-Za-z0-9._-]+$/.test(name)) {


### PR DESCRIPTION
## 증상
**아바타/업로드 이미지 로드 (imgSrc + /uploads ?token=)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
<img> 태그는 Authorization 헤더를 못 싣고 네이티브 앱은 쿠키도 cross-site ITP 에 막혀
/uploads 이미지(아바타·첨부)를 인증할 수 없었다. 헤더/쿠키가 없을 때 ?token=<jwt> 쿼리를
Bearer 로 승격하는 미들웨어를 /uploads 앞에 추가. 접근 로그는 token 쿼리를 마스킹.

## 수정
**작업 항목 (커밋 단위)**
- feat(server): /uploads 를 ?token= 쿼리로도 인증 허용 (네이티브 이미지)
- fix(client): 네이티브에서 아바타/업로드 이미지 로드 (imgSrc 헬퍼)
- style(mobile): 하단 네비바 높이 44→49px (약 +5)

**변경 대상 (28개 파일)**
- `client/src/api.ts`
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatFab.tsx`
- `client/src/components/CreateProjectModal.tsx`
- `client/src/components/DocMemoModal.tsx`
- `client/src/components/MentionList.tsx`
- `client/src/components/ProjectCalendar.tsx`
- `client/src/components/ProjectQaList.tsx`
- `client/src/components/ProjectSettingsModal.tsx`
- `client/src/components/RevisionHistoryModal.tsx`
- `client/src/components/SearchModal.tsx`
- `client/src/components/chat/theme.tsx`
- … 외 16개

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #263** ↔ **이슈 #686** 로 연결됩니다.

Closes #686
