### PR TITLE
🔀 :: (#301) 출시 전 QA 하드닝 (세션만료·중복제출·SSE백오프·모달Portal 등)

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -130,6 +130,17 @@ export async function api<T = any>(
     err.status = res.status;
     err.code = code;
     err.data = data;
+    // 세션 만료/무효(401) — 인증 엔드포인트 자체(로그인 실패·세션 복원 등)가 아니면 전역으로
+    // 알려 AuthProvider 가 로그아웃 처리(→ /login)하게 한다. 페이지 사용 중 세션이 끊겼는데
+    // 호출부가 catch{} 로 삼켜 빈 화면·stale 데이터로 방치되던 문제를 근본 해결.
+    if (
+      res.status === 401 &&
+      typeof window !== "undefined" &&
+      !path.startsWith("/api/auth") &&
+      !path.startsWith("/api/me")
+    ) {
+      try { window.dispatchEvent(new Event("hinest:unauthorized")); } catch {}
+    }
     throw err;
   }
   if (res.status === 204) return undefined as T;

--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -64,6 +64,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     refresh();
   }, [refresh]);
 
+  // 세션 만료/무효 전역 처리 — 페이지 사용 도중 세션이 끊기면 api.ts 가 'hinest:unauthorized'
+  // 를 디스패치한다. 토큰·세션 캐시를 비우고 user 를 null 로 만들면 Protected(App.tsx)가
+  // 자동으로 /login 으로 보낸다. (인증 엔드포인트의 401 = 로그인 실패 등은 api.ts 에서 제외.)
+  useEffect(() => {
+    function onUnauthorized() {
+      clearAuthToken();
+      clearApiCache();
+      setUser(null);
+      setImpersonator(null);
+    }
+    window.addEventListener("hinest:unauthorized", onUnauthorized);
+    return () => window.removeEventListener("hinest:unauthorized", onUnauthorized);
+  }, []);
+
   // iOS 원격 푸시(APNs) 등록 — 로그인·회원가입뿐 아니라 세션 복원(앱 재실행) 시에도
   // 토큰을 재등록하고 탭→이동 리스너를 다시 건다. setupIosPush 는 멱등이며 iOS 외엔 no-op.
   // user.id 가 바뀔 때만(=로그인/계정전환) 1회 실행 — 매 리렌더마다 register() 가 불리지 않게.

