### PR TITLE
🔀 :: (#291) 로그인 위치 + 새로고침 스피너 파란색

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -999,7 +999,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
                     width="2"
                     height="6"
                     rx="1"
-                    fill="var(--c-text-3)"
+                    fill="var(--c-brand)"
                     opacity={0.18 + (0.82 * i) / 11}
                     transform={`rotate(${i * 30} 12 12)`}
                   />

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -60,7 +60,7 @@ export default function LoginPage() {
       </header>
 
       {/* 본문 — 중앙 정렬, 한 단 */}
-      <main className="flex-1 flex items-center justify-center px-6 pb-12">
+      <main className="flex-1 flex items-center justify-center px-6 pb-32">
         <div className="w-full max-w-[360px]">
           {/* 인사말 */}
           <div className="mb-9">


### PR DESCRIPTION
## 증상
**로그인 위치 + 새로고침 스피너 파란색**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- 로그인 본문 pb-12 → pb-32 로 중앙 콘텐츠를 위로 약 5%.
- 당겨서 새로고침 스피너 색을 회색(--c-text-3) → 브랜드 블루(--c-brand).

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 로그인 화면 위로 올림 + 당겨서 새로고침 스피너 파란색

**변경 대상 (2개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/pages/LoginPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #291** 에서 진행됩니다.

