### PR TITLE
🔀 :: (#688) SSE 실시간을 ?token= 쿼리 인증으로 (모바일 채팅/알림 실시간)

### DIFF
--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { api, apiUrl } from "./api";
+import { getAuthToken } from "./lib/authToken";
 import { deliverPendingNotifications, markSeen } from "./lib/desktopNotify";
 import { shouldDeliverNotif } from "./lib/notifPrefs";
 
@@ -137,7 +138,13 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     };
     function connect() {
       try {
-        const es = new EventSource(apiUrl("/api/notification/stream"), { withCredentials: true });
+        // 네이티브 앱은 EventSource 가 헤더를 못 싣고 쿠키도 cross-site ITP 로 막혀 SSE 가 안 붙는다.
+        // 세션 토큰을 ?token= 쿼리로 보내 인증한다(서버 queryTokenAuth 가 Bearer 로 승격). 웹/데스크톱은
+        // 토큰이 없어 쿼리 없이 기존 쿠키 인증 그대로.
+        const streamToken = getAuthToken();
+        const streamUrl =
+          apiUrl("/api/notification/stream") + (streamToken ? `?token=${encodeURIComponent(streamToken)}` : "");
+        const es = new EventSource(streamUrl, { withCredentials: true });
         esRef.current = es;
         es.addEventListener("notification", (ev: MessageEvent) => {
           try {

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -165,6 +165,20 @@ export function clearAuthCookie(res: Response, req?: Request) {
   res.clearCookie(COOKIE, cookieBase(req));
 }
 
+/**
+ * ?token= 쿼리를 Authorization: Bearer 로 승격(헤더·쿠키가 없을 때만).
+ * <img>·EventSource 처럼 커스텀 헤더를 못 싣는 클라이언트가 인증하도록 — 네이티브 SSE 스트림용.
+ * (EventSource 는 헤더를 못 싣고 네이티브 쿠키는 cross-site ITP 로 막히므로 쿼리 토큰이 유일한 경로.)
+ * requireAuth 앞에 두고, GET 스트림처럼 안전한 라우트에만 적용한다. (/api/notification/stream 은
+ * 접근 로그에서도 제외되어 토큰 노출 없음.)
+ */
+export function queryTokenAuth(req: Request, _res: Response, next: NextFunction) {
+  if (!req.headers.authorization && typeof req.query.token === "string" && req.query.token) {
+    req.headers.authorization = `Bearer ${req.query.token}`;
+  }
+  next();
+}
+
 export async function requireAuth(req: Request, res: Response, next: NextFunction) {
   // 네이티브 앱은 Bearer 헤더, 웹/데스크톱은 httpOnly 쿠키. 헤더 우선, 없으면 쿠키 폴백.
   const token = bearerToken(req) ?? req.cookies?.[COOKIE];

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
+import { notify } from "../lib/notify.js";
 import { todayStr } from "../lib/dates.js";
 
 const router = Router();
@@ -162,6 +163,16 @@ router.patch("/leave/:id", async (req, res) => {
     data: { status, reviewer: u.id },
   });
   await writeLog(u.id, "LEAVE_REVIEW", leave.id, status);
+  // 신청자에게 결재 결과 알림 — 승인/반려일 때만(보류 전환은 알리지 않음), 본인 심사 자기알림 방지.
+  if ((status === "APPROVED" || status === "REJECTED") && existing.userId !== u.id) {
+    await notify({
+      userId: existing.userId,
+      type: "APPROVAL_REVIEW",
+      title: status === "APPROVED" ? "휴가 신청이 승인됐어요" : "휴가 신청이 반려됐어요",
+      linkUrl: "/attendance",
+      actorName: u.name,
+    });
+  }
   res.json({ leave });
 });
 

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -183,6 +183,20 @@ router.post("/rooms", async (req, res) => {
   });
   await writeLog(u.id, "ROOM_CREATE", room.id, `${d.type}:${d.name}`);
   broadcastToRoom(room.id, "chat:room", { kind: "create", roomId: room.id });
+  // 초대된 멤버에게 대화방 초대 알림 — 생성자 본인은 제외.
+  const invited = memberIds.filter((id) => id !== u.id);
+  if (invited.length) {
+    await notifyMany(
+      invited.map((userId) => ({
+        userId,
+        type: "SYSTEM" as const,
+        title: `${u.name}님이 대화방에 초대했어요`,
+        body: d.name,
+        linkUrl: `/chat?room=${room.id}`,
+        actorName: u.name,
+      })),
+    );
+  }
   res.json({ room });
 });
 

--- a/server/src/routes/expense.ts
+++ b/server/src/routes/expense.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
+import { notify } from "../lib/notify.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -109,6 +110,17 @@ router.patch("/:id", async (req, res) => {
       data: { status: body.status, reviewer: u.id },
     });
     await writeLog(u.id, "EXPENSE_REVIEW", exist.id, body.status);
