### PR TITLE
🔀 :: (#272) 채팅방별 알림 음소거 (RoomMember.muted, 서버 영속화)

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -143,6 +143,33 @@ export default function ChatMiniApp({
       saveAllRoomSettings(next);
       return next;
     });
+    // 음소거는 서버에도 영속화 — 기기 간 동기화 + 서버가 음소거 방의 APNs(폰 푸시) 를 생략하도록.
+    // (별명은 로컬 전용이므로 muted 가 명시될 때만 호출.) 낙관적 — 실패해도 다음 동기화에서 보정.
+    if (patch.muted !== undefined) {
+      void api(`/api/chat/rooms/${roomId}/mute`, { method: "PATCH", json: { muted: patch.muted } }).catch(() => {});
+    }
+  };
+
+  // 서버의 RoomMember.muted → 로컬 roomSettings.muted 동기화.
+  // notifPrefs.shouldDeliverNotif 가 localStorage 를 직접 읽으므로 localStorage 도 함께 갱신.
+  const hydrateMutedFromServer = (list: Room[]) => {
+    const meId = user?.id;
+    if (!meId) return;
+    setRoomSettings((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const r of list) {
+        const mine = r.members.find((m) => m.user.id === meId);
+        if (!mine) continue;
+        const serverMuted = !!mine.muted;
+        if (serverMuted !== !!next[r.id]?.muted) {
+          next[r.id] = { ...next[r.id], muted: serverMuted };
+          changed = true;
+        }
+      }
+      if (changed) saveAllRoomSettings(next);
+      return changed ? next : prev;
+    });
   };
 
   const roomUnread = useMemo(() => {
@@ -163,6 +190,7 @@ export default function ChatMiniApp({
     try {
       const res = await api<{ rooms: Room[] }>("/api/chat/rooms");
       setRooms(res.rooms);
+      hydrateMutedFromServer(res.rooms);
     } catch {}
   };
   // 메시지 로더.

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -3,7 +3,7 @@
  * ChatMiniApp / MessageBubble / 확장 뷰들에서 공통으로 사용.
  */
 
-export type RoomMember = { user: { id: string; name: string; avatarColor?: string; avatarUrl?: string | null } };
+export type RoomMember = { muted?: boolean; user: { id: string; name: string; avatarColor?: string; avatarUrl?: string | null } };
 
 export type Room = {
   id: string;

--- a/server/prisma/migrations/20260603000000_room_member_muted/migration.sql
+++ b/server/prisma/migrations/20260603000000_room_member_muted/migration.sql
@@ -1,0 +1,4 @@
+-- 방별 알림 음소거. RoomMember 에 muted 컬럼 추가.
+-- 가산형(ADD COLUMN, DEFAULT 상수) — PostgreSQL 11+ 에서 메타데이터 전용 연산이라
+-- 테이블 재작성/락 없이 즉시 적용된다. 기존 행은 모두 false 로 채워짐(비파괴적).
+ALTER TABLE "RoomMember" ADD COLUMN "muted" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -722,6 +722,9 @@ model RoomMember {
   roomId     String
   userId     String
   lastReadAt DateTime?
+  // 방별 알림 음소거 — true 면 서버가 이 방 채팅 알림의 APNs(폰 푸시) 를 보내지 않음.
+  // (알림 레코드·SSE·미읽음 뱃지는 유지 — 조용히 쌓이기만 함.) 기기 간 동기화를 위해 서버에 저장.
+  muted      Boolean   @default(false)
   room       ChatRoom  @relation(fields: [roomId], references: [id], onDelete: Cascade)
   user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -47,6 +47,34 @@ async function resolveDelivery(userIds: string[], type: NotifyType): Promise<Map
   return out;
 }
 
+/** linkUrl 에서 ?room=<id> 추출. 채팅(DM/MENTION) 알림만 이 패턴을 가짐. */
+function roomIdFromLink(linkUrl?: string | null): string | null {
+  if (!linkUrl) return null;
+  const m = /[?&]room=([^&]+)/.exec(linkUrl);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/**
+ * (userId, roomId) 쌍 중 "이 방을 음소거한" 조합을 `${userId}:${roomId}` Set 으로 반환.
+ * 음소거된 방의 채팅 알림은 APNs(폰 푸시) 만 건너뛴다 — 알림 레코드·SSE 는 그대로라
+ * 미읽음 뱃지·실시간 채팅목록 갱신은 유지된다. 채팅 외 알림(roomId 없음) 은 항상 빈 결과.
+ */
+async function mutedApnsSet(targets: { userId: string; linkUrl?: string | null }[]): Promise<Set<string>> {
+  const pairs = targets
+    .map((t) => ({ userId: t.userId, roomId: roomIdFromLink(t.linkUrl) }))
+    .filter((p): p is { userId: string; roomId: string } => !!p.roomId);
+  if (!pairs.length) return new Set();
+  const muted = await prisma.roomMember.findMany({
+    where: {
+      muted: true,
+      roomId: { in: Array.from(new Set(pairs.map((p) => p.roomId))) },
+      userId: { in: Array.from(new Set(pairs.map((p) => p.userId))) },
+    },
+    select: { roomId: true, userId: true },
+  });
+  return new Set(muted.map((m) => `${m.userId}:${m.roomId}`));
+}
+
 export async function notify(input: NotifyInput) {
   try {
     const map = await resolveDelivery([input.userId], input.type);
@@ -55,8 +83,18 @@ export async function notify(input: NotifyInput) {
     const created = await prisma.notification.create({ data: input });
     if (!d || d.allowPush) {
       publish(input.userId, "notification", created);
+      // 방 음소거 시 APNs(폰 푸시) 만 생략 — 레코드/SSE 는 위에서 이미 보냄.
+      let muted = false;
+      const rid = roomIdFromLink(input.linkUrl);
+      if (rid) {
+        const mem = await prisma.roomMember.findUnique({
+          where: { roomId_userId: { roomId: rid, userId: input.userId } },
+          select: { muted: true },
+        });
+        muted = !!mem?.muted;
+      }
       // 원격 푸시(iOS APNs) — fire-and-forget. 미설정/토큰없음이면 내부 no-op.
-      void sendApnsToUser(input.userId, { title: input.title, body: input.body, linkUrl: input.linkUrl });
+      if (!muted) void sendApnsToUser(input.userId, { title: input.title, body: input.body, linkUrl: input.linkUrl });
     }
   } catch (e) {
     console.error("notify failed", e);
@@ -105,11 +143,18 @@ export async function notifyMany(inputs: NotifyInput[]) {
     for (const n of fresh) {
       if (!picked.has(n.userId)) picked.set(n.userId, n);
     }
+    // 음소거된 방의 채팅 알림은 APNs(폰 푸시) 만 생략 — 한 번에 조회.
+    const mutedSet = await mutedApnsSet(
+      Array.from(picked.values()).map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
+    );
     for (const [uid, n] of picked) {
       if (pushFlag.get(`${uid}:${n.type as NotifyType}`) !== false) {
         publish(uid, "notification", n);
+        const rid = roomIdFromLink(n.linkUrl);
         // 원격 푸시(iOS APNs) — fire-and-forget. 미설정/토큰없음이면 내부 no-op.
-        void sendApnsToUser(uid, { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined });
+        if (!(rid && mutedSet.has(`${uid}:${rid}`))) {
+          void sendApnsToUser(uid, { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined });
+        }
       }
     }
   } catch (e) {

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -448,6 +448,23 @@ router.post("/rooms/:id/read", async (req, res) => {
 });
 
 /**
+ * 방별 알림 음소거 토글. 본인의 RoomMember.muted 를 갱신.
+ * muted=true 면 서버가 이 방 채팅 알림의 APNs(폰 푸시) 를 보내지 않는다.
+ * (알림 레코드·SSE·미읽음 뱃지는 유지 — 조용히 쌓이기만. 기기 간 동기화를 위해 서버 저장.)
+ */
+router.patch("/rooms/:id/mute", async (req, res) => {
+  const u = (req as any).user;
+  const muted = !!req.body?.muted;
+  const member = await prisma.roomMember.findUnique({
+    where: { roomId_userId: { roomId: req.params.id, userId: u.id } },
+    select: { id: true },
+  });
+  if (!member) return res.status(404).json({ error: "not a member" });
+  await prisma.roomMember.update({ where: { id: member.id }, data: { muted } });
+  res.json({ ok: true, muted });
+});
+
+/**
  * 메시지 전송 (즉시 또는 예약).
  * 본문, 첨부, scheduledAt 지원.
  */
@@ -555,7 +572,7 @@ router.post("/rooms/:id/messages", async (req, res) => {
     } else {
       // GROUP/TEAM: 보낸 사람 제외 모든 멤버에게 알림. 멘션된 사람은 MENTION(강조), 나머지는 일반 채팅.
       // (예전엔 멘션만 알림 → 단체방 메시지·사진이 알림 없이 묻혔음. 작업용 단체방 표준 동작으로 변경.
-      //  시끄러운 방 대비 '방별 음소거'는 후속 권장 — RoomMember 에 muted 필드 추가 필요.)
+      //  시끄러운 방은 RoomMember.muted 로 음소거 가능 — notify() 가 음소거 멤버의 APNs 를 생략한다.)
       const members = await prisma.roomMember.findMany({
         where: { roomId: req.params.id, userId: { not: u.id } },
         select: { userId: true },


### PR DESCRIPTION
## 증상
**채팅방별 알림 음소거 (RoomMember.muted, 서버 영속화)**

새 기능을 추가합니다.

## 원인
- schema: RoomMember.muted Boolean @default(false) + 가산형 마이그레이션
  (ADD COLUMN DEFAULT false — PG11+ 메타데이터 전용, 비파괴적. 배포 시
  컨테이너 CMD 의 prisma migrate deploy 가 자동 적용.)
- notify(): 음소거한 방의 채팅 알림은 APNs(폰 푸시) 만 생략. 알림 레코드·
  SSE 는 유지 → 미읽음 뱃지·실시간 채팅목록 갱신은 그대로(조용히 쌓임).
  linkUrl 의 ?room= 으로 방을 식별, notifyMany 는 1회 배치 조회로 처리.
- PATCH /api/chat/rooms/:id/mute — 본인 RoomMember.muted 토글(기기 간 동기화).

## 수정
**작업 항목 (커밋 단위)**
- feat(server): 채팅방별 알림 음소거 (RoomMember.muted)
- feat(client): 채팅방 음소거를 서버에 영속화 + 기기 간 동기화

**변경 대상 (6개 파일)**
- `client/src/components/ChatMiniApp.tsx`
- `client/src/components/chat/types.ts`
- `server/prisma/migrations/20260603000000_room_member_muted/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/lib/notify.ts`
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #272** 에서 진행됩니다.

