### PR TITLE
🔀 :: (#281) 회의록 타이틀 + 달력 풀블리드

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1605,6 +1605,7 @@ const BREADCRUMB: Record<string, string> = {
   "/accounts": "계정 관리",
   "/snippets": "스니펫",
   "/approvals": "전자결재",
+  "/meetings": "회의록",
   "/expense": "법인카드",
   "/admin": "관리자",
   "/profile": "내 프로필",

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -221,7 +221,7 @@ export default function SchedulePage() {
         }
       />
 
-      <div className="card p-0 overflow-hidden">
+      <div className="card cal-fullbleed p-0 overflow-hidden">
         <div className="grid grid-cols-7 bg-slate-50 border-b border-slate-100">
           {["일", "월", "화", "수", "목", "금", "토"].map((d, i) => (
             <div key={d} className={`px-1 sm:px-3 py-2 text-[11px] sm:text-xs font-bold text-center ${i === 0 ? "text-rose-500" : i === 6 ? "text-accent-500" : "text-ink-500"}`}>
@@ -248,7 +248,7 @@ export default function SchedulePage() {
             return (
               <div
                 key={i}
-                className={`min-h-[64px] sm:min-h-[110px] border-b border-r border-ink-100 p-1 sm:p-2 ${
+                className={`min-h-[64px] sm:min-h-[110px] border-b border-ink-100 ${i % 7 !== 6 ? "border-r" : ""} p-1 sm:p-2 ${
                   holiday ? "bg-rose-50/40 dark:bg-rose-500/10" : ""
                 } ${d ? "cursor-pointer sm:cursor-default hover:bg-ink-25 sm:hover:bg-transparent" : ""}`}
                 onClick={() => {

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -294,6 +294,17 @@ html.dark .panel {
   .card { padding: 14px; }
   .card-tight { padding: 10px; }
 }
+/* 모바일에서 달력 등을 화면 양끝까지 꽉 채운다 — 본문 px-4(16px) 를 상쇄하고
+   좌우 테두리/모서리를 없애 '양끝 선' 제거. 데스크톱(md+)은 카드 그대로. */
+@media (max-width: 767.98px) {
+  .cal-fullbleed {
+    margin-left: -16px;
+    margin-right: -16px;
+    border-left-width: 0;
+    border-right-width: 0;
+    border-radius: 0;
+  }
+}
 
 .section-head {
   display: flex;


### PR DESCRIPTION
## 증상
**회의록 타이틀 + 달력 풀블리드**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- 회의록(/meetings) 이 BREADCRUMB 맵에 없어 상단바에 'HiNest' 로 표시되던 것 →
  '회의록' 으로 수정.
- 일정 달력이 모바일에서 좁아 보이고 좌우 테두리(양끝 선)가 있던 것 → .cal-fullbleed
  로 본문 px-4 를 상쇄해 화면 양끝까지 확장 + 좌우 테두리/모서리 제거, 그리드도
  마지막 열 border-r 제거. 데스크톱(md+)은 기존 카드 그대로.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 회의록 상단 타이틀 표기 + 달력 모바일 풀블리드

**변경 대상 (3개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/pages/SchedulePage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #281** 에서 진행됩니다.

