### PR TITLE
🔀 :: (#270) 그룹/팀 채팅 알림 전체 멤버에게 (사진/메시지 미수신)

### DIFF
--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -552,13 +552,21 @@ router.post("/rooms/:id/messages", async (req, res) => {
           actorName: u.name,
         }))
       );
-    } else if (mentions.length) {
+    } else {
+      // GROUP/TEAM: 보낸 사람 제외 모든 멤버에게 알림. 멘션된 사람은 MENTION(강조), 나머지는 일반 채팅.
+      // (예전엔 멘션만 알림 → 단체방 메시지·사진이 알림 없이 묻혔음. 작업용 단체방 표준 동작으로 변경.
+      //  시끄러운 방 대비 '방별 음소거'는 후속 권장 — RoomMember 에 muted 필드 추가 필요.)
+      const members = await prisma.roomMember.findMany({
+        where: { roomId: req.params.id, userId: { not: u.id } },
+        select: { userId: true },
+      });
+      const mentionSet = new Set(mentions);
       await notifyMany(
-        mentions.map((uid) => ({
-          userId: uid,
-          type: "MENTION" as const,
-          title: `@${u.name} · ${roomName}`,
-          body: preview.slice(0, 140),
+        members.map((m) => ({
+          userId: m.userId,
+          type: (mentionSet.has(m.userId) ? "MENTION" : "DM") as "MENTION" | "DM",
+          title: mentionSet.has(m.userId) ? `@${u.name} · ${roomName}` : roomName,
+          body: `${u.name}: ${preview}`.slice(0, 140),
           linkUrl: `/chat?room=${msg.roomId}`,
           actorName: u.name,
         }))


### PR DESCRIPTION
## 증상
**그룹/팀 채팅 알림 전체 멤버에게 (사진/메시지 미수신)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
기존엔 GROUP/TEAM 방은 @멘션된 사람만 알림 → 사진/일반 메시지가 알림 없이 묻혔다
(사용자 보고: '사진 보냈을 때 알림 안 옴'). 보낸 사람 제외 전체 멤버에게 알림하도록 변경 —
멘션된 사람은 MENTION(강조), 나머지는 일반 채팅 알림(title=방이름, body=보낸이: 내용).
DM 은 기존대로(사진 포함 정상). notify 가 환경설정/DND 는 자동 준수.
서버 전용 — 현재 설치 빌드에도 즉시 적용(앱 재빌드 불필요).

후속 권장: RoomMember.muted 추가해 '방별 음소거'(시끄러운 단체방 대비).

## 수정
**작업 항목 (커밋 단위)**
- fix(server): 그룹/팀 채팅 알림을 전체 멤버에게 (사진·일반 메시지 미수신 해결)

**변경 대상 (1개 파일)**
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #270** 에서 진행됩니다.

