### PR TITLE
🔀 :: (#280) 진짜 네이티브 Liquid Glass 하단 탭 바 (UIGlassEffect)

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -59,3 +59,163 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
+
+// ============================================================================
+// 네이티브 Liquid Glass 하단 탭 바 (iOS 26 UIGlassEffect)
+//  - 웹(WebView) 위에 실제 애플 Liquid Glass 머티리얼의 "떠 있는" 탭 바를 올린다.
+//  - 탭 선택은 notifyListeners("tabSelected") 로 웹 라우터에 전달, 웹은 현재 경로를
+//    setSelected 로 다시 알려 하이라이트를 동기화한다.
+//  - iOS 26 미만 / 호스트 뷰 없음 → configure 가 reject → 웹 CSS 글래스 바가 그대로 폴백.
+//    (즉 이 플러그인이 동작하지 않아도 앱은 절대 깨지지 않는다.)
+// ============================================================================
+@objc(LiquidGlassTabBarPlugin)
+public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "LiquidGlassTabBarPlugin"
+    public let jsName = "LiquidGlassTabBar"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "configure", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setSelected", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setBadge", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setVisible", returnType: CAPPluginReturnPromise),
+    ]
+
+    private var glassView: UIView?
+    private var buttons: [UIButton] = []
+    private var keys: [String] = []
+    private var badgeViews: [String: UILabel] = [:]
+    private let brandColor = UIColor(red: 0x3B / 255.0, green: 0x5C / 255.0, blue: 0xF0 / 255.0, alpha: 1.0)
+
+    @objc func configure(_ call: CAPPluginCall) {
+        let tabs = call.getArray("tabs", JSObject.self) ?? []
+        DispatchQueue.main.async {
+            guard #available(iOS 26.0, *) else { call.reject("liquid-glass-unavailable"); return }
+            guard let host = self.bridge?.viewController?.view else { call.reject("no-host-view"); return }
+            self.build(host: host, tabs: tabs)
+            call.resolve(["active": true])
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func build(host: UIView, tabs: [JSObject]) {
+        glassView?.removeFromSuperview()
+        buttons.removeAll(); keys.removeAll(); badgeViews.removeAll()
+
+        // 실제 애플 Liquid Glass 머티리얼.
+        let effectView = UIVisualEffectView(effect: UIGlassEffect())
+        effectView.translatesAutoresizingMaskIntoConstraints = false
+        effectView.layer.cornerRadius = 26
+        effectView.clipsToBounds = true
+        host.addSubview(effectView)
+
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.distribution = .fillEqually
+        stack.alignment = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        effectView.contentView.addSubview(stack)
+
+        for (i, tab) in tabs.enumerated() {
+            let key = (tab["key"] as? String) ?? ""
+            let title = (tab["title"] as? String) ?? ""
+            let sf = (tab["sf"] as? String) ?? "circle"
+            keys.append(key)
+
+            var cfg = UIButton.Configuration.plain()
+            cfg.image = UIImage(systemName: sf)
+            cfg.imagePlacement = .top
+            cfg.imagePadding = 3
+            cfg.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(pointSize: 18, weight: .semibold)
+            var cont = AttributeContainer()
+            cont.font = UIFont.systemFont(ofSize: 10.5, weight: .semibold)
+            cfg.attributedTitle = AttributedString(title, attributes: cont)
+            cfg.baseForegroundColor = .secondaryLabel
+
+            let btn = UIButton(configuration: cfg)
+            btn.tag = i
+            btn.addTarget(self, action: #selector(self.onTap(_:)), for: .touchUpInside)
+            stack.addArrangedSubview(btn)
+            buttons.append(btn)
+        }
+
+        let guide = host.safeAreaLayoutGuide
+        let widthC = effectView.widthAnchor.constraint(equalTo: guide.widthAnchor, constant: -24)
+        widthC.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: effectView.contentView.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: effectView.contentView.bottomAnchor),
+            stack.leadingAnchor.constraint(equalTo: effectView.contentView.leadingAnchor, constant: 6),
+            stack.trailingAnchor.constraint(equalTo: effectView.contentView.trailingAnchor, constant: -6),
+            effectView.centerXAnchor.constraint(equalTo: guide.centerXAnchor),
+            effectView.bottomAnchor.constraint(equalTo: guide.bottomAnchor, constant: -8),
+            effectView.heightAnchor.constraint(equalToConstant: 58),
+            effectView.widthAnchor.constraint(lessThanOrEqualToConstant: 480),
+            widthC,
+        ])
+        glassView = effectView
+    }
+
+    @objc private func onTap(_ sender: UIButton) {
+        let i = sender.tag
+        guard i >= 0, i < keys.count else { return }
+        applySelected(i)
+        notifyListeners("tabSelected", data: ["key": keys[i]])
+    }
+
+    private func applySelected(_ index: Int) {
+        for (i, btn) in buttons.enumerated() {
+            guard var cfg = btn.configuration else { continue }
+            cfg.baseForegroundColor = (i == index) ? brandColor : .secondaryLabel
+            btn.configuration = cfg
+        }
+    }
+
+    @objc func setSelected(_ call: CAPPluginCall) {
+        let key = call.getString("key") ?? ""
+        DispatchQueue.main.async {
+            self.applySelected(self.keys.firstIndex(of: key) ?? -1)
+            call.resolve()
+        }
+    }
+
+    @objc func setVisible(_ call: CAPPluginCall) {
+        let visible = call.getBool("visible") ?? true
+        DispatchQueue.main.async {
+            self.glassView?.isHidden = !visible
+            call.resolve()
+        }
+    }
+
+    @objc func setBadge(_ call: CAPPluginCall) {
+        let key = call.getString("key") ?? ""
+        let count = call.getInt("count") ?? 0
+        DispatchQueue.main.async {
+            self.updateBadge(key: key, count: count)
+            call.resolve()
+        }
+    }
+
+    private func updateBadge(key: String, count: Int) {
+        guard let i = keys.firstIndex(of: key), i < buttons.count else { return }
+        badgeViews[key]?.removeFromSuperview()
+        badgeViews[key] = nil
+        guard count > 0 else { return }
+        let btn = buttons[i]
+        let badge = UILabel()
+        badge.text = count > 99 ? "99+" : "\(count)"
+        badge.font = UIFont.systemFont(ofSize: 10, weight: .bold)
+        badge.textColor = .white
+        badge.textAlignment = .center
+        badge.backgroundColor = .systemRed
+        badge.layer.cornerRadius = 8
+        badge.clipsToBounds = true
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        btn.addSubview(badge)
+        NSLayoutConstraint.activate([
+            badge.heightAnchor.constraint(equalToConstant: 16),
+            badge.widthAnchor.constraint(greaterThanOrEqualToConstant: 16),
+            badge.topAnchor.constraint(equalTo: btn.topAnchor, constant: 1),
+            badge.centerXAnchor.constraint(equalTo: btn.centerXAnchor, constant: 13),
+        ])
+        badgeViews[key] = badge
+    }
+}

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -19,6 +19,7 @@ import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
 import { isPreviewMode } from "../lib/previewMock";
 import { isInstalledApp, nativePlatform } from "../lib/platform";
