### PR TITLE
🔀 :: (#306) 채팅 알림 발신자 아바타(Communication Notification) 토대 + NSE 템플릿

### DIFF
--- a/client/ios/App/NotificationServiceExtension/NotificationService.swift
+++ b/client/ios/App/NotificationServiceExtension/NotificationService.swift
@@ -1,0 +1,93 @@
+import UserNotifications
+import Intents
+
+/// HiNest 푸시 알림 서비스 확장 — Communication Notification(발신자 아바타).
+///
+/// 채팅 푸시(`aps.mutable-content: 1` + `senderName`)가 오면 발신자 아바타를 받아
+/// `INSendMessageIntent` 를 도네이트해, iOS 가 "발신자 프로필 사진 + 코너에 작은 앱 로고"
+/// 형태(카톡/iMessage 스타일)로 알림을 표시하게 만든다.
+///
+/// ⚠️ 이 파일만으로는 동작하지 않는다. 아래 셋업이 필요(자세한 건 README.md):
+///   1) Xcode 에서 이 파일을 담는 Notification Service Extension 타깃 추가.
+///   2) 앱 + 확장 모두 "Communication Notifications" 엔타이틀먼트(+ App ID 권한 in Apple 포털).
+///   3) 앱 + 확장이 같은 App Group(`group.com.hivits.hinest`) 공유, 앱은 로그인 시 세션 토큰을
+///      이 그룹의 UserDefaults(`hinest.session.token`)에 기록(아바타 /uploads 인증용).
+///   4) 서버 푸시 페이로드: `aps.mutable-content=1`, `senderName`, `senderAvatarPath`(/uploads/...),
+///      `aps.thread-id`(roomId) — 서버측은 이미 구현됨(lib/apns.ts, lib/notify.ts).
+final class NotificationService: UNNotificationServiceExtension {
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttempt: UNMutableNotificationContent?
+
+    /// 앱 본체와 합의된 App Group / API 오리진. 실제 값으로 맞출 것.
+    private let appGroupId = "group.com.hivits.hinest"
+    private let apiBase = "https://nest.hi-vits.com" // = VITE_API_BASE
+
+    override func didReceive(_ request: UNNotificationRequest,
+                             withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        self.contentHandler = contentHandler
+        guard let best = request.content.mutableCopy() as? UNMutableNotificationContent else {
+            contentHandler(request.content); return
+        }
+        self.bestAttempt = best
+
+        let info = request.content.userInfo
+        // senderName 이 없으면 채팅 알림이 아니다 → 원본 그대로 전달.
+        guard let senderName = info["senderName"] as? String, !senderName.isEmpty else {
+            contentHandler(best); return
+        }
+        let avatarPath = info["senderAvatarPath"] as? String
+        let roomId = (info["aps"] as? [String: Any])?["thread-id"] as? String
+
+        fetchAvatar(path: avatarPath) { [weak self] image in
+            self?.deliverCommunication(best, senderName: senderName, roomId: roomId, image: image)
+        }
+    }
+
+    private func deliverCommunication(_ content: UNMutableNotificationContent,
+                                      senderName: String, roomId: String?, image: INImage?) {
+        let handle = INPersonHandle(value: roomId ?? senderName, type: .unknown)
+        let sender = INPerson(personHandle: handle, nameComponents: nil, displayName: senderName,
+                              image: image, contactIdentifier: nil, customIdentifier: nil)
+
+        let intent = INSendMessageIntent(
+            recipients: nil,
+            outgoingMessageType: .outgoingMessageText,
+            content: content.body,
+            speakableGroupName: nil,
+            conversationIdentifier: roomId,
+            serviceName: nil,
+            sender: sender,
+            attachments: nil
+        )
+        if let image = image { intent.setImage(image, forParameterNamed: \.sender) }
+
+        let interaction = INInteraction(intent: intent, response: nil)
+        interaction.direction = .incoming
+        interaction.donate(completion: nil)
+
+        if let updated = try? content.updating(from: intent) {
+            contentHandler?(updated)
+        } else {
+            contentHandler?(content)
+        }
+    }
+
+    /// 아바타(/uploads/...)를 App Group 세션 토큰으로 인증해 받아 INImage 로.
+    private func fetchAvatar(path: String?, completion: @escaping (INImage?) -> Void) {
+        guard let path = path, path.hasPrefix("/uploads/") else { completion(nil); return }
+        let token = UserDefaults(suiteName: appGroupId)?.string(forKey: "hinest.session.token")
+        var urlStr = apiBase + path
+        if let token = token, !token.isEmpty,
+           let enc = token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+            urlStr += (urlStr.contains("?") ? "&" : "?") + "token=" + enc
+        }
+        guard let url = URL(string: urlStr) else { completion(nil); return }
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            completion(data.flatMap { INImage(imageData: $0) })
+        }.resume()
+    }
+
+    override func serviceExtensionTimeWillExpire() {
+        if let handler = contentHandler, let best = bestAttempt { handler(best) }
+    }
+}

