### PR TITLE
🔀 :: (#285) 로그아웃 애플 확인 시트 + 둘러보기 노치 수정

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -77,6 +77,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "setSelected", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setBadge", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setVisible", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "confirm", returnType: CAPPluginReturnPromise),
     ]
 
     private var glassView: UIView?
@@ -198,6 +199,35 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         DispatchQueue.main.async {
             self.glassView?.isHidden = !visible
             call.resolve()
+        }
+    }
+
+    /// 애플 기본 확인 시트(UIAlertController .actionSheet) — 로그아웃 등 재확인용.
+    /// resolve({confirmed}). VC 없으면 confirmed:false.
+    @objc func confirm(_ call: CAPPluginCall) {
+        let title = call.getString("title")
+        let message = call.getString("message")
+        let confirmText = call.getString("confirmText") ?? "확인"
+        let cancelText = call.getString("cancelText") ?? "취소"
+        let destructive = call.getBool("destructive") ?? false
+        DispatchQueue.main.async {
+            guard let vc = self.bridge?.viewController else {
+                call.resolve(["confirmed": false]); return
+            }
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
+            alert.addAction(UIAlertAction(title: confirmText, style: destructive ? .destructive : .default) { _ in
+                call.resolve(["confirmed": true])
+            })
+            alert.addAction(UIAlertAction(title: cancelText, style: .cancel) { _ in
+                call.resolve(["confirmed": false])
+            })
+            // 아이패드는 액션시트에 앵커가 필요(없으면 크래시) — 화면 하단 중앙에 앵커.
+            if let pop = alert.popoverPresentationController {
+                pop.sourceView = vc.view
+                pop.sourceRect = CGRect(x: vc.view.bounds.midX, y: vc.view.bounds.maxY - 40, width: 0, height: 0)
+                pop.permittedArrowDirections = []
+            }
+            vc.present(alert, animated: true)
         }
     }
 

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -20,6 +20,7 @@ import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
 import { isPreviewMode } from "../lib/previewMock";
 import { isInstalledApp, nativePlatform } from "../lib/platform";
 import { LiquidGlassTabBar } from "../lib/liquidGlassTabBar";
+import { confirmLogout } from "../lib/confirmLogout";
 
 /**
  * 사이드바 hover/focus prefetch — 사용자가 클릭하기 전에 해당 페이지 청크를
@@ -864,6 +865,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
             {isDevAccount(user) && <DevQuickToggle />}
             <button
               onClick={async () => {
+                if (!(await confirmLogout())) return;
                 await logout();
                 nav("/login");
               }}
@@ -1331,7 +1333,7 @@ export function MobileMenuPage() {
       {/* 로그아웃 */}
       <button
         type="button"
-        onClick={async () => { await logout(); nav("/login"); }}
+        onClick={async () => { if (!(await confirmLogout())) return; await logout(); nav("/login"); }}
         className="w-full flex items-center justify-center gap-2 h-[46px] rounded-full border border-ink-150 text-[13px] font-bold text-ink-600 hover:bg-ink-100 hover:text-ink-900 transition"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 import AdminLockup from "./AdminLockup";
+import { confirmLogout } from "../lib/confirmLogout";
 
 /**
  * 운영 콘솔 셸 — 총관리자(개발자)/플랫폼 운영자 전용. 회사 앱(AppLayout)과
@@ -86,6 +87,7 @@ export default function ConsoleLayout() {
   const hasCompany = !!user?.companyId;
 
   async function doLogout() {
+    if (!(await confirmLogout())) return;
     await logout();
     nav("/login");
   }

--- a/client/src/components/PreviewOnboarding.tsx
+++ b/client/src/components/PreviewOnboarding.tsx
@@ -121,8 +121,11 @@ export default function PreviewOnboarding() {
       {/* 미세 그레인 노이즈 (SVG) — AI 룩 탈피용 텍스처 */}
       <div className="hinest-onb-noise" aria-hidden />
 