+import { LiquidGlassTabBar } from "../lib/liquidGlassTabBar";
 
 /**
  * 사이드바 hover/focus prefetch — 사용자가 클릭하기 전에 해당 페이지 청크를
@@ -452,6 +453,22 @@ const BOTTOM_NAV: NavItem[] = [
   { to: "/meetings", label: "회의록", icon: MeetingIcon },
 ];
 
+/** 네이티브 Liquid Glass 탭 바 구성(iOS). 웹 BOTTOM_NAV + "전체" 와 동일 순서, SF Symbol 매핑. */
+const NATIVE_GLASS_TABS = [
+  { key: "/", title: "개요", sf: "house.fill" },
+  { key: "/schedule", title: "일정", sf: "calendar" },
+  { key: "/approvals", title: "전자결재", sf: "checkmark.seal.fill" },
+  { key: "/meetings", title: "회의록", sf: "doc.text.fill" },
+  { key: "/menu", title: "전체", sf: "line.3.horizontal" },
+];
+/** 현재 경로에 해당하는 네이티브 탭 key. 일치 없으면 빈 문자열(하이라이트 없음). */
+function matchNativeTabKey(pathname: string): string {
+  for (const k of ["/schedule", "/approvals", "/meetings", "/menu"]) {
+    if (pathname === k || pathname.startsWith(k + "/")) return k;
+  }
+  return pathname === "/" ? "/" : "";
+}
+
 export default function AppLayout({ children }: { children?: React.ReactNode } = {}) {
   return (
     <NotificationProvider>
@@ -658,6 +675,41 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     el.classList.toggle("hinest-ios", nativePlatform() === "ios");
     return () => el.classList.remove("hinest-shell-lock");
   }, []);