--- a/client/ios/App/NotificationServiceExtension/README.md
+++ b/client/ios/App/NotificationServiceExtension/README.md
@@ -1,0 +1,55 @@
+# 채팅 알림 발신자 아바타 (Communication Notification)
+
+채팅 푸시를 카톡/iMessage처럼 **발신자 프로필 사진 + 코너에 작은 앱 로고**로 표시하기 위한
+Notification Service Extension(NSE) 설정 가이드.
+
+> 이 폴더의 `NotificationService.swift`는 **아직 어떤 Xcode 타깃에도 속하지 않은 템플릿**입니다.
+> 현재 앱 빌드에는 영향이 없고, 아래 단계를 거쳐 NSE 타깃에 넣어야 동작합니다.
+> ⚠️ 이 코드는 샌드박스(Xcode 없음)에서 **컴파일 검증을 못 했습니다.** Xcode에서 빌드·실기기 테스트 필요.
+
+## 이미 끝난 것 (서버 — 배포만 하면 됨)
+서버는 채팅 APNs 페이로드에 NSE가 쓸 데이터를 이미 싣습니다 (`server/src/lib/apns.ts`, `lib/notify.ts`):
+- `aps.mutable-content = 1` — NSE 호출 트리거 (senderName 있을 때만 = 채팅만)
+- `senderName` — 발신자 표시 이름
+- `senderAvatarPath` — `/uploads/...` 상대경로
+- `aps.thread-id = roomId` — 대화 그룹핑 (#303)
+
+## 남은 것 (네이티브 — Xcode/Apple 포털, 사용자/네이티브 빌드 작업)
+
+### 1. NSE 타깃 추가
+Xcode → File → New → Target → **Notification Service Extension**. 이름 예: `NotificationServiceExtension`.
+생성된 `NotificationService.swift`를 이 폴더의 것으로 교체(또는 내용 복사). Deployment Target은 앱과 동일하게.
+
+### 2. App Group 공유 (아바타 인증용)
+앱 타깃 + NSE 타깃 **둘 다** Signing & Capabilities → **App Groups** 추가 → 동일 그룹
+`group.com.hivits.hinest` 체크. (Apple 포털 App ID에도 App Group 권한 필요.)
+
+그리고 **앱이 로그인 시 세션 토큰을 이 그룹에 기록**해야 NSE가 `/uploads`(인증 필요) 아바타를 받습니다.
+`AppDelegate.swift`(또는 작은 Capacitor 플러그인)에서, JS가 토큰을 받은 직후 호출되게:
+```swift
+UserDefaults(suiteName: "group.com.hivits.hinest")?
+    .set(sessionToken, forKey: "hinest.session.token")
+```
+JS에서 네이티브로 토큰을 넘기는 브리지가 필요합니다(로그인/세션복원 시 1회). 로그아웃 시 제거.
+
+> **대안(App Group 없이):** 서버가 푸시에 **짧은 수명 서명 URL**(`/uploads/x?token=<단기토큰>`)을 직접
+> 실으면 NSE는 그 URL을 그대로 받으면 됩니다. App Group/토큰기록이 불필요한 대신, 푸시·서버로그에
+> 토큰이 남는 보안 트레이드오프가 있습니다(감사에서 지적된 JWT-in-URL 확장). 팀이 택1.
+> 이 경우 서버 `notify.ts`에서 `senderAvatarPath` 대신 절대 서명 URL을 싣도록 바꾸고, NSE의
+> `fetchAvatar`는 토큰 부착 로직을 빼면 됩니다.
+
+### 3. Communication Notifications 엔타이틀먼트
+- Apple Developer 포털 → 앱 App ID → **Communication Notifications** capability 활성화 → 프로비저닝 재생성.
+- Xcode에서 **앱 타깃 + NSE 타깃 둘 다** `com.apple.developer.usernotifications.communication = true` 엔타이틀먼트 추가.
+
+### 4. 빌드 & 테스트
+- `npm run cap:ios`로 웹 자산 동기화 후 Xcode 빌드(앱+확장 임베드 확인).
+- 실기기에서 채팅 수신 → 발신자 아바타로 뜨는지 확인. (mutable-content는 lock/background에서 NSE 호출)
+- NSE 디버깅: Xcode에서 NSE 스킴 선택 후 attach.
+
+## 동작 요약
+채팅 푸시 도착 → `mutable-content`로 NSE 깨어남 → `senderAvatarPath`를 App Group 토큰으로 받아
+`INSendMessageIntent`(sender=발신자, image=아바타) 도네이트 → `content.updating(from: intent)`로
+Communication Notification 스타일 적용 → 발신자 아바타 + 코너 앱로고로 표시.
+
+NSE가 없거나 실패해도 `aps.alert`로 **일반 알림으로 정상 표시**(현재와 동일)되므로 점진 적용 안전.

--- a/server/src/jobs/dispatchScheduled.ts
+++ b/server/src/jobs/dispatchScheduled.ts
@@ -61,6 +61,7 @@ async function dispatchOne(id: string): Promise<void> {
         body: preview.slice(0, 140),
         linkUrl: `/chat?room=${msg.roomId}`,
         actorName: msg.sender.name,
+        actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
       })),
     );
   } else {
@@ -73,6 +74,7 @@ async function dispatchOne(id: string): Promise<void> {
         body: `${msg.sender.name}: ${preview}`.slice(0, 140),
         linkUrl: `/chat?room=${msg.roomId}`,
         actorName: msg.sender.name,
+        actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
       })),
     );
   }

