### PR TITLE
🔀 :: (#273) 터치 기기 hover 전용 버튼 접근성 + iOS 입력 줌 억제 (아이폰·아이패드)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1475,7 +1475,7 @@ function PinsSection() {
               <button
                 type="button"
                 onClick={(e) => { e.stopPropagation(); toggle(p.targetType, p.targetId); }}
-                className="md:opacity-0 md:group-hover:opacity-100 w-7 h-7 md:w-4 md:h-4 grid place-items-center rounded text-ink-400 hover:text-ink-900"
+                className="touch-reveal md:opacity-0 md:group-hover:opacity-100 w-7 h-7 md:w-4 md:h-4 grid place-items-center rounded text-ink-400 hover:text-ink-900"
                 title="핀 해제"
               >
                 <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/components/MeetingAttachments.tsx
+++ b/client/src/components/MeetingAttachments.tsx
@@ -302,7 +302,7 @@ export default function MeetingAttachments({
                     type="button"
                     onClick={() => remove(att)}
                     disabled={busy}
-                    className="btn-icon opacity-0 group-hover:opacity-100 transition flex-shrink-0"
+                    className="btn-icon touch-reveal opacity-0 group-hover:opacity-100 transition flex-shrink-0"
                     title="삭제"
                     aria-label={`${att.name} 삭제`}
                   >

--- a/client/src/components/ProjectQaList.tsx
+++ b/client/src/components/ProjectQaList.tsx
@@ -957,7 +957,7 @@ function QaRow({
           {item.status !== "DONE" ? (
             <button
               type="button"
-              className="btn-icon text-ink-400 hover:text-emerald-600 opacity-0 group-hover:opacity-100 transition-opacity"
+              className="btn-icon touch-reveal text-ink-400 hover:text-emerald-600 opacity-0 group-hover:opacity-100 transition-opacity"
               title="완료로 표시"
               aria-label="완료로 표시"
               onClick={() => onPatch({ status: "DONE" })}
@@ -969,7 +969,7 @@ function QaRow({
           ) : (
             <button
               type="button"
-              className="btn-icon text-ink-400 hover:text-amber-600 opacity-0 group-hover:opacity-100 transition-opacity"
+              className="btn-icon touch-reveal text-ink-400 hover:text-amber-600 opacity-0 group-hover:opacity-100 transition-opacity"
               title="다시 열기 (BUG 로 되돌림)"
               aria-label="다시 열기"
               onClick={() => onPatch({ status: "BUG" })}
@@ -982,7 +982,7 @@ function QaRow({
           )}
           <button
             type="button"
-            className="btn-icon text-ink-400 hover:text-rose-600 opacity-0 group-hover:opacity-100 transition-opacity"
+            className="btn-icon touch-reveal text-ink-400 hover:text-rose-600 opacity-0 group-hover:opacity-100 transition-opacity"
             title="삭제"
             aria-label="삭제"
             onClick={onDelete}
@@ -1410,7 +1410,7 @@ function RemoveDot({ onRemove }: { onRemove: () => void }) {
       onClick={onRemove}
       // 모바일에서도 누르기 편하도록 터치 타겟을 28px 로 확대,
       // 터치 디바이스에선 항상 보이게 (hover 로는 안 떠서 누를 수가 없음).
-      className="absolute top-1 right-1 w-7 h-7 rounded-full bg-black/60 text-white text-[13px] leading-none flex items-center justify-center md:opacity-0 md:group-hover/thumb:opacity-100 transition-opacity shadow"
+      className="touch-reveal absolute top-1 right-1 w-7 h-7 rounded-full bg-black/60 text-white text-[13px] leading-none flex items-center justify-center md:opacity-0 md:group-hover/thumb:opacity-100 transition-opacity shadow"
       aria-label="첨부 제거"
       title="제거"
     >

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -418,7 +418,7 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
       <div className="hidden md:block flex-1 min-w-0">
         {u.team && <span className="chip-blue">{u.team}</span>}
       </div>
-      <div className="flex items-center gap-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition">
+      <div className="touch-reveal flex items-center gap-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition">
         <a href={`mailto:${u.email}`} className="btn-icon" title="이메일">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="3" y="5" width="18" height="14" rx="2" />

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1214,7 +1214,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                   <div className="text-[11px] text-ink-500 tabular">{new Date(f.createdAt).toLocaleDateString("ko-KR")}</div>
                 </div>
                 {/* 호버 액션은 absolute 오버레이 — 평소엔 레이아웃을 먹지 않아 이름·날짜 영역이 잘리지 않음. */}
-                <div className="absolute top-2 right-2 hidden group-hover:flex items-center gap-0.5 bg-[color:var(--c-surface)]/95 backdrop-blur-sm rounded-lg px-1 py-0.5 shadow-sm border border-ink-100">
+                <div className="touch-reveal-flex absolute top-2 right-2 hidden group-hover:flex items-center gap-0.5 bg-[color:var(--c-surface)]/95 backdrop-blur-sm rounded-lg px-1 py-0.5 shadow-sm border border-ink-100">
                   <button className="btn-icon" onClick={(e) => { e.stopPropagation(); downloadFolder(f); }} title="폴더 전체 다운로드 (ZIP)">
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></svg>
                   </button>

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -274,7 +274,7 @@ function MemberRow({
         <div className="text-[11px] text-ink-500 truncate">{u.position ?? "—"}</div>
       </div>
       {u.id !== meId && (
-        <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100">
+        <div className="touch-reveal flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100">
           <button
             onClick={() => onSchedule(u)}
             className="btn-icon"
@@ -472,7 +472,7 @@ function PersonNode({
         </div>
       </div>
       {!isMe && (
-        <div className="flex items-center gap-0.5 md:opacity-0 md:group-hover:opacity-100 flex-shrink-0">
+        <div className="touch-reveal flex items-center gap-0.5 md:opacity-0 md:group-hover:opacity-100 flex-shrink-0">
           <button
             onClick={() => onSchedule(u)}
             className="btn-icon !w-6 !h-6"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -337,6 +337,21 @@ textarea.input {
   .input { font-size: 16px; }
   .filter-input { font-size: 16px; }
 }
+/* 위 max-width:640px 은 세로 아이폰만 커버 → 아이패드·가로 아이폰(>640px) 은 여전히
+   14px/12.5px 라 포커스 시 화면이 줌-점프한다. 호버 불가(=터치) 기기 전반에서 16px 로
+   올려 자동 줌을 막는다. 마우스 데스크톱/Electron(pointer:fine) 은 기존 콤팩트 크기 유지. */
+@media (pointer: coarse) {
+  .input, textarea.input, .filter-input, select.filter-input, .ghost-select { font-size: 16px; }
+}
+
+/* 터치(호버 불가) 기기에서는 hover 로만 드러나는 액션 버튼을 항상 보이게 한다.
+   any-hover:none = 호버 가능한 입력장치가 전혀 없는 기기(아이폰·마우스 없는 아이패드).
+   기존엔 opacity-0 group-hover:opacity-100 / hidden group-hover:flex 로 숨겨져 터치에서
+   삭제·공유 등 버튼이 아예 닿지 않았다. 마우스 데스크톱/Electron(any-hover:hover) 은 무영향. */
+@media (any-hover: none) {
+  .touch-reveal { opacity: 1 !important; }
+  .touch-reveal-flex { display: flex !important; }
+}
 /* iOS Safari 는 네이티브 date/time/datetime-local 입력에 내장 min-width 를
    강제해서 w-full 지정에도 컨테이너 밖으로 튀어나올 수 있음. 강제로 shrink 허용 */
 input.input[type="date"],


### PR DESCRIPTION
## 증상
**터치 기기 hover 전용 버튼 접근성 + iOS 입력 줌 억제 (아이폰·아이패드)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
문제 1) hover 로만 드러나던 버튼들이 터치(아이폰·마우스 없는 아이패드)에서
아예 닿지 않았다. 특히 삭제 같은 파괴적 액션이 모바일에서 실행 불가:
- 프로젝트 Q&A 행: 완료/다시열기/삭제 (아이폰·아이패드 둘 다 숨김)
- 문서 폴더: 다운로드/공유/이름변경/삭제 오버레이 (둘 다 숨김)
- 회의 첨부 삭제 (둘 다 숨김)
- 사이드바 핀 해제·인명부 메일·조직도 일정/DM·QA 썸네일 제거 (아이패드에서 숨김)

해결: styles.css 에 @media (any-hover: none) → .touch-reveal/.touch-reveal-flex
유틸 추가. 호버 가능한 입력장치가 없는 기기에서만 항상 노출. 마우스 데스크톱·
Electron(any-hover:hover) 은 기존 hover 노출 동작 그대로 → 데스크톱 무회귀.

문제 2) font-size<16px 입력 필드는 iOS 포커스 시 화면이 줌-점프.
기존 16px 보정이 max-width:640px(세로 아이폰) 에만 걸려 아이패드·가로
아이폰은 누락. @media (pointer: coarse) 로 .input/.filter-input/.ghost-select
등을 터치 기기 전반에서 16px 로. 마우스 데스크톱은 콤팩트 크기 유지.

클라이언트 전용. tsc + vite build 통과.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 터치 기기에서 hover 전용 액션 버튼 접근 가능하게 + iOS 입력 줌 억제

**변경 대상 (7개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/MeetingAttachments.tsx`
- `client/src/components/ProjectQaList.tsx`
- `client/src/pages/DirectoryPage.tsx`
- `client/src/pages/DocumentsPage.tsx`
- `client/src/pages/OrgChartPage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #273** 에서 진행됩니다.

