### PR TITLE
🔀 :: (#309) 키보드 가림 — 입력 모달이 키보드 위로 (visualViewport 인셋)

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -34,6 +34,24 @@ if (typeof window !== "undefined" && (window as any).Capacitor?.isNativePlatform
     .catch(() => {});
 }
 
+// 키보드가 뜰 때 가운데 모달이 가려지지 않도록 — visualViewport 로 키보드 높이를 추적해
+// CSS 변수 --hinest-kb-inset 에 싣는다. .modal-safe 오버레이가 이만큼 하단 패딩을 받아
+// place-items-center 패널이 키보드 위로 올라온다. (모든 모달이 body 로 포털돼 일괄 적용)
+if (typeof window !== "undefined" && window.visualViewport) {
+  const vv = window.visualViewport;
+  const root = document.documentElement;
+  let raf = 0;
+  const update = () => {
+    raf = 0;
+    const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+    root.style.setProperty("--hinest-kb-inset", inset > 1 ? `${Math.round(inset)}px` : "0px");
+  };
+  const schedule = () => { if (!raf) raf = requestAnimationFrame(update); };
+  vv.addEventListener("resize", schedule);
+  vv.addEventListener("scroll", schedule);
+  update();
+}
+
 // iOS Safari 는 user-scalable=no 를 무시하므로 제스처/더블탭 확대를 JS 로 차단.
 if (typeof window !== "undefined") {
   // ─────────────────────────────────────────────────────────────

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -445,9 +445,12 @@ textarea.input {
    env() 는 데스크톱에서 0 이라 웹/Electron 외형은 변하지 않음(p-4 동등). */
 .modal-safe {
   padding-top: max(1rem, env(safe-area-inset-top));
-  padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  /* --hinest-kb-inset = 키보드 높이(main.tsx visualViewport 추적). 키보드가 뜨면 그만큼 하단
+     패딩이 늘어 가운데 패널이 키보드 위로 올라온다. 키보드 없으면 0 → 기존과 동일. */
+  padding-bottom: calc(max(1rem, env(safe-area-inset-bottom)) + var(--hinest-kb-inset, 0px));
   padding-left: max(1rem, env(safe-area-inset-left));
   padding-right: max(1rem, env(safe-area-inset-right));
+  transition: padding-bottom 0.18s ease;
 }
 /* iOS Safari 는 네이티브 date/time/datetime-local 입력에 내장 min-width 를
    강제해서 w-full 지정에도 컨테이너 밖으로 튀어나올 수 있음. 강제로 shrink 허용 */


### PR DESCRIPTION
## 증상
**키보드 가림 — 입력 모달이 키보드 위로 (visualViewport 인셋)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
입력 모달에서 iOS 키보드가 올라오면 화면 중앙 고정 모달의 하단(제출 버튼·아래 입력)이
키보드에 가렸다. (SchedulePage 만 useViewportInset 으로 개별 대응돼 있었음)

모든 모달이 body 로 포털(#302)된 지금, 단일 지점으로 일괄 해결:
- main.tsx: visualViewport 로 키보드 높이를 추적해 CSS 변수 --hinest-kb-inset 에 싣음.
- styles.css: .modal-safe 하단 패딩에 인셋을 더해(calc) 패널이 키보드 위로 올라오게.
  키보드 없으면 인셋 0 → 기존과 동일(무회귀).

검증: tsc -b ✅ · build ✅ · 프리뷰에서 --hinest-kb-inset 주입 시 padding-bottom 정상 반응 확인.

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 키보드가 뜰 때 가운데 모달이 가려지는 문제 — visualViewport 인셋

**변경 대상 (2개 파일)**
- `client/src/main.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #309** 에서 진행됩니다.

