### PR TITLE
🔀 :: (#268) 네이티브 포그라운드 알림 배너 (데스크톱 동등)

### DIFF
--- a/client/src/lib/desktopNotify.ts
+++ b/client/src/lib/desktopNotify.ts
@@ -13,6 +13,9 @@
  *  - https 또는 localhost 에서만 동작 (HiNest dev: localhost:1000 ✅)
  */
 
+import { isCapacitorNative } from "./platform";
+import { showNativeNotifications } from "./nativeNotify";
+
 export type DesktopNotifPermission = "default" | "granted" | "denied" | "unsupported";
 
 const LS_SEEN = "hinest.notif.seen"; // 이미 알려준 notification id 목록 (localStorage)
@@ -152,6 +155,15 @@ export function showDesktopNotification(opts: {
 export function deliverPendingNotifications(
   items: { id: string; title: string; body?: string; linkUrl?: string }[]
 ) {
+  // 네이티브(Capacitor): WKWebView 는 Web Notification 미지원 → local-notifications 로 배너 표시(데스크톱 동등).
+  if (isCapacitorNative()) {
+    const fresh = items.filter((it) => !alreadySeen(it.id));
+    if (fresh.length) {
+      void showNativeNotifications(fresh);
+      markSeen(fresh.map((f) => f.id));
+    }
+    return;
+  }
   if (!supported() || Notification.permission !== "granted" || !isDesktopEnabled()) return;
   for (const it of items) {
     if (alreadySeen(it.id)) continue;

--- a/client/src/lib/nativeNotify.ts
+++ b/client/src/lib/nativeNotify.ts
@@ -1,0 +1,71 @@
+import { isCapacitorNative } from "./platform";
+
+/**
+ * 네이티브(Capacitor iOS/Android) 포그라운드 OS 알림 배너.
+ *
+ * 데스크톱은 Web Notification API(desktopNotify.ts)로 앱을 보고 있을 때도 OS 배너를 띄우는데,
+ * WKWebView 는 Web Notification 을 지원하지 않아 모바일에선 포그라운드 배너가 안 떴다.
+ * 모바일은 @capacitor/local-notifications 로 같은 배너를 띄워 데스크톱과 동등하게 만든다.
+ * (백그라운드/종료 상태는 APNs 원격 푸시가 담당 — 별개 경로.)
+ *
+ * 웹/데스크톱에서는 전부 no-op.
+ */
+
+export type NotifItem = { id: string; title: string; body?: string; linkUrl?: string };
+
+/** 알림 탭 시 인앱 라우팅 — 데스크톱 OS 알림 onclick 과 동일(채팅방 열기 / SPA 이동). */
+export function routeNotifLink(url?: string | null) {
+  if (!url || typeof window === "undefined") return;
+  try {
+    const chatMatch = /^\/chat(?:\?|#).*?room=([^&]+)/.exec(url);
+    if (chatMatch) {
+      window.dispatchEvent(new CustomEvent("chat:open"));
+      window.dispatchEvent(new CustomEvent("chat:open-room", { detail: { roomId: chatMatch[1] } }));
+    } else if (url.startsWith("/chat")) {
+      window.dispatchEvent(new CustomEvent("chat:open"));
+    } else {
+      window.history.pushState({}, "", url);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
+  } catch {
+    /* noop */
+  }
+}
+
+let _seq = 1;
+
+/** 포그라운드에서 받은 알림을 로컬 OS 알림 배너로 표시. 권한 없으면 조용히 스킵. */
+export async function showNativeNotifications(items: NotifItem[]): Promise<void> {
+  if (!isCapacitorNative() || !items.length) return;
+  try {
+    const { LocalNotifications } = await import("@capacitor/local-notifications");
+    const perm = await LocalNotifications.checkPermissions();
+    if (perm.display !== "granted") return; // 권한은 로그인 시 푸시 흐름에서 요청됨
+    await LocalNotifications.schedule({
+      notifications: items.slice(0, 5).map((it) => ({
+        // LocalNotifications id 는 32bit 정수여야 한다.
+        id: (Date.now() + _seq++) % 2_147_483_000,
+        title: it.title,
+        body: it.body ?? "",
+        extra: { linkUrl: it.linkUrl ?? null },
+      })),
+    });
+  } catch {
+    /* 플러그인 미탑재/실패 — 조용히 무시 */
+  }
+}
+
+let _wired = false;
+/** 로컬 알림 탭 → 인앱 라우팅 리스너. 앱 시작 시 1회만. */
+export async function initNativeNotificationTaps(): Promise<void> {
+  if (!isCapacitorNative() || _wired) return;
+  _wired = true;
+  try {
+    const { LocalNotifications } = await import("@capacitor/local-notifications");
+    await LocalNotifications.addListener("localNotificationActionPerformed", (a) => {
+      routeNotifLink((a.notification.extra as { linkUrl?: string | null } | undefined)?.linkUrl);
+    });
+  } catch {
+    /* noop */
+  }
+}

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { api, apiUrl } from "./api";
 import { getAuthToken } from "./lib/authToken";
 import { deliverPendingNotifications, markSeen } from "./lib/desktopNotify";
+import { initNativeNotificationTaps } from "./lib/nativeNotify";
 import { shouldDeliverNotif } from "./lib/notifPrefs";
 
 export type NotifType = "NOTICE" | "DM" | "APPROVAL_REQUEST" | "APPROVAL_REVIEW" | "MENTION" | "SYSTEM";
@@ -126,6 +127,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       setReady(true);
       return;
     }
+    void initNativeNotificationTaps(); // 네이티브 로컬 알림 탭 → 인앱 라우팅
     reload();
 
     let retry: number | null = null;

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { api, invalidateCache, clearApiCache, apiFetch , imgSrc} from "../api";
+import { isCapacitorNative } from "../lib/platform";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { useTheme, type ThemeMode } from "../theme";
@@ -296,7 +297,7 @@ export default function ProfilePage() {
 
           <PresencePanel />
           <ThemePanel />
-          <DesktopNotifyPanel />
+          {isCapacitorNative() ? <NativePushPanel /> : <DesktopNotifyPanel />}
           <ShortcutsPanel />
           <SessionInfoPanel />
           {user.isDeveloper && <DevOptionsPanel />}
@@ -482,6 +483,62 @@ function DangerZonePanel() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * 모바일(네이티브) 전용 푸시 알림 패널 — "데스크톱 알림(Web Notification)" 은 WKWebView 미지원이라
+ * 모바일에선 의미가 없다. 대신 iOS 푸시 상태 안내 + 이 기기로 실제 테스트 푸시를 쏘는 버튼을 둔다.
+ */
+function NativePushPanel() {
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  async function test() {
+    setBusy(true);
+    setResult(null);
+    try {
+      const d = await api<{
+        enabled: boolean;
+        tokens: number;
+        results: { status: number; reason?: string }[];
+      }>("/api/push/diag");
+      let msg: string;
+      if (!d.enabled) {
+        msg = "❌ 서버에 APNs 키가 설정되지 않았어요 (관리자: APNS_KEY/KEY_ID/TEAM_ID 환경변수 확인).";
+      } else if (!d.tokens) {
+        msg = "⚠️ 이 기기의 푸시 토큰이 등록되지 않았어요. 아래 안내대로 알림 권한을 켠 뒤 앱을 다시 실행해 주세요.";
+      } else if (d.results.some((r) => r.status === 200)) {
+        msg = "✅ 발송 성공! 잠시 후 이 기기에 테스트 알림이 도착합니다.";
+      } else {
+        msg = "❌ 발송 실패: " + d.results.map((r) => `${r.status} ${r.reason ?? ""}`).join(", ");
+      }
+      setResult(msg);
+    } catch (e: any) {
+      setResult("진단 실패: " + (e?.message ?? "오류"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="panel p-6">
+      <div className="h-sub">푸시 알림</div>
+      <div className="t-caption mt-0.5">
+        앱이 백그라운드이거나 꺼져 있을 때도 새 메시지·결재·공지 등을 iOS 푸시로 받아요.
+      </div>
+      <button type="button" className="btn-primary mt-4" onClick={test} disabled={busy}>
+        {busy ? "테스트 중…" : "테스트 알림 보내기"}
+      </button>
+      {result && (
+        <div className="mt-3 p-3 rounded-lg bg-ink-50 border border-ink-150 text-[12px] text-ink-700 leading-relaxed">
+          {result}
+        </div>
+      )}
+      <div className="t-caption mt-3 text-ink-500">
+        알림이 안 오면 — iOS 설정 → HiNest → 알림에서 "알림 허용"이 켜져 있는지 확인하세요.
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 증상
**네이티브 포그라운드 알림 배너 (데스크톱 동등)**

새 기능을 추가합니다.

## 원인
데스크톱은 앱 포커스 중에도 OS 알림 배너를 띄우는데(Web Notification), WKWebView 는
Web Notification 미지원이라 모바일 포그라운드엔 배너가 안 떴다. deliverPendingNotifications
의 네이티브 분기에서 @capacitor/local-notifications 로 배너를 띄워(중복 seen 가드 동일 적용)
채팅 등 모든 알림을 데스크톱과 동일하게 표시. 탭 시 인앱 라우팅(채팅방 열기 등) 리스너도 연결.
백그라운드/종료는 APNs 가 담당(별개).

## 수정
**작업 항목 (커밋 단위)**
- feat(client): 네이티브 포그라운드 알림 배너 (데스크톱 동등)
- feat(client): 모바일 푸시 알림 패널 + 테스트 버튼

**변경 대상 (4개 파일)**
- `client/src/lib/desktopNotify.ts`
- `client/src/lib/nativeNotify.ts`
- `client/src/notifications.tsx`
- `client/src/pages/ProfilePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #268** 에서 진행됩니다.