--- a/client/src/lib/passkey.ts
+++ b/client/src/lib/passkey.ts
@@ -28,7 +28,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 export async function registerPasskey(deviceName?: string) {
   console.info("[passkey] registerPasskey start");
   const opts = await api<any>("/api/passkey/register/options", { method: "POST", json: {} });
-  console.info("[passkey] got register options", { rpId: opts?.rp?.id, user: opts?.user?.name });
+  console.info("[passkey] got register options", { rpId: opts?.rp?.id });
   let response: any;
   try {
     response = await withTimeout(startRegistration({ optionsJSON: opts }), 65_000, "패스키 등록");

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -131,6 +131,13 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     reload();
 
     let retry: number | null = null;
+    // SSE 재연결 백오프 — 서버 장애/인증 만료 시 3초마다 무한 재시도해 /stream 을
+    // 두드리지 않도록 지수 백오프(3→6→…→최대 60초). 연결 성공(onopen) 시 3초로 리셋.
+    let reconnectDelay = 3000;
+    function scheduleReconnect() {
+      retry = window.setTimeout(connect, reconnectDelay);
+      reconnectDelay = Math.min(reconnectDelay * 2, 60_000);
+    }
     // 채팅 이벤트는 별도 컴포넌트(ChatMiniApp) 에서 소비하므로 DOM CustomEvent 로
     // 재방송한다. 기존 "chat:open" / "chat:open-room" 같은 in-app event 와 동일 패턴.
     const rebroadcast = (name: "chat:sse-message" | "chat:sse-update" | "chat:sse-room", payload: unknown) => {
@@ -148,6 +155,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
           apiUrl("/api/notification/stream") + (streamToken ? `?token=${encodeURIComponent(streamToken)}` : "");
         const es = new EventSource(streamUrl, { withCredentials: true });
         esRef.current = es;
+        es.onopen = () => { reconnectDelay = 3000; }; // 연결 성공 → 백오프 리셋
         es.addEventListener("notification", (ev: MessageEvent) => {
           try {
             const n = JSON.parse(ev.data) as Notif;
@@ -184,10 +192,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         es.onerror = () => {
           es.close();
           esRef.current = null;
-          retry = window.setTimeout(connect, 3000);
+          scheduleReconnect();
         };
       } catch {
-        retry = window.setTimeout(connect, 3000);
+        scheduleReconnect();
       }
     }
     connect();

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -47,6 +47,9 @@ export default function ProfilePage() {
   const [pwForm, setPwForm] = useState({ current: "", next: "", confirm: "" });
   const [pwMsg, setPwMsg] = useState("");
   const [pwErr, setPwErr] = useState("");
+  // 중복 제출 가드 — 빠른 더블탭으로 프로필 저장/비밀번호 변경이 두 번 POST 되는 것 방지.
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [savingPw, setSavingPw] = useState(false);
 
   // 업로드/저장 중에 사용자가 페이지를 떠나면 setState 가 언마운트 후 호출될 수 있음.
   // setTimeout 으로 메시지 초기화도 언마운트 후에 불릴 수 있어 일괄 가드.
@@ -66,7 +69,9 @@ export default function ProfilePage() {
 
   async function saveProfile(e: React.FormEvent) {
     e.preventDefault();
+    if (savingProfile) return;
     setErr(""); setSavedMsg("");
+    setSavingProfile(true);
     try {
       // avatarUrl 은 명시적으로 항상 함께 전송 — 이미지 제거도 PATCH 로 반영해야 하니까.
       await api("/api/profile", {
@@ -90,6 +95,8 @@ export default function ProfilePage() {
       }, 2000);
     } catch (e: any) {
       if (aliveRef.current) setErr(e.message ?? "저장 실패");
+    } finally {
+      if (aliveRef.current) setSavingProfile(false);
     }
   }
 
@@ -134,9 +141,11 @@ export default function ProfilePage() {
 
   async function changePw(e: React.FormEvent) {
     e.preventDefault();
+    if (savingPw) return;
     setPwErr(""); setPwMsg("");
     if (pwForm.next !== pwForm.confirm) return setPwErr("새 비밀번호 확인이 일치하지 않습니다");
     if (pwForm.next.length < 8) return setPwErr("새 비밀번호는 8자 이상이어야 합니다");
+    setSavingPw(true);
     try {
       await api("/api/profile/password", {
         method: "POST",
@@ -149,6 +158,8 @@ export default function ProfilePage() {
       }, 3000);
     } catch (e: any) {
       if (aliveRef.current) setPwErr(e.message ?? "변경 실패");
+    } finally {
+      if (aliveRef.current) setSavingPw(false);
     }
   }
 
@@ -290,7 +301,7 @@ export default function ProfilePage() {
               {err && <InlineAlert tone="error">{err}</InlineAlert>}
               {savedMsg && <InlineAlert tone="success">{savedMsg}</InlineAlert>}
               <div className="flex justify-end">
-                <button className="btn-primary">저장</button>
+                <button className="btn-primary" disabled={savingProfile}>{savingProfile ? "저장 중…" : "저장"}</button>
               </div>
             </form>
           </div>
@@ -345,7 +356,7 @@ export default function ProfilePage() {
               {pwErr && <InlineAlert tone="error">{pwErr}</InlineAlert>}
               {pwMsg && <InlineAlert tone="success">{pwMsg}</InlineAlert>}
               <div className="flex justify-end">
-                <button className="btn-primary">비밀번호 변경</button>
+                <button className="btn-primary" disabled={savingPw}>{savingPw ? "변경 중…" : "비밀번호 변경"}</button>
               </div>
             </form>
           </div>

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -46,6 +46,8 @@ export default function SchedulePage() {
   const { user } = useAuth();
   const [cursor, setCursor] = useState(() => new Date());
   const [events, setEvents] = useState<Event[]>([]);
+  // 일정 로드 실패 표시 — 조용히 빈 달력으로 두지 않고 재시도 배너를 띄운다.
+  const [loadErr, setLoadErr] = useState(false);
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
     title: "",
@@ -76,11 +78,18 @@ export default function SchedulePage() {
     const toD = endOfMonth(cursor); toD.setDate(toD.getDate() + 7);
     const from = fromD.toISOString();
     const to = toD.toISOString();
-    const res = await api<{ events: Event[] }>(
-      `/api/schedule?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
-    );
-    if (aliveRef && !aliveRef.current) return;
-    setEvents(res.events);
+    try {
+      const res = await api<{ events: Event[] }>(
+        `/api/schedule?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+      );
+      if (aliveRef && !aliveRef.current) return;
+      setEvents(res.events);
+      setLoadErr(false);
+    } catch {
+      // 401(세션 만료)은 api.ts 가 전역 처리(→ /login). 그 외(500·네트워크)는 재시도 배너.
+      if (aliveRef && !aliveRef.current) return;
+      setLoadErr(true);
+    }
   }
 
   // cursor 빠르게 넘길 때 이전 달 응답이 나중에 와서 덮는 레이스 방지.
@@ -260,6 +269,13 @@ export default function SchedulePage() {
           </div>
         }
       />
+
+      {loadErr && (
+        <div className="card cal-fullbleed p-3 mb-3 flex items-center justify-between gap-3">
+          <span className="text-[13px] text-ink-600">일정을 불러오지 못했어요.</span>
+          <button type="button" className="btn-ghost btn-xs" onClick={() => load()}>다시 시도</button>
+        </div>
+      )}
 
       {view === "month" ? (
       <>
@@ -576,6 +592,7 @@ function DayDetailModal({
 }) {
   const holiday = getHoliday(date);
   return (
+    <Portal>
     <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div
         className="panel w-full max-w-[480px] shadow-pop overflow-hidden"
@@ -677,6 +694,7 @@ function DayDetailModal({
         </div>
       </div>
     </div>
+    </Portal>
   );
 }
 


### PR DESCRIPTION
## 증상
**출시 전 QA 하드닝 (세션만료·중복제출·SSE백오프·모달Portal 등)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
페이지 사용 도중 세션이 만료되면 이후 api() 가 401 을 던지는데 다수 호출부가
catch{} 로 삼켜, 빈 화면·stale 데이터로 방치되고 유저는 로그아웃된 줄 몰랐다.
api.ts 가 401(인증 엔드포인트 제외)에 'hinest:unauthorized' 디스패치 →
AuthProvider 가 토큰·캐시 비우고 user=null → Protected 가 /login 으로.

## 수정
**작업 항목 (커밋 단위)**
- fix(auth): 세션 만료(401) 전역 처리 — 사용 중 끊기면 자동 로그아웃→/login
- fix(profile): 프로필 저장·비밀번호 변경 중복 제출 가드
- fix(net/sec): SSE 재연결 지수 백오프 + 패스키 로그 PII 제거
- fix(schedule): DayDetail 모달 Portal 처리 + 일정 로드 실패 재시도 배너

**변경 대상 (6개 파일)**
- `client/src/api.ts`
- `client/src/auth.tsx`
- `client/src/lib/passkey.ts`
- `client/src/notifications.tsx`
- `client/src/pages/ProfilePage.tsx`
- `client/src/pages/SchedulePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #301** 에서 진행됩니다.