+    // 경비 소유자에게 심사 결과 알림 — 승인/반려일 때만, 본인 심사 자기알림 방지(가드 중복이나 안전).
+    if ((body.status === "APPROVED" || body.status === "REJECTED") && exist.userId !== u.id) {
+      await notify({
+        userId: exist.userId,
+        type: "APPROVAL_REVIEW",
+        title: body.status === "APPROVED" ? "법인카드 사용내역이 승인됐어요" : "법인카드 사용내역이 반려됐어요",
+        body: `${exist.merchant} ${exist.amount.toLocaleString("ko-KR")}원`,
+        linkUrl: "/expense",
+        actorName: u.name,
+      });
+    }
     return res.json({ expense: updated });
   }
 

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -443,6 +443,23 @@ router.post("/", async (req, res) => {
   });
   await writeLog(u.id, "MEETING_CREATE", meeting.id, d.title);
 
+  // 지정 열람자(SPECIFIC)로 공유된 사람에게 회의록 공유 알림 — 작성자 본인은 제외.
+  if (d.visibility === "SPECIFIC" && d.viewerIds?.length) {
+    const sharedWith = Array.from(new Set(d.viewerIds.filter((id) => id !== u.id)));
+    if (sharedWith.length) {
+      await notifyMany(
+        sharedWith.map((userId) => ({
+          userId,
+          type: "SYSTEM" as const,
+          title: `${u.name}님이 회의록을 공유했어요`,
+          body: d.title,
+          linkUrl: `/meetings?id=${meeting.id}`,
+          actorName: u.name,
+        })),
+      );
+    }
+  }
+
   // 멘션 알림 — 열람 권한 있는 사람에게만. 본인 제외.
   const mentionIds = Array.from(extractMentionIds(d.content)).filter((id) => id !== u.id);
   if (mentionIds.length) {
@@ -514,6 +531,18 @@ router.patch("/:id", async (req, res) => {
     d.viewerIds !== undefined &&
     ((d.visibility ?? existing.visibility) === "SPECIFIC");
 
+  // 교체 전 기존 열람자 스냅샷 — 트랜잭션 후 새로 추가된 사람에게만 공유 알림을 보내기 위함.
+  const prevViewerIds = replaceViewers
+    ? new Set(
+        (
+          await prisma.meetingViewer.findMany({
+            where: { meetingId: existing.id },
+            select: { userId: true },
+          })
+        ).map((v) => v.userId),
+      )
+    : new Set<string>();
+
   const updated = await prisma.$transaction(async (tx) => {
     if (replaceViewers) {
       await tx.meetingViewer.deleteMany({ where: { meetingId: existing.id } });
@@ -546,6 +575,25 @@ router.patch("/:id", async (req, res) => {
     timeout: 8_000,
   });
   await writeLog(u.id, "MEETING_UPDATE", updated.id);
+
+  // 열람자가 교체된 경우, 새로 추가된 사람에게만 회의록 공유 알림 — 작성자/본인 제외.
+  if (replaceViewers && d.viewerIds) {
+    const newlyShared = Array.from(
+      new Set(d.viewerIds.filter((id) => id !== existing.authorId && id !== u.id)),
+    ).filter((id) => !prevViewerIds.has(id));
+    if (newlyShared.length) {
+      await notifyMany(
+        newlyShared.map((userId) => ({
+          userId,
+          type: "SYSTEM" as const,
+          title: `${u.name}님이 회의록을 공유했어요`,
+          body: updated.title,
+          linkUrl: `/meetings?id=${updated.id}`,
+          actorName: u.name,
+        })),
+      );
+    }
+  }
 
   // 본문이 바뀌었고 새로 추가된 멘션이 있다면 그 사람들에게만 알림. 이미 언급됐던 사람은 스킵.
   if (d.content !== undefined) {

--- a/server/src/routes/notification.ts
+++ b/server/src/routes/notification.ts
@@ -1,13 +1,15 @@
 import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
-import { requireAuth } from "../lib/auth.js";
+import { requireAuth, queryTokenAuth } from "../lib/auth.js";
 import { addClient, removeClient } from "../lib/sse.js";
 
 const router = Router();
 
-/* ===== Server-Sent Events 스트림 (인증 쿠키 사용) ===== */
-router.get("/stream", requireAuth, async (req, res) => {
+/* ===== Server-Sent Events 스트림 =====
+ * 웹/데스크톱: httpOnly 쿠키로 인증. 네이티브 앱: EventSource 가 헤더를 못 싣고 쿠키는
+ * cross-site ITP 로 막히므로 ?token=<jwt> 쿼리로 인증(queryTokenAuth 가 Bearer 로 승격). */
+router.get("/stream", queryTokenAuth, requireAuth, async (req, res) => {
   const u = (req as any).user;
 
   res.setHeader("Content-Type", "text/event-stream");

--- a/server/src/routes/payslip.ts
+++ b/server/src/routes/payslip.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../lib/db.js";
 import { requireAuth, requireAdmin, writeLog } from "../lib/auth.js";
 import { sendEmailWithAttachment } from "../lib/email.js";
+import { notify } from "../lib/notify.js";
 
 /* ===== 급여(임금)명세서 =====
  * - 작성·수정·삭제·목록(전체)·발송: ADMIN 전용.
@@ -457,6 +458,16 @@ router.post("/:id/send", requireAdmin, async (req, res) => {
     select: PAYSLIP_SELECT,
   });
   await writeLog(u.id, "PAYSLIP_SEND", p.id, `${p.year}-${p.month} ${p.employeeName}`);
+  // 직원 본인에게 급여명세서 도착 알림 — 발송한 관리자가 본인일 가능성은 낮지만 자기알림 방지.
+  if (p.employeeId !== u.id) {
+    await notify({
+      userId: p.employeeId,
+      type: "SYSTEM",
+      title: `${p.year}년 ${p.month}월 급여명세서가 도착했어요`,
+      linkUrl: "/payroll",
+      actorName: u.name,
+    });
+  }
   res.json({ payslip: updated });
 });
 

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
+import { notify, notifyMany } from "../lib/notify.js";
 import { generateWebhookToken } from "./webhook.js";
 import { allSameCompanyUsers } from "../lib/tenantValidate.js";
 
@@ -84,6 +85,20 @@ router.post("/", async (req, res) => {
     include: { _count: { select: { members: true } } },
   });
   await writeLog(u.id, "PROJECT_CREATE", project.id, d.name);
+  // 초기 멤버에게 프로젝트 초대 알림 — 생성자 본인은 제외.
+  const invited = Array.from(memberSet).filter((uid) => uid !== u.id);
+  if (invited.length) {
+    await notifyMany(
+      invited.map((uid) => ({
+        userId: uid,
+        type: "SYSTEM" as const,
+        title: `${u.name}님이 프로젝트에 초대했어요`,
+        body: d.name,
+        linkUrl: `/projects/${project.id}`,
+        actorName: u.name,
+      })),
+    );
+  }
   res.json({ project });
 });
 
@@ -526,6 +541,17 @@ router.post("/:id/qa", async (req, res) => {
     include: { attachments: { orderBy: { createdAt: "asc" } } },
   });
   await writeLog(u.id, "PROJECT_QA_CREATE", item.id, d.title);
+  // 담당자가 지정됐고 본인이 아니면 배정 알림.
+  if (assigneeId && assigneeId !== u.id) {
+    await notify({
+      userId: assigneeId,
+      type: "SYSTEM",
+      title: `${u.name}님이 QA 항목을 배정했어요`,
+      body: d.title,
+      linkUrl: `/projects/${req.params.id}`,
+      actorName: u.name,
+    });
+  }
   res.json({ item });
 });
 
@@ -556,11 +582,19 @@ router.patch("/:id/qa/:itemId", async (req, res) => {
     return res.status(404).json({ error: "not found" });
 
   let assigneePatch: { assigneeId: string | null } | {} = {};
+  // 새로 배정된(이전과 다른) 담당자에게만 알림을 보내기 위해 변경 여부를 추적.
+  let newlyAssignedId: string | null = null;
   if ("assigneeId" in d) {
     try {
       const resolved = await resolveAssigneeIdOrThrow(req.params.id, d.assigneeId);
       // undefined 는 미지정(노-op), null 은 해지.
-      if (resolved !== undefined) assigneePatch = { assigneeId: resolved };
+      if (resolved !== undefined) {
+        assigneePatch = { assigneeId: resolved };
+        // 실제로 담당자가 바뀌었고, 새 담당자가 본인이 아닐 때만 알림 대상으로 표시.
+        if (resolved && resolved !== existing.assigneeId && resolved !== u.id) {
+          newlyAssignedId = resolved;
+        }
+      }
     } catch {
       return res.status(400).json({ error: "담당자는 이 프로젝트 멤버여야 합니다" });
     }
@@ -594,6 +628,17 @@ router.patch("/:id/qa/:itemId", async (req, res) => {
     },
     include: { attachments: { orderBy: { createdAt: "asc" } } },
   });
+  // 담당자가 새로 바뀐 경우에만 배정 알림.
+  if (newlyAssignedId) {
+    await notify({
+      userId: newlyAssignedId,
+      type: "SYSTEM",
+      title: `${u.name}님이 QA 항목을 배정했어요`,
+      body: item.title,
+      linkUrl: `/projects/${req.params.id}`,
+      actorName: u.name,
+    });
+  }
   res.json({ item });
 });
 
@@ -671,11 +716,31 @@ router.post("/:id/member", async (req, res) => {
   }
   if (!(await allSameCompanyUsers([body.data.userId])))
     return res.status(400).json({ error: "추가하려는 멤버를 찾을 수 없어요." });
+  // 신규 합류 여부 판정 — 기존 멤버의 역할 변경엔 알림을 보내지 않기 위해 upsert 전에 확인.
+  const already = await prisma.projectMember.findUnique({
+    where: { projectId_userId: { projectId: req.params.id, userId: body.data.userId } },
+    select: { userId: true },
+  });
   const created = await prisma.projectMember.upsert({
     where: { projectId_userId: { projectId: req.params.id, userId: body.data.userId } },
     update: { role: targetRole },
     create: { projectId: req.params.id, userId: body.data.userId, role: targetRole },
   });
+  // 새로 합류한 멤버에게만 초대 알림 — 본인이 자기를 추가하는 경우 제외.
+  if (!already && body.data.userId !== u.id) {
+    const project = await prisma.project.findUnique({
+      where: { id: req.params.id },
+      select: { name: true },
+    });
+    await notify({
+      userId: body.data.userId,
+      type: "SYSTEM",
+      title: `${u.name}님이 프로젝트에 초대했어요`,
+      body: project?.name,
+      linkUrl: `/projects/${req.params.id}`,
+      actorName: u.name,
+    });
+  }
   res.json({ member: created });
 });
 


### PR DESCRIPTION
## 증상
**SSE 실시간을 ?token= 쿼리 인증으로 (모바일 채팅/알림 실시간)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
EventSource 는 Authorization 헤더를 못 싣고 네이티브 앱 쿠키는 cross-site ITP 로 막혀
/api/notification/stream 이 네이티브에서 연결조차 안 됐다(채팅 목록·알림 실시간 0).
queryTokenAuth 미들웨어를 추가해 ?token=<jwt> 를 Bearer 로 승격, /stream 앞에 적용.
이 라우트는 접근 로그 제외 대상이라 토큰 노출 없음. 웹/데스크톱은 기존 쿠키 그대로.

## 수정
**작업 항목 (커밋 단위)**
- feat(server): SSE 스트림을 ?token= 쿼리로도 인증 (네이티브 실시간)
- feat(client): 네이티브에서 SSE 를 ?token= 으로 연결 (실시간 알림/채팅)
- feat(server): 누락된 알림 트리거 7종 추가 (전수 점검)

**변경 대상 (9개 파일)**
- `client/src/notifications.tsx`
- `server/src/lib/auth.ts`
- `server/src/routes/attendance.ts`
- `server/src/routes/chat.ts`
- `server/src/routes/expense.ts`
- `server/src/routes/meeting.ts`
- `server/src/routes/notification.ts`
- `server/src/routes/payslip.ts`
- `server/src/routes/project.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #265** ↔ **이슈 #688** 로 연결됩니다.

Closes #688
