### PR TITLE
🔀 :: (#308) GET 동시호출 dedup + 포그라운드 복귀 재싱크

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -59,7 +59,34 @@ export function imgSrc(url?: string | null): string | undefined {
   return abs + (abs.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(t);
 }
 
+const _inflight = new Map<string, Promise<any>>();
+
+/**
+ * 동일 GET 동시 호출 합치기(in-flight dedup). 한 화면 + 열린 모달이 같은 엔드포인트(예: /api/users)를
+ * 동시에 요청하면 fetch 가 1번만 나가고 결과를 공유한다(React 18 StrictMode 이중 호출도 1회로).
+ * 커스텀 signal(취소 의도)·요청 바디·미리보기 모드는 제외 — 각자 독립 실행. 실제 fetch 로직은
+ * 아래 apiInner 그대로(무변경) — 이 래퍼는 합치기만 담당.
+ */
 export async function api<T = any>(
+  path: string,
+  init: RequestInit & { json?: any } = {}
+): Promise<T> {
+  const method = (init.method ?? "GET").toUpperCase();
+  let previewOn = false;
+  if (typeof window !== "undefined" && (window as any).__HINEST_PREVIEW__ === true) {
+    try { previewOn = sessionStorage.getItem("hinest:preview") === "1"; } catch {}
+  }
+  const dedupable = method === "GET" && !init.signal && init.json === undefined && !init.body && !previewOn;
+  if (!dedupable) return apiInner<T>(path, init);
+  const existing = _inflight.get(path);
+  if (existing) return existing as Promise<T>;
+  const p = apiInner<T>(path, init);
+  _inflight.set(path, p);
+  p.finally(() => { if (_inflight.get(path) === p) _inflight.delete(path); });
+  return p;
+}
+
+async function apiInner<T = any>(
   path: string,
   init: RequestInit & { json?: any } = {}
 ): Promise<T> {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -20,6 +20,18 @@ if (typeof window !== "undefined" && (window as any).Capacitor?.isNativePlatform
     .then(({ SplashScreen }) => SplashScreen.hide())
     .catch(() => {})
     .finally(() => { (window as any).__hinestSplashGo?.(); });
+  // 백그라운드→포그라운드 복귀 시 데이터 재싱크 — iOS WKWebView 는 복귀 때 visibilitychange 가
+  // 항상 발화하진 않는다. @capacitor/app 의 appStateChange(isActive) 를 받아 visibilitychange 를
+  // 합성 발화해, 기존 가시성 핸들러(알림 reload·결재 카운트·채팅 presence)가 재실행되게 한다(중앙/DRY).
+  import("@capacitor/app")
+    .then(({ App }) => {
+      App.addListener("appStateChange", ({ isActive }) => {
+        if (isActive && document.visibilityState === "visible") {
+          document.dispatchEvent(new Event("visibilitychange"));
+        }
+      });
+    })
+    .catch(() => {});
 }
 
 // iOS Safari 는 user-scalable=no 를 무시하므로 제스처/더블탭 확대를 JS 로 차단.


### PR DESCRIPTION
## 증상
**GET 동시호출 dedup + 포그라운드 복귀 재싱크**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- api.ts: in-flight dedup 래퍼. 한 화면+모달이 /api/users 등을 동시에 요청하면 fetch
  1회만(StrictMode 이중 호출도 1회). 커스텀 signal·바디·미리보기 제외. 실 fetch 로직(apiInner)은
  무변경 — 래퍼는 합치기만. 프리뷰에서 /admin 데이터 로드 회귀 없음 확인.
- main.tsx: @capacitor/app appStateChange(isActive) → visibilitychange 합성 발화. iOS WKWebView 가
  복귀 때 visibilitychange 를 항상 안 쏘는 문제 보완 → 기존 가시성 핸들러(알림 reload·결재
  카운트·채팅 presence) 재실행. (네이티브 전용, additive)

검증: tsc -b ✅ · build ✅ · 프리뷰 /admin 로드 ✅. (네이티브 resume 동작은 cap:ios 후 확인)

## 수정
**작업 항목 (커밋 단위)**
- fix(net): 동일 GET 동시호출 합치기 + 포그라운드 복귀 재싱크

**변경 대상 (2개 파일)**
- `client/src/api.ts`
- `client/src/main.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #308** 에서 진행됩니다.

