### PR TITLE
🔀 :: (#277) 아이폰 하단 네비를 애플 글래스(리퀴드 글래스) 스타일로

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -18,7 +18,7 @@ import { ROUTE_PREFETCH, loadProject } from "../routes";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
 import { isPreviewMode } from "../lib/previewMock";
-import { isInstalledApp } from "../lib/platform";
+import { isInstalledApp, nativePlatform } from "../lib/platform";
 
 /**
  * 사이드바 hover/focus prefetch — 사용자가 클릭하기 전에 해당 페이지 청크를
@@ -653,6 +653,9 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
   useEffect(() => {
     const el = document.documentElement;
     el.classList.add("hinest-shell-lock");
+    // iOS 네이티브(아이폰·아이패드)에서만 글래스 하단 네비 스타일 + 본문 하단 클리어런스 적용.
+    // (웹/안드로이드/Electron 데스크톱은 클래스가 안 붙어 기존 디자인 그대로.)
+    el.classList.toggle("hinest-ios", nativePlatform() === "ios");
     return () => el.classList.remove("hinest-shell-lock");
   }, []);
 
@@ -1050,20 +1053,41 @@ function NavSection({ label, items, dev }: { label: string; items: NavItem[]; de
 function BottomNav({ items }: { items: NavItem[] }) {
   // 전자결재 대기 건수 배지 — 사이드바와 동일한 폴링 hook 재사용.
   const approvalCounts = useApprovalCounts();
+  // iOS 네이티브(아이폰)에서는 화면 하단에 떠 있는 애플 리퀴드 글래스 스타일 바(반투명+blur).
+  // 그 외(웹·안드로이드·Electron 데스크톱)는 기존 in-flow 솔리드 바 그대로 — 무회귀.
+  // (본문이 바 뒤로 지나가도록 클리어런스는 styles.css 의 html.hinest-ios --hinest-main-pb 가 담당.)
+  const ios = nativePlatform() === "ios";
   return (
     <nav
-      className="md:hidden flex-shrink-0 flex items-stretch"
-      style={{
-        // 테마 변수로 칠해 다크 모드에서도 자연스럽게(이전엔 bg-white 고정이라 다크에서 깨졌음).
-        background: "var(--c-surface)",
-        borderTop: "1px solid var(--c-border)",
-        // 홈 인디케이터 회피용 하단 여백 — 단, 전체 safe-area(노치 기기 ~34px)를 그대로
-        // 비워두면 네비가 surface 색으로 칠해진 뒤(하단 seam 수정) 그 빈 영역까지 바의
-        // 일부로 보여 바가 과하게 높아 보인다. "아직도 높다" 는 피드백에 10px 덜어 빈
-        // 공간을 더 줄인다(인디케이터 클리어런스 ~24px 유지). safe-area 없으면(env=0) 0.
-        paddingBottom: "max(env(safe-area-inset-bottom) - 10px, 0px)",
-        boxShadow: "0 -8px 24px rgba(20,22,27,0.06)",
-      }}
+      className={"md:hidden flex items-stretch" + (ios ? "" : " flex-shrink-0")}
+      style={
+        ios
+          ? {
+              // 화면 하단에 12px 여백을 두고 떠 있는 알약형 글래스 바.
+              position: "fixed",
+              left: 12,
+              right: 12,
+              bottom: "max(10px, env(safe-area-inset-bottom))",
+              zIndex: 30,
+              borderRadius: 26,
+              // 반투명 + blur — 뒤로 스크롤되는 본문이 비쳐 보이는 글래스 질감.
+              background: "var(--c-glass)",
+              backdropFilter: "blur(22px) saturate(180%)",
+              WebkitBackdropFilter: "blur(22px) saturate(180%)",
+              border: "1px solid var(--c-glass-border)",
+              boxShadow: "0 10px 30px rgba(16,18,27,0.22), inset 0 1px 0 rgba(255,255,255,0.22)",
+              padding: "6px 4px",
+              overflow: "hidden",
+            }
+          : {
+              // 테마 변수로 칠해 다크 모드에서도 자연스럽게(이전엔 bg-white 고정이라 다크에서 깨졌음).
+              background: "var(--c-surface)",
+              borderTop: "1px solid var(--c-border)",
+              // 홈 인디케이터 회피용 하단 여백. safe-area 없으면(env=0) 0.
+              paddingBottom: "max(env(safe-area-inset-bottom) - 10px, 0px)",
+              boxShadow: "0 -8px 24px rgba(20,22,27,0.06)",
+            }
+      }
       aria-label="주요 메뉴"
     >
       {items.map((n) => {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -17,6 +17,9 @@
   --c-surface-3:  #F2F4F6;
   --c-border:     #E6E8EC;
   --c-border-strong: #DDE0E4;
+  /* 글래스 하단 네비(iOS) — 반투명 + blur 로 뒤 콘텐츠가 비치는 애플 리퀴드 글래스 스타일. */
+  --c-glass:        rgba(255,255,255,0.66);
+  --c-glass-border: rgba(255,255,255,0.6);
   /* 채팅 상대 버블 — surface(white) 위에 올라가므로 한 톤 더 어둡게 잡아야 보임 */
   --c-chat-bubble-other: #E9EDF2;
 
@@ -61,6 +64,12 @@
     /* 모바일: 하단 바가 safe-area 를 책임지므로 본문은 24px 만(이중 여백 방지). */
     --hinest-main-pb: 24px;
   }
