### PR TITLE
🔀 :: (#300) 새로고침 시 하단 탭 '개요' 깜빡임 제거

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -90,13 +90,15 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func configure(_ call: CAPPluginCall) {
         let tabs = call.getArray("tabs", JSObject.self) ?? []
+        // 초기 선택 탭 키(현재 경로). 없으면 첫 탭으로 폴백.
+        let selected = call.getString("selected")
         NSLog("[LGTB] configure called, tabs=\(tabs.count)")
         DispatchQueue.main.async {
             guard let host = self.bridge?.viewController?.view else {
                 NSLog("[LGTB] no host view -> reject")
                 call.reject("no-host-view"); return
             }
-            self.build(host: host, tabs: tabs)
+            self.build(host: host, tabs: tabs, selected: selected)
             NSLog("[LGTB] configured (real UITabBar), active=true")
             call.resolve(["active": true])
         }
@@ -105,7 +107,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
     /// 실제 애플 UIKit 탭 바(UITabBar) 를 웹뷰 위에 올린다. iOS 26 에선 시스템이 자동으로
     /// Liquid Glass 머티리얼을 입힌다(앱이 직접 그리지 않음 = 정품 시스템 컴포넌트).
     /// iOS 26 미만에선 일반 탭 바로 자연스럽게 폴백.
-    private func build(host: UIView, tabs: [JSObject]) {
+    private func build(host: UIView, tabs: [JSObject], selected: String? = nil) {
         tabBarView?.removeFromSuperview()
         keys.removeAll()
 
@@ -129,7 +131,14 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
             items.append(item)
         }
         tabBar.setItems(items, animated: false)
-        tabBar.selectedItem = items.first
+        // 초기 선택을 현재 경로 탭으로 맞춘다. 기본값(items.first = 개요)으로 두면 새로고침
+        // 때 개요가 한 번 하이라이트됐다가 현재 탭으로 점프하는(개요 깜빡임) 문제가 생긴다.
+        // 매칭 탭이 없으면(탭이 아닌 경로: /profile 등) applySelected 와 동일하게 선택 없음(nil).
+        if let sel = selected, let i = keys.firstIndex(of: sel), i < items.count {
+            tabBar.selectedItem = items[i]
+        } else {
+            tabBar.selectedItem = nil
+        }
 
         host.addSubview(tabBar)
         NSLayoutConstraint.activate([

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -705,7 +705,12 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     let removeListener: (() => void) | undefined;
     (async () => {
       try {
-        const res = await LiquidGlassTabBar.configure({ tabs: NATIVE_GLASS_TABS });
+        // 초기 선택을 현재 경로 탭으로 넘겨 바가 처음부터 올바른 탭에 켜지게 한다.
+        // (안 넘기면 네이티브가 첫 탭=개요로 켜졌다가 아래 setSelected 로 점프 → 개요 깜빡임)
+        const res = await LiquidGlassTabBar.configure({
+          tabs: NATIVE_GLASS_TABS,
+          selected: matchNativeTabKey(window.location.pathname),
+        });
         if (cancelled || !res?.active) return;
         document.documentElement.classList.add("hinest-native-tabbar");
         const handle = await LiquidGlassTabBar.addListener("tabSelected", (d) => {

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -21,7 +21,8 @@ export interface LiquidGlassTab {
 }
 
 export interface LiquidGlassTabBarPlugin {
-  configure(options: { tabs: LiquidGlassTab[] }): Promise<{ active: boolean }>;
+  /** selected: 초기 선택 탭 key(현재 경로). 새로고침 시 개요가 깜빡였다 점프하는 것 방지. */
+  configure(options: { tabs: LiquidGlassTab[]; selected?: string }): Promise<{ active: boolean }>;
   setSelected(options: { key: string }): Promise<void>;
   setBadge(options: { key: string; count: number }): Promise<void>;
   setVisible(options: { visible: boolean }): Promise<void>;


### PR DESCRIPTION
## 증상
**새로고침 시 하단 탭 '개요' 깜빡임 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
네이티브 탭바를 (재)생성하는 build() 가 항상 첫 탭(개요)을 selectedItem 으로
켜둔 뒤, JS 가 한 박자 늦게 setSelected(현재 경로) 로 바로잡았다. 그래서 새로고침
때 하단 탭 하이라이트가 '개요 → 현재 탭' 으로 한 번 점프(개요 깜빡임)했다.

- configure 에 selected(현재 경로 탭 key)를 전달 → build 가 처음부터 올바른 탭 선택.
- 매칭 탭이 없는 경로(/profile 등)는 nil(선택 없음)으로 applySelected 와 일치시켜
  그 경우의 개요 깜빡임도 제거.

검증: 클라이언트 tsc 클린. 네이티브는 이 샌드박스에 xcodebuild 가 없어 코드 검토로
확인(작은 변경 + build() 기본 인자라 하위호환). 실제 반영은 cap:ios 재빌드 시.

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 새로고침 시 하단 탭이 '개요'로 깜빡였다 돌아오는 문제 수정

**변경 대상 (3개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/src/components/AppLayout.tsx`
- `client/src/lib/liquidGlassTabBar.ts`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #300** 에서 진행됩니다.

