### PR TITLE
🔀 :: (#276) 아이패드 사이드바 탭 타겟 44px + 모달 safe-area 패딩

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -757,7 +757,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
           <div className="border-t border-ink-150 px-2 pt-2">
             <NavLink
               to="/download"
-              className="flex items-center gap-2.5 h-[40px] md:h-[32px] px-3 rounded-full text-[13px] md:text-[12.5px] font-semibold text-ink-500 hover:bg-ink-100 hover:text-ink-900 transition"
+              className="tap-row flex items-center gap-2.5 h-[40px] md:h-[32px] px-3 rounded-full text-[13px] md:text-[12.5px] font-semibold text-ink-500 hover:bg-ink-100 hover:text-ink-900 transition"
               title="데스크톱 · 모바일 앱 다운로드"
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -1464,7 +1464,7 @@ function PinsSection() {
               onDragOver={(e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; }}
               onDrop={(e) => { e.preventDefault(); onDrop(p.id); }}
               onDragEnd={() => setDragId(null)}
-              className={`group flex items-center gap-2 h-[40px] md:h-[30px] px-3 rounded-full text-[12.5px] font-semibold cursor-pointer transition ${
+              className={`tap-row group flex items-center gap-2 h-[40px] md:h-[30px] px-3 rounded-full text-[12.5px] font-semibold cursor-pointer transition ${
                 dragId === p.id ? "opacity-40" : ""
               } ${p.missing ? "text-ink-400" : "text-ink-700 hover:bg-ink-100 hover:text-ink-900"}`}
               title={p.missing ? "원본이 삭제되었어요 — 클릭해서 핀 해제" : label}
@@ -1508,7 +1508,7 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 
 function navClass(active: boolean) {
   return [
-    "flex items-center gap-2.5 h-[40px] md:h-[34px] px-3 rounded-full text-[13px] font-bold transition",
+    "tap-row flex items-center gap-2.5 h-[40px] md:h-[34px] px-3 rounded-full text-[13px] font-bold transition",
     active ? "nav-active" : "text-ink-700 hover:bg-ink-100 hover:text-ink-900",
   ].join(" ");
 }

--- a/client/src/components/ConfirmHost.tsx
+++ b/client/src/components/ConfirmHost.tsx
@@ -167,7 +167,7 @@ export default function ConfirmHost() {
 
   return (
     <div
-      className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-[200]"
+      className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-[200]"
       onClick={onCancel}
     >
       <div

--- a/client/src/components/CreateProjectModal.tsx
+++ b/client/src/components/CreateProjectModal.tsx
@@ -114,7 +114,7 @@ export default function CreateProjectModal({ open, onClose, onCreated }: Props) 
       // 에 고정되어 모바일에서 모달이 사이드바 폭 안으로 찌그러지는 버그가 있었음.
   return createPortal(
     <div
-      className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-[100]"
+      className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-[100]"
       onClick={onClose}
     >
       <div

--- a/client/src/components/NotificationPrefsModal.tsx
+++ b/client/src/components/NotificationPrefsModal.tsx
@@ -60,7 +60,7 @@ export default function NotificationPrefsModal({ open, onClose }: { open: boolea
   }
 
   return (
-    <div className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-[70]" onClick={onClose}>
+    <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-[70]" onClick={onClose}>
       <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
         <h3 className="text-lg font-bold mb-1">알림 설정</h3>
         <p className="text-[12px] text-ink-500 mb-4">타입별 수신·방해금지·이메일 중계를 설정할 수 있어요.</p>

--- a/client/src/components/PayslipComposer.tsx
+++ b/client/src/components/PayslipComposer.tsx
@@ -168,7 +168,7 @@ export default function PayslipComposer({
   const years = Array.from({ length: 6 }, (_, i) => defaultYear - i + 1);
 
   return (
-    <div className="fixed inset-0 bg-slate-900/45 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-slate-900/45 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div
         className="card w-full max-w-3xl max-h-[92vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}

--- a/client/src/components/PayslipPreview.tsx
+++ b/client/src/components/PayslipPreview.tsx
@@ -44,7 +44,7 @@ export default function PayslipPreview({
 
   return (
     <div
-      className="fixed inset-0 bg-slate-900/50 grid place-items-center p-4 z-50"
+      className="fixed inset-0 bg-slate-900/50 grid place-items-center modal-safe z-50"
       onClick={onClose}
     >
       <div

--- a/client/src/components/ProjectCalendar.tsx
+++ b/client/src/components/ProjectCalendar.tsx
@@ -387,7 +387,7 @@ export default function ProjectCalendar({
 
       {/* 생성 모달 */}
       {openCreate && (
-        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-50" onClick={() => setOpenCreate(false)}>
+        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setOpenCreate(false)}>
           <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-bold mb-4">새 일정</h3>
             <form onSubmit={submitCreate} className="space-y-3">
@@ -467,7 +467,7 @@ export default function ProjectCalendar({
 
       {/* 상세 모달 */}
       {selected && (
-        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-50" onClick={() => setSelected(null)}>
+        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setSelected(null)}>
           <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center gap-2 mb-2">
               <span className="w-3 h-3 rounded-full" style={{ background: selected.color }} />

--- a/client/src/components/ProjectSettingsModal.tsx
+++ b/client/src/components/ProjectSettingsModal.tsx
@@ -70,7 +70,7 @@ export default function ProjectSettingsModal({
 
   return (
     <div
-      className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-50"
+      className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50"
       onClick={onClose}
     >
       <div

--- a/client/src/components/ProjectWebhooks.tsx
+++ b/client/src/components/ProjectWebhooks.tsx
@@ -270,7 +270,7 @@ export default function ProjectWebhooks({ projectId }: { projectId: string }) {
       {/* 생성 모달 */}
       {openCreate && (
         <div
-          className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-50"
+          className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50"
           onClick={() => setOpenCreate(false)}
         >
           <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>

--- a/client/src/components/RevisionHistoryModal.tsx
+++ b/client/src/components/RevisionHistoryModal.tsx
@@ -70,7 +70,7 @@ export default function RevisionHistoryModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()}>
         <div className="section-head">
           <div className="title">버전 히스토리 · {title}</div>

--- a/client/src/components/ShareLinkModal.tsx
+++ b/client/src/components/ShareLinkModal.tsx
@@ -91,7 +91,7 @@ export default function ShareLinkModal({ documentId, folderId, documentTitle, on
   }
 
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="공유 링크 관리">
         <div className="section-head">
           <div className="title">

--- a/client/src/components/superadmin/ErrorsPanel.tsx
+++ b/client/src/components/superadmin/ErrorsPanel.tsx
@@ -117,7 +117,7 @@ export default function ErrorsPanel() {
       </div>
 
       {openHash && (
-        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={() => setOpenHash(null)}>
+        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setOpenHash(null)}>
           <div className="panel w-full max-w-[840px] max-h-[88vh] flex flex-col overflow-hidden" onClick={(e) => e.stopPropagation()}>
             <div className="px-5 py-3 border-b border-ink-150 flex items-center justify-between">
               <div className="text-[14px] font-extrabold text-ink-900">에러 상세 · {openHash}</div>

--- a/client/src/components/superadmin/FlagsPanel.tsx
+++ b/client/src/components/superadmin/FlagsPanel.tsx
@@ -96,7 +96,7 @@ export default function FlagsPanel() {
       </div>
 
       {editing && (
-        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={() => setEditing(null)}>
+        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setEditing(null)}>
           <form
             className="panel w-full max-w-[480px] p-5"
             onClick={(e) => e.stopPropagation()}

--- a/client/src/components/superadmin/SecurityPanel.tsx
+++ b/client/src/components/superadmin/SecurityPanel.tsx
@@ -184,7 +184,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 function Modal({ onClose, onSubmit, children }: { onClose: () => void; onSubmit: () => void; children: React.ReactNode }) {
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <form
         className="panel w-full max-w-[460px] p-5 max-h-[88vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -751,7 +751,7 @@ function ResignModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black/40 grid place-items-center z-50 p-4" onClick={onClose}>
+    <div className="fixed inset-0 bg-black/40 grid place-items-center z-50 modal-safe" onClick={onClose}>
       <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-1">
           <h3 className="text-lg font-bold">{isResigned ? "퇴사 정보 수정" : "퇴사 처리"}</h3>
@@ -901,7 +901,7 @@ function UserDetailEditModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div
         className="card w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col"
         onClick={(e) => e.stopPropagation()}
@@ -1480,7 +1480,7 @@ function AttendanceEditModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black/40 grid place-items-center z-50 p-4" onClick={onClose}>
+    <div className="fixed inset-0 bg-black/40 grid place-items-center z-50 modal-safe" onClick={onClose}>
       <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-1">
           <h3 className="text-lg font-bold">출근 기록 수정</h3>

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -427,7 +427,7 @@ function ConfirmModal({
   }, [busy, onCancel]);
 
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={() => !busy && onCancel()}>
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => !busy && onCancel()}>
       <div className="panel w-full max-w-[420px] shadow-pop" onClick={(e) => e.stopPropagation()}>
         <div className="section-head">
           <div className="title">{title}</div>
@@ -852,7 +852,7 @@ function CreateModal({
   const needDestination = form.type === "TRIP" || form.type === "OFFSITE";
 
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div className="panel w-full max-w-[560px] shadow-pop overflow-hidden" onClick={(e) => e.stopPropagation()}>
         <div className="section-head">
           <div className="title">{reviseFromId ? "수정해서 재상신" : "새 결재 올리기"}</div>

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -411,7 +411,7 @@ export default function AttendancePage() {
       {/* 신청 모달 */}
       {open && (
         <div
-          className="fixed inset-0 z-50 grid place-items-center p-4"
+          className="fixed inset-0 z-50 grid place-items-center modal-safe"
           style={{ background: "rgba(0,0,0,0.45)", backdropFilter: "blur(4px)" }}
           onClick={() => !saving && setOpen(false)}
         >

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1427,7 +1427,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       {/* /폴더+문서 공용 드롭존 */}
 
       {creating === "folder" && (
-        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={() => setCreating(null)}>
+        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setCreating(null)}>
           <div className="panel w-full max-w-md" onClick={(e) => e.stopPropagation()}>
             <div className="section-head">
               <div className="title">새 폴더</div>
@@ -1537,7 +1537,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       )}
 
       {creating === "doc" && (
-        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={() => setCreating(null)}>
+        <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setCreating(null)}>
           <div className="panel w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
             <div className="section-head">
               <div className="title">문서 업로드</div>

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -340,7 +340,7 @@ export default function ExpensePage() {
       </div>
 
       {open && (
-        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4 z-50" onClick={() => setOpen(false)}>
+        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setOpen(false)}>
           <div className="card w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-bold mb-4">법인카드 사용내역 등록</h3>
             <form onSubmit={submit} className="space-y-3">
@@ -443,7 +443,7 @@ export default function ExpensePage() {
       )}
 
       {preview && (
-        <div className="fixed inset-0 bg-slate-900/70 grid place-items-center p-4 z-50" onClick={() => setPreview(null)}>
+        <div className="fixed inset-0 bg-slate-900/70 grid place-items-center modal-safe z-50" onClick={() => setPreview(null)}>
           <img src={preview} alt="receipt" decoding="async" className="max-h-[90vh] max-w-[90vw] rounded-xl" loading="lazy"/>
         </div>
       )}

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -357,7 +357,7 @@ export default function JournalPage() {
 
       {confirmRemoveId && (
         <div
-          className="fixed inset-0 z-50 grid place-items-center p-4"
+          className="fixed inset-0 z-50 grid place-items-center modal-safe"
           style={{ background: "rgba(0,0,0,0.45)", backdropFilter: "blur(4px)" }}
           onClick={() => removingId ? null : setConfirmRemoveId(null)}
         >

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -353,7 +353,7 @@ export default function NoticePage() {
       </div>
 
       {open && (
-        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center p-4" onClick={() => setOpen(false)}>
+        <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe" onClick={() => setOpen(false)}>
           <div className="card w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-bold mb-4">공지 작성</h3>
             <form onSubmit={submit} className="space-y-3">

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -419,7 +419,7 @@ function DangerZonePanel() {
 
       {open && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center modal-safe"
           style={{ background: "rgba(0,0,0,0.45)" }}
           onClick={close}
         >

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -411,7 +411,7 @@ function DayDetailModal({
 }) {
   const holiday = getHoliday(date);
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div
         className="panel w-full max-w-[480px] shadow-pop overflow-hidden"
         onClick={(e) => e.stopPropagation()}

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -959,7 +959,7 @@ function AccountModal({
   ];
 
   return (
-    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center p-4 z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="계정 편집">
         <div className="section-head">
           <div className="title">{mode === "new" ? "새 계정 추가" : "계정 편집"}</div>

--- a/client/src/pages/SnippetsPage.tsx
+++ b/client/src/pages/SnippetsPage.tsx
@@ -295,7 +295,7 @@ function SnippetEditor({
 
   return (
     <div
-      className="fixed inset-0 z-50 grid place-items-center p-4"
+      className="fixed inset-0 z-50 grid place-items-center modal-safe"
       style={{ background: "rgba(0,0,0,0.5)" }}
       onClick={() => { if (!saving) onClose(); }}
     >

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -542,7 +542,7 @@ function ChatAuditPwModal({ onClose, onSubmit }: { onClose: () => void; onSubmit
   }
   return (
     <div
-      className="fixed inset-0 z-50 grid place-items-center p-4"
+      className="fixed inset-0 z-50 grid place-items-center modal-safe"
       style={{ background: "rgba(0,0,0,0.55)", backdropFilter: "blur(6px)", WebkitBackdropFilter: "blur(6px)" }}
       onClick={onClose}
     >

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -352,6 +352,20 @@ textarea.input {
   .touch-reveal { opacity: 1 !important; }
   .touch-reveal-flex { display: flex !important; }
 }
+/* 터치 기기에서 사이드바 행(아이패드는 데스크톱 사이드바를 쓰지만 터치)의 탭 타겟을
+   최소 44px(Apple HIG) 로 확보. 사이드바는 md+ 에서만 렌더되므로 사실상 아이패드 전용.
+   마우스 데스크톱(pointer:fine) 은 기존 콤팩트 높이(34px 등) 유지 → 밀도 무회귀. */
+@media (pointer: coarse) {
+  .tap-row { min-height: 44px; }
+}
+/* 풀높이 모달이 노치/홈인디케이터에 가리지 않도록 오버레이에 safe-area 패딩.
+   env() 는 데스크톱에서 0 이라 웹/Electron 외형은 변하지 않음(p-4 동등). */
+.modal-safe {
+  padding-top: max(1rem, env(safe-area-inset-top));
+  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  padding-left: max(1rem, env(safe-area-inset-left));
+  padding-right: max(1rem, env(safe-area-inset-right));
+}
 /* iOS Safari 는 네이티브 date/time/datetime-local 입력에 내장 min-width 를
    강제해서 w-full 지정에도 컨테이너 밖으로 튀어나올 수 있음. 강제로 shrink 허용 */
 input.input[type="date"],


### PR DESCRIPTION
## 증상
**아이패드 사이드바 탭 타겟 44px + 모달 safe-area 패딩**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
C) 사이드바 행(아이패드는 데스크톱 사이드바 사용하지만 터치)의 높이가 30~34px
   라 탭하기 작았다. .tap-row 유틸 추가 → @media(pointer:coarse) 에서만 min-height
   44px(Apple HIG). 사이드바는 md+ 에서만 렌더 → 사실상 아이패드 전용, 마우스
   데스크톱은 기존 밀도 유지(무회귀). navClass·핀 행·앱다운로드 행에 적용.

D) 모달 오버레이 25개(스크림 31곳)의 p-4 → .modal-safe 로 교체. 풀높이 모달이
   노치/홈인디케이터에 가리지 않도록 safe-area 패딩. env() 는 데스크톱에서 0 →
   max(1rem,0)=1rem 이라 웹/Electron 외형 무변경, 노치 기기에서만 인셋 추가.

클라이언트 전용. tsc + vite build 통과.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 아이패드 사이드바 탭 타겟 44px + 모달 safe-area 패딩

**변경 대상 (27개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ConfirmHost.tsx`
- `client/src/components/CreateProjectModal.tsx`
- `client/src/components/NotificationPrefsModal.tsx`
- `client/src/components/PayslipComposer.tsx`
- `client/src/components/PayslipPreview.tsx`
- `client/src/components/ProjectCalendar.tsx`
- `client/src/components/ProjectSettingsModal.tsx`
- `client/src/components/ProjectWebhooks.tsx`
- `client/src/components/RevisionHistoryModal.tsx`
- `client/src/components/ShareLinkModal.tsx`
- `client/src/components/superadmin/ErrorsPanel.tsx`
- … 외 15개

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #276** 에서 진행됩니다.

