### PR TITLE
🔀 :: (#299) 다크모드 새로고침 흰 화면 깜빡임(FOUC) 제거

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <!-- ───────── 테마 부트스트랩 (FOUC 방지) ─────────
+         CSS 번들/React(theme.tsx)가 로드되기 전에 다크 클래스와 배경색을 먼저 적용한다.
+         이게 없으면 새로고침 때 한 프레임 흰 화면이 번쩍였다가 다크로 바뀐다.
+         규칙은 theme.tsx 와 동일: 저장값(hinest.theme) 우선, 없으면 시스템 설정.
+         색상은 styles.css --c-bg 와 일치(라이트 #F5F6F8 / 다크 #0E1014). -->
+    <style>
+      html { background-color: #F5F6F8; color-scheme: light; }
+      html.dark { background-color: #0E1014; color-scheme: dark; }
+    </style>
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('hinest.theme');
+          var dark = t === 'dark' || ((t === 'system' || !t) && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (dark) document.documentElement.classList.add('dark');
+        } catch (e) {}
+      })();
+    </script>
     <meta name="theme-color" content="#3B5CF0" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="HiNest" />


### PR DESCRIPTION
## 증상
**다크모드 새로고침 흰 화면 깜빡임(FOUC) 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
새로고침하면 CSS 번들/React(theme.tsx)가 다크 클래스를 붙이기 전에 문서가
한 프레임 흰색으로 그려졌다가 다크로 바뀌어 번쩍였다.

index.html <head> 에 동기 부트스트랩을 추가 — 첫 페인트 전에 html.dark 클래스와
배경색(color-scheme 포함)을 선적용한다. theme.tsx 와 동일 규칙(hinest.theme 우선,
없으면 prefers-color-scheme), 색은 styles.css --c-bg 와 일치(라이트 #F5F6F8 / 다크 #0E1014).

## 수정
**작업 항목 (커밋 단위)**
- fix(theme): 다크모드 새로고침 시 흰 화면 깜빡임(FOUC) 제거

**변경 대상 (1개 파일)**
- `client/index.html`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #299** 에서 진행됩니다.

