### PR TITLE
🔀 :: (#687) 푸시 미수신·권한 크래시·네이티브 첨부 미디어 (round 2)

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -46,4 +46,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 
+    // APNs 원격 푸시 등록 콜백 — @capacitor/push-notifications 가 이 NotificationCenter 이벤트를
+    // 구독해 디바이스 토큰을 JS 의 'registration' 리스너로 전달한다. 이 두 메서드가 없으면
+    // PushNotifications.register() 가 토큰을 못 받아 서버 등록(/api/push/register)이 일어나지 않고
+    // 푸시가 영영 오지 않는다. (Capacitor 기본 템플릿에 누락돼 있던 것)
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    }
+
 }

--- a/client/ios/App/App/Info.plist
+++ b/client/ios/App/App/Info.plist
@@ -26,6 +26,12 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>채팅·경비·프로필에 사진이나 동영상을 촬영해 첨부할 때 카메라를 사용합니다.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>동영상을 촬영해 첨부할 때 소리를 함께 녹음하기 위해 마이크를 사용합니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>사진·동영상을 선택해 채팅·경비·프로필 등에 첨부하기 위해 사진 보관함에 접근합니다.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/client/ios/App/CapApp-SPM/Package.swift
+++ b/client/ios/App/CapApp-SPM/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4"),
         .package(name: "CapacitorApp", path: "../../../node_modules/@capacitor/app"),
+        .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
         .package(name: "CapacitorKeyboard", path: "../../../node_modules/@capacitor/keyboard"),
         .package(name: "CapacitorLocalNotifications", path: "../../../node_modules/@capacitor/local-notifications"),
         .package(name: "CapacitorPushNotifications", path: "../../../node_modules/@capacitor/push-notifications"),
