### PR TITLE
🔀 :: (#302) 출시 QA 라운드2 — 전 모달 Portal 통일 + 로드 견고화/로딩/법적고지

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1398,6 +1398,13 @@ export function MobileMenuPage() {
         </svg>
         <span>로그아웃</span>
       </button>
+
+      {/* 법적 고지 — 로그인 후에도 메뉴에서 접근 가능하게(가입/로그인 화면 외 추가 노출). */}
+      <div className="flex items-center justify-center gap-3 mt-3 text-[12px] text-ink-400">
+        <NavLink to="/privacy" className="hover:text-ink-700 transition">개인정보처리방침</NavLink>
+        <span className="text-ink-200">·</span>
+        <NavLink to="/terms" className="hover:text-ink-700 transition">이용약관</NavLink>
+      </div>
     </div>
   );
 }

--- a/client/src/components/NotificationPrefsModal.tsx
+++ b/client/src/components/NotificationPrefsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../api";
 import { alertAsync } from "./ConfirmHost";
+import Portal from "./Portal";
 
 type Prefs = Record<string, boolean>;
 type Loaded = { prefs: Prefs; dndStart: string | null; dndEnd: string | null; emailOn: boolean };
@@ -60,6 +61,7 @@ export default function NotificationPrefsModal({ open, onClose }: { open: boolea
   }
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-[70]" onClick={onClose}>
       <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
         <h3 className="text-lg font-bold mb-1">알림 설정</h3>
@@ -133,5 +135,6 @@ export default function NotificationPrefsModal({ open, onClose }: { open: boolea
         </div>
       </div>
     </div>
+    </Portal>
   );
 }

--- a/client/src/components/PayslipComposer.tsx
+++ b/client/src/components/PayslipComposer.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { api } from "../api";
 import { useModalDismiss } from "../lib/useModalDismiss";
+import Portal from "./Portal";
 import {
   type Payslip,
   type LineItem,
@@ -168,6 +169,7 @@ export default function PayslipComposer({
   const years = Array.from({ length: 6 }, (_, i) => defaultYear - i + 1);
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-slate-900/45 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div
         className="card w-full max-w-3xl max-h-[92vh] overflow-y-auto"
@@ -292,6 +294,7 @@ export default function PayslipComposer({
         </div>
       </div>
     </div>
+    </Portal>
   );
 }
 

--- a/client/src/components/PayslipPreview.tsx
+++ b/client/src/components/PayslipPreview.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useModalDismiss } from "../lib/useModalDismiss";
+import Portal from "./Portal";
 import {
   type Payslip,
   attendanceEntries,
@@ -43,6 +44,7 @@ export default function PayslipPreview({
   const calc = p.calcRows ?? [];
 
   return (
+    <Portal>
     <div
       className="fixed inset-0 bg-slate-900/50 grid place-items-center modal-safe z-50"
       onClick={onClose}
@@ -212,6 +214,7 @@ export default function PayslipPreview({
         )}
       </div>
     </div>
+    </Portal>
   );
 }
 

--- a/client/src/components/ProjectCalendar.tsx
+++ b/client/src/components/ProjectCalendar.tsx
@@ -3,6 +3,7 @@ import { api, apiSWR , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import DateTimePicker from "./DateTimePicker";
 import { confirmAsync, alertAsync } from "./ConfirmHost";
+import Portal from "./Portal";
 
 type ProjectEvent = {
   id: string;
@@ -387,6 +388,7 @@ export default function ProjectCalendar({
 
       {/* 생성 모달 */}
       {openCreate && (
+        <Portal>
         <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setOpenCreate(false)}>
           <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-bold mb-4">새 일정</h3>
@@ -463,10 +465,12 @@ export default function ProjectCalendar({
             </form>
           </div>
         </div>
+        </Portal>
       )}
 
       {/* 상세 모달 */}
       {selected && (
+        <Portal>
         <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setSelected(null)}>
           <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center gap-2 mb-2">
@@ -533,6 +537,7 @@ export default function ProjectCalendar({
             </div>
           </div>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/components/ProjectSettingsModal.tsx
+++ b/client/src/components/ProjectSettingsModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api, invalidateCache , imgSrc} from "../api";
 import { confirmAsync } from "./ConfirmHost";
+import Portal from "./Portal";
 
 type Role = "OWNER" | "MANAGER" | "MEMBER";
 
@@ -69,6 +70,7 @@ export default function ProjectSettingsModal({
   const canDelete = myRole === "OWNER" || myRole === "ADMIN";
 
   return (
+    <Portal>
     <div
       className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50"
       onClick={onClose}
@@ -119,6 +121,7 @@ export default function ProjectSettingsModal({
         )}
       </div>
     </div>
+    </Portal>
   );
 }
 

--- a/client/src/components/ProjectWebhooks.tsx
+++ b/client/src/components/ProjectWebhooks.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { api, apiSWR } from "../api";
 import { confirmAsync, alertAsync, promptAsync } from "./ConfirmHost";
+import Portal from "./Portal";
 
 type Channel = {
   id: string;
@@ -269,6 +270,7 @@ export default function ProjectWebhooks({ projectId }: { projectId: string }) {
 
       {/* 생성 모달 */}
       {openCreate && (
+        <Portal>
         <div
           className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50"
           onClick={() => setOpenCreate(false)}
@@ -315,6 +317,7 @@ export default function ProjectWebhooks({ projectId }: { projectId: string }) {
             </form>
           </div>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/components/RevisionHistoryModal.tsx
+++ b/client/src/components/RevisionHistoryModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { api , imgSrc} from "../api";
 import { confirmAsync, alertAsync } from "./ConfirmHost";
 import { fmtSize } from "../lib/fmt";
+import Portal from "./Portal";
 
 /**
  * 문서/회의록 공용 히스토리 모달. API 경로만 prefix 로 갈아끼우면 됨.
@@ -70,6 +71,7 @@ export default function RevisionHistoryModal({
   }
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()}>
         <div className="section-head">
@@ -121,6 +123,7 @@ export default function RevisionHistoryModal({
         </div>
       </div>
     </div>
+    </Portal>
   );
 }
 

--- a/client/src/components/ShareLinkModal.tsx
+++ b/client/src/components/ShareLinkModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { api } from "../api";
 import { alertAsync } from "./ConfirmHost";
 import DateTimePicker from "./DateTimePicker";
+import Portal from "./Portal";
 
 /**
  * 외부 공유 링크 관리 모달.
@@ -91,6 +92,7 @@ export default function ShareLinkModal({ documentId, folderId, documentTitle, on
   }
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="공유 링크 관리">
         <div className="section-head">
@@ -182,5 +184,6 @@ export default function ShareLinkModal({ documentId, folderId, documentTitle, on
         </div>
       </div>
     </div>
+    </Portal>
   );
 }

--- a/client/src/components/superadmin/ErrorsPanel.tsx
+++ b/client/src/components/superadmin/ErrorsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync } from "../ConfirmHost";
+import Portal from "../Portal";
 
 type Group = {
   hash: string;
@@ -117,6 +118,7 @@ export default function ErrorsPanel() {
       </div>
 
       {openHash && (
+        <Portal>
         <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setOpenHash(null)}>
           <div className="panel w-full max-w-[840px] max-h-[88vh] flex flex-col overflow-hidden" onClick={(e) => e.stopPropagation()}>
             <div className="px-5 py-3 border-b border-ink-150 flex items-center justify-between">
@@ -149,6 +151,7 @@ export default function ErrorsPanel() {
             </div>
           </div>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/components/superadmin/FlagsPanel.tsx
+++ b/client/src/components/superadmin/FlagsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync } from "../ConfirmHost";
+import Portal from "../Portal";
 
 type Flag = {
   key: string;
@@ -96,6 +97,7 @@ export default function FlagsPanel() {
       </div>
 
       {editing && (
+        <Portal>
         <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setEditing(null)}>
           <form
             className="panel w-full max-w-[480px] p-5"
@@ -157,6 +159,7 @@ export default function FlagsPanel() {
             </div>
           </form>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/components/superadmin/SecurityPanel.tsx
+++ b/client/src/components/superadmin/SecurityPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync } from "../ConfirmHost";
 import DateTimePicker from "../DateTimePicker";
+import Portal from "../Portal";
 
 type Rate = { id: string; routeGlob: string; perMin: number; perHour: number; scope: string; enabled: boolean; note: string | null; createdAt: string };
 type Block = { id: string; cidr: string; country: string | null; reason: string | null; enabled: boolean; expiresAt: string | null; createdAt: string };
@@ -184,6 +185,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 function Modal({ onClose, onSubmit, children }: { onClose: () => void; onSubmit: () => void; children: React.ReactNode }) {
   return (
+    <Portal>
     <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <form
         className="panel w-full max-w-[460px] p-5 max-h-[88vh] overflow-y-auto"
@@ -197,5 +199,6 @@ function Modal({ onClose, onSubmit, children }: { onClose: () => void; onSubmit:
         </div>
       </form>
     </div>
+    </Portal>
   );
 }

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { api, imgSrc, invalidateCache } from "../api";
 import PageHeader from "../components/PageHeader";
+import Portal from "../components/Portal";
 import { downloadCSV, downloadXLSX, openPrintable, parseSheet, type TableColumn } from "../lib/exportTable";
 import DatePicker from "../components/DatePicker";
 import TimePicker from "../components/TimePicker";
@@ -751,6 +752,7 @@ function ResignModal({
   }
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-black/40 grid place-items-center z-50 modal-safe" onClick={onClose}>
       <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-1">
@@ -830,6 +832,7 @@ function ResignModal({
         </div>
       </div>
     </div>
+    </Portal>
   );
 }
 
@@ -901,6 +904,7 @@ function UserDetailEditModal({
   }
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div
         className="card w-full max-w-3xl max-h-[90vh] overflow-hidden flex flex-col"
@@ -1049,6 +1053,7 @@ function UserDetailEditModal({
         </div>
       </div>
     </div>
+    </Portal>
   );
 }
 
@@ -1480,6 +1485,7 @@ function AttendanceEditModal({
   }
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-black/40 grid place-items-center z-50 modal-safe" onClick={onClose}>
       <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-1">
@@ -1565,6 +1571,7 @@ function AttendanceEditModal({
         </div>
       </div>
     </div>
+    </Portal>
   );
 }
 

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -116,6 +116,7 @@ export default function ApprovalsPage() {
     setSp(next, { replace: true });
   };
   const [approvals, setApprovals] = useState<Approval[]>([]);
+  const [loadErr, setLoadErr] = useState(false);
   const [selected, setSelected] = useState<Approval | null>(null);
   const [creating, setCreating] = useState(false);
   // 재상신 시에는 원본 id와 prefill 을 함께 넘겨 POST /:id/revise 로 라우팅.
@@ -144,18 +145,27 @@ export default function ApprovalsPage() {
 
   async function load() {
     const myToken = ++loadTokenRef.current;
-    const res = await api<{ approvals: Approval[] }>(`/api/approval?scope=${scope}`);
-    if (!aliveRef.current || myToken !== loadTokenRef.current) return;
-    setApprovals(res.approvals);
-    if (selected) {
-      const fresh = res.approvals.find((a) => a.id === selected.id);
-      if (fresh) setSelected(fresh);
+    try {
+      const res = await api<{ approvals: Approval[] }>(`/api/approval?scope=${scope}`);
+      if (!aliveRef.current || myToken !== loadTokenRef.current) return;
+      setApprovals(res.approvals);
+      setLoadErr(false);
+      if (selected) {
+        const fresh = res.approvals.find((a) => a.id === selected.id);
+        if (fresh) setSelected(fresh);
+      }
+    } catch {
+      // 401(세션 만료)은 api.ts 가 전역 처리(→ /login). 그 외(500·네트워크)는 재시도 배너.
+      if (!aliveRef.current || myToken !== loadTokenRef.current) return;
+      setLoadErr(true);
     }
   }
   async function loadDirectory() {
-    const res = await api<{ users: DirUser[] }>("/api/users");
-    if (!aliveRef.current) return;
-    setDirectory(res.users);
+    try {
+      const res = await api<{ users: DirUser[] }>("/api/users");
+      if (!aliveRef.current) return;
+      setDirectory(res.users);
+    } catch { /* 디렉터리는 결재 생성 보조용 — 실패해도 목록 자체엔 영향 없음 */ }
   }
   useEffect(() => { load(); /* eslint-disable-next-line */ }, [scope]);
   useEffect(() => { loadDirectory(); }, []);
@@ -261,6 +271,13 @@ export default function ApprovalsPage() {
           </>
         }
       />
+
+      {loadErr && (
+        <div className="card p-3 mb-3 flex items-center justify-between gap-3">
+          <span className="text-[13px] text-ink-600">결재 목록을 불러오지 못했어요.</span>
+          <button type="button" className="btn-ghost btn-xs" onClick={() => load()}>다시 시도</button>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
         <div className="lg:col-span-2 panel p-0 overflow-hidden">

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -4,6 +4,7 @@ import PageHeader from "../components/PageHeader";
 import { useAuth } from "../auth";
 import MonthPicker from "../components/MonthPicker";
 import DateTimePicker from "../components/DateTimePicker";
+import Portal from "../components/Portal";
 import { alertAsync } from "../components/ConfirmHost";
 import { useModalDismiss } from "../lib/useModalDismiss";
 
@@ -410,6 +411,7 @@ export default function AttendancePage() {
 
       {/* 신청 모달 */}
       {open && (
+        <Portal>
         <div
           className="fixed inset-0 z-50 grid place-items-center modal-safe"
           style={{ background: "rgba(0,0,0,0.45)", backdropFilter: "blur(4px)" }}
@@ -482,6 +484,7 @@ export default function AttendancePage() {
             </form>
           </div>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -45,6 +45,7 @@ export default function AttendancePage() {
   const { user } = useAuth();
   const [month, setMonth] = useState(ymNow());
   const [records, setRecords] = useState<Attendance[]>([]);
+  const [loading, setLoading] = useState(true);
   const [leaves, setLeaves] = useState<Leave[]>([]);
   const [allLeaves, setAllLeaves] = useState<Leave[]>([]);
   const [open, setOpen] = useState(false);
@@ -85,9 +86,11 @@ export default function AttendancePage() {
   const isReviewer = user?.role === "ADMIN" || user?.role === "MANAGER";
   useEffect(() => {
     let alive = true;
+    setLoading(true);
     apiSWR<{ attendances: Attendance[] }>(`/api/attendance/month?month=${month}`, {
-      onCached: (d) => { if (alive) setRecords(d.attendances); },
-      onFresh: (d) => { if (alive) setRecords(d.attendances); },
+      onCached: (d) => { if (alive) { setRecords(d.attendances); setLoading(false); } },
+      onFresh: (d) => { if (alive) { setRecords(d.attendances); setLoading(false); } },
+      onError: () => { if (alive) setLoading(false); },
     });
     apiSWR<{ leaves: Leave[] }>("/api/attendance/leave", {
       onCached: (d) => { if (alive) setLeaves(d.leaves); },
@@ -239,7 +242,13 @@ export default function AttendancePage() {
               <div className="text-[12px] text-ink-500 mt-0.5">총 {records.length}일 기록</div>
             </div>
           </div>
-          {records.length === 0 ? (
+          {loading && records.length === 0 ? (
+            <div className="p-4 space-y-2">
+              {[0, 1, 2, 3, 4].map((i) => (
+                <div key={i} className="h-10 rounded-lg bg-ink-100 dark:bg-ink-800 animate-pulse" />
+              ))}
+            </div>
+          ) : records.length === 0 ? (
             <EmptyState
               icon={
                 <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { api, apiFetch , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import Portal from "../components/Portal";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
 import ShareLinkModal from "../components/ShareLinkModal";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
@@ -1427,6 +1428,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       {/* /폴더+문서 공용 드롭존 */}
 
       {creating === "folder" && (
+        <Portal>
         <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setCreating(null)}>
           <div className="panel w-full max-w-md" onClick={(e) => e.stopPropagation()}>
             <div className="section-head">
@@ -1534,9 +1536,11 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
             </form>
           </div>
         </div>
+        </Portal>
       )}
 
       {creating === "doc" && (
+        <Portal>
         <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={() => setCreating(null)}>
           <div className="panel w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
             <div className="section-head">
@@ -1686,6 +1690,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
             </form>
           </div>
         </div>
+        </Portal>
       )}
 
       {sharingDoc && (

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import Portal from "../components/Portal";
 import MonthPicker from "../components/MonthPicker";
 import DateTimePicker from "../components/DateTimePicker";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
@@ -340,6 +341,7 @@ export default function ExpensePage() {
       </div>
 
       {open && (
+        <Portal>
         <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setOpen(false)}>
           <div className="card w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-bold mb-4">법인카드 사용내역 등록</h3>
@@ -440,12 +442,15 @@ export default function ExpensePage() {
             </form>
           </div>
         </div>
+        </Portal>
       )}
 
       {preview && (
+        <Portal>
         <div className="fixed inset-0 bg-slate-900/70 grid place-items-center modal-safe z-50" onClick={() => setPreview(null)}>
           <img src={preview} alt="receipt" decoding="async" className="max-h-[90vh] max-w-[90vw] rounded-xl" loading="lazy"/>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -31,6 +31,7 @@ type Mode = "view" | "create" | "edit";
 
 export default function JournalPage() {
   const [list, setList] = useState<Journal[]>([]);
+  const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<Journal | null>(null);
   const [form, setForm] = useState({ date: today(), title: "", content: "" });
   const [mode, setMode] = useState<Mode>("view");
@@ -55,13 +56,16 @@ export default function JournalPage() {
       onCached: (d) => {
         if (!aliveRef.current) return;
         setList(d.journals);
+        setLoading(false);
         if (d.journals.length && !selected) setSelected(d.journals[0]);
       },
       onFresh: (d) => {
         if (!aliveRef.current) return;
         setList(d.journals);
+        setLoading(false);
         if (d.journals.length && !selected) setSelected(d.journals[0]);
       },
+      onError: () => { if (aliveRef.current) setLoading(false); },
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -197,7 +201,13 @@ export default function JournalPage() {
             </div>
           </div>
           <div className="flex-1 overflow-auto">
-            {filtered.length === 0 ? (
+            {loading && filtered.length === 0 ? (
+              <div className="px-4 py-4 space-y-2">
+                {[0, 1, 2, 3, 4].map((i) => (
+                  <div key={i} className="h-14 rounded-lg bg-ink-100 dark:bg-ink-800 animate-pulse" />
+                ))}
+              </div>
+            ) : filtered.length === 0 ? (
               <div className="px-4 py-12 text-center">
                 <div className="text-[34px] mb-2">📝</div>
                 <div className="text-[13px] font-bold text-ink-900">{q ? "검색 결과가 없어요" : "아직 일지가 없어요"}</div>

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
 import DateTimePicker from "../components/DateTimePicker";
+import Portal from "../components/Portal";
 import { alertAsync } from "../components/ConfirmHost";
 import { useModalDismiss } from "../lib/useModalDismiss";
 
@@ -356,6 +357,7 @@ export default function JournalPage() {
       </div>
 
       {confirmRemoveId && (
+        <Portal>
         <div
           className="fixed inset-0 z-50 grid place-items-center modal-safe"
           style={{ background: "rgba(0,0,0,0.45)", backdropFilter: "blur(4px)" }}
@@ -397,6 +399,7 @@ export default function JournalPage() {
             </div>
           </div>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -6,6 +6,7 @@ import { useNotifications } from "../notifications";
 import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
+import Portal from "../components/Portal";
 import { copyToClipboard, absoluteUrl } from "../lib/clipboard";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 
@@ -353,6 +354,7 @@ export default function NoticePage() {
       </div>
 
       {open && (
+        <Portal>
         <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe" onClick={() => setOpen(false)}>
           <div className="card w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-bold mb-4">공지 작성</h3>
@@ -389,6 +391,7 @@ export default function NoticePage() {
             </form>
           </div>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { api, invalidateCache, clearApiCache, apiFetch , imgSrc} from "../api";
 import { isCapacitorNative } from "../lib/platform";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import Portal from "../components/Portal";
 import { useTheme, type ThemeMode } from "../theme";
 import { PRESENCE_CHOICES, resolvePresence, type PresenceStatus } from "../lib/presence";
 import {
@@ -429,6 +430,7 @@ function DangerZonePanel() {
       </button>
 
       {open && (
+        <Portal>
         <div
           className="fixed inset-0 z-50 flex items-center justify-center modal-safe"
           style={{ background: "rgba(0,0,0,0.45)" }}
@@ -493,6 +495,7 @@ function DangerZonePanel() {
             </form>
           </div>
         </div>
+        </Portal>
       )}
     </div>
   );

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { api, apiFetch , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import Portal from "../components/Portal";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
 import { safeExternalUrl } from "../lib/safeUrl";
 import { openExternal } from "../lib/openExternal";
@@ -959,6 +960,7 @@ function AccountModal({
   ];
 
   return (
+    <Portal>
     <div className="fixed inset-0 bg-ink-900/40 grid place-items-center modal-safe z-50" onClick={onClose}>
       <div className="panel w-full max-w-lg shadow-pop" onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="계정 편집">
         <div className="section-head">
@@ -1231,5 +1233,6 @@ function AccountModal({
         </form>
       </div>
     </div>
+    </Portal>
   );
 }

--- a/client/src/pages/SnippetsPage.tsx
+++ b/client/src/pages/SnippetsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import Portal from "../components/Portal";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import { useModalDismiss } from "../lib/useModalDismiss";
 import { copyToClipboard } from "../lib/clipboard";
@@ -294,6 +295,7 @@ function SnippetEditor({
   }
 
   return (
+    <Portal>
     <div
       className="fixed inset-0 z-50 grid place-items-center modal-safe"
       style={{ background: "rgba(0,0,0,0.5)" }}
@@ -378,5 +380,6 @@ function SnippetEditor({
         </div>
       </div>
     </div>
+    </Portal>
   );
 }

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -17,6 +17,7 @@ import TokensPanel from "../components/superadmin/TokensPanel";
 import SecurityPanel from "../components/superadmin/SecurityPanel";
 import TwoFAPanel from "../components/superadmin/TwoFAPanel";
 import RolePermissionsPanel from "../components/superadmin/RolePermissionsPanel";
+import Portal from "../components/Portal";
 
 type Log = {
   id: string;
@@ -541,6 +542,7 @@ function ChatAuditPwModal({ onClose, onSubmit }: { onClose: () => void; onSubmit
     }
   }
   return (
+    <Portal>
     <div
       className="fixed inset-0 z-50 grid place-items-center modal-safe"
       style={{ background: "rgba(0,0,0,0.55)", backdropFilter: "blur(6px)", WebkitBackdropFilter: "blur(6px)" }}
@@ -570,6 +572,7 @@ function ChatAuditPwModal({ onClose, onSubmit }: { onClose: () => void; onSubmit
         </div>
       </div>
     </div>
+    </Portal>
   );
 }
 


### PR DESCRIPTION
## 증상
**출시 QA 라운드2 — 전 모달 Portal 통일 + 로드 견고화/로딩/법적고지**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
iOS WKWebView 는 본문 스크롤러(overflow+-webkit-overflow-scrolling:touch) 안의
position:fixed 를 뷰포트가 아닌 스크롤 컨테이너 기준으로 잡아, 페이지에서 렌더된
모달이 상단바 밑에 갇히고 헤더/풋터가 잘렸다. 기존에 일부 모달만 적용돼 있던
<Portal>(=document.body 로 포털) 을 나머지 ~22개 모달에 일괄 적용해 통일한다.

- pages: Notice/Journal/Attendance/Snippets/ServiceAccounts/Profile/Documents(2)/
  Expense(2)/Admin(3)/SuperAdmin
- components: NotificationPrefs/PayslipComposer/PayslipPreview/ProjectSettings/
  ProjectWebhooks/RevisionHistory/ShareLink/ProjectCalendar(2)/superadmin(Errors/Flags/Security)
- CreateProjectModal 은 이미 createPortal 직접 사용이라 제외.

검증: tsc -b ✅ · build ✅ · 프리뷰에서 공지작성 모달 open→body 포털·top:0·뷰포트 커버 확인.

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 전 화면 풀스크린 모달을 <Portal> 로 통일 — fixed-position 잘림 버그 제거
- fix(qa): 결재 로드 실패 재시도·로딩 스켈레톤·메뉴 법적고지

**변경 대상 (23개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/NotificationPrefsModal.tsx`
- `client/src/components/PayslipComposer.tsx`
- `client/src/components/PayslipPreview.tsx`
- `client/src/components/ProjectCalendar.tsx`
- `client/src/components/ProjectSettingsModal.tsx`
- `client/src/components/ProjectWebhooks.tsx`
- `client/src/components/RevisionHistoryModal.tsx`
- `client/src/components/ShareLinkModal.tsx`
- `client/src/components/superadmin/ErrorsPanel.tsx`
- `client/src/components/superadmin/FlagsPanel.tsx`
- `client/src/components/superadmin/SecurityPanel.tsx`
- … 외 11개

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #302** 에서 진행됩니다.

