### PR TITLE
🔀 :: (#296) 운영 콘솔 비밀번호 재확인(step-up) 제거

### DIFF
--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -5,7 +5,6 @@ import { safeUploadUrl } from "../lib/safeUrl";
 import { isCapacitorNative } from "../lib/platform";
 import { Browser } from "@capacitor/browser";
 import { useTheme } from "../theme";
-import SuperStepUpGate from "../components/SuperStepUpGate";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import SessionsPanel from "../components/superadmin/SessionsPanel";
 import ErrorsPanel from "../components/superadmin/ErrorsPanel";
@@ -112,9 +111,8 @@ export default function SuperAdminPage() {
         />
       )}
     >
-      <SuperStepUpGate>
-        <SuperConsoleInner />
-      </SuperStepUpGate>
+      {/* 단계 인증(비밀번호 재확인) 게이트 제거 — 사용자 요청. superAdmin 로그인 세션만으로 진입. */}
+      <SuperConsoleInner />
     </ErrorBoundary>
   );
 }

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -301,14 +301,12 @@ export function verifySuperToken(req: Request, userId: string): { exp: number } 
 export function requireSuperAdminStepUp(req: Request, res: Response, next: NextFunction) {
   const u = (req as any).user as AuthUser | undefined;
   if (!u || !u.superAdmin) return res.status(403).json({ error: "forbidden" });
+  // 단계 인증(비밀번호 재확인) 요구 제거 — 사용자 요청. superAdmin 로그인 세션만으로 통과.
+  // step-up 토큰이 있으면 만료시각만 그대로 싣고(레거시 호환), 없어도 막지 않는다.
+  // ⚠️ 보안: 콘솔의 민감 작업(피처플래그·역할권한·2FA정책 등)이 재인증 없이 superAdmin
+  //    세션만으로 보호된다. step-up 게이트를 되살리려면 아래 401 분기를 복원할 것.
   const v = verifySuperToken(req, u.id);
-  if (!v) {
-    return res.status(401).json({
-      error: "비밀번호 재확인이 필요합니다",
-      code: "SUPER_STEPUP_REQUIRED",
-    });
-  }
-  (req as any).superExpiresAt = v.exp;
+  if (v) (req as any).superExpiresAt = v.exp;
   next();
 }
 


### PR DESCRIPTION
## 증상
**운영 콘솔 비밀번호 재확인(step-up) 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
사용자 요청으로 superAdmin 콘솔 진입 시 비밀번호 재확인(step-up) 단계를 없앤다.

- server: requireSuperAdminStepUp 미들웨어가 더 이상 verifySuperToken 을
  강제하지 않음. superAdmin 로그인 세션이면 통과(403 역할체크는 유지).
- client: SuperAdminPage 의 <SuperStepUpGate> 래퍼 및 import 제거.

⚠️ 보안: 콘솔의 민감 작업(피처플래그·역할권한·2FA정책 등)이 재인증 없이
superAdmin 세션만으로 보호된다. 서버 배포가 적용되어야 효과가 발생한다.

## 수정
**작업 항목 (커밋 단위)**
- fix(console): 운영 콘솔 단계 인증(비밀번호 재확인) 게이트 제거

**변경 대상 (2개 파일)**
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/lib/auth.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #296** 에서 진행됩니다.