@@ -26,6 +27,7 @@ let package = Package(
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
+                .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
                 .product(name: "CapacitorKeyboard", package: "CapacitorKeyboard"),
                 .product(name: "CapacitorLocalNotifications", package: "CapacitorLocalNotifications"),
                 .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications"),

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@capacitor/app": "^8.1.0",
+        "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.3.4",
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/local-notifications": "^8.2.0",
@@ -802,6 +803,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
+      "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
     },
     "node_modules/@capacitor/cli": {
       "version": "8.3.4",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@capacitor/app": "^8.1.0",
+    "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.3.4",
     "@capacitor/keyboard": "^8.0.3",
     "@capacitor/local-notifications": "^8.2.0",

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -79,14 +79,42 @@ export async function api<T = any>(
   if (typeof window !== "undefined" && (window as any).__HINEST_PREVIEW__ === true) {
     try { preview = sessionStorage.getItem("hinest:preview") === "1"; } catch {}
   }
-  const res = preview
-    ? await (await import("./lib/previewMock")).previewMockFetch(path, { ...init, json: init.json })
-    : await fetch(apiUrl(path), {
-        ...init,
-        headers,
-        body,
-        credentials: "include",
-      });
+  // 네트워크 지연·끊김 시 UI 가 무한 대기하지 않도록 타임아웃(기본 30초)을 건다.
+  // 호출부가 자체 signal 을 주면 그대로 존중하고 타임아웃은 적용하지 않는다.
+  // 느린 작업(예: 대용량 CSV 임포트)은 init.timeoutMs 로 늘리거나 0 으로 끌 수 있다.
+  const timeoutMs = (init as any).timeoutMs ?? 30_000;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let signal = init.signal ?? undefined;
+  if (!signal && typeof AbortController !== "undefined" && timeoutMs > 0) {
+    const ac = new AbortController();
+    signal = ac.signal;
+    timeoutId = setTimeout(() => ac.abort(), timeoutMs);
+  }
+  let res: Response;
+  try {
+    res = preview
+      ? await (await import("./lib/previewMock")).previewMockFetch(path, { ...init, json: init.json })
+      : await fetch(apiUrl(path), {
+          ...init,
+          headers,
+          body,
+          credentials: "include",
+          signal,
+        });
+  } catch (e: any) {
+    // 타임아웃(abort)·오프라인·DNS 실패 등 fetch 단계 오류를 사용자 친화 메시지로 변환.
+    // (그대로 두면 "Failed to fetch" 가 노출되고 무한 로딩처럼 보인다.)
+    const aborted = e?.name === "AbortError";
+    const nerr = new Error(
+      aborted
+        ? "요청 시간이 초과됐어요. 네트워크 상태를 확인하고 다시 시도해주세요."
+        : "네트워크에 연결할 수 없어요. 연결을 확인해주세요.",
+    ) as Error & { status?: number; code?: string };
+    nerr.code = aborted ? "TIMEOUT" : "NETWORK";
+    throw nerr;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
   if (!res.ok) {
     let msg = "요청 실패";
     let code: string | undefined;

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -5,6 +5,8 @@ import { useAuth } from "../auth";
 import { useNotifications } from "../notifications";
 import { resolvePresence } from "../lib/presence";
 import { downloadFromUrl } from "../lib/download";
+import { isCapacitorNative } from "../lib/platform";
+import { Browser } from "@capacitor/browser";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
 import { SnippetSlashMenu, type SnippetSlashHandle } from "./chat/SnippetSlashMenu";
 import {
@@ -1562,6 +1564,7 @@ function SharedMediaTabs({ messages }: { messages: Message[] }) {
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(url); if (u) void Browser.open({ url: u }); } }}
                   style={{ aspectRatio: "1 / 1", overflow: "hidden", borderRadius: 8, background: C.gray100 }}
                   title={m.fileName ?? ""}
                 >
@@ -1590,6 +1593,7 @@ function SharedMediaTabs({ messages }: { messages: Message[] }) {
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(url); if (u) void Browser.open({ url: u }); } }}
                   style={{ position: "relative", aspectRatio: "16 / 10", overflow: "hidden", borderRadius: 8, background: "#000" }}
                   title={m.fileName ?? ""}
                 >

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { api, apiFetch } from "../api";
+import { api, apiFetch, imgSrc } from "../api";
 import { useAuth } from "../auth";
 import { useNotifications } from "../notifications";
 import { resolvePresence } from "../lib/presence";
@@ -1566,7 +1566,7 @@ function SharedMediaTabs({ messages }: { messages: Message[] }) {
                   title={m.fileName ?? ""}
                 >
                   <img
-                    src={url}
+                    src={imgSrc(url)}
                     alt={m.fileName ?? ""}
                     loading="lazy"
                     style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
@@ -1594,7 +1594,7 @@ function SharedMediaTabs({ messages }: { messages: Message[] }) {
                   title={m.fileName ?? ""}
                 >
                   <video
-                    src={url}
+                    src={imgSrc(url)}
                     preload="metadata"
                     style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
                   />

--- a/client/src/components/Linkify.tsx
+++ b/client/src/components/Linkify.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { openExternal } from "../lib/openExternal";
 
 /**
  * 텍스트 안의 URL을 자동으로 <a>로 변환.
@@ -45,7 +46,7 @@ export default function Linkify({
         target="_blank"
         rel="noopener noreferrer"
         className={linkClassName ?? "underline underline-offset-2 hover:opacity-80 break-all"}
-        onClick={(e) => e.stopPropagation()}
+        onClick={(e) => { e.stopPropagation(); e.preventDefault(); openExternal(href); }}
       >
         {label}
       </a>

--- a/client/src/components/MeetingAttachments.tsx
+++ b/client/src/components/MeetingAttachments.tsx
@@ -1,8 +1,11 @@
 import { useRef, useState } from "react";
-import { api, apiFetch } from "../api";
+import { api, apiFetch, imgSrc } from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync, alertAsync } from "./ConfirmHost";
 import { safeAttachmentUrl } from "../lib/safeUrl";
+import { isCapacitorNative } from "../lib/platform";
+import { openExternal } from "../lib/openExternal";
+import { Browser } from "@capacitor/browser";
 
 /**
  * 회의록 본문 아래에 떠있는 첨부 섹션 — 파일(이미지/영상/문서) + 외부 링크 모두 한 곳에서 관리.
@@ -262,6 +265,13 @@ export default function MeetingAttachments({
                       target="_blank"
                       rel="noopener noreferrer"
                       {...(isLink ? {} : { download: att.name })}
+                      onClick={(e) => {
+                        if (!isCapacitorNative()) return;
+                        e.preventDefault();
+                        if (isLink) { openExternal(safeHref); return; }
+                        const u = imgSrc(safeHref);
+                        if (u) void Browser.open({ url: u });
+                      }}
                       className="text-[13px] font-semibold text-ink-900 hover:text-brand-600 truncate block"
                       title={isLink ? safeHref : att.name}
                     >

--- a/client/src/components/ProjectCalendar.tsx
+++ b/client/src/components/ProjectCalendar.tsx
@@ -345,7 +345,7 @@ export default function ProjectCalendar({
                 style={{ background: meUrl ? "transparent" : (me?.avatarColor ?? "#64748B") }}
               >
                 {meUrl ? (
-                  <img src={meUrl} alt={me?.name ?? "내 프로필"} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
+                  <img src={imgSrc(meUrl)} alt={me?.name ?? "내 프로필"} className="w-full h-full object-cover" loading="lazy" decoding="async"/>
                 ) : (
                   (me?.name ?? user.name ?? "나")[0]
                 )}

--- a/client/src/components/ProjectQaList.tsx
+++ b/client/src/components/ProjectQaList.tsx
@@ -1338,7 +1338,7 @@ function AttachmentThumb({
       <div className={box} style={{ width: 112, height: 112 }}>
         <a href={safeHref} target="_blank" rel="noreferrer" title={att.name}>
           <img
-            src={safeHref}
+            src={imgSrc(safeHref)}
             alt={att.name}
             className="w-full h-full object-cover"
             loading="lazy"
@@ -1360,7 +1360,7 @@ function AttachmentThumb({
     return (
       <div className={box} style={{ width: 180, height: 112 }}>
         <video
-          src={safeHref}
+          src={imgSrc(safeHref)}
           className="w-full h-full object-cover"
           controls
           preload="metadata"

--- a/client/src/components/ProjectQaList.tsx
+++ b/client/src/components/ProjectQaList.tsx
@@ -3,6 +3,8 @@ import { api, apiSWR, apiFetch , imgSrc} from "../api";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
 import DatePicker from "./DatePicker";
 import { safeAttachmentUrl } from "../lib/safeUrl";
+import { isCapacitorNative } from "../lib/platform";
+import { Browser } from "@capacitor/browser";
 
 type Status = "BUG" | "IN_PROGRESS" | "NEEDS_FIX" | "NEEDS_TEST" | "DONE" | "ON_HOLD";
 type Priority = "LOW" | "NORMAL" | "HIGH";
@@ -1336,7 +1338,13 @@ function AttachmentThumb({
     }
     return (
       <div className={box} style={{ width: 112, height: 112 }}>
-        <a href={safeHref} target="_blank" rel="noreferrer" title={att.name}>
+        <a
+          href={safeHref}
+          target="_blank"
+          rel="noreferrer"
+          title={att.name}
+          onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(safeHref); if (u) void Browser.open({ url: u }); } }}
+        >
           <img
             src={imgSrc(safeHref)}
             alt={att.name}
@@ -1380,6 +1388,7 @@ function AttachmentThumb({
           href={safeHref}
           target="_blank"
           rel="noreferrer"
+          onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(safeHref); if (u) void Browser.open({ url: u }); } }}
           className="truncate text-ink-700 hover:underline"
           title={att.name}
         >

--- a/client/src/components/chat/LinkPreview.tsx
+++ b/client/src/components/chat/LinkPreview.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { api } from "../../api";
 import { safeExternalUrl } from "../../lib/safeUrl";
+import { openExternal } from "../../lib/openExternal";
 
 /**
  * 메시지 본문 안 첫 URL 의 OG/Twitter Card 메타를 가져와 카드로 표시.
@@ -89,11 +90,8 @@ export function LinkPreview({ url, mine }: { url: string; mine: boolean }) {
       rel="noopener noreferrer"
       onClick={(e) => {
         e.stopPropagation();
-        const bridge = (window as any).hinest;
-        if (bridge?.openExternal) {
-          e.preventDefault();
-          bridge.openExternal(safeUrl).catch(() => {});
-        }
+        e.preventDefault();
+        openExternal(safeUrl);
       }}
       style={{
         display: "flex",

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { C, FONT, formatBytes } from "./theme";
 import type { Attachment, Message, Reaction } from "./types";
-import { api } from "../../api";
+import { api, imgSrc } from "../../api";
 import { alertAsync } from "../ConfirmHost";
 import { parseCodeSegments } from "../../lib/codeDetect";
 import { copyToClipboard } from "../../lib/clipboard";
@@ -270,7 +270,7 @@ function ChatVideoPlayer({ src, fileName }: { src: string; fileName: string | nu
     <div ref={wrapRef} style={{ position: "relative", display: "inline-block" }}>
       <video
         ref={videoRef}
-        src={src}
+        src={imgSrc(src)}
         controls
         // 기본 메뉴 항목 전부 숨김 → 3점 메뉴 자체가 사라짐.
         controlsList="nodownload noplaybackrate nofullscreen noremoteplayback"
@@ -497,7 +497,7 @@ function ImageThumb({ src, alt }: { src: string; alt: string }) {
         }}
       >
         <img
-          src={src}
+          src={imgSrc(src)}
           alt={alt}
           loading="lazy"
           decoding="async"
@@ -564,7 +564,7 @@ function ImageLightbox({
     >
       <style>{`@keyframes hinest-fade { from { opacity: 0 } to { opacity: 1 } }`}</style>
       <img
-        src={src}
+        src={imgSrc(src)}
         alt={alt}
         onMouseDown={(e) => e.stopPropagation()}
         style={{
@@ -1505,7 +1505,7 @@ export function AttachmentPreview({
   if (att.kind === "IMAGE") {
     body = (
       <img
-        src={att.url}
+        src={imgSrc(att.url)}
         alt={att.name}
         loading="lazy"
         decoding="async"

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -7,6 +7,7 @@ import { alertAsync } from "../ConfirmHost";
 import { parseCodeSegments } from "../../lib/codeDetect";
 import { copyToClipboard } from "../../lib/clipboard";
 import { downloadFromUrl } from "../../lib/download";
+import { openExternal } from "../../lib/openExternal";
 import { useModalDismiss } from "../../lib/useModalDismiss";
 import { HljsCode } from "../../lib/useHighlightedCode";
 import { LangIcon } from "../../lib/langIcon";
@@ -1067,12 +1068,8 @@ function renderWithLinks(content: string, mine: boolean): React.ReactNode[] {
         }}
         onClick={(e) => {
           e.stopPropagation();
-          // Electron 데스크톱 앱 안에서는 OS 기본 브라우저로 강제 열기
-          const bridge = window.hinest;
-          if (bridge?.openExternal) {
-            e.preventDefault();
-            bridge.openExternal(href).catch(() => {});
-          }
+          e.preventDefault();
+          openExternal(href);
         }}
       >
         {clean}

--- a/client/src/lib/download.ts
+++ b/client/src/lib/download.ts
@@ -1,3 +1,7 @@
+import { Browser } from "@capacitor/browser";
+import { isCapacitorNative } from "./platform";
+import { imgSrc } from "../api";
+
 /**
  * 크로스 브라우저 파일 다운로드 트리거.
  *
@@ -24,6 +28,14 @@
  *   이 경우 브라우저가 서버의 Content-Disposition 파일명으로 폴백한다.
  */
 export function downloadFromUrl(href: string, filename = ""): void {
+  // 네이티브 앱(Capacitor WKWebView)은 <a download> 로 파일을 저장하지 못한다.
+  // 인증된 절대 URL 을 인앱 브라우저(SFSafariViewController)로 열어 iOS 가 미리보기 +
+  // 공유/저장 시트를 제공하게 한다. imgSrc 가 /uploads 상대경로를 절대화하고 ?token= 을 붙인다.
+  if (isCapacitorNative()) {
+    const url = imgSrc(href) ?? href;
+    void Browser.open({ url }).catch(() => {});
+    return;
+  }
   const a = document.createElement("a");
   a.href = href;
   a.download = filename;

--- a/client/src/lib/openExternal.ts
+++ b/client/src/lib/openExternal.ts
@@ -1,0 +1,26 @@
+import { Browser } from "@capacitor/browser";
+import { isCapacitorNative, isDesktopApp } from "./platform";
+
+/**
+ * 외부(타사) 웹 링크 열기.
+ *
+ * 환경별 동작:
+ *  - Electron 데스크톱: 기존 네이티브 셸 브리지(window.hinest.openExternal)로 시스템 브라우저.
+ *  - Capacitor 네이티브(iOS/Android): 인앱 브라우저(SFSafariViewController / Custom Tab).
+ *    그냥 <a target="_blank"> 면 WKWebView 안에서 열려 뒤로가기 없이 갇히므로 반드시 이걸 쓴다.
+ *  - 웹 브라우저: 새 탭(noopener,noreferrer).
+ *
+ * 외부 링크 전용이다. 앱 내부 파일(/uploads)은 lib/download.ts 의 downloadFromUrl 을 쓸 것.
+ */
+export function openExternal(url: string | null | undefined): void {
+  if (!url) return;
+  if (typeof window !== "undefined" && isDesktopApp() && window.hinest?.openExternal) {
+    window.hinest.openExternal(url).catch(() => window.open(url, "_blank", "noopener,noreferrer"));
+    return;
+  }
+  if (isCapacitorNative()) {
+    void Browser.open({ url }).catch(() => {});
+    return;
+  }
+  if (typeof window !== "undefined") window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -9,6 +9,8 @@ import RevisionHistoryModal from "../components/RevisionHistoryModal";
 import type { MemoDoc } from "../components/DocMemoModal";
 import { safeUploadUrl } from "../lib/safeUrl";
 import { downloadFromUrl, downloadBlob } from "../lib/download";
+import { isCapacitorNative } from "../lib/platform";
+import { Browser } from "@capacitor/browser";
 
 // DocMemoModal 은 TipTap(무거운 번들)을 포함 → 실제 열릴 때만 로드.
 const DocMemoModal = lazy(() => import("../components/DocMemoModal"));
@@ -1354,6 +1356,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                       );
                       return (
                         <a href={safe} target="_blank" rel="noreferrer" title={d.fileName ?? undefined}
+                          onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(safe); if (u) void Browser.open({ url: u }); } }}
                           className="inline-flex items-center gap-1 max-w-[180px] sm:max-w-[260px] align-middle text-[12px] font-bold text-brand-600 hover:underline tabular">
                           <span className="truncate">{d.fileName}</span>
                           <span className="text-ink-400 flex-shrink-0">({humanSize(d.fileSize ?? 0)})</span>

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
 import { safeExternalUrl } from "../lib/safeUrl";
+import { openExternal } from "../lib/openExternal";
 
 /**
  * 서비스 계정 레지스트리 — 회사에서 쓰는 AWS/Vercel/GitHub/테스트 계정을 한 곳에 모으는 페이지.
@@ -745,7 +746,13 @@ function AccountCard({
                 {/* href 는 http(s) 만 허용 — javascript:/data: 스킴 저장형 XSS 차단.
                     안전하지 않으면 링크 대신 평문으로만 노출(텍스트는 React 가 escape). */}
                 {safeExternalUrl(a.url) ? (
-                  <a href={safeExternalUrl(a.url)!} target="_blank" rel="noopener noreferrer" className="text-brand-600 hover:underline truncate">
+                  <a
+                    href={safeExternalUrl(a.url)!}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => { e.preventDefault(); openExternal(safeExternalUrl(a.url)); }}
+                    className="text-brand-600 hover:underline truncate"
+                  >
                     {a.url}
                   </a>
                 ) : (

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -2,6 +2,8 @@ import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, Route, Routes, useNavigate, useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { safeUploadUrl } from "../lib/safeUrl";
+import { isCapacitorNative } from "../lib/platform";
+import { Browser } from "@capacitor/browser";
 import { useTheme } from "../theme";
 import SuperStepUpGate from "../components/SuperStepUpGate";
 import { ErrorBoundary } from "../components/ErrorBoundary";
@@ -892,6 +894,7 @@ function AuditAttachment({ msg }: { msg: Message }) {
   if (msg.kind === "VIDEO") return <video src={imgSrc(fileUrl)} controls className="max-h-56 rounded mb-1" />;
   return (
     <a href={fileUrl} target="_blank" rel="noreferrer"
+      onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(fileUrl); if (u) void Browser.open({ url: u }); } }}
       className="flex items-center gap-2 p-2 rounded-md mb-1 bg-ink-50 border border-ink-200 no-underline">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" />

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -888,8 +888,8 @@ function AuditAttachment({ msg }: { msg: Message }) {
   // /uploads/ 경로만 허용 — 비정상 스킴(javascript:/data:)이 src/href 로 들어가는 것을 방어.
   const fileUrl = safeUploadUrl(msg.fileUrl);
   if (!fileUrl) return null;
-  if (msg.kind === "IMAGE") return <img src={fileUrl} alt={msg.fileName ?? ""} loading="lazy" decoding="async" className="max-h-56 rounded mb-1" />;
-  if (msg.kind === "VIDEO") return <video src={fileUrl} controls className="max-h-56 rounded mb-1" />;
+  if (msg.kind === "IMAGE") return <img src={imgSrc(fileUrl)} alt={msg.fileName ?? ""} loading="lazy" decoding="async" className="max-h-56 rounded mb-1" />;
+  if (msg.kind === "VIDEO") return <video src={imgSrc(fileUrl)} controls className="max-h-56 rounded mb-1" />;
   return (
     <a href={fileUrl} target="_blank" rel="noreferrer"
       className="flex items-center gap-2 p-2 rounded-md mb-1 bg-ink-50 border border-ink-200 no-underline">

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,6 +25,7 @@
         "jsonwebtoken": "^9.0.2",
         "mime-types": "^2.1.35",
         "multer": "^1.4.5-lts.1",
+        "pg": "^8.21.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -37,6 +38,7 @@
         "@types/jsonwebtoken": "^9.0.7",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^22.8.4",
+        "@types/pg": "^8.20.0",
         "dotenv": "^17.4.2",
         "prisma": "^5.22.0",
         "tsx": "^4.19.2",
@@ -2525,6 +2527,18 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -4297,6 +4311,135 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/prisma": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
@@ -4653,6 +4796,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/statuses": {

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "jsonwebtoken": "^9.0.2",
     "mime-types": "^2.1.35",
     "multer": "^1.4.5-lts.1",
+    "pg": "^8.21.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -42,6 +43,7 @@
     "@types/jsonwebtoken": "^9.0.7",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.8.4",
+    "@types/pg": "^8.20.0",
     "dotenv": "^17.4.2",
     "prisma": "^5.22.0",
     "tsx": "^4.19.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,8 @@ import helmet from "helmet";
 import compression from "compression";
 import rateLimit from "express-rate-limit";
 import { requireAuth, NATIVE_ORIGINS } from "./lib/auth.js";
+import { initSsePubsub } from "./lib/ssePubsub.js";
+import { deliverLocal } from "./lib/sse.js";
 import authRouter from "./routes/auth.js";
 import adminRouter from "./routes/admin.js";
 import usersRouter from "./routes/users.js";
@@ -533,6 +535,8 @@ async function backfillNoticeLinks() {
 
 const server = app.listen(PORT, () => {
   console.log(`[HiNest API] http://localhost:${PORT}`);
+  // 멀티 인스턴스 SSE 팬아웃(Postgres LISTEN/NOTIFY) 시작 — 태스크 간 알림 실시간 전달.
+  initSsePubsub(deliverLocal);
   backfillNoticeLinks();
   backfillUserIdentity();
   // 자동 퇴근 스케줄러 — 매 분 tick, 설정된 시각의 사용자를 자동 퇴근 처리.

--- a/server/src/lib/sse.ts
+++ b/server/src/lib/sse.ts
@@ -1,4 +1,5 @@
 import type { Response } from "express";
+import { publishCrossInstance } from "./ssePubsub.js";
 
 /**
  * Server-Sent Events 허브.
@@ -29,7 +30,8 @@ export function removeClient(client: Client) {
   if (set.size === 0) clients.delete(client.userId);
 }
 
-export function publish(userId: string, event: string, data: unknown) {
+/** 이 인스턴스에 연결된 클라이언트에게만 SSE 전달(로컬). cross-instance LISTEN 수신 시에도 이걸 호출. */
+export function deliverLocal(userId: string, event: string, data: unknown) {
   const set = clients.get(userId);
   if (!set) return;
   const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
@@ -40,6 +42,15 @@ export function publish(userId: string, event: string, data: unknown) {
       // ignore broken pipe
     }
   }
+}
+
+/**
+ * 로컬 클라이언트 + 타 Fargate 인스턴스(Postgres LISTEN/NOTIFY) 모두에 전달.
+ * 로컬은 즉시, 타 인스턴스는 pg_notify 로. (멀티 인스턴스에서 알림 실시간 누락 → 폴링 지연 해결)
+ */
+export function publish(userId: string, event: string, data: unknown) {
+  deliverLocal(userId, event, data);
+  publishCrossInstance(userId, event, data);
 }
 
 export function publishMany(userIds: string[], event: string, data: unknown) {

--- a/server/src/lib/ssePubsub.ts
+++ b/server/src/lib/ssePubsub.ts
@@ -1,0 +1,88 @@
+import pg from "pg";
+import { randomUUID } from "node:crypto";
+import { prisma } from "./db.js";
+
+/**
+ * SSE 멀티 인스턴스 팬아웃 — Postgres LISTEN/NOTIFY.
+ *
+ * 문제: sse.ts 의 클라이언트 맵은 프로세스 메모리라, Fargate 가 태스크를 N개 띄우면
+ * 알림을 만든 요청(태스크 A)과 대상 유저의 SSE 커넥션(태스크 B)이 서로 다른 태스크에
+ * 있을 때 publish 가 로컬에서 대상을 못 찾아 실시간 전달이 누락된다 → 클라가 90초
+ * 폴링으로 떨어져 "알림이 느림"으로 체감(데스크톱). ALB 스티키로도 못 고친다(트리거
+ * 유저 ≠ 대상 유저).
+ *
+ * 해결: publish 시 pg_notify 로 한 채널에 브로드캐스트하고, 모든 태스크가 LISTEN 하다가
+ * 자기 인스턴스에서 보낸 게 아니면 로컬 클라이언트로 전달한다. Redis 불필요(기존 Postgres
+ * 재사용 → 추가 비용 0).
+ *
+ * 무회귀 설계: 로컬 전달(deliverLocal)은 그대로 즉시 수행하고, cross-instance 는 순수
+ * 추가분이다. pg/LISTEN 이 실패하거나(pooler 등) NOTIFY 가 막혀도 동작은 "현재(폴링)"로
+ * 안전하게 떨어질 뿐 더 나빠지지 않는다.
+ *
+ * 주의: LISTEN 은 세션 모드 커넥션이 필요하다. 운영 DATABASE_URL 이 PgBouncer 트랜잭션
+ * 풀러를 가리키면 LISTEN 이 동작하지 않을 수 있다(이 경우 cross-instance 는 폴링 폴백).
+ * 보내는 쪽(pg_notify)은 풀러에서도 정상 동작한다.
+ */
+
+const CHANNEL = "sse_events";
+export const INSTANCE_ID = randomUUID();
+const MAX_PAYLOAD_BYTES = 7000; // pg_notify 한도 8000B 보다 여유
+
+type Deliver = (userId: string, event: string, data: unknown) => void;
+let onDeliver: Deliver | null = null;
+let listenClient: pg.Client | null = null;
+let connecting = false;
+
+/** 서버 기동 시 1회 호출 — 로컬 전달 콜백을 받아 LISTEN 을 시작한다. */
+export function initSsePubsub(deliver: Deliver): void {
+  onDeliver = deliver;
+  void connectListen();
+}
+
+async function connectListen(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url || connecting || listenClient) return;
+  connecting = true;
+  try {
+    const c = new pg.Client({ connectionString: url });
+    await c.connect();
+    await c.query(`LISTEN ${CHANNEL}`);
+    c.on("notification", (msg) => {
+      if (!msg.payload || !onDeliver) return;
+      try {
+        const m = JSON.parse(msg.payload) as { origin: string; userId: string; event: string; data: unknown };
+        if (m.origin === INSTANCE_ID) return; // 같은 인스턴스 → 이미 로컬 전달함(중복 방지)
+        onDeliver(m.userId, m.event, m.data);
+      } catch {
+        /* 잘못된 payload 무시 */
+      }
+    });
+    const reconnect = (why: string) => {
+      console.error("[sse] LISTEN 연결 끊김 — 재연결 예약:", why);
+      listenClient = null;
+      connecting = false;
+      setTimeout(() => void connectListen(), 5000);
+    };
+    c.on("error", (e) => reconnect((e as Error)?.message || "error"));
+    c.on("end", () => reconnect("end"));
+    listenClient = c;
+    connecting = false;
+    console.log(`[sse] cross-instance LISTEN 연결됨 (instance ${INSTANCE_ID.slice(0, 8)})`);
+  } catch (e) {
+    connecting = false;
+    console.error("[sse] LISTEN 연결 실패 — 재시도 예약:", (e as Error)?.message || e);
+    setTimeout(() => void connectListen(), 5000);
+  }
+}
+
+/** 다른 인스턴스들에게 이 이벤트를 브로드캐스트(pg_notify). 로컬 전달은 sse.publish 가 이미 함. */
+export function publishCrossInstance(userId: string, event: string, data: unknown): void {
+  try {
+    const payload = JSON.stringify({ origin: INSTANCE_ID, userId, event, data });
+    // 8KB 한도 — 너무 큰 이벤트는 cross-instance 생략(로컬은 이미 전달됨, 타 인스턴스는 폴링 폴백).
+    if (Buffer.byteLength(payload, "utf8") > MAX_PAYLOAD_BYTES) return;
+    void prisma.$executeRaw`SELECT pg_notify(${CHANNEL}, ${payload})`.catch(() => {});
+  } catch {
+    /* 직렬화 실패 등 무시 — 로컬 전달은 이미 됨 */
+  }
+}


### PR DESCRIPTION
## 증상
**푸시 미수신·권한 크래시·네이티브 첨부 미디어 (round 2)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
AppDelegate 에 didRegisterForRemoteNotificationsWithDeviceToken /
didFailToRegisterForRemoteNotificationsWithError 가 누락돼 있어,
@capacitor/push-notifications 가 토큰을 못 받고 'registration' 이벤트가
발생하지 않았다 → 서버 등록(/api/push/register)이 안 돼 푸시가 영영 미수신.
두 콜백에서 Capacitor NotificationCenter 이벤트를 post 하도록 추가.

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): APNs 디바이스 토큰 등록 콜백 추가 (푸시 미수신 해결)
- fix(ios): 카메라·사진·마이크 권한 사용 설명 추가 (크래시·심사 차단 해결)
- fix(client): 채팅·Q&A·관리자 첨부 이미지/영상 네이티브 표시 (imgSrc 확장)
- feat(client): @capacitor/browser 도입 + 네이티브 다운로드/외부링크 헬퍼
- fix(client): 외부 링크·첨부 파일 열기 네이티브 대응
- fix(client): API 호출 타임아웃 + 오프라인/지연 친화 메시지 (모바일 안정성)
- fix(server): SSE 멀티 인스턴스 팬아웃 (Postgres LISTEN/NOTIFY) — 데스크톱 알림 지연 해결

**변경 대상 (23개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/ios/App/App/Info.plist`
- `client/ios/App/CapApp-SPM/Package.swift`
- `client/package-lock.json`
- `client/package.json`
- `client/src/api.ts`
- `client/src/components/ChatMiniApp.tsx`
- `client/src/components/Linkify.tsx`
- `client/src/components/MeetingAttachments.tsx`
- `client/src/components/ProjectCalendar.tsx`
- `client/src/components/ProjectQaList.tsx`
- `client/src/components/chat/LinkPreview.tsx`
- … 외 11개

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #264** ↔ **이슈 #687** 로 연결됩니다.

Closes #687
