### PR TITLE
🔀 :: (#307) 음소거 알림 영구차단(markSeen) 제거 — 해제 후 정상 표시

### DIFF
--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -173,10 +173,12 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
               deliverPendingNotifications([
                 { id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl },
               ]);
-            } else {
-              // 가드에 걸린 알림도 "이미 본 것" 으로 마킹해서 reload() 시 재발송 방지.
-              markSeen([n.id]);
             }
+            // (음소거·카테고리로 가로막힌 건 위 if 가 OS 배너만 생략 — 벨/미읽음은 이미 반영됨.)
+            // 예전엔 여기서 markSeen 해 "영구 차단" 했는데, 그러면 다른 기기에서 음소거를 풀어도
+            // 그 알림이 영영 안 떴다(localStorage 음소거 미러가 stale 인 채 markSeen 까지 박혀서).
+            // reload() 도 shouldDeliverNotif 로 동일하게 필터하므로 markSeen 없이도 재발송되지 않고,
+            // 음소거 해제 후엔 reload 가 정상 배너를 띄운다. → markSeen 제거(근본 수정).
           } catch {}
         });
         // 채팅 실시간 푸시 — ChatMiniApp 이 window 리스너로 수신.


### PR DESCRIPTION
## 증상
**음소거 알림 영구차단(markSeen) 제거 — 해제 후 정상 표시**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
SSE 핸들러가 음소거(shouldDeliverNotif=false) 알림을 markSeen 으로 '영구 차단' 했다.
다른 기기에서 음소거를 풀어도, 그 알림 id 가 이미 seen 에 박혀 영영 OS 배너가 안 떴다
(localStorage 음소거 미러가 stale 인 채 markSeen 까지 더해져 누락).

reload() 도 shouldDeliverNotif 로 동일 필터하므로 markSeen 없이도 재발송되지 않고,
음소거 해제 후엔 reload 가 정상 배너를 띄운다 → 음소거 분기의 markSeen 제거.

검증: client tsc -b ✅. (실기기 음소거 토글 동작은 cap:ios 후 확인 권장)

## 수정
**작업 항목 (커밋 단위)**
- fix(notif): 음소거 알림의 markSeen 영구차단 제거 — 음소거 해제 후 정상 표시

**변경 대상 (1개 파일)**
- `client/src/notifications.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #307** 에서 진행됩니다.

