### PR TITLE
🔀 :: (#290) 달력 풀블리드/스크롤 + 데스크톱 폰UI 방지 + 선택 탭 볼드

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -123,6 +123,9 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
                 image: UIImage(named: (tab["icon"] as? String) ?? "")?.withRenderingMode(.alwaysTemplate),
                 tag: i
             )
+            // 선택된 탭 라벨을 살짝 더 두껍게(semibold). 비선택은 regular. (글래스 배경은 건드리지 않음)
+            item.setTitleTextAttributes([.font: UIFont.systemFont(ofSize: 10, weight: .regular)], for: .normal)
+            item.setTitleTextAttributes([.font: UIFont.systemFont(ofSize: 10, weight: .semibold)], for: .selected)
             items.append(item)
         }
         tabBar.setItems(items, animated: false)

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -18,7 +18,7 @@ import { ROUTE_PREFETCH, loadProject } from "../routes";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
 import { isPreviewMode } from "../lib/previewMock";
-import { isInstalledApp, nativePlatform } from "../lib/platform";
+import { isInstalledApp, isDesktopApp, nativePlatform } from "../lib/platform";
 import { LiquidGlassTabBar, setNativeTabBarHidden, syncNativeTabBarVisibility } from "../lib/liquidGlassTabBar";
 import { confirmLogout } from "../lib/confirmLogout";
 
@@ -674,6 +674,12 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     // iOS 네이티브(아이폰·아이패드)에서만 글래스 하단 네비 스타일 + 본문 하단 클리어런스 적용.
     // (웹/안드로이드/Electron 데스크톱은 클래스가 안 붙어 기존 디자인 그대로.)
     el.classList.toggle("hinest-ios", nativePlatform() === "ios");
+    // 데스크톱(Electron 또는 마우스+호버 가능 브라우저)은 창을 폰 크기로 줄여도 모바일
+    // 레이아웃으로 바뀌지 않도록 플래그. 실제 터치 폰/태블릿(coarse pointer)은 제외.
+    const isDesktopDevice =
+      isDesktopApp() ||
+      (typeof window !== "undefined" && !!window.matchMedia?.("(hover: hover) and (pointer: fine)").matches);
+    el.classList.toggle("hinest-desktop", isDesktopDevice);
     return () => el.classList.remove("hinest-shell-lock");
   }, []);
 
@@ -933,6 +939,9 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
             overscrollBehaviorY: "contain",
             // iOS Safari momentum scrolling 안정화.
             WebkitOverflowScrolling: "touch",
+            // 가로 스크롤 차단 — 풀블리드 달력 등 일부 요소가 미세하게 넘쳐도 좌우 스크롤이
+            // 생기지 않게 한다(세로 스크롤은 유지). 본문은 vertical 스크롤만 필요.
+            overflowX: "hidden",
             // 당겨서 새로고침 인디케이터의 절대 배치 기준.
             position: "relative",
           }}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -82,6 +82,12 @@ html.hinest-ios .app-bottomnav { display: flex !important; }
    (이 규칙이 위 hinest-ios .app-bottomnav 보다 뒤라 둘 다 있을 때 display:none 이 이긴다.) */
 html.hinest-native-tabbar .app-bottomnav { display: none !important; }
 
+/* 데스크톱(마우스/호버 가능 기기 또는 Electron)은 창을 폰 크기로 줄여도 모바일 레이아웃으로
+   전환되지 않게 — 사이드바 유지 + 하단 탭 바 숨김(md 폭 기준 전환 무시). 실제 모바일/터치
+   기기는 .hinest-desktop 이 안 붙어 기존 반응형 그대로. */
+html.hinest-desktop .app-sidebar { display: flex !important; }
+html.hinest-desktop .app-bottomnav { display: none !important; }
+
 html.dark {
   color-scheme: dark;
 
@@ -298,13 +304,11 @@ html.dark .panel {
    좌우 테두리/모서리를 없애 '양끝 선' 제거. 데스크톱(md+)은 카드 그대로. */
 @media (max-width: 767.98px) {
   .cal-fullbleed {
-    /* 부모 패딩과 무관하게 정확히 뷰포트 폭으로 풀블리드 — 음수 마진(-16px)은 중첩
-       패딩이 있으면 좌우 스크롤을 유발할 수 있어, width:100vw + calc 중앙정렬로 교체.
-       100vw = 화면 폭이라 가로 오버플로(좌우 스크롤)가 생기지 않는다. */
-    width: 100vw;
-    max-width: 100vw;
-    margin-left: calc(50% - 50vw);
-    margin-right: calc(50% - 50vw);
+    /* 본문 px-4(16px) 만 상쇄해 화면 양끝까지. (100vw 는 일부 기기에서 그리드가 뷰포트
+       밖으로 밀려 잘리는 문제가 있어 부모 기준 음수 마진으로 변경. 가로 스크롤은 메인
+       스크롤러의 overflow-x:hidden 으로 차단.) */
+    margin-left: -16px;
+    margin-right: -16px;
     border-left-width: 0;
     border-right-width: 0;
     border-radius: 0;


### PR DESCRIPTION
## 증상
**달력 풀블리드/스크롤 + 데스크톱 폰UI 방지 + 선택 탭 볼드**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- 달력 풀블리드를 100vw → 부모기준 음수마진(-16px)으로 변경(일부 기기서 그리드가
  뷰포트 밖으로 밀려 잘리던 문제 해결) + 메인 스크롤러 overflow-x:hidden 으로 가로
  스크롤 차단.
- 데스크톱(Electron 또는 hover+fine pointer 브라우저)은 창을 폰 크기로 줄여도 모바일
  레이아웃으로 안 바뀌게 — .hinest-desktop 클래스로 사이드바 유지 + 하단 탭바 숨김.
  실제 터치 폰/태블릿(coarse pointer)은 영향 없음.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 달력 풀블리드 그리드 잘림/가로 스크롤 + 데스크톱 폰UI 전환 방지
- feat(ios): 네이티브 탭 바 선택 탭 라벨 살짝 더 두껍게(semibold)

**변경 대상 (3개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/src/components/AppLayout.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #290** 에서 진행됩니다.