+  /* iOS 네이티브(아이폰): 하단 네비가 플로팅 글래스(position:fixed → out-of-flow)라
+     본문 끝이 바 아래로 가리지 않도록 [바 높이 ~60px + 하단 오프셋 + 여유] 만큼 패딩.
+     html.hinest-ios 는 AppLayout 이 iOS 네이티브일 때만 토글 → 웹/안드/데스크톱 무영향. */
+  html.hinest-ios {
+    --hinest-main-pb: calc(60px + max(10px, env(safe-area-inset-bottom)) + 14px);
+  }
 }
 
 html.dark {
@@ -72,6 +81,9 @@ html.dark {
   --c-surface-3:  #23272F;
   --c-border:     #2A2F38;
   --c-border-strong: #363B45;
+  /* 글래스 하단 네비(iOS) — 다크에선 어두운 반투명 + 옅은 흰 테두리 하이라이트. */
+  --c-glass:        rgba(22,25,31,0.6);
+  --c-glass-border: rgba(255,255,255,0.12);
   /* 다크에선 surface(#171A20) 위에 올라가므로 surface-3 정도면 충분 */
   --c-chat-bubble-other: #2A2F38;
 


### PR DESCRIPTION
## 증상
**아이폰 하단 네비를 애플 글래스(리퀴드 글래스) 스타일로**

새 기능을 추가합니다.

## 원인
iOS 네이티브(아이폰)에서만 하단 탭 바를 화면 하단에 떠 있는 반투명 알약형
글래스 바로 변경 — 뒤로 스크롤되는 본문이 비쳐 blur 되는 애플 신규 디자인.

- styles.css: --c-glass / --c-glass-border 토큰(라이트·다크). html.hinest-ios +
  모바일 미디어쿼리에서 --hinest-main-pb 를 바 높이+오프셋+여유로 키워 본문이
  플로팅 바 뒤로 가리지 않게 클리어런스 확보.
- AppLayout: nativePlatform()==='ios' 일 때만 .hinest-ios 클래스 토글 + 바를
  position:fixed 플로팅 + backdrop-filter blur(22px) saturate(180%) + 반투명
  배경 + 라운드(26px) + 그림자/내부 하이라이트로 렌더. 그 외(웹·안드·데스크톱)는
  기존 in-flow 솔리드 바 그대로 → 무회귀.

iPad 는 md+ 라 사이드바 레이아웃을 쓰므로 하단 바가 표시되지 않음(=아이폰에 적용).
클라이언트 전용. tsc + vite build 통과.

## 수정
**작업 항목 (커밋 단위)**
- feat(mobile): 아이폰 하단 네비게이션을 애플 글래스(리퀴드 글래스) 스타일로

**변경 대상 (2개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #277** 에서 진행됩니다.

