### PR TITLE
🔀 :: (#271) 프로필 카드 개발자·팀 뱃지 중첩 깨짐 수정

### DIFF
--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -323,8 +323,8 @@ function GridCard({
             <PresenceDot u={u} size={12} ring={2} />
           </div>
           <Link to={`/users/${u.id}`} className="min-w-0 flex-1 hover:opacity-80 transition">
-            <div className="text-[15px] font-extrabold text-ink-900 tracking-tight truncate inline-flex items-center gap-1.5">
-              {u.name}
+            <div className="text-[15px] font-extrabold text-ink-900 tracking-tight flex items-center gap-1.5 min-w-0">
+              <span className="truncate">{u.name}</span>
               {isDevAccount(u) && <DevBadge />}
             </div>
             <div className="text-[12px] text-ink-600 truncate mt-0.5">
@@ -403,9 +403,9 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
         <PresenceDot u={u} size={12} ring={2} />
       </div>
       <Link to={`/users/${u.id}`} className="min-w-0 flex-1 md:w-[28%] md:flex-initial hover:opacity-80 transition">
-        <div className="flex items-center gap-1.5">
-          <div className="text-[14px] font-extrabold text-ink-900 truncate tracking-tight inline-flex items-center gap-1.5">
-            {u.name}
+        <div className="flex items-center gap-1.5 min-w-0">
+          <div className="text-[14px] font-extrabold text-ink-900 tracking-tight flex items-center gap-1.5 min-w-0">
+            <span className="truncate">{u.name}</span>
             {isDevAccount(u) && <DevBadge />}
           </div>
           <PresenceBadge u={u} />

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -266,10 +266,10 @@ function MemberRow({
     <div className="group flex items-center gap-3 px-4 py-2.5 hover:bg-ink-25">
       <UserAvatar u={u} size={36} />
       <div className="flex-1 min-w-0">
-        <div className="text-[13px] font-bold text-ink-900 truncate inline-flex items-center gap-1.5">
+        <div className="text-[13px] font-bold text-ink-900 flex items-center gap-1.5 min-w-0">
           <span className="truncate min-w-0">{u.name}</span>
           {isDevAccount(u) && <DevBadge iconOnly />}
-          {u.id === meId && <span className="chip-gray">나</span>}
+          {u.id === meId && <span className="chip-gray flex-shrink-0">나</span>}
         </div>
         <div className="text-[11px] text-ink-500 truncate">{u.position ?? "—"}</div>
       </div>


### PR DESCRIPTION
## 증상
**프로필 카드 개발자·팀 뱃지 중첩 깨짐 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
DirectoryPage 그리드/리스트 카드와 OrgChart 행에서 이름 컨테이너가
truncate 와 inline-flex 를 동시에 사용 → flex 레이아웃에선 text-overflow
가 적용되지 않아 이름+DevBadge 가 칼럼을 넘쳐 옆 팀 뱃지와 겹쳐 보였다.

컨테이너를 flex+min-w-0 으로 바꾸고 이름만 truncate span 으로 감싸
이름은 말줄임, 뱃지는 flex-shrink-0 으로 항상 온전히 노출되도록 수정.

## 수정
**작업 항목 (커밋 단위)**
- fix(client): 프로필 카드 개발자·팀 뱃지 중첩 깨짐 수정

**변경 대상 (2개 파일)**
- `client/src/pages/DirectoryPage.tsx`
- `client/src/pages/OrgChartPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #271** 에서 진행됩니다.

