### PR TITLE
🔀 :: (#267) 푸시 진단 엔드포인트 /api/push/diag

### DIFF
--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -223,3 +223,40 @@ export async function sendApnsToUser(userId: string, payload: ApnsPayload): Prom
     console.error("sendApnsToUser failed", (e as Error)?.message || e);
   }
 }
+
+/**
+ * 진단용 — 호출 유저의 iOS 토큰으로 테스트 푸시를 실제 발송하고 APNs 응답을 그대로 반환한다.
+ * 푸시 미수신 원인을 정확히 식별: 키 미설정 / 토큰 0개 / status 400 BadDeviceToken(환경 불일치) /
+ * status 403(인증·키 오류) / status 200(정상 — 기기에 테스트 푸시 도착).
+ */
+export async function apnsDiag(userId: string): Promise<{
+  enabled: boolean;
+  production: boolean;
+  host: string;
+  bundleId: string;
+  tokens: number;
+  results: { token: string; status: number; reason?: string }[];
+  note?: string;
+}> {
+  const base = { enabled: apnsEnabled(), production: PRODUCTION, host: HOST, bundleId: BUNDLE_ID };
+  if (!base.enabled) {
+    return { ...base, tokens: 0, results: [], note: "APNs 미설정 — APNS_KEY/APNS_KEY_ID/APNS_TEAM_ID 환경변수 확인" };
+  }
+  const tokens = await prisma.pushToken.findMany({ where: { userId, platform: "ios" }, select: { token: true } });
+  if (!tokens.length) {
+    return {
+      ...base,
+      tokens: 0,
+      results: [],
+      note: "등록된 iOS 토큰 없음 — 앱이 토큰 등록을 못 함(빌드에 AppDelegate 수정 미포함 / 알림 권한 거부 / 새 빌드 재로그인 필요)",
+    };
+  }
+  const results = await Promise.all(
+    tokens.map((t) => sendOne(t.token, { title: "테스트 알림", body: "푸시 진단 테스트입니다.", linkUrl: "/" })),
+  );
+  return {
+    ...base,
+    tokens: tokens.length,
+    results: results.map((r) => ({ token: r.token.slice(0, 10) + "…", status: r.status, reason: r.reason })),
+  };
+}

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth } from "../lib/auth.js";
+import { apnsDiag } from "../lib/apns.js";
 
 /**
  * 원격 푸시(APNs/FCM) 기기 토큰 등록·해제.
@@ -52,6 +53,16 @@ router.post("/unregister", async (req, res) => {
   await prisma.pushToken.deleteMany({ where: { token: parsed.data.token, userId: u.id } });
 
   res.json({ ok: true });
+});
+
+/**
+ * 진단 — 본인 iOS 토큰으로 테스트 푸시를 실제 발송하고 APNs 응답을 그대로 돌려준다.
+ * 브라우저에서 로그인된 채로 /api/push/diag 를 열면 결과 JSON 을 볼 수 있고,
+ * 정상이면 등록된 기기에 "테스트 알림" 푸시가 도착한다. 본인 토큰만 대상이라 안전.
+ */
+router.get("/diag", async (req, res) => {
+  const u = (req as any).user;
+  res.json(await apnsDiag(u.id));
 });
 
 export default router;


### PR DESCRIPTION
## 증상
**푸시 진단 엔드포인트 /api/push/diag**

유지보수 작업을 진행합니다.

## 원인
본인 iOS 토큰으로 테스트 푸시를 실제 발송하고 APNs 응답을 그대로 반환 — 미수신 원인
(키 미설정 / 토큰 0개 / BadDeviceToken 환경불일치 / 403 인증오류 / 200 정상)을 정확히 식별.
본인 토큰만 대상이라 안전.

## 수정
**작업 항목 (커밋 단위)**
- chore(server): 푸시 진단 엔드포인트 GET /api/push/diag

**변경 대상 (2개 파일)**
- `server/src/lib/apns.ts`
- `server/src/routes/push.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #267** 에서 진행됩니다.

