### PR TITLE
🔀 :: (#289) 풀스크린 화면에서 네이티브 탭 바 숨김 (채팅·알림·모달)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -19,7 +19,7 @@ import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
 import { isPreviewMode } from "../lib/previewMock";
 import { isInstalledApp, nativePlatform } from "../lib/platform";
-import { LiquidGlassTabBar } from "../lib/liquidGlassTabBar";
+import { LiquidGlassTabBar, setNativeTabBarHidden, syncNativeTabBarVisibility } from "../lib/liquidGlassTabBar";
 import { confirmLogout } from "../lib/confirmLogout";
 
 /**
@@ -693,6 +693,8 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
         });
         removeListener = () => { try { void handle?.remove?.(); } catch {} };
         LiquidGlassTabBar.setSelected({ key: matchNativeTabKey(window.location.pathname) }).catch(() => {});
+        // 바 생성 직후 현재 숨김 사유(채팅·모달·라우트) 기준으로 가시성 재적용.
+        syncNativeTabBarVisibility();
       } catch {
         // iOS<26 / 미지원 → 웹 CSS 글래스 바 폴백(아무 것도 하지 않음).
       }
@@ -706,11 +708,34 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 경로 변화 → 네이티브 탭 하이라이트 동기화.
+  // 경로 변화 → 네이티브 탭 하이라이트 동기화 + 포커스 화면(알림 등)에선 바 숨김.
   useEffect(() => {
     if (nativePlatform() !== "ios") return;
     LiquidGlassTabBar.setSelected({ key: matchNativeTabKey(pathname) }).catch(() => {});
+    // 하단 바를 숨길 라우트(전체 화면 포커스 뷰).
+    const hideOnRoutes = ["/notifications"];
+    setNativeTabBarHidden("route", hideOnRoutes.some((r) => pathname === r || pathname.startsWith(r + "/")));
   }, [pathname]);
+
+  // 모달이 열려 있는 동안 네이티브 바 숨김. 모달 오버레이는 .modal-safe 로 표시돼 있으므로
+  // DOM 에 그게 존재하는지 관찰한다. (채팅 풀스크린은 ChatFab 이 별도로 'chat' 사유로 숨김.)
+  useEffect(() => {
+    if (nativePlatform() !== "ios") return;
+    let raf = 0;
+    const check = () => {
+      raf = 0;
+      setNativeTabBarHidden("modal", !!document.querySelector(".modal-safe"));
+    };
+    const schedule = () => { if (!raf) raf = requestAnimationFrame(check); };
+    const obs = new MutationObserver(schedule);
+    obs.observe(document.body, { childList: true, subtree: true });
+    check();
+    return () => {
+      obs.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+      setNativeTabBarHidden("modal", false);
+    };
+  }, []);
 
   // 모바일 당겨서 새로고침 — main 스크롤러에 ref 를 물려 제스처를 감지한다.
   // 당김 비주얼(인디케이터·링·본문 오프셋)은 훅이 ref 로 직접 DOM 에 쓰므로

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, lazy, Suspense } from "react";
 import { useLocation } from "react-router-dom";
 import { useNotifications } from "../notifications";
 import { imgSrc } from "../api";
+import { setNativeTabBarHidden } from "../lib/liquidGlassTabBar";
 // highlight.js(~92KB) 등 무거운 의존성을 끌고오므로 초기 번들에서 분리한다.
 // 채팅 패널은 사용자가 처음 열 때(mounted=true) 비로소 마운트되므로 lazy 로딩이 안전.
 const ChatMiniApp = lazy(() => import("./ChatMiniApp"));
@@ -49,6 +50,12 @@ export default function ChatFab() {
   const { chatUnread, ready } = useNotifications();
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
+
+  // 채팅이 열려 있는 동안엔 네이티브 하단 탭 바를 숨긴다(풀스크린 채팅을 바가 덮는 것 방지).
+  useEffect(() => {
+    setNativeTabBarHidden("chat", open);
+    return () => setNativeTabBarHidden("chat", false);
+  }, [open]);
   // 모바일(≤640px) 에서는 사내톡을 풀스크린 페이지처럼 띄움.
   // 뷰포트 크기 변화(회전/리사이즈) 시 갱신.
   const [isMobile, setIsMobile] = useState<boolean>(

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -1,4 +1,5 @@
 import { registerPlugin } from "@capacitor/core";
+import { isCapacitorNative } from "./platform";
 
 /**
  * 네이티브 Liquid Glass 하단 탭 바 브리지 (iOS 26 UIGlassEffect).
@@ -39,3 +40,33 @@ export interface LiquidGlassTabBarPlugin {
 }
 
 export const LiquidGlassTabBar = registerPlugin<LiquidGlassTabBarPlugin>("LiquidGlassTabBar");
+
+/* ===========================================================================
+ * 네이티브 탭 바 가시성 관리.
+ * 탭 바는 웹뷰 위에 떠 있는 네이티브 오버레이라, 풀스크린 웹 화면(채팅·알림·모달)에선
+ * 가려야 한다. 여러 곳에서 "이유(reason)" 별로 숨김을 요청할 수 있고, 하나라도 숨김이면 숨긴다.
+ * iOS 네이티브에서만 동작(그 외엔 no-op).
+ * ======================================================================== */
+const hideReasons = new Set<string>();
+let lastVisible: boolean | null = null;
+
+function applyVisibility() {
+  if (!isCapacitorNative()) return;
+  const visible = hideReasons.size === 0;
+  if (visible === lastVisible) return;
+  lastVisible = visible;
+  LiquidGlassTabBar.setVisible({ visible }).catch(() => {});
+}
+
+/** 사유별 숨김 토글. (예: "chat", "modal", "route") */
+export function setNativeTabBarHidden(reason: string, hidden: boolean) {
+  if (hidden) hideReasons.add(reason);
+  else hideReasons.delete(reason);
+  applyVisibility();
+}
+
+/** 바를 (재)생성한 직후 현재 사유 집합 기준으로 가시성 재적용. */
+export function syncNativeTabBarVisibility() {
+  lastVisible = null;
+  applyVisibility();
+}


### PR DESCRIPTION
## 증상
**풀스크린 화면에서 네이티브 탭 바 숨김 (채팅·알림·모달)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
네이티브 탭 바는 웹뷰 위 오버레이라 풀스크린 웹 화면을 덮어버렸음. 사유(reason)별
가시성 매니저(setNativeTabBarHidden) 추가 — 하나라도 숨김이면 setVisible(false):
- 채팅(ChatFab open) → 'chat'
- 알림 등 포커스 라우트(/notifications) → 'route'
- 모달(.modal-safe 오버레이 존재) → 'modal' (MutationObserver)
configure 직후 syncNativeTabBarVisibility 로 현재 사유 기준 재적용.

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 채팅·알림·모달 등 풀스크린 화면에선 네이티브 탭 바 숨김

**변경 대상 (3개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatFab.tsx`
- `client/src/lib/liquidGlassTabBar.ts`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #289** 에서 진행됩니다.

