### PR TITLE
🔀 :: (#278) 총관리자 알림 발송(전체/특정 회사/특정 사람)

### DIFF
--- a/client/src/components/superadmin/BroadcastPanel.tsx
+++ b/client/src/components/superadmin/BroadcastPanel.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../../api";
+import { confirmAsync, alertAsync } from "../ConfirmHost";
+
+/**
+ * 알림 발송(브로드캐스트) — 전체 / 특정 회사 / 특정 사람에게 제목·설명을 넣어 즉시 알림.
+ * 서버: POST /api/platform/broadcast (platformAdmin/개발자 전용). 표준 알림 경로를 타므로
+ * 벨·SSE·APNs(폰 푸시)·사용자별 알림설정/DND 가 그대로 적용된다.
+ */
+
+type Company = { id: string; name: string; status: string; _count?: { users: number } };
+type PickUser = { id: string; name: string; email: string; company?: { name: string } | null };
+type Target = "all" | "company" | "user";
+
+const TARGETS: { key: Target; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "company", label: "특정 회사" },
+  { key: "user", label: "특정 사람" },
+];
+
+export default function BroadcastPanel() {
+  const [target, setTarget] = useState<Target>("all");
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [companyId, setCompanyId] = useState("");
+  const [q, setQ] = useState("");
+  const [results, setResults] = useState<PickUser[]>([]);
+  const [picked, setPicked] = useState<PickUser | null>(null);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+
+  // '특정 회사' 선택 시 회사 목록 로드(ACTIVE 만). 최초 1회.
+  useEffect(() => {
+    if (target !== "company" || companies.length) return;
+    api<{ companies: Company[] }>("/api/platform/companies")
+      .then((r) => setCompanies(r.companies.filter((c) => c.status === "ACTIVE")))
+      .catch(() => {});
+  }, [target, companies.length]);
+
+  // '특정 사람' 검색 — 이름/이메일 부분일치, debounce 250ms.
+  const tRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (target !== "user") return;
+    if (tRef.current) window.clearTimeout(tRef.current);
+    tRef.current = window.setTimeout(async () => {
+      try {
+        const r = await api<{ users: PickUser[] }>(
+          `/api/platform/users?q=${encodeURIComponent(q.trim())}`,
+        );
+        setResults(r.users);
+      } catch {}
+    }, 250);
+    return () => {
+      if (tRef.current) window.clearTimeout(tRef.current);
+    };
+  }, [q, target]);
+
+  const canSend =
+    title.trim().length > 0 &&
+    !sending &&
+    (target === "all" ||
+      (target === "company" && !!companyId) ||
+      (target === "user" && !!picked));
+
+  function scopeText() {
+    if (target === "all") return "전체 사용자";
+    if (target === "company")
+      return `회사 「${companies.find((c) => c.id === companyId)?.name ?? ""}」`;
+    return `「${picked?.name ?? ""}」`;
+  }
+
+  async function send() {
+    if (!canSend) return;
+    const ok = await confirmAsync({
+      title: "알림을 보낼까요?",
+      description: `${scopeText()} 에게 보냅니다.\n제목: ${title.trim()}\n\n받는 사람의 알림 설정·방해금지(DND) 시간은 그대로 적용됩니다.`,
+      tone: target === "all" ? "danger" : "primary",
+    });
+    if (!ok) return;
+    setSending(true);
+    try {
+      const r = await api<{ count: number }>("/api/platform/broadcast", {
+        method: "POST",
+        json: {
+          target,
+          companyId: target === "company" ? companyId : undefined,
+          userId: target === "user" ? picked?.id : undefined,
+          title: title.trim(),
+          body: body.trim() || undefined,
+        },
+      });
+      await alertAsync({
+        title: "발송 완료",
+        description: `${r.count}명에게 알림을 보냈어요.`,
+      });
+      setTitle("");
+      setBody("");
+    } catch (e: any) {
+      await alertAsync({ title: "발송 실패", description: e?.message || "알림을 보내지 못했어요." });
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="panel p-5 max-w-[640px]">
+      <div className="text-[14px] font-extrabold text-ink-900">알림 발송</div>
+      <div className="text-[12px] text-ink-500 mt-0.5 mb-4">
+        전체 · 특정 회사 · 특정 사람에게 제목과 내용을 넣어 즉시 알림을 보냅니다. 벨·실시간·폰 푸시로 전달돼요.
+      </div>
+
+      {/* 대상 선택 */}
+      <label className="field-label">받는 대상</label>
+      <div className="flex gap-1 p-1 rounded-xl bg-ink-100 mb-3">
+        {TARGETS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTarget(t.key)}
+            className="flex-1 h-9 rounded-lg text-[13px] font-bold transition"
+            style={{
+              background: target === t.key ? "var(--c-surface)" : "transparent",
+              color: target === t.key ? "var(--c-brand)" : "var(--c-text-3)",
+              boxShadow: target === t.key ? "0 1px 3px rgba(20,22,27,0.1)" : "none",
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 특정 회사 */}
+      {target === "company" && (
+        <div className="mb-3">
+          <label className="field-label">회사</label>
+          <select className="input" value={companyId} onChange={(e) => setCompanyId(e.target.value)}>
+            <option value="">회사를 선택하세요</option>
+            {companies.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name} ({c._count?.users ?? 0}명)
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* 특정 사람 */}
+      {target === "user" && (
+        <div className="mb-3">
+          <label className="field-label">받는 사람</label>
+          {picked ? (
+            <div className="flex items-center gap-2 p-2 rounded-lg bg-ink-50 border border-ink-150">
+              <div className="min-w-0 flex-1">
+                <div className="text-[13px] font-bold text-ink-900 truncate">{picked.name}</div>
+                <div className="text-[11px] text-ink-500 truncate">
+                  {picked.email}
+                  {picked.company?.name ? ` · ${picked.company.name}` : ""}
+                </div>
+              </div>
+              <button className="btn-ghost btn-xs" onClick={() => setPicked(null)}>
+                변경
+              </button>
+            </div>
+          ) : (
+            <>
+              <input
+                className="input"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="이름 또는 이메일 검색"
+              />
+              {results.length > 0 && (
+                <div className="mt-1 border border-ink-150 rounded-lg overflow-auto" style={{ maxHeight: 220 }}>
+                  {results.map((u) => (
+                    <button
+                      key={u.id}
+                      type="button"
+                      onClick={() => {
+                        setPicked(u);
+                        setResults([]);
+                        setQ("");
+                      }}
+                      className="w-full text-left px-3 py-2 hover:bg-ink-50 border-b border-ink-100 last:border-0"
+                    >
+                      <div className="text-[13px] font-semibold text-ink-900 truncate">{u.name}</div>
+                      <div className="text-[11px] text-ink-500 truncate">
+                        {u.email}
+                        {u.company?.name ? ` · ${u.company.name}` : ""}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* 제목 · 내용 */}
+      <div className="mb-3">
+        <label className="field-label">제목</label>
+        <input
+          className="input"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={200}
+          placeholder="알림 제목"
+        />
+      </div>
+      <div className="mb-4">
+        <label className="field-label">내용 (선택)</label>
+        <textarea
+          className="input"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          maxLength={2000}
+          rows={4}
+          placeholder="알림 내용"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div className="text-[11.5px] text-ink-500">
+          대상: <b className="text-ink-700">{scopeText()}</b>
+        </div>
+        <button
+          className="btn-primary btn-xs ml-auto"
+          style={{ opacity: canSend ? 1 : 0.5 }}
+          disabled={!canSend}
+          onClick={send}
+        >
+          {sending ? "보내는 중…" : "알림 보내기"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -13,6 +13,7 @@ import HealthPanel from "../components/superadmin/HealthPanel";
 import TrashPanel from "../components/superadmin/TrashPanel";
 import AuditPanel from "../components/superadmin/AuditPanel";
 import FlagsPanel from "../components/superadmin/FlagsPanel";
+import BroadcastPanel from "../components/superadmin/BroadcastPanel";
 import TokensPanel from "../components/superadmin/TokensPanel";
 import SecurityPanel from "../components/superadmin/SecurityPanel";
 import TwoFAPanel from "../components/superadmin/TwoFAPanel";
@@ -52,7 +53,7 @@ type Message = {
   sender: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
 };
 
-type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions" | "errors" | "health" | "trash" | "audit" | "flags" | "tokens" | "security" | "twofa" | "roles";
+type Tab = "logs" | "chat" | "api" | "console" | "server" | "nav" | "sessions" | "errors" | "health" | "trash" | "audit" | "flags" | "tokens" | "security" | "twofa" | "roles" | "broadcast";
 
 type ApiSpecRoute = {
   method: string;
@@ -70,14 +71,14 @@ export type ConsoleGroup = "logs" | "system" | "security" | "devtools";
  *  사내톡 감사(chat)는 평소 숨김이라 목록에 넣지 않고, 잠금 해제 시 logs 그룹에 동적으로 덧붙인다. */
 const GROUP_TABS: Record<ConsoleGroup, Tab[]> = {
   logs: ["logs", "audit", "server", "errors"],
-  system: ["health", "sessions", "trash", "flags", "nav"],
+  system: ["broadcast", "health", "sessions", "trash", "flags", "nav"],
   security: ["security", "twofa", "roles", "tokens"],
   devtools: ["api", "console"],
 };
 
 const TAB_LABEL: Record<Tab, string> = {
   logs: "활동 로그", chat: "사내톡 감사", audit: "감사 로그", server: "서버 로그", errors: "에러",
-  health: "헬스", sessions: "세션", trash: "휴지통", flags: "기능 플래그", nav: "메뉴 관리",
+  health: "헬스", sessions: "세션", trash: "휴지통", flags: "기능 플래그", nav: "메뉴 관리", broadcast: "알림 발송",
   security: "보안 룰", twofa: "2FA 정책", roles: "역할 권한", tokens: "API 토큰",
   api: "API 명세서", console: "콘솔",
 };
@@ -481,6 +482,7 @@ function renderPanel(tab: Tab) {
     case "trash": return <TrashPanel />;
     case "audit": return <AuditPanel />;
     case "flags": return <FlagsPanel />;
+    case "broadcast": return <BroadcastPanel />;
     case "tokens": return <TokensPanel />;
     case "security": return <SecurityPanel />;
     case "twofa": return <TwoFAPanel />;

--- a/server/src/routes/platform.ts
+++ b/server/src/routes/platform.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, requirePlatformAdmin, writeLog } from "../lib/auth.js";
 import { runUnscoped } from "../lib/tenant.js";
+import { notifyMany } from "../lib/notify.js";
 
 /**
  * 플랫폼 운영 API — 회사(테넌트) 가입 승인 워크플로우.
@@ -103,6 +104,104 @@ router.post("/companies/:id/suspend", async (req, res) => {
   });
   await writeLog(u.id, "COMPANY_SUSPEND", company.id, company.name, req.ip);
   res.json({ company: updated });
+});
+
+/* ===========================================================================
+ * 알림 발송(브로드캐스트) — 전체 / 특정 회사 / 특정 사람에게 즉시 알림.
+ * platformAdmin/개발자 전용. 알림 표준 경로(notifyMany)를 타므로 벨·SSE·APNs(폰 푸시)·
+ * 사용자별 알림설정/DND 가 모두 그대로 적용된다.
+ * ======================================================================== */
+
+// 받는 사람 검색(특정 사람 선택용) — 이름/이메일 부분일치, 최대 50명. 회사명 동봉.
+router.get("/users", async (req, res) => {
+  const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+  const companyId =
+    typeof req.query.companyId === "string" && req.query.companyId ? req.query.companyId : null;
+  const where: any = { active: true };
+  if (companyId) where.companyId = companyId;
+  if (q) {
+    where.OR = [
+      { name: { contains: q, mode: "insensitive" } },
+      { email: { contains: q, mode: "insensitive" } },
+    ];
+  }
+  const users = await prisma.user.findMany({
+    where,
+    select: { id: true, name: true, email: true, company: { select: { name: true } } },
+    orderBy: { name: "asc" },
+    take: 50,
+  });
+  res.json({ users });
+});
+
+const broadcastSchema = z.object({
+  target: z.enum(["all", "company", "user"]),
+  companyId: z.string().max(50).optional(),
+  userId: z.string().max(50).optional(),
+  title: z.string().trim().min(1).max(200),
+  body: z.string().trim().max(2000).optional(),
+});
+
+router.post("/broadcast", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = broadcastSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "제목과 대상을 확인해주세요" });
+  const d = parsed.data;
+
+  // 대상 활성 사용자 id 목록 결정.
+  let userIds: string[] = [];
+  let scopeLabel = "";
+  let logTarget = "all";
+  if (d.target === "all") {
+    const users = await prisma.user.findMany({ where: { active: true }, select: { id: true } });
+    userIds = users.map((x) => x.id);
+    scopeLabel = "전체";
+  } else if (d.target === "company") {
+    if (!d.companyId) return res.status(400).json({ error: "회사를 선택해주세요" });
+    const company = await prisma.company.findUnique({
+      where: { id: d.companyId },
+      select: { id: true, name: true },
+    });
+    if (!company) return res.status(404).json({ error: "회사를 찾을 수 없습니다" });
+    const users = await prisma.user.findMany({
+      where: { active: true, companyId: company.id },
+      select: { id: true },
+    });
+    userIds = users.map((x) => x.id);
+    scopeLabel = `회사 「${company.name}」`;
+    logTarget = company.id;
+  } else {
+    if (!d.userId) return res.status(400).json({ error: "받는 사람을 선택해주세요" });
+    const target = await prisma.user.findUnique({
+      where: { id: d.userId },
+      select: { id: true, name: true, active: true },
+    });
+    if (!target) return res.status(404).json({ error: "사용자를 찾을 수 없습니다" });
+    if (!target.active) return res.status(400).json({ error: "비활성 사용자입니다" });
+    userIds = [target.id];
+    scopeLabel = `「${target.name}」`;
+    logTarget = target.id;
+  }
+
+  if (!userIds.length) return res.json({ count: 0 });
+
+  await notifyMany(
+    userIds.map((id) => ({
+      userId: id,
+      type: "SYSTEM" as const,
+      title: d.title,
+      body: d.body,
+      actorName: u.name,
+    })),
+  );
+  await writeLog(
+    u.id,
+    "PLATFORM_BROADCAST",
+    logTarget,
+    `${scopeLabel} · ${d.title} → ${userIds.length}명`,
+    req.ip,
+  );
+  res.json({ count: userIds.length });
 });
 
 export default router;


### PR DESCRIPTION
## 증상
**총관리자 알림 발송(전체/특정 회사/특정 사람)**

새 기능을 추가합니다.

## 원인
총관리자 콘솔(시스템·운영 > 알림 발송)에서 제목·내용을 넣어 즉시 알림을 보냄.

- server/platform.ts (platformAdmin/개발자, 크로스테넌트):
  · GET /api/platform/users?q=&companyId= — 받는 사람 검색(이름·이메일, 최대 50, 회사명 동봉)
  · POST /api/platform/broadcast { target: all|company|user, companyId?, userId?, title, body? }
    → 대상 활성 사용자에게 notifyMany(type SYSTEM). 벨·SSE·APNs(폰 푸시)·사용자
      알림설정/DND 가 표준대로 적용. writeLog(PLATFORM_BROADCAST) 감사 기록.
- client: BroadcastPanel + SuperAdminPage 시스템 그룹에 '알림 발송' 탭.
  대상 세그먼트(전체/특정회사/특정사람) + 회사 셀렉트 / 사용자 검색·선택 +
  제목·내용 + 발송 전 confirm + 결과 토스트.

서버 전용 변경은 마이그레이션 없음. tsc(서버/클라) + vite build 통과.

## 수정
**작업 항목 (커밋 단위)**
- feat: 총관리자 알림 발송(브로드캐스트) — 전체/특정 회사/특정 사람

**변경 대상 (3개 파일)**
- `client/src/components/superadmin/BroadcastPanel.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/routes/platform.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #278** 에서 진행됩니다.