-      {/* 상단 바 — 브랜드 마크 + 챕터 카운터 + 건너뛰기 */}
-      <div className="hinest-onb-topbar absolute top-0 left-0 right-0 flex items-center justify-between px-6 sm:px-8 pt-6">
+      {/* 상단 바 — 브랜드 마크 + 챕터 카운터 + 건너뛰기. 노치/다이내믹아일랜드 회피용 safe-area 패딩. */}
+      <div
+        className="hinest-onb-topbar absolute top-0 left-0 right-0 flex items-center justify-between px-6 sm:px-8"
+        style={{ paddingTop: "max(24px, calc(env(safe-area-inset-top) + 8px))" }}
+      >
         <div className="flex items-center gap-2.5">
           <span
             className="inline-block rounded-md"

--- a/client/src/lib/confirmLogout.ts
+++ b/client/src/lib/confirmLogout.ts
@@ -1,0 +1,32 @@
+import { isCapacitorNative } from "./platform";
+import { LiquidGlassTabBar } from "./liquidGlassTabBar";
+import { confirmAsync } from "../components/ConfirmHost";
+
+/**
+ * 로그아웃 전 재확인.
+ * - 네이티브 iOS: 애플 기본 확인 시트(UIAlertController .actionSheet) — 빨간 "로그아웃" + "취소".
+ * - 웹/데스크톱(또는 네이티브 confirm 실패 시): 기존 웹 confirm(ConfirmHost) 폴백.
+ * 반환 true = 로그아웃 진행.
+ */
+export async function confirmLogout(): Promise<boolean> {
+  if (isCapacitorNative()) {
+    try {
+      const r = await LiquidGlassTabBar.confirm({
+        title: "로그아웃",
+        message: "정말 로그아웃할까요?",
+        confirmText: "로그아웃",
+        cancelText: "취소",
+        destructive: true,
+      });
+      return !!r?.confirmed;
+    } catch {
+      // 네이티브 시트 실패 → 웹 폴백.
+    }
+  }
+  const ok = await confirmAsync({
+    title: "로그아웃",
+    description: "정말 로그아웃할까요?",
+    tone: "danger",
+  });
+  return ok === true;
+}

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -24,6 +24,14 @@ export interface LiquidGlassTabBarPlugin {
   setSelected(options: { key: string }): Promise<void>;
   setBadge(options: { key: string; count: number }): Promise<void>;
   setVisible(options: { visible: boolean }): Promise<void>;
+  /** 애플 기본 확인 시트(action sheet). 로그아웃 등 재확인용. */
+  confirm(options: {
+    title?: string;
+    message?: string;
+    confirmText?: string;
+    cancelText?: string;
+    destructive?: boolean;
+  }): Promise<{ confirmed: boolean }>;
   addListener(
     eventName: "tabSelected",
     listenerFunc: (data: { key: string }) => void,


### PR DESCRIPTION
## 증상
**로그아웃 애플 확인 시트 + 둘러보기 노치 수정**

새 기능을 추가합니다.

## 원인
로그아웃 버튼 → '정말 로그아웃할까요?' 재확인 후 진행.
- 네이티브 플러그인에 confirm 메서드 추가: UIAlertController(.actionSheet) 로
  애플 기본 액션시트(빨간 '로그아웃' + '취소'). 아이패드 앵커 처리 포함.
- lib/confirmLogout: 네이티브 iOS 면 액션시트, 그 외/실패 시 웹 confirm 폴백.
- 로그아웃 3곳(사이드바·모바일 메뉴·운영 콘솔) 모두 confirmLogout 경유.

## 수정
**작업 항목 (커밋 단위)**
- feat(mobile): 로그아웃 시 애플 기본 확인 시트로 재확인
- fix(mobile): 둘러보기 온보딩 상단바 노치 침범 수정

**변경 대상 (6개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/src/components/AppLayout.tsx`
- `client/src/components/ConsoleLayout.tsx`
- `client/src/components/PreviewOnboarding.tsx`
- `client/src/lib/confirmLogout.ts`
- `client/src/lib/liquidGlassTabBar.ts`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #285** 에서 진행됩니다.

