### PR TITLE
🔀 :: (#303) 재배너 중복 완화 + 채팅 알림 대화별 그룹핑

### DIFF
--- a/client/src/lib/desktopNotify.ts
+++ b/client/src/lib/desktopNotify.ts
@@ -20,7 +20,10 @@ export type DesktopNotifPermission = "default" | "granted" | "denied" | "unsuppo
 
 const LS_SEEN = "hinest.notif.seen"; // 이미 알려준 notification id 목록 (localStorage)
 const LS_ENABLED = "hinest.notif.desktop"; // 사용자 토글 (on/off)
-const MAX_SEEN = 500;
+// 이미-표시한 알림 id 캐시 상한. 너무 작으면(구 500) 채팅 다량 수신 시 아직 안 읽은
+// 알림 id 가 밀려나 → 폴백 reload 가 그걸 '처음 본 것'으로 오인해 같은 배너를 다시 띄움(중복).
+// 상한을 크게 잡아 현실적인 세션 내 churn 으론 밀려나지 않게 한다. (id 1건 ~25B → 3000건 ~75KB)
+const MAX_SEEN = 3000;
 
 function supported() {
   return typeof window !== "undefined" && "Notification" in window;

--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -104,8 +104,10 @@ export interface ApnsPayload {
   sound?: string;
   /** 탭 시 이동할 인앱 경로(클라이언트가 읽어 라우팅). */
   linkUrl?: string;
-  /** 동일 스레드 묶음용 식별자(예: DM 방 id). */
+  /** 동일 스레드 묶음용 식별자(예: DM 방 id). apns-collapse-id 헤더로 = '교체' 동작. */
   threadId?: string;
+  /** OS 알림센터 그룹핑용 aps.thread-id. collapse(교체) 아님 — 같은 대화 배너를 묶기만 함. */
+  groupId?: string;
 }
 
 interface SendResult {
@@ -123,6 +125,8 @@ function sendOne(deviceToken: string, payload: ApnsPayload, host: string): Promi
       sound: payload.sound || "default",
     };
     if (typeof payload.badge === "number") aps.badge = payload.badge;
+    // OS 알림센터에서 같은 대화(방)끼리 묶이도록 thread-id 지정. (collapse-id 와 달리 교체가 아님)
+    if (payload.groupId) aps["thread-id"] = payload.groupId;
     const bodyObj: Record<string, unknown> = { aps };
     if (payload.linkUrl) bodyObj.linkUrl = payload.linkUrl;
     const body = Buffer.from(JSON.stringify(bodyObj));

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -94,7 +94,7 @@ export async function notify(input: NotifyInput) {
         muted = !!mem?.muted;
       }
       // 원격 푸시(iOS APNs) — fire-and-forget. 미설정/토큰없음이면 내부 no-op.
-      if (!muted) void sendApnsToUser(input.userId, { title: input.title, body: input.body, linkUrl: input.linkUrl });
+      if (!muted) void sendApnsToUser(input.userId, { title: input.title, body: input.body, linkUrl: input.linkUrl, groupId: rid ?? undefined });
     }
   } catch (e) {
     console.error("notify failed", e);
@@ -147,13 +147,13 @@ export async function notifyMany(inputs: NotifyInput[]) {
     const mutedSet = await mutedApnsSet(
       Array.from(picked.values()).map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
     );
-    const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string } }[] = [];
+    const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string; groupId?: string } }[] = [];
     for (const [uid, n] of picked) {
       if (pushFlag.get(`${uid}:${n.type as NotifyType}`) !== false) {
         publish(uid, "notification", n);
         const rid = roomIdFromLink(n.linkUrl);
         if (!(rid && mutedSet.has(`${uid}:${rid}`))) {
-          apnsTargets.push({ userId: uid, payload: { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined } });
+          apnsTargets.push({ userId: uid, payload: { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined, groupId: rid ?? undefined } });
         }
       }
     }


### PR DESCRIPTION
## 증상
**재배너 중복 완화 + 채팅 알림 대화별 그룹핑**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- client: 이미-표시 알림 id 캐시 500→3000. 채팅 다량 수신 시 안 읽은 알림 id 가
  밀려나 폴백 reload 가 같은 배너를 다시 띄우던 중복을 크게 줄임.
- server: 채팅 APNs 에 aps.thread-id=roomId 추가 → iOS 알림센터에서 같은 방
  알림이 한 묶음으로. collapse(교체)가 아니라 그룹핑이라 누락 없음. (additive)

검증: client tsc -b ✅ · server tsc --noEmit ✅. (실기기 푸시 동작은 cap:ios 재빌드+서버 배포 후 확인 필요)

## 수정
**작업 항목 (커밋 단위)**
- fix(notif): 재배너 중복 완화(seen 캐시↑) + 채팅 알림 대화별 그룹핑(thread-id)

**변경 대상 (3개 파일)**
- `client/src/lib/desktopNotify.ts`
- `server/src/lib/apns.ts`
- `server/src/lib/notify.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #303** 에서 진행됩니다.

