### PR TITLE
🔀 :: (#279) 글래스 하단 네비를 아이패드에도 (iOS 네이티브 모바일 레이아웃)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -692,7 +692,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
       <ImpersonationBanner safeAreaTop={topSlot === "impersonation"} />
       <div className="flex flex-1 min-h-0">
       {/* 사이드바 — 데스크톱(md+) 전용. 모바일은 하단 바 + /menu 페이지를 쓰므로 숨긴다. */}
-      <aside className="hidden md:flex w-[232px] bg-white border-r border-ink-150 flex-col flex-shrink-0">
+      <aside className="app-sidebar hidden md:flex w-[232px] bg-white border-r border-ink-150 flex-col flex-shrink-0">
         {/* 신호등 영역용 드래그 가능 상단바 — 사이드바 배경과 통일 */}
         {showTitlebarSpace && (
           <div
@@ -1059,14 +1059,17 @@ function BottomNav({ items }: { items: NavItem[] }) {
   const ios = nativePlatform() === "ios";
   return (
     <nav
-      className={"md:hidden flex items-stretch" + (ios ? "" : " flex-shrink-0")}
+      className={"app-bottomnav md:hidden flex items-stretch" + (ios ? "" : " flex-shrink-0")}
       style={
         ios
           ? {
-              // 화면 하단에 12px 여백을 두고 떠 있는 알약형 글래스 바.
+              // 화면 하단에 떠 있는 알약형 글래스 바. 좌우 12px 여백 안에서 중앙 정렬 +
+              // 최대 폭 제한 → 아이패드처럼 넓은 화면에서도 가로로 늘어지지 않고 가운데 알약.
               position: "fixed",
-              left: 12,
-              right: 12,
+              left: "50%",
+              transform: "translateX(-50%)",
+              width: "calc(100% - 24px)",
+              maxWidth: 480,
               bottom: "max(10px, env(safe-area-inset-bottom))",
               zIndex: 30,
               borderRadius: 26,

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -64,13 +64,19 @@
     /* 모바일: 하단 바가 safe-area 를 책임지므로 본문은 24px 만(이중 여백 방지). */
     --hinest-main-pb: 24px;
   }
-  /* iOS 네이티브(아이폰): 하단 네비가 플로팅 글래스(position:fixed → out-of-flow)라
-     본문 끝이 바 아래로 가리지 않도록 [바 높이 ~60px + 하단 오프셋 + 여유] 만큼 패딩.
-     html.hinest-ios 는 AppLayout 이 iOS 네이티브일 때만 토글 → 웹/안드/데스크톱 무영향. */
-  html.hinest-ios {
-    --hinest-main-pb: calc(60px + max(10px, env(safe-area-inset-bottom)) + 14px);
-  }
 }
+
+/* iOS 네이티브(아이폰·아이패드): 폭과 무관하게 모바일 레이아웃(플로팅 글래스 하단 네비)을 쓴다.
+   아이패드(≥768px)도 사이드바 대신 하단 글래스 바를 쓰도록 사이드바를 숨기고 하단 바를
+   강제 노출한다. html.hinest-ios 는 iOS 네이티브에서만 붙으므로 웹·안드·데스크톱은 무영향. */
+html.hinest-ios {
+  /* 플로팅 글래스 바(out-of-flow) 클리어런스 — 전 폭 공통. */
+  --hinest-main-pb: calc(60px + max(10px, env(safe-area-inset-bottom)) + 14px);
+  /* ChatFab(우하단)을 글래스 바 위로 띄우는 높이(아이패드에서 FAB 노출 시). */
+  --hinest-bottomnav-h: 78px;
+}
+html.hinest-ios .app-sidebar { display: none !important; }
+html.hinest-ios .app-bottomnav { display: flex !important; }
 
 html.dark {
   color-scheme: dark;


### PR DESCRIPTION
## 증상
**글래스 하단 네비를 아이패드에도 (iOS 네이티브 모바일 레이아웃)**

새 기능을 추가합니다.

## 원인
아이패드는 폭이 md(768px) 이상이라 사이드바를 썼는데, iOS 네이티브에선 폭과
무관하게 하단 글래스 바를 쓰도록 변경 — 아이폰·아이패드 모두 동일한 글래스 네비.

- styles.css: html.hinest-ios 에서
  · .app-sidebar { display:none } — 데스크톱 사이드바 숨김(아이패드 포함)
  · .app-bottomnav { display:flex } — md:hidden 을 덮어 아이패드에서도 하단 바 노출
  · --hinest-main-pb 클리어런스를 전 폭 공통으로(미디어쿼리 밖) → 아이패드도 본문이
    플로팅 바에 안 가림
  · --hinest-bottomnav-h:78px → 아이패드에서 노출되는 ChatFab 을 글래스 바 위로 띄움
- AppLayout: 사이드바 <aside> 에 app-sidebar, 하단 <nav> 에 app-bottomnav 훅 추가.
  글래스 바를 좌우 12px 안에서 중앙정렬 + maxWidth 480 알약으로 → 넓은 아이패드에서도
  가로로 늘어지지 않고 가운데 알약으로 보임.

웹·안드로이드·Electron 데스크톱은 hinest-ios 미적용이라 기존 사이드바 그대로(무회귀).
클라이언트 전용. tsc + vite build 통과.

## 수정
**작업 항목 (커밋 단위)**
- feat(mobile): 글래스 하단 네비를 아이패드에도 적용 (iOS 네이티브 = 모바일 레이아웃)

**변경 대상 (2개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #279** 에서 진행됩니다.

