### PR TITLE
🔀 :: (#284) 네이티브 글래스 플러그인 등록 + 일정 좌우 스크롤

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -85,12 +85,28 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
     private var badgeViews: [String: UILabel] = [:]
     private let brandColor = UIColor(red: 0x3B / 255.0, green: 0x5C / 255.0, blue: 0xF0 / 255.0, alpha: 1.0)
 
+    override public func load() {
+        NSLog("[LGTB] plugin loaded (discovered by Capacitor)")
+    }
+
     @objc func configure(_ call: CAPPluginCall) {
         let tabs = call.getArray("tabs", JSObject.self) ?? []
+        NSLog("[LGTB] configure called, tabs=\(tabs.count)")
         DispatchQueue.main.async {
-            guard #available(iOS 26.0, *) else { call.reject("liquid-glass-unavailable"); return }
-            guard let host = self.bridge?.viewController?.view else { call.reject("no-host-view"); return }
-            self.build(host: host, tabs: tabs)
+            if #available(iOS 26.0, *) {
+                NSLog("[LGTB] iOS 26 available")
+            } else {
+                NSLog("[LGTB] iOS <26 -> reject")
+                call.reject("liquid-glass-unavailable"); return
+            }
+            guard let host = self.bridge?.viewController?.view else {
+                NSLog("[LGTB] no host view -> reject")
+                call.reject("no-host-view"); return
+            }
+            if #available(iOS 26.0, *) {
+                self.build(host: host, tabs: tabs)
+            }
+            NSLog("[LGTB] configured, active=true")
             call.resolve(["active": true])
         }
     }
@@ -217,5 +233,15 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
             badge.centerXAnchor.constraint(equalTo: btn.centerXAnchor, constant: 13),
         ])
         badgeViews[key] = badge
+    }
+}
+
+/// Capacitor 브리지 VC 서브클래스.
+/// 앱에 직접 넣은(app-local) 플러그인은 Capacitor 가 자동 발견하지 못하므로(npm 패키지
+/// 플러그인만 자동 등록됨) 여기서 명시적으로 등록한다. Main.storyboard 의 customClass 를
+/// 이 클래스로 지정해야 적용된다.
+class MainViewController: CAPBridgeViewController {
+    override func capacitorDidLoad() {
+        bridge?.registerPluginInstance(LiquidGlassTabBarPlugin())
     }
 }

--- a/client/ios/App/App/Base.lproj/Main.storyboard
+++ b/client/ios/App/App/Base.lproj/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Bridge View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="CAPBridgeViewController" customModule="Capacitor" sceneMemberID="viewController"/>
+                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="App" customModuleProvider="target" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
         </scene>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -298,8 +298,13 @@ html.dark .panel {
    좌우 테두리/모서리를 없애 '양끝 선' 제거. 데스크톱(md+)은 카드 그대로. */
 @media (max-width: 767.98px) {
   .cal-fullbleed {
-    margin-left: -16px;
-    margin-right: -16px;
+    /* 부모 패딩과 무관하게 정확히 뷰포트 폭으로 풀블리드 — 음수 마진(-16px)은 중첩
+       패딩이 있으면 좌우 스크롤을 유발할 수 있어, width:100vw + calc 중앙정렬로 교체.
+       100vw = 화면 폭이라 가로 오버플로(좌우 스크롤)가 생기지 않는다. */
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: calc(50% - 50vw);
+    margin-right: calc(50% - 50vw);
     border-left-width: 0;
     border-right-width: 0;
     border-radius: 0;


### PR DESCRIPTION
## 증상
**네이티브 글래스 플러그인 등록 + 일정 좌우 스크롤**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
증상: 시뮬레이터(iOS 26)에서도 글래스 바가 안 뜨고 CSS 폴백만 보임.
원인: 앱 내장(app-local) 플러그인은 Capacitor 8/SPM 에서 자동 발견되지 않는다
(npm 패키지 플러그인만 자동 등록). 그래서 LiquidGlassTabBar.configure 가 '미구현'
으로 reject → 항상 CSS 폴백. (시뮬레이터 로그로 'plugin loaded' 미출력 확인.)

해결: CAPBridgeViewController 서브클래스(MainViewController)의 capacitorDidLoad 에서
bridge.registerPluginInstance(LiquidGlassTabBarPlugin()) 로 등록하고, Main.storyboard
의 customClass 를 MainViewController(App 모듈) 로 지정.
검증: 시뮬레이터 빌드·실행 로그에 '[LGTB] plugin loaded' 출력 확인. (진단 NSLog 유지)

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 네이티브 Liquid Glass 플러그인을 명시적으로 등록
- fix(mobile): 일정 달력 풀블리드를 100vw 기반으로 — 좌우 스크롤 제거

**변경 대상 (3개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/ios/App/App/Base.lproj/Main.storyboard`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #284** 에서 진행됩니다.