+
+  // 네이티브 Liquid Glass 탭 바(iOS 26 UIGlassEffect) — 성공하면 웹 하단 바를 숨기고
+  // 실제 애플 글래스 바가 대체한다. 미지원(iOS<26)/실패면 아무 일도 없고 웹 CSS 글래스 바가 폴백.
+  useEffect(() => {
+    if (nativePlatform() !== "ios") return;
+    let cancelled = false;
+    let removeListener: (() => void) | undefined;
+    (async () => {
+      try {
+        const res = await LiquidGlassTabBar.configure({ tabs: NATIVE_GLASS_TABS });
+        if (cancelled || !res?.active) return;
+        document.documentElement.classList.add("hinest-native-tabbar");
+        const handle = await LiquidGlassTabBar.addListener("tabSelected", (d) => {
+          if (d?.key) nav(d.key);
+        });
+        removeListener = () => { try { void handle?.remove?.(); } catch {} };
+        LiquidGlassTabBar.setSelected({ key: matchNativeTabKey(window.location.pathname) }).catch(() => {});
+      } catch {
+        // iOS<26 / 미지원 → 웹 CSS 글래스 바 폴백(아무 것도 하지 않음).
+      }
+    })();
+    return () => {
+      cancelled = true;
+      removeListener?.();
+      document.documentElement.classList.remove("hinest-native-tabbar");
+      LiquidGlassTabBar.setVisible({ visible: false }).catch(() => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 경로 변화 → 네이티브 탭 하이라이트 동기화.
+  useEffect(() => {
+    if (nativePlatform() !== "ios") return;
+    LiquidGlassTabBar.setSelected({ key: matchNativeTabKey(pathname) }).catch(() => {});
+  }, [pathname]);
 
   // 모바일 당겨서 새로고침 — main 스크롤러에 ref 를 물려 제스처를 감지한다.
   // 당김 비주얼(인디케이터·링·본문 오프셋)은 훅이 ref 로 직접 DOM 에 쓰므로

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -1,0 +1,33 @@
+import { registerPlugin } from "@capacitor/core";
+
+/**
+ * 네이티브 Liquid Glass 하단 탭 바 브리지 (iOS 26 UIGlassEffect).
+ * 네이티브 구현은 ios/App/App/AppDelegate.swift 의 LiquidGlassTabBarPlugin.
+ *
+ * - configure: 탭 구성 + 바 생성. iOS 26 미만/실패 시 reject → 호출부가 catch 해서
+ *   웹 CSS 글래스 바를 그대로 폴백으로 둔다(앱이 깨지지 않음).
+ * - tabSelected 이벤트: 네이티브 탭을 누르면 발생 → 웹 라우터가 해당 경로로 이동.
+ * - setSelected: 웹 경로 변화 시 네이티브 하이라이트 동기화.
+ */
+
+export interface LiquidGlassTab {
+  /** 라우트 경로 (예: "/schedule"). tabSelected 시 그대로 전달된다. */
+  key: string;
+  /** 탭 라벨. */
+  title: string;
+  /** SF Symbol 이름 (예: "house.fill"). */
+  sf: string;
+}
+
+export interface LiquidGlassTabBarPlugin {
+  configure(options: { tabs: LiquidGlassTab[] }): Promise<{ active: boolean }>;
+  setSelected(options: { key: string }): Promise<void>;
+  setBadge(options: { key: string; count: number }): Promise<void>;
+  setVisible(options: { visible: boolean }): Promise<void>;
+  addListener(
+    eventName: "tabSelected",
+    listenerFunc: (data: { key: string }) => void,
+  ): Promise<{ remove: () => Promise<void> }>;
+}
+
+export const LiquidGlassTabBar = registerPlugin<LiquidGlassTabBarPlugin>("LiquidGlassTabBar");

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -77,6 +77,10 @@ html.hinest-ios {
 }
 html.hinest-ios .app-sidebar { display: none !important; }
 html.hinest-ios .app-bottomnav { display: flex !important; }
+/* 네이티브 Liquid Glass 탭 바가 활성화되면(JS 가 configure 성공 시 .hinest-native-tabbar 추가)
+   웹 하단 바를 숨긴다 — 네이티브 바가 대체. configure 실패/iOS<26 이면 클래스가 안 붙어 웹 바 폴백.
+   (이 규칙이 위 hinest-ios .app-bottomnav 보다 뒤라 둘 다 있을 때 display:none 이 이긴다.) */
+html.hinest-native-tabbar .app-bottomnav { display: none !important; }
 
 html.dark {
   color-scheme: dark;


### PR DESCRIPTION
## 증상
**진짜 네이티브 Liquid Glass 하단 탭 바 (UIGlassEffect)**

새 기능을 추가합니다.

## 원인
CSS 모방이 아니라 실제 애플 Liquid Glass 머티리얼을 사용한다.

- AppDelegate.swift: LiquidGlassTabBarPlugin (Capacitor 플러그인). 웹 WebView 위에
  UIVisualEffectView(effect: UIGlassEffect()) 의 떠 있는 알약형 탭 바를 올리고,
  탭 탭 → notifyListeners('tabSelected') 로 웹 라우터에 전달. configure/setSelected/
  setBadge/setVisible 제공. iOS 26 미만/호스트뷰 없음 → reject.
- lib/liquidGlassTabBar.ts: registerPlugin 브리지(타입 포함).
- AppLayout: iOS 네이티브에서 configure 성공 시 .hinest-native-tabbar 추가 → 웹 하단
  바 숨김(네이티브 바가 대체) + tabSelected→nav, 경로변화→setSelected 동기화.
  실패/미지원이면 아무 것도 안 함 → 웹 CSS 글래스 바가 그대로 폴백(앱 무손상).
- styles.css: html.hinest-native-tabbar .app-bottomnav { display:none }.

웹/데스크톱/안드로이드 무영향. 웹 빌드(tsc+vite) 통과. Swift 는 Xcode(26 SDK)에서 컴파일.
알려진 한계: 웹 모달 위에 네이티브 바가 떠 있음(후속에서 모달 시 setVisible(false) 예정).

## 수정
**작업 항목 (커밋 단위)**
- feat(ios): 진짜 네이티브 Liquid Glass 하단 탭 바 (UIGlassEffect, iOS 26)

**변경 대상 (4개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/src/components/AppLayout.tsx`
- `client/src/lib/liquidGlassTabBar.ts`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #280** 에서 진행됩니다.