--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -108,6 +108,10 @@ export interface ApnsPayload {
   threadId?: string;
   /** OS 알림센터 그룹핑용 aps.thread-id. collapse(교체) 아님 — 같은 대화 배너를 묶기만 함. */
   groupId?: string;
+  /** Communication Notification 용 — 발신자 표시 이름(채팅 알림만). NSE 가 INPerson 으로 사용. */
+  senderName?: string;
+  /** 발신자 아바타 /uploads 상대경로(예: /uploads/x.png). NSE 가 App Group 세션토큰으로 받아 이미지로. */
+  senderAvatarPath?: string;
 }
 
 interface SendResult {
@@ -127,8 +131,13 @@ function sendOne(deviceToken: string, payload: ApnsPayload, host: string): Promi
     if (typeof payload.badge === "number") aps.badge = payload.badge;
     // OS 알림센터에서 같은 대화(방)끼리 묶이도록 thread-id 지정. (collapse-id 와 달리 교체가 아님)
     if (payload.groupId) aps["thread-id"] = payload.groupId;
+    // Communication Notification — senderName 이 있으면(채팅) NSE 가 발신자 아바타로 알림을 재구성하도록
+    // mutable-content 를 켜고, NSE 가 읽을 발신자 정보를 커스텀 키로 싣는다. NSE 미존재 시엔 일반 표시(무해).
+    if (payload.senderName) aps["mutable-content"] = 1;
     const bodyObj: Record<string, unknown> = { aps };
     if (payload.linkUrl) bodyObj.linkUrl = payload.linkUrl;
+    if (payload.senderName) bodyObj.senderName = payload.senderName;
+    if (payload.senderAvatarPath) bodyObj.senderAvatarPath = payload.senderAvatarPath;
     const body = Buffer.from(JSON.stringify(bodyObj));
 
     let session: http2.ClientHttp2Session;

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -19,6 +19,8 @@ export interface NotifyInput {
   linkUrl?: string;
   actorName?: string;
   actorColor?: string;
+  /** 발신자 아바타 /uploads 상대경로 — 채팅 알림의 Communication Notification(아바타) 용. DB 저장 X, 푸시에만. */
+  actorAvatarUrl?: string;
 }
 
 /**
@@ -128,20 +130,31 @@ export async function notifyMany(inputs: NotifyInput[]) {
     // 동시에 도는 다른 배치가 같은 유저의 창을 오염시켜 "유저당 1건만" 추려 푸시 → 같은 유저에게
     // 거의 동시에 온 두 알림 중 하나의 실시간 SSE/APNs 가 누락됐다(레코드는 남아 다음 새로고침엔 보임).
     // 근본 수정: 각 행의 id 를 미리 생성해 넣고, 그 id 들로 정확히 되짚어 "전부" 푸시한다.
-    const rows = filtered.map((i) => ({ ...i, id: randomUUID() }));
+    const rows = filtered.map((i) => ({ ...i, id: randomUUID() as string }));
     await prisma.notification.createMany({ data: rows });
     const created = await prisma.notification.findMany({ where: { id: { in: rows.map((r) => r.id) } } });
     // 음소거된 방의 채팅 알림은 APNs(폰 푸시) 만 생략 — 한 번에 조회.
     const mutedSet = await mutedApnsSet(
       created.map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
     );
-    const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string; groupId?: string } }[] = [];
+    // 아바타(actorAvatarUrl)는 Notification 컬럼이 아니라 입력에만 있으므로 id 로 되짚는다.
+    const inputById = new Map(rows.map((r) => [r.id, r]));
+    const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string; groupId?: string; senderName?: string; senderAvatarPath?: string } }[] = [];
     for (const n of created) {
       if (pushFlag.get(`${n.userId}:${n.type as NotifyType}`) === false) continue;
       publish(n.userId, "notification", n);
       const rid = roomIdFromLink(n.linkUrl);
       if (!(rid && mutedSet.has(`${n.userId}:${rid}`))) {
-        apnsTargets.push({ userId: n.userId, payload: { title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined, groupId: rid ?? undefined } });
+        // 채팅(DM/MENTION)만 Communication Notification(발신자 아바타) 대상. 결재/공지 등은 일반 알림.
+        const isChat = n.type === "DM" || n.type === "MENTION";
+        const inp = inputById.get(n.id);
+        apnsTargets.push({
+          userId: n.userId,
+          payload: {
+            title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined, groupId: rid ?? undefined,
+            ...(isChat ? { senderName: n.actorName ?? undefined, senderAvatarPath: inp?.actorAvatarUrl ?? undefined } : {}),
+          },
+        });
       }
     }
     // 원격 푸시(iOS APNs) — fire-and-forget. pushToken 조회를 1회로 묶어 일괄 발송. 미설정/토큰없음이면 내부 no-op.

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -567,6 +567,7 @@ router.post("/rooms/:id/messages", async (req, res) => {
           body: preview.slice(0, 140),
           linkUrl: `/chat?room=${msg.roomId}`,
           actorName: u.name,
+          actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
         }))
       );
     } else {
@@ -586,6 +587,7 @@ router.post("/rooms/:id/messages", async (req, res) => {
           body: `${u.name}: ${preview}`.slice(0, 140),
           linkUrl: `/chat?room=${msg.roomId}`,
           actorName: u.name,
+          actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
         }))
       );
     }


### PR DESCRIPTION
## 증상
**채팅 알림 발신자 아바타(Communication Notification) 토대 + NSE 템플릿**

새 기능을 추가합니다.

## 원인
채팅 푸시를 카톡/iMessage 처럼 '발신자 프로필 + 코너 앱로고'로 표시하기 위한 토대.

서버(배포 시 적용·additive·무해):
- apns.ts: senderName 있으면 aps.mutable-content=1 + senderName/senderAvatarPath 커스텀 키.
- notify.ts: NotifyInput.actorAvatarUrl 추가, 채팅(DM/MENTION)만 발신자 정보 동봉(결재/공지 제외).
- chat.ts + dispatchScheduled.ts: 발신자 avatarUrl 전달.
- NSE 미존재 시엔 일반 알림으로 정상 표시(점진 적용 안전).

네이티브(사용자/Xcode 작업 필요):
- client/ios/App/NotificationServiceExtension/ 에 NotificationService.swift(템플릿) + README.md(가이드).
  현재 어떤 타깃에도 안 속해 빌드 무영향. Xcode 에서 NSE 타깃 추가 + Communication Notifications
  엔타이틀먼트 + App Group(세션토큰 공유) 설정해야 활성화.

⚠️ 서버 tsc ✅. NSE Swift 는 이 환경에 Xcode 없어 컴파일 미검증(템플릿) — Xcode 빌드+실기기 검증 필요.

## 수정
**작업 항목 (커밋 단위)**
- feat(notif): 채팅 알림 발신자 아바타 (Communication Notification) 토대 + NSE 템플릿

**변경 대상 (6개 파일)**
- `client/ios/App/NotificationServiceExtension/NotificationService.swift`
- `client/ios/App/NotificationServiceExtension/README.md`
- `server/src/jobs/dispatchScheduled.ts`
- `server/src/lib/apns.ts`
- `server/src/lib/notify.ts`
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #306** 에서 진행됩니다.

