### PR TITLE
🔀 :: (#274) presence 폴링 경량화 + 미사용 요청 제거

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -103,7 +103,9 @@ export default function ChatMiniApp({
     let cancelled = false;
     const fetchPresence = async () => {
       try {
-        const res = await api<{ users: Array<{ id: string; presenceStatus?: string | null; workStatus?: string | null; presenceMessage?: string | null }> }>("/api/users");
+        // 경량 전용 엔드포인트 — 풀 유저행(이메일/아바타/HR 필드 등) 대신 presence 4필드만.
+        // 30초 폴링(채팅 패널 열림 시)의 응답 크기를 ~8x 줄인다. (서버 users.ts /presence)
+        const res = await api<{ users: Array<{ id: string; presenceStatus?: string | null; workStatus?: string | null; presenceMessage?: string | null }> }>("/api/users/presence");
         if (cancelled) return;
         const m: Record<string, { presenceStatus: string | null; workStatus: string | null; presenceMessage: string | null }> = {};
         for (const u of res.users) {

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -51,13 +51,10 @@ export default function OrgChartPage() {
   }, []);
 
   async function load() {
-    const [u, p] = await Promise.all([
-      api<{ users: DirUser[] }>("/api/users"),
-      api<{ teams: string[] }>("/api/users/teams").catch(() => ({ teams: [] })),
-    ]);
+    // 팀 목록은 users 배열에서 파생하므로 별도 /api/users/teams 호출은 불필요(과거 미사용 요청 제거).
+    const u = await api<{ users: DirUser[] }>("/api/users");
     if (!aliveRef.current) return;
     setUsers(u.users);
-    void p;
   }
 
   async function loadPositions() {


### PR DESCRIPTION
## 증상
**presence 폴링 경량화 + 미사용 요청 제거**

성능을 개선합니다.

## 원인
- ChatMiniApp presence 폴링(채팅 패널 열림 시 30초): /api/users(풀 유저행
  +출근/휴가 조인, 최대 5000명) → /api/users/presence(presence 4필드만).
  응답 크기 ~8x 감소 → 데이터 전송량·RDS 부하 절감. 소비 필드 동일(무회귀).
- OrgChartPage: 결과를 쓰지 않던 /api/users/teams 요청 제거(팀은 users 에서 파생).

클라이언트 전용. tsc + vite build 통과.

## 수정
**작업 항목 (커밋 단위)**
- perf(client): presence 폴링 경량 엔드포인트로 전환 + 조직도 미사용 요청 제거

**변경 대상 (2개 파일)**
- `client/src/components/ChatMiniApp.tsx`
- `client/src/pages/OrgChartPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #274** 에서 진행됩니다.

