### PR TITLE
🔀 :: (#275) APNs 발송 N→1 배치 + 자기 유저 중복 조회 제거

### DIFF
--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -244,6 +244,51 @@ export async function sendApnsToUser(userId: string, payload: ApnsPayload): Prom
 }
 
 /**
+ * 여러 유저에게 각자의 페이로드로 일괄 발송 (브로드캐스트/그룹 알림 경로용).
+ * sendApnsToUser 를 유저마다 부르면 pushToken 조회가 N회 발생한다 → 여기선 토큰 조회를
+ * 1회로 묶는다(N→1). 토큰별 발송/폴백/죽은토큰 정리 로직은 sendApnsToUser 와 동일(sendWithFallback 재사용).
+ */
+export async function sendApnsToUsers(items: { userId: string; payload: ApnsPayload }[]): Promise<void> {
+  if (!apnsEnabled() || !items.length) return;
+  try {
+    const userIds = Array.from(new Set(items.map((i) => i.userId)));
+    const rows = await prisma.pushToken.findMany({
+      where: { userId: { in: userIds }, platform: "ios" },
+      select: { token: true, userId: true },
+    });
+    if (!rows.length) return;
+    const byUser = new Map<string, string[]>();
+    for (const r of rows) {
+      const arr = byUser.get(r.userId);
+      if (arr) arr.push(r.token);
+      else byUser.set(r.userId, [r.token]);
+    }
+
+    // 유저별 페이로드로 각 토큰 발송 — 모든 (토큰,페이로드) 쌍을 병렬 처리.
+    const sends: Promise<SendResult>[] = [];
+    for (const it of items) {
+      const toks = byUser.get(it.userId);
+      if (!toks) continue;
+      for (const t of toks) sends.push(sendWithFallback(t, it.payload));
+    }
+    const results = await Promise.all(sends);
+
+    const dead = results.filter(isDeadToken).map((r) => r.token);
+    const ok = results.filter((r) => r.status === 200).map((r) => r.token);
+    if (dead.length) await prisma.pushToken.deleteMany({ where: { token: { in: dead } } });
+    if (ok.length) {
+      await prisma.pushToken.updateMany({ where: { token: { in: ok } }, data: { lastUsedAt: new Date() } });
+    }
+    const other = results.filter((r) => r.status !== 200 && !isDeadToken(r));
+    if (other.length) {
+      console.error("apns batch send partial failure", other.map((r) => ({ status: r.status, reason: r.reason })));
+    }
+  } catch (e) {
+    console.error("sendApnsToUsers failed", (e as Error)?.message || e);
+  }
+}
+
+/**
  * 진단용 — 호출 유저의 iOS 토큰으로 테스트 푸시를 실제 발송하고 APNs 응답을 그대로 반환한다.
  * 푸시 미수신 원인을 정확히 식별: 키 미설정 / 토큰 0개 / status 400 BadDeviceToken(환경 불일치) /
  * status 403(인증·키 오류) / status 200(정상 — 기기에 테스트 푸시 도착).

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -1,6 +1,6 @@
 import { prisma } from "./db.js";
 import { publish } from "./sse.js";
-import { sendApnsToUser } from "./apns.js";
+import { sendApnsToUser, sendApnsToUsers } from "./apns.js";
 
 export type NotifyType =
   | "NOTICE"
@@ -147,16 +147,18 @@ export async function notifyMany(inputs: NotifyInput[]) {
     const mutedSet = await mutedApnsSet(
       Array.from(picked.values()).map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
     );
+    const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string } }[] = [];
     for (const [uid, n] of picked) {
       if (pushFlag.get(`${uid}:${n.type as NotifyType}`) !== false) {
         publish(uid, "notification", n);
         const rid = roomIdFromLink(n.linkUrl);
-        // 원격 푸시(iOS APNs) — fire-and-forget. 미설정/토큰없음이면 내부 no-op.
         if (!(rid && mutedSet.has(`${uid}:${rid}`))) {
-          void sendApnsToUser(uid, { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined });
+          apnsTargets.push({ userId: uid, payload: { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined } });
         }
       }
     }
+    // 원격 푸시(iOS APNs) — fire-and-forget. pushToken 조회를 1회로 묶어 일괄 발송(N→1). 미설정/토큰없음이면 내부 no-op.
+    void sendApnsToUsers(apnsTargets);
   } catch (e) {
     console.error("notifyMany failed", e);
   }

--- a/server/src/routes/journal.ts
+++ b/server/src/routes/journal.ts
@@ -29,10 +29,9 @@ router.get("/", async (req, res) => {
   if (userId !== u.id) {
     if (u.role === "MEMBER") return res.status(403).json({ error: "forbidden" });
     if (u.role === "MANAGER") {
-      const [me, target] = await Promise.all([
-        prisma.user.findUnique({ where: { id: u.id }, select: { team: true } }),
-        prisma.user.findUnique({ where: { id: userId }, select: { team: true } }),
-      ]);
+      // 내 팀은 requireAuth 캐시 유저행에서 — 대상(다른 유저) 팀만 조회.
+      const me = (req as any).userRecord as { team?: string | null } | undefined;
+      const target = await prisma.user.findUnique({ where: { id: userId }, select: { team: true } });
       // 팀 미지정이거나 다른 팀이면 거부 — null/undefined 동일 취급 안 함(둘 다 null 이면 거부).
       if (!me?.team || !target?.team || me.team !== target.team) {
         return res.status(403).json({ error: "forbidden" });

--- a/server/src/routes/schedule.ts
+++ b/server/src/routes/schedule.ts
@@ -58,7 +58,8 @@ const ADMIN_ONLY_CATEGORIES = new Set(["COMPANY_HOLIDAY", "COMPANY_LEAVE"]);
  */
 router.get("/", async (req, res) => {
   const u = (req as any).user;
-  const meUser = await prisma.user.findUnique({ where: { id: u.id } });
+  // requireAuth 가 붙여둔 풀 유저행(30s 캐시) 재사용 — 매 목록 요청마다 하던 중복 self 조회 제거.
+  const meUser = (req as any).userRecord;
   // Invalid Date 를 그대로 Prisma 에 넣으면 500 — 파싱 실패 시 필터 자체를 생략.
   const parseOrNull = (s: unknown) => {
     if (!s) return undefined;
@@ -157,7 +158,7 @@ router.post("/", async (req, res) => {
     if (!membership) return res.status(403).json({ error: "프로젝트 멤버만 일정을 등록할 수 있어요" });
   }
 
-  const me = await prisma.user.findUnique({ where: { id: u.id } });
+  const me = (req as any).userRecord; // requireAuth 캐시 유저행 재사용 (중복 self 조회 제거)
 
   const targets = (d.targetUserIds ?? []).filter((id) => id && id !== u.id);
   if (targets.length && !(await allSameCompanyUsers(targets)))


### PR DESCRIPTION
## 증상
**APNs 발송 N→1 배치 + 자기 유저 중복 조회 제거**

성능을 개선합니다.

## 원인
- apns.ts: sendApnsToUsers() 추가. notifyMany 가 수신자마다 sendApnsToUser 를
  부르면 pushToken.findMany 가 N회 발생(전사 공지·대형 그룹방에서 수백 회). 토큰
  조회를 1회로 묶고 토큰별 발송/폴백/죽은토큰 정리는 sendWithFallback 그대로 재사용
  → 동작 동일, DB 왕복만 N→1. 단건 sendApnsToUser 경로는 그대로 유지.
- notify.ts: notifyMany 푸시 루프를 apnsTargets 수집 후 sendApnsToUsers 1회 호출로.
  SSE publish 는 유저별 그대로. 음소거 게이트 동일.
- schedule.ts(목록·생성), journal.ts(매니저 조회): requireAuth 가 붙여둔 userRecord
  (풀 유저행, 30s 캐시) 를 재사용해 매 요청 self user 재조회(uncached) 제거.
  journal 의 '다른 유저' 팀 조회는 유지.

서버 전용, 마이그레이션 없음. tsc 통과.

## 수정
**작업 항목 (커밋 단위)**
- perf(server): APNs 발송 pushToken 조회 N→1 배치 + 자기 유저 중복 조회 제거

**변경 대상 (4개 파일)**
- `server/src/lib/apns.ts`
- `server/src/lib/notify.ts`
- `server/src/routes/journal.ts`
- `server/src/routes/schedule.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #275** 에서 진행됩니다.

