### PR TITLE
🔀 :: (#294) 스플래시 동안 네이티브 탭바 숨김

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -111,10 +111,19 @@
         var s = document.getElementById('hinest-splash');
         if (!s) return;
         var started = false, removed = false;
-        function remove() { if (removed) return; removed = true; try { s.parentNode && s.parentNode.removeChild(s); } catch (e) {} }
+        function remove() {
+          if (removed) return; removed = true;
+          // 스플래시 종료 신호 — AppLayout 이 듣고 네이티브 탭바를 다시 보이게 한다.
+          window.__hinestSplashActive = false;
+          try { s.parentNode && s.parentNode.removeChild(s); } catch (e) {}
+          try { window.dispatchEvent(new Event('hinest:splash-done')); } catch (e) {}
+        }
         function dismiss() { s.classList.add('hs-hide'); setTimeout(remove, 480); }
         window.__hinestSplashGo = function () {
-          if (started) return; started = true;
+          if (started || removed) return; started = true;
+          // 스플래시 표시 중 — 네이티브 탭바(웹뷰 위에 뜨는 별도 뷰)가 스플래시를 가리지
+          // 않도록 숨김 신호. AppLayout 이 이 플래그를 보고 탭바를 숨긴다.
+          window.__hinestSplashActive = true;
           s.classList.add('hs-go');     // 배지 페이드인 → 로고 슬라이드인
           setTimeout(dismiss, 2000);    // 2초 유지 후 페이드아웃
         };

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -683,6 +683,20 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     return () => el.classList.remove("hinest-shell-lock");
   }, []);
 
+  // 스플래시(index.html 의 웹 오버레이) 동안엔 네이티브 탭 바를 숨긴다 — 네이티브 바는
+  // 웹뷰 위에 뜨는 별도 뷰라 웹 스플래시로는 가려지지 않아 위로 비친다. 스플래시가 끝나면
+  // (hinest:splash-done) 숨김 사유를 풀어 다시 보이게 한다.
+  useEffect(() => {
+    if (nativePlatform() !== "ios") return;
+    // 스플래시 오버레이가 DOM 에 살아있으면(콜드 실행) 탭바 숨김. 새로고침 땐 인덱스 스크립트가
+    // 파싱 즉시 제거하므로 마운트 시점엔 이미 없어 숨기지 않는다. (window 플래그는 main.tsx 가
+    // 비동기로 늦게 세팅돼 마운트보다 늦을 수 있어, 요소 존재 여부를 신호로 쓴다.)
+    setNativeTabBarHidden("splash", !!document.getElementById("hinest-splash"));
+    const onDone = () => setNativeTabBarHidden("splash", false);
+    window.addEventListener("hinest:splash-done", onDone);
+    return () => window.removeEventListener("hinest:splash-done", onDone);
+  }, []);
+
   // 네이티브 Liquid Glass 탭 바(iOS 26 UIGlassEffect) — 성공하면 웹 하단 바를 숨기고
   // 실제 애플 글래스 바가 대체한다. 미지원(iOS<26)/실패면 아무 일도 없고 웹 CSS 글래스 바가 폴백.
   useEffect(() => {


### PR DESCRIPTION
## 증상
**스플래시 동안 네이티브 탭바 숨김**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
스플래시는 웹 오버레이인데 네이티브 탭바(LiquidGlassTabBar)는 웹뷰 위에 뜨는 별도
네이티브 뷰라 웹 오버레이로는 가려지지 않아 스플래시 위로 보였다(사용자 제보).

수정: 스플래시 오버레이가 DOM 에 존재하는 동안 setNativeTabBarHidden("splash", true) 로
탭바를 숨기고, 스플래시 종료 시 index.html 이 'hinest:splash-done' 이벤트를 쏘면 풀어
다시 보이게 한다. 콜드 실행에서만 숨기고(요소 존재로 판단) 새로고침엔 영향 없음.
하드 타임아웃(5.2초)이 안전망으로 항상 done 을 쏴 탭바가 영영 숨는 일은 없다.

## 수정
**작업 항목 (커밋 단위)**
- fix(mobile): 스플래시 동안 네이티브 탭바 숨김

**변경 대상 (2개 파일)**
- `client/index.html`
- `client/src/components/AppLayout.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #294** 에서 진행됩니다.

