### PR TITLE
🔀 :: (#297) 관리자·운영 콘솔 페이지 모바일 카드 UI

### DIFF
--- a/client/src/components/superadmin/AuditPanel.tsx
+++ b/client/src/components/superadmin/AuditPanel.tsx
@@ -86,30 +86,30 @@ export default function AuditPanel() {
         {grouped.map(([day, items]) => (
           <div key={day} className="mb-3">
             <div className="text-[10.5px] font-extrabold tracking-[0.06em] uppercase text-ink-500 mb-1.5 px-1">{day}</div>
-            <table className="w-full text-[12px]">
+            <table className="w-full text-[12px] pro-cards">
               <tbody>
                 {items.map((l) => {
                   const color = ACTION_COLORS[l.action] ?? "#64748B";
                   return (
                     <tr key={l.id} className="border-b border-ink-100">
-                      <td className="py-1.5 pr-2 whitespace-nowrap text-ink-500 font-mono text-[11px]" style={{ width: 70 }}>
+                      <td data-label="시각" className="py-1.5 pr-2 whitespace-nowrap text-ink-500 font-mono text-[11px]" style={{ width: 70 }}>
                         {new Date(l.createdAt).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false })}
                       </td>
-                      <td className="py-1.5 pr-2 whitespace-nowrap" style={{ width: 200 }}>
+                      <td className="cell-primary py-1.5 pr-2 whitespace-nowrap" style={{ width: 200 }}>
                         <span className="inline-block px-1.5 py-0.5 rounded text-[10.5px] font-bold" style={{ background: color + "22", color }}>
                           {l.action}
                         </span>
                       </td>
-                      <td className="py-1.5 pr-2 whitespace-nowrap" style={{ width: 160 }}>
+                      <td data-label="사용자" className="py-1.5 pr-2 whitespace-nowrap" style={{ width: 160 }}>
                         {l.user ? (
                           <span className="font-bold text-ink-900">{l.user.name}</span>
                         ) : (
                           <span className="text-ink-400">—</span>
                         )}
                       </td>
-                      <td className="py-1.5 pr-2 text-ink-700 truncate max-w-[280px] font-mono text-[11px]" title={l.target ?? ""}>{l.target ?? ""}</td>
-                      <td className="py-1.5 pr-2 text-ink-500 truncate max-w-[260px]" title={l.detail ?? ""}>{l.detail ?? ""}</td>
-                      <td className="py-1.5 pr-2 text-ink-500 font-mono text-[10.5px] whitespace-nowrap">{l.ip ?? ""}</td>
+                      <td data-label="대상" className="py-1.5 pr-2 text-ink-700 sm:truncate sm:max-w-[280px] font-mono text-[11px]" title={l.target ?? ""}>{l.target ?? ""}</td>
+                      <td data-label="상세" className="py-1.5 pr-2 text-ink-500 sm:truncate sm:max-w-[260px]" title={l.detail ?? ""}>{l.detail ?? ""}</td>
+                      <td data-label="IP" className="py-1.5 pr-2 text-ink-500 font-mono text-[10.5px] whitespace-nowrap">{l.ip ?? ""}</td>
                     </tr>
                   );
                 })}

--- a/client/src/components/superadmin/FlagsPanel.tsx
+++ b/client/src/components/superadmin/FlagsPanel.tsx
@@ -48,7 +48,7 @@ export default function FlagsPanel() {
       </div>
 
       <div className="overflow-auto" style={{ maxHeight: "60vh" }}>
-        <table className="w-full text-[12px]">
+        <table className="w-full text-[12px] pro-cards">
           <thead>
             <tr className="text-ink-500 text-left border-b border-ink-150">
               <th className="py-2 pr-2">키</th>
@@ -62,8 +62,8 @@ export default function FlagsPanel() {
           <tbody>
             {rows.map((f) => (
               <tr key={f.key} className="border-b border-ink-100">
-                <td className="py-2 pr-2 font-mono text-[11.5px] font-bold text-ink-900">{f.key}</td>
-                <td className="py-2 pr-2">
+                <td className="py-2 pr-2 font-mono text-[11.5px] font-bold text-ink-900 cell-primary">{f.key}</td>
+                <td className="py-2 pr-2" data-label="활성">
                   <button
                     onClick={() => toggle(f)}
                     style={{
@@ -79,17 +79,17 @@ export default function FlagsPanel() {
                     }} />
                   </button>
                 </td>
-                <td className="py-2 pr-2 text-ink-700">{f.scope}</td>
-                <td className="py-2 pr-2 text-ink-500 truncate max-w-[220px]" title={f.targets ?? ""}>{f.targets || "—"}</td>
-                <td className="py-2 pr-2 text-ink-700 truncate max-w-[260px]">{f.description || "—"}</td>
-                <td className="py-2 pr-2 text-right">
+                <td className="py-2 pr-2 text-ink-700" data-label="범위">{f.scope}</td>
+                <td className="py-2 pr-2 text-ink-500 sm:truncate sm:max-w-[220px]" data-label="대상" title={f.targets ?? ""}>{f.targets || "—"}</td>
+                <td className="py-2 pr-2 text-ink-700 sm:truncate sm:max-w-[260px]" data-label="설명">{f.description || "—"}</td>
+                <td className="py-2 pr-2 text-right cell-actions">
                   <button className="btn-ghost btn-xs" onClick={() => setEditing(f)}>편집</button>
                   <button className="btn-ghost btn-xs ml-1" style={{ color: "var(--c-danger)" }} onClick={() => remove(f.key)}>삭제</button>
                 </td>
               </tr>
             ))}
             {!loading && rows.length === 0 && (
-              <tr><td colSpan={6} className="py-12 text-center text-ink-500">플래그 없음 — 우상단 \"+ 새 플래그\"</td></tr>
+              <tr><td colSpan={6} className="py-12 text-center text-ink-500 cell-full">플래그 없음 — 우상단 \"+ 새 플래그\"</td></tr>
             )}
           </tbody>
         </table>

--- a/client/src/components/superadmin/RolePermissionsPanel.tsx
+++ b/client/src/components/superadmin/RolePermissionsPanel.tsx
@@ -94,7 +94,7 @@ export default function RolePermissionsPanel() {
       </div>
 
       <div className="overflow-auto" style={{ maxHeight: "65vh" }}>
-        <table className="w-full text-[12.5px]">
+        <table className="w-full text-[12.5px]" style={{ minWidth: 520 }}>
           <thead>
             <tr className="text-ink-500 text-left border-b border-ink-150">
               <th className="py-2 pr-3 w-[42%]">권한</th>

--- a/client/src/components/superadmin/SecurityPanel.tsx
+++ b/client/src/components/superadmin/SecurityPanel.tsx
@@ -52,7 +52,7 @@ function RateRules() {
         <div className="text-[11px] text-ink-500">{rows.length}개 룰</div>
         <button className="btn-primary btn-xs ml-auto" onClick={() => setEditing({ routeGlob: "/api/auth/*", perMin: 60, perHour: 600, scope: "ip", enabled: true })}>+ 새 룰</button>
       </div>
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[12px] pro-cards">
         <thead>
           <tr className="text-ink-500 text-left border-b border-ink-150">
             <th className="py-2 pr-2">경로</th>
@@ -66,12 +66,12 @@ function RateRules() {
         <tbody>
           {rows.map((r) => (
             <tr key={r.id} className="border-b border-ink-100">
-              <td className="py-2 pr-2 font-mono text-[11.5px] font-bold text-ink-900">{r.routeGlob}</td>
-              <td className="py-2 pr-2 tabular-nums">{r.perMin}</td>
-              <td className="py-2 pr-2 tabular-nums">{r.perHour}</td>
-              <td className="py-2 pr-2">{r.scope}</td>
-              <td className="py-2 pr-2 text-[11px] font-bold" style={{ color: r.enabled ? "var(--c-success)" : "var(--c-text-3)" }}>{r.enabled ? "ON" : "OFF"}</td>
-              <td className="py-2 pr-2 text-right">
+              <td className="cell-primary py-2 pr-2 font-mono text-[11.5px] font-bold text-ink-900">{r.routeGlob}</td>
+              <td data-label="분당" className="py-2 pr-2 tabular-nums">{r.perMin}</td>
+              <td data-label="시간당" className="py-2 pr-2 tabular-nums">{r.perHour}</td>
+              <td data-label="스코프" className="py-2 pr-2">{r.scope}</td>
+              <td data-label="활성" className="py-2 pr-2 text-[11px] font-bold" style={{ color: r.enabled ? "var(--c-success)" : "var(--c-text-3)" }}>{r.enabled ? "ON" : "OFF"}</td>
+              <td className="cell-actions py-2 pr-2 text-right">
                 <button className="btn-ghost btn-xs" onClick={() => setEditing(r)}>편집</button>
                 <button className="btn-ghost btn-xs ml-1" style={{ color: "var(--c-danger)" }} onClick={() => remove(r.id)}>삭제</button>
               </td>
@@ -126,7 +126,7 @@ function IpBlocks() {
         <div className="text-[11px] text-ink-500">{rows.length}개 차단 룰</div>
         <button className="btn-primary btn-xs ml-auto" onClick={() => setEditing({ cidr: "", country: "", enabled: true })}>+ 차단 추가</button>
       </div>
-      <table className="w-full text-[12px]">
+      <table className="w-full text-[12px] pro-cards">
         <thead>
           <tr className="text-ink-500 text-left border-b border-ink-150">
             <th className="py-2 pr-2">대상</th>
@@ -139,11 +139,11 @@ function IpBlocks() {
         <tbody>
           {rows.map((b) => (
             <tr key={b.id} className="border-b border-ink-100">
-              <td className="py-2 pr-2 font-mono text-[11.5px] text-ink-900">{b.country ? `🌍 ${b.country}` : b.cidr}</td>
-              <td className="py-2 pr-2 text-ink-700 truncate max-w-[260px]">{b.reason ?? "—"}</td>
-              <td className="py-2 pr-2 text-ink-700">{b.expiresAt ? new Date(b.expiresAt).toLocaleDateString("ko-KR") : "—"}</td>
-              <td className="py-2 pr-2 text-[11px] font-bold" style={{ color: b.enabled ? "var(--c-danger)" : "var(--c-text-3)" }}>{b.enabled ? "차단 중" : "OFF"}</td>
-              <td className="py-2 pr-2 text-right">
+              <td className="cell-primary py-2 pr-2 font-mono text-[11.5px] text-ink-900">{b.country ? `🌍 ${b.country}` : b.cidr}</td>
+              <td data-label="사유" className="py-2 pr-2 text-ink-700 sm:truncate sm:max-w-[260px]">{b.reason ?? "—"}</td>
+              <td data-label="만료" className="py-2 pr-2 text-ink-700">{b.expiresAt ? new Date(b.expiresAt).toLocaleDateString("ko-KR") : "—"}</td>
+              <td data-label="활성" className="py-2 pr-2 text-[11px] font-bold" style={{ color: b.enabled ? "var(--c-danger)" : "var(--c-text-3)" }}>{b.enabled ? "차단 중" : "OFF"}</td>
+              <td className="cell-actions py-2 pr-2 text-right">
                 <button className="btn-ghost btn-xs" onClick={() => setEditing(b)}>편집</button>
                 <button className="btn-ghost btn-xs ml-1" style={{ color: "var(--c-danger)" }} onClick={() => remove(b.id)}>해제</button>
               </td>

--- a/client/src/components/superadmin/SessionsPanel.tsx
+++ b/client/src/components/superadmin/SessionsPanel.tsx
@@ -77,7 +77,7 @@ export default function SessionsPanel() {
       </div>
       <div className="text-[11px] text-ink-500 mb-2">총 {filtered.length}개 활성 세션</div>
       <div className="overflow-auto" style={{ maxHeight: "60vh" }}>
-        <table className="w-full text-[12px]">
+        <table className="w-full text-[12px] pro-cards">
           <thead>
             <tr className="text-ink-500 text-left border-b border-ink-150">
               <th className="py-2 pr-2">사용자</th>
@@ -90,14 +90,14 @@ export default function SessionsPanel() {
           <tbody>
             {filtered.map((s) => (
               <tr key={s.id} className="border-b border-ink-100">
-                <td className="py-2 pr-2">
+                <td className="py-2 pr-2 cell-primary">
                   <div className="font-bold text-ink-900">{s.user.name}</div>
                   <div className="text-[10.5px] text-ink-500">{s.user.email}</div>
                 </td>
-                <td className="py-2 pr-2 text-ink-700 truncate max-w-[280px]" title={s.ua ?? ""}>{shortenUA(s.ua)}</td>
-                <td className="py-2 pr-2 text-ink-700 font-mono text-[11px]">{s.ip ?? "—"}</td>
-                <td className="py-2 pr-2 text-ink-700">{relTime(s.lastSeenAt)}</td>
-                <td className="py-2 pr-2 text-right">
+                <td className="py-2 pr-2 text-ink-700 sm:truncate sm:max-w-[280px]" data-label="디바이스" title={s.ua ?? ""}>{shortenUA(s.ua)}</td>
+                <td className="py-2 pr-2 text-ink-700 font-mono text-[11px]" data-label="IP">{s.ip ?? "—"}</td>
+                <td className="py-2 pr-2 text-ink-700" data-label="최근 활동">{relTime(s.lastSeenAt)}</td>
+                <td className="py-2 pr-2 text-right cell-actions">
                   <button className="btn-ghost btn-xs" onClick={() => revokeOne(s.id, s.user.name)} disabled={busy}>이 세션 종료</button>
                   <button className="btn-ghost btn-xs ml-1" onClick={() => revokeUser(s.userId, s.user.name)} disabled={busy}>전 디바이스</button>
                 </td>

--- a/client/src/components/superadmin/TokensPanel.tsx
+++ b/client/src/components/superadmin/TokensPanel.tsx
@@ -92,7 +92,7 @@ export default function TokensPanel() {
       )}
 
       <div className="overflow-auto" style={{ maxHeight: "55vh" }}>
-        <table className="w-full text-[12px]">
+        <table className="w-full text-[12px] pro-cards">
           <thead>
             <tr className="text-ink-500 text-left border-b border-ink-150">
               <th className="py-2 pr-2">이름</th>
@@ -107,15 +107,15 @@ export default function TokensPanel() {
           <tbody>
             {rows.map((t) => (
               <tr key={t.id} className="border-b border-ink-100" style={{ opacity: t.revokedAt ? 0.5 : 1 }}>
-                <td className="py-2 pr-2 font-bold text-ink-900">{t.name}</td>
-                <td className="py-2 pr-2 font-mono text-[11px] text-ink-700">{t.prefix}…</td>
-                <td className="py-2 pr-2 font-mono text-[10.5px] text-ink-700 truncate max-w-[200px]" title={t.scopes ?? ""}>{t.scopes || "—"}</td>
-                <td className="py-2 pr-2 text-ink-700">{t.lastUsedAt ? new Date(t.lastUsedAt).toLocaleString("ko-KR") : "사용 안 됨"}</td>
-                <td className="py-2 pr-2 text-ink-700">{t.expiresAt ? new Date(t.expiresAt).toLocaleDateString("ko-KR") : "—"}</td>
-                <td className="py-2 pr-2 text-[11px] font-bold">
+                <td className="py-2 pr-2 font-bold text-ink-900 cell-primary">{t.name}</td>
+                <td className="py-2 pr-2 font-mono text-[11px] text-ink-700" data-label="prefix">{t.prefix}…</td>
+                <td className="py-2 pr-2 font-mono text-[10.5px] text-ink-700 sm:truncate sm:max-w-[200px]" data-label="스코프" title={t.scopes ?? ""}>{t.scopes || "—"}</td>
+                <td className="py-2 pr-2 text-ink-700" data-label="최근 사용">{t.lastUsedAt ? new Date(t.lastUsedAt).toLocaleString("ko-KR") : "사용 안 됨"}</td>
+                <td className="py-2 pr-2 text-ink-700" data-label="만료">{t.expiresAt ? new Date(t.expiresAt).toLocaleDateString("ko-KR") : "—"}</td>
+                <td className="py-2 pr-2 text-[11px] font-bold" data-label="상태">
                   {t.revokedAt ? <span style={{ color: "var(--c-danger)" }}>회수됨</span> : <span style={{ color: "var(--c-success)" }}>활성</span>}
                 </td>
-                <td className="py-2 pr-2 text-right">
+                <td className="py-2 pr-2 text-right cell-actions">
                   {!t.revokedAt && (
                     <button className="btn-ghost btn-xs" style={{ color: "var(--c-danger)" }} onClick={() => revoke(t)}>회수</button>
                   )}
@@ -123,7 +123,7 @@ export default function TokensPanel() {
               </tr>
             ))}
             {!loading && rows.length === 0 && (
-              <tr><td colSpan={7} className="py-12 text-center text-ink-500">발급된 토큰이 없어요</td></tr>
+              <tr><td colSpan={7} className="py-12 text-center text-ink-500 cell-full">발급된 토큰이 없어요</td></tr>
             )}
           </tbody>
         </table>

--- a/client/src/components/superadmin/TrashPanel.tsx
+++ b/client/src/components/superadmin/TrashPanel.tsx
@@ -86,7 +86,7 @@ export default function TrashPanel() {
         ) : items.length === 0 ? (
           <div className="py-12 text-center text-ink-500 text-[12px]">비어 있음 ✨</div>
         ) : (
-          <table className="w-full text-[12px]">
+          <table className="w-full text-[12px] pro-cards">
             <thead>
               <tr className="text-ink-500 text-left border-b border-ink-150">
                 <th className="py-2 pr-2">제목</th>
@@ -101,13 +101,13 @@ export default function TrashPanel() {
                 const willPurgeIn = Math.max(0, 30 - days);
                 return (
                   <tr key={it.id} className="border-b border-ink-100">
-                    <td className="py-2 pr-2 font-bold text-ink-900 truncate max-w-[420px]">{it.title || "(제목 없음)"}</td>
-                    <td className="py-2 pr-2 text-ink-700">{it.author?.name ?? "—"}</td>
-                    <td className="py-2 pr-2 text-ink-700">
+                    <td className="cell-primary py-2 pr-2 font-bold text-ink-900 sm:truncate sm:max-w-[420px]">{it.title || "(제목 없음)"}</td>
+                    <td data-label="작성자" className="py-2 pr-2 text-ink-700">{it.author?.name ?? "—"}</td>
+                    <td data-label="삭제 시각" className="py-2 pr-2 text-ink-700">
                       {new Date(it.deletedAt).toLocaleString("ko-KR")}
                       <span className="text-[10px] text-ink-400 ml-1">· {willPurgeIn}일 후 영구</span>
                     </td>
-                    <td className="py-2 pr-2 text-right">
+                    <td className="cell-actions py-2 pr-2 text-right">
                       <button className="btn-ghost btn-xs" onClick={() => restore(tab, it.id, it.title)} disabled={busy}>복구</button>
                       <button className="btn-ghost btn-xs ml-1" style={{ color: "var(--c-danger)" }} onClick={() => purge(tab, it.id, it.title)} disabled={busy}>영구 삭제</button>
                     </td>

--- a/client/src/components/superadmin/TwoFAPanel.tsx
+++ b/client/src/components/superadmin/TwoFAPanel.tsx
@@ -78,7 +78,7 @@ export default function TwoFAPanel() {
         ) : non.length === 0 ? (
           <div className="py-8 text-center text-ink-500 text-[12px]">전원 충족 ✨</div>
         ) : (
-          <table className="w-full text-[12px]">
+          <table className="w-full text-[12px] pro-cards">
             <thead>
               <tr className="text-ink-500 text-left border-b border-ink-150">
                 <th className="py-2 pr-2">사용자</th>
@@ -91,14 +91,14 @@ export default function TwoFAPanel() {
             <tbody>
               {non.map((u) => (
                 <tr key={u.id} className="border-b border-ink-100">
-                  <td className="py-2 pr-2">
+                  <td className="py-2 pr-2 cell-primary">
                     <div className="font-bold text-ink-900">{u.name}</div>
                     <div className="text-[10.5px] text-ink-500">{u.email}</div>
                   </td>
-                  <td className="py-2 pr-2 text-ink-700">{ROLE_LABEL[u.role] ?? u.role}</td>
-                  <td className="py-2 pr-2 text-ink-700">{u.team ?? "—"}</td>
-                  <td className="py-2 pr-2 text-ink-700">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</td>
-                  <td className="py-2 pr-2 text-right font-bold" style={{ color: "var(--c-danger)" }}>+{u.daysOverdue}일</td>
+                  <td className="py-2 pr-2 text-ink-700" data-label="role">{ROLE_LABEL[u.role] ?? u.role}</td>
+                  <td className="py-2 pr-2 text-ink-700" data-label="팀">{u.team ?? "—"}</td>
+                  <td className="py-2 pr-2 text-ink-700" data-label="가입일">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</td>
+                  <td className="py-2 pr-2 text-right font-bold" data-label="초과" style={{ color: "var(--c-danger)" }}>+{u.daysOverdue}일</td>
                 </tr>
               ))}
             </tbody>

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -442,8 +442,8 @@ function UsersTab({
           <BulkUnlockButton users={users} onUnlocked={reload} />
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          {/* 기본/상세 뷰 토글 */}
-          <div className="tabs">
+          {/* 기본/상세 뷰 토글 — 상세(HR 전 컬럼)는 데스크톱 전용이라 모바일에선 숨김 */}
+          <div className="tabs hidden sm:flex">
             {(["basic", "detail"] as const).map((v) => (
               <button
                 key={v}
@@ -456,7 +456,7 @@ function UsersTab({
             ))}
           </div>
           {/* 엑셀 일괄 업로드 — 내부 검토중이라 일단 비노출. 다시 열 땐 이 블록 주석 해제.
-          <span className="mx-1 h-4 w-px bg-ink-200" />
+          <span className="mx-1 h-4 w-px bg-ink-200 hidden sm:block" />
           <label
             className="btn-ghost !h-[32px] !px-3 text-[12px] cursor-pointer"
             title="엑셀(.xlsx) 파일로 HR 정보 일괄 업데이트 (email/사번/HR번호 기준 매칭)"
@@ -470,7 +470,7 @@ function UsersTab({
             />
           </label>
           */}
-          <span className="mx-1 h-4 w-px bg-ink-200" />
+          <span className="mx-1 h-4 w-px bg-ink-200 hidden sm:block" />
           {/* 현재 필터/검색 결과 기준으로 내보내기 — 권한/상태는 앱 UI 전용이므로 제외. */}
           <button
             type="button"
@@ -509,7 +509,7 @@ function UsersTab({
             <PdfLogo />
             PDF
           </button>
-          <span className="mx-1 h-4 w-px bg-ink-200" />
+          <span className="mx-1 h-4 w-px bg-ink-200 hidden sm:block" />
           <input className="input text-[12px] h-[32px] w-full sm:w-[200px]" placeholder="이름·이메일·팀 검색" value={q} onChange={(e) => setQ(e.target.value)} />
           <select className="input text-[12px] h-[32px] w-full sm:w-[120px]" value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)}>
             <option value="">모든 권한</option>
@@ -532,7 +532,7 @@ function UsersTab({
       )}
       {view === "basic" && (
       <div className="overflow-x-auto">
-      <table className="pro" style={{ minWidth: 720 }}>
+      <table className="pro pro-cards" style={{ minWidth: 720 }}>
         <thead>
           <tr>
             <th style={{ width: "30%" }}>구성원</th>
@@ -553,7 +553,7 @@ function UsersTab({
             const teamInList = !u.team || teams.some((t) => t.name === u.team);
             return (
               <tr key={u.id}>
-                <td>
+                <td className="cell-primary">
                   <div className="flex items-center gap-3">
                     <UserAvatar name={u.name} color={u.avatarColor ?? "#3D54C4"} imageUrl={u.avatarUrl ?? null} />
                     <div className="min-w-0">
@@ -562,7 +562,7 @@ function UsersTab({
                     </div>
                   </div>
                 </td>
-                <td>
+                <td data-label="직급">
                   <select
                     className={`ghost-select ${!u.position ? "placeholder" : ""}`}
                     value={u.position ?? ""}
@@ -577,7 +577,7 @@ function UsersTab({
                     )}
                   </select>
                 </td>
-                <td>
+                <td data-label="팀">
                   <select
                     className={`ghost-select ${!u.team ? "placeholder" : ""}`}
                     value={u.team ?? ""}
@@ -592,7 +592,7 @@ function UsersTab({
                     )}
                   </select>
                 </td>
-                <td>
+                <td data-label="권한">
                   <select
                     className={`ghost-select role-select ${roleClass}`}
                     value={u.role}
@@ -603,7 +603,7 @@ function UsersTab({
                     <option value="ADMIN">ADMIN</option>
                   </select>
                 </td>
-                <td>
+                <td data-label="상태">
                   {u.resignedAt ? (
                     <span className="chip-gray" title={`퇴사일 ${new Date(u.resignedAt).toLocaleDateString("ko-KR")}`}>
                       <span className="badge-dot" style={{ background: "#F97316" }} />
@@ -627,7 +627,7 @@ function UsersTab({
                     </button>
                   )}
                 </td>
-                <td style={{ textAlign: "right" }}>
+                <td className="cell-actions" style={{ textAlign: "right" }}>
                   <button className="btn-icon" title="상세 정보 편집" onClick={() => setEditTarget(u)}>
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                       <path d="M12 20h9" />
@@ -668,7 +668,7 @@ function UsersTab({
           })}
           {filtered.length === 0 && (
             <tr>
-              <td colSpan={6}>
+              <td colSpan={6} className="cell-full">
                 <EmptyState title="구성원이 없습니다" description="초대키를 발급해 팀원을 추가해보세요." />
               </td>
             </tr>
@@ -1697,7 +1697,7 @@ function InvitesTab({
           <div className="title">초대키 목록 <span className="text-ink-400 font-medium tabular ml-1">{invites.length}</span></div>
         </div>
         <div className="overflow-x-auto">
-        <table className="pro" style={{ minWidth: 640 }}>
+        <table className="pro pro-cards" style={{ minWidth: 640 }}>
           <thead>
             <tr>
               <th>키</th>
@@ -1712,25 +1712,25 @@ function InvitesTab({
               const expired = !k.used && k.expiresAt && new Date(k.expiresAt) < new Date();
               return (
                 <tr key={k.id}>
-                  <td>
+                  <td className="cell-primary">
                     <div className="flex items-center gap-2">
                       <button onClick={() => copy(k.key)} className="font-mono text-[12px] font-bold text-ink-900 hover:text-brand-600" title="클릭하여 복사">
                         {k.key}
                       </button>
                     </div>
                   </td>
-                  <td>
+                  <td data-label="대상">
                     <div className="text-[13px] font-bold text-ink-900">{k.name ?? "—"}</div>
                     <div className="text-[11px] text-ink-500 truncate tabular">{k.email ?? "이메일 제한 없음"}</div>
                   </td>
-                  <td>
+                  <td data-label="권한·팀·직급">
                     <div className="flex flex-wrap gap-1 items-center">
                       <span className="chip-gray">{k.role}</span>
                       {k.team && <span className="chip-blue">{k.team}</span>}
                       {k.position && <span className="chip-brand">{k.position}</span>}
                     </div>
                   </td>
-                  <td>
+                  <td data-label="상태">
                     {k.used ? (
                       <div>
                         <span className="chip-gray">사용완료</span>
@@ -1744,7 +1744,7 @@ function InvitesTab({
                       </span>
                     )}
                   </td>
-                  <td style={{ textAlign: "right" }}>
+                  <td className="cell-actions" style={{ textAlign: "right" }}>
                     <button className="btn-icon" title="삭제" onClick={() => remove(k.id)}>
                       <TrashIcon />
                     </button>
@@ -1754,7 +1754,7 @@ function InvitesTab({
             })}
             {invites.length === 0 && (
               <tr>
-                <td colSpan={5}>
+                <td colSpan={5} className="cell-full">
                   <EmptyState title="발급된 초대키가 없어요" description="좌측에서 새 초대키를 발급해보세요." />
                 </td>
               </tr>
@@ -2005,7 +2005,7 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
                     if (v && v !== p.name) rename(p, v);
                   }}
                 />
-                <div className="text-[11px] text-ink-500 tabular w-[88px] text-right">
+                <div className="text-[11px] text-ink-500 tabular w-[88px] text-right hidden sm:block">
                   {new Date(p.createdAt).toLocaleDateString("ko-KR")}
                 </div>
                 <button className="btn-icon" title="삭제" onClick={() => remove(p)}>

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -662,7 +662,7 @@ function LogsPanel() {
         </div>
       </div>
       <div className="overflow-x-auto">
-      <table className="pro" style={{ minWidth: 820 }}>
+      <table className="pro pro-cards" style={{ minWidth: 820 }}>
         <thead>
           <tr>
             <th>시각</th>
@@ -676,17 +676,17 @@ function LogsPanel() {
         <tbody>
           {filtered.map((l) => (
             <tr key={l.id}>
-              <td className="tabular text-[11px] text-ink-600">{new Date(l.createdAt).toLocaleString("ko-KR")}</td>
-              <td>{l.user?.name ?? "—"}</td>
-              <td><span className="chip-gray tabular">{l.action}</span></td>
-              <td className="tabular text-[11px] text-ink-600 max-w-[180px] truncate" title={l.target ?? ""}>{l.target ?? "—"}</td>
-              <td className="text-[11px] text-ink-600 max-w-[280px] truncate" title={l.detail ?? ""}>{l.detail ?? "—"}</td>
-              <td className="tabular text-[11px] text-ink-500">{l.ip ?? "—"}</td>
+              <td className="cell-primary tabular text-[12px] font-semibold text-ink-800 sm:text-[11px] sm:font-normal sm:text-ink-600">{new Date(l.createdAt).toLocaleString("ko-KR")}</td>
+              <td data-label="사용자">{l.user?.name ?? "—"}</td>
+              <td data-label="액션"><span className="chip-gray tabular">{l.action}</span></td>
+              <td data-label="대상" className="tabular text-[11px] text-ink-600 sm:max-w-[180px] sm:truncate" title={l.target ?? ""}>{l.target ?? "—"}</td>
+              <td data-label="상세" className="text-[11px] text-ink-600 sm:max-w-[280px] sm:truncate" title={l.detail ?? ""}>{l.detail ?? "—"}</td>
+              <td data-label="IP" className="tabular text-[11px] text-ink-500">{l.ip ?? "—"}</td>
             </tr>
           ))}
           {filtered.length === 0 && (
             <tr>
-              <td colSpan={6} style={{ textAlign: "center", padding: "40px 0" }} className="t-caption">
+              <td colSpan={6} style={{ textAlign: "center", padding: "40px 0" }} className="t-caption cell-full">
                 로그가 없습니다.
               </td>
             </tr>
@@ -847,7 +847,7 @@ function ChatAuditPanel() {
                           )}
                         </div>
                         <div className="max-w-[72%]">
-                          <div className="flex items-center gap-1.5 mb-0.5">
+                          <div className="flex flex-wrap items-center gap-1.5 mb-0.5">
                             <span className="text-[11px] font-semibold text-ink-700">{m.sender.name}</span>
                             <span className="text-[10px] text-ink-400 tabular">
                               {new Date(m.createdAt).toLocaleString("ko-KR", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })}
@@ -1630,7 +1630,9 @@ function ConsolePanel() {
           <TrafficLight color="#FEBC2E" />
           <TrafficLight color="#28C840" />
         </div>
+        {/* 가운데 절대배치 타이틀 — 좁은 화면에선 양쪽 신호등/컨트롤과 겹쳐 모바일에선 숨김 */}
         <div
+          className="hidden sm:flex items-center gap-1.5"
           style={{
             position: "absolute",
             left: "50%",
@@ -1639,9 +1641,6 @@ function ConsolePanel() {
             fontSize: 11.5,
             fontWeight: 700,
             letterSpacing: "0.04em",
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
           }}
         >
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -436,6 +436,11 @@ textarea.input {
 @media (pointer: coarse) {
   .tap-row { min-height: 44px; }
 }
+/* 터치 기기에서 아이콘 버튼(편집·삭제 등)의 탭 타겟을 40px 로 키운다. 아이콘 자체
+   크기는 그대로(가운데 정렬), 히트 영역만 확대. 마우스(pointer:fine)는 32px 유지. */
+@media (pointer: coarse) {
+  .btn-icon { width: 40px; height: 40px; }
+}
 /* 풀높이 모달이 노치/홈인디케이터에 가리지 않도록 오버레이에 safe-area 패딩.
    env() 는 데스크톱에서 0 이라 웹/Electron 외형은 변하지 않음(p-4 동등). */
 .modal-safe {


### PR DESCRIPTION
## 증상
**관리자·운영 콘솔 페이지 모바일 카드 UI**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- 구성원·초대키 목록 표를 모바일에서 카드(.pro-cards)로 — 가로 스크롤 없이
  한 명/한 건이 라벨·값 카드로 보이고 액션 버튼은 카드 하단에 정렬.
- HR 상세(21컬럼) 뷰 토글은 데스크톱 전용 → 모바일에선 숨겨 기본 카드 유지.
- 툴바 세로 구분선·직급 생성일은 모바일에서 숨겨 좁은 화면 정리.
- .btn-icon 터치 타겟을 coarse 포인터에서 40px 로(아이콘 크기는 유지).

## 수정
**작업 항목 (커밋 단위)**
- fix(admin): 관리자 페이지 모바일 카드화 + 터치 타겟 정리
- fix(console): 운영 콘솔 모바일 카드화 + 레이아웃 정리

**변경 대상 (11개 파일)**
- `client/src/components/superadmin/AuditPanel.tsx`
- `client/src/components/superadmin/FlagsPanel.tsx`
- `client/src/components/superadmin/RolePermissionsPanel.tsx`
- `client/src/components/superadmin/SecurityPanel.tsx`
- `client/src/components/superadmin/SessionsPanel.tsx`
- `client/src/components/superadmin/TokensPanel.tsx`
- `client/src/components/superadmin/TrashPanel.tsx`
- `client/src/components/superadmin/TwoFAPanel.tsx`
- `client/src/pages/AdminPage.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #297** 에서 진행됩니다.

