### PR TITLE
🔀 :: (#266) 변경 후 UI 즉시 미갱신 수정 (cross-component staleness)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1352,6 +1352,14 @@ function ProjectsSection() {
     };
   }, [isAdmin, reloadKey]);
 
+  // 다른 화면(프로젝트 설정 모달의 이름/색/보관/삭제 등)에서 프로젝트가 바뀌면
+  // 사이드바 목록도 다시 불러온다(projects:reload 커스텀 이벤트).
+  useEffect(() => {
+    const onReload = () => setReloadKey((k) => k + 1);
+    window.addEventListener("projects:reload", onReload);
+    return () => window.removeEventListener("projects:reload", onReload);
+  }, []);
+
   const active = projects.filter((p) => p.status === "ACTIVE");
 
   return (

--- a/client/src/components/ProjectSettingsModal.tsx
+++ b/client/src/components/ProjectSettingsModal.tsx
@@ -183,6 +183,9 @@ function InfoTab({
         },
       });
       onUpdated?.({ ...project, ...r.project, members: project.members });
+      // 사이드바 프로젝트 목록(AppLayout)도 갱신 — 이름/색/보관 변경이 즉시 반영되도록.
+      invalidateCache("/api/project");
+      window.dispatchEvent(new CustomEvent("projects:reload"));
       setSaved(true);
     } catch (e: any) {
       setErr(e?.message ?? "저장에 실패했습니다.");
@@ -205,6 +208,8 @@ function InfoTab({
     setErr(null);
     try {
       await api(`/api/project/${project.id}`, { method: "DELETE" });
+      invalidateCache("/api/project");
+      window.dispatchEvent(new CustomEvent("projects:reload"));
       onDeleted();
     } catch (e: any) {
       setErr(e?.message ?? "삭제에 실패했습니다.");

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { api , imgSrc} from "../api";
+import { api, imgSrc, invalidateCache } from "../api";
 import PageHeader from "../components/PageHeader";
 import { downloadCSV, downloadXLSX, openPrintable, parseSheet, type TableColumn } from "../lib/exportTable";
 import DatePicker from "../components/DatePicker";
@@ -1873,12 +1873,14 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
     if (!n) return;
     try {
       await api("/api/admin/positions", { method: "POST", json: { name: n } });
+      invalidateCache("/api/admin/positions"); // 조직도(OrgChart)가 보는 캐시 무효화
       setName("");
       reload();
     } catch (e: any) { alertAsync({ title: "생성 실패", description: e.message }); }
   }
   async function rename(p: Position, newName: string) {
     await api(`/api/admin/positions/${p.id}`, { method: "PATCH", json: { name: newName } });
+    invalidateCache("/api/admin/positions");
     reload();
   }
   async function remove(p: Position) {
@@ -1891,6 +1893,7 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
     if (!ok) return;
     try {
       await api(`/api/admin/positions/${p.id}`, { method: "DELETE" });
+      invalidateCache("/api/admin/positions");
       reload();
     } catch (e: any) { alertAsync({ title: "삭제 실패", description: e.message }); }
   }
@@ -1898,6 +1901,7 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
   async function persistOrder(next: Position[]) {
     try {
       await api("/api/admin/positions/reorder", { method: "POST", json: { ids: next.map((p) => p.id) } });
+      invalidateCache("/api/admin/positions");
     } catch (e: any) {
       alertAsync({ title: "정렬 저장 실패", description: e.message });
       reload(); // 서버 상태로 복구

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { api, apiSWR , imgSrc} from "../api";
+import { api, apiSWR, imgSrc, invalidateCache } from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
@@ -177,6 +177,7 @@ export default function MeetingDetailPage() {
       };
       if (visibility === "SPECIFIC") payload.viewerIds = viewerIds;
       await api(`/api/meeting/${meeting.id}`, { method: "PATCH", json: payload });
+      invalidateCache("/api/meeting");
       setLastSaved(Date.now());
       setErr(null);
     } catch (e: any) {
@@ -205,6 +206,7 @@ export default function MeetingDetailPage() {
     setDeleting(true);
     try {
       await api(`/api/meeting/${meeting.id}`, { method: "DELETE" });
+      invalidateCache("/api/meeting");
       nav("/meetings");
     } catch (e: any) {
       alertAsync({ title: "삭제 실패", description: e?.message ?? "삭제 실패" });

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -945,6 +945,8 @@ function PresencePanel() {
       setSavedAt(Date.now());
       // /api/me 로 사용자 새로고침 → 다른 패널/페이지에도 반영
       await refresh?.();
+      // 디렉터리/조직도/채팅이 보는 /api/users 캐시도 무효화 — presence 가 거기 임베드됨.
+      invalidateCache("/api/users");
     } catch (e: any) {
       setErrMsg(e?.message ?? "저장 실패");
     } finally {


### PR DESCRIPTION
## 증상
**변경 후 UI 즉시 미갱신 수정 (cross-component staleness)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
mutation 후 다른 화면이 옛 데이터를 보이던 cross-component staleness 수정.
(대부분 핸들러는 이미 정상 — optimistic/refetch/invalidate. 아래만 누락)

- 프로젝트 이름·색·보관·삭제 → 사이드바 목록 즉시 갱신
  (ProjectSettingsModal 에서 invalidateCache + projects:reload 이벤트, AppLayout 이 수신)
- 관리자 직급 추가/수정/삭제/정렬 → 조직도 캐시(/api/admin/positions, 10분 TTL) 무효화
- 프로필 presence 변경 → 디렉터리/조직도/채팅이 보는 /api/users 캐시 무효화
- 회의록 저장/삭제 → 회의 목록(/api/meeting) 캐시 무효화

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 변경 후 화면 즉시 미갱신 4곳 수정 (전수 점검)

**변경 대상 (5개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ProjectSettingsModal.tsx`
- `client/src/pages/AdminPage.tsx`
- `client/src/pages/MeetingDetailPage.tsx`
- `client/src/pages/ProfilePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #266** 에서 진행됩니다.

