### PR TITLE
🔀 :: (#310) 아바타 NSE용 App Group 토큰 브리지 (코드 완성)

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -78,6 +78,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "setBadge", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setVisible", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "confirm", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setSharedToken", returnType: CAPPluginReturnPromise),
     ]
 
     private var tabBarView: UITabBar?
@@ -86,6 +87,23 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
 
     override public func load() {
         NSLog("[LGTB] plugin loaded (discovered by Capacitor)")
+    }
+
+    /// 알림 서비스 확장(NSE)이 채팅 발신자 아바타(/uploads, 인증 필요)를 받을 수 있도록,
+    /// 앱 세션 토큰을 공유 App Group 에 기록한다. JS 가 로그인/세션복원 시 호출, 로그아웃 시 빈 값으로 제거.
+    /// ⚠️ Xcode 에서 앱+NSE 타깃에 App Group(group.com.hivits.hinest) capability 가 설정돼야 동작한다.
+    ///    미설정이면 suiteName 이 nil → 무동작(무해). NSE 는 같은 그룹에서 이 키를 읽는다.
+    @objc func setSharedToken(_ call: CAPPluginCall) {
+        let token = call.getString("token") ?? ""
+        let groupId = call.getString("group") ?? "group.com.hivits.hinest"
+        if let defaults = UserDefaults(suiteName: groupId) {
+            if token.isEmpty {
+                defaults.removeObject(forKey: "hinest.session.token")
+            } else {
+                defaults.set(token, forKey: "hinest.session.token")
+            }
+        }
+        call.resolve()
     }
 
     @objc func configure(_ call: CAPPluginCall) {

--- a/client/ios/App/NotificationServiceExtension/README.md
+++ b/client/ios/App/NotificationServiceExtension/README.md
@@ -24,13 +24,13 @@ Xcode → File → New → Target → **Notification Service Extension**. 이름
 앱 타깃 + NSE 타깃 **둘 다** Signing & Capabilities → **App Groups** 추가 → 동일 그룹
 `group.com.hivits.hinest` 체크. (Apple 포털 App ID에도 App Group 권한 필요.)
 
-그리고 **앱이 로그인 시 세션 토큰을 이 그룹에 기록**해야 NSE가 `/uploads`(인증 필요) 아바타를 받습니다.
-`AppDelegate.swift`(또는 작은 Capacitor 플러그인)에서, JS가 토큰을 받은 직후 호출되게:
-```swift
-UserDefaults(suiteName: "group.com.hivits.hinest")?
-    .set(sessionToken, forKey: "hinest.session.token")
-```
-JS에서 네이티브로 토큰을 넘기는 브리지가 필요합니다(로그인/세션복원 시 1회). 로그아웃 시 제거.
+**세션 토큰 → App Group 기록(아바타 인증)은 이미 코드로 구현됨** ✅ — 직접 작성할 필요 없습니다:
+- 네이티브: `AppDelegate.swift` `LiquidGlassTabBarPlugin.setSharedToken` 가 토큰을 App Group 에 기록.
+- JS: `src/lib/authToken.ts` `setAuthToken()` 이 로그인/세션복원/로그아웃 때 자동으로 위 메서드를 호출.
+- NSE: 같은 그룹에서 `hinest.session.token` 키를 읽어 `/uploads` 에 `?token=` 으로 인증(코드에 이미 있음).
+
+→ 따라서 **App Groups capability(2번 위)만 설정**하면 토큰 공유가 동작합니다. (capability 미설정이면
+`UserDefaults(suiteName:)` 가 nil 이라 기록이 무동작·무해 — 빌드/기능엔 영향 없음.)
 
 > **대안(App Group 없이):** 서버가 푸시에 **짧은 수명 서명 URL**(`/uploads/x?token=<단기토큰>`)을 직접
 > 실으면 NSE는 그 URL을 그대로 받으면 됩니다. App Group/토큰기록이 불필요한 대신, 푸시·서버로그에

--- a/client/src/lib/authToken.ts
+++ b/client/src/lib/authToken.ts
@@ -13,6 +13,7 @@
  * WKWebView 에서 새로고침·앱 재실행 후에도 유지된다.
  */
 import { isCapacitorNative } from "./platform";
+import { LiquidGlassTabBar } from "./liquidGlassTabBar";
 
 const KEY = "hinest.authToken";
 
@@ -34,6 +35,13 @@ export function setAuthToken(token: string | null | undefined): void {
     else localStorage.removeItem(KEY);
   } catch {
     /* storage 비활성/quota — 무시 */
+  }
+  // NSE(채팅 발신자 아바타)가 /uploads 인증에 쓰도록 공유 App Group 에도 기록한다.
+  // App Group capability 미설정 / 구버전 네이티브면 내부 no-op·reject → 무시(무해). 토큰 없으면 빈 값=제거.
+  try {
+    void LiquidGlassTabBar.setSharedToken({ token: token ?? "" }).catch(() => {});
+  } catch {
+    /* 플러그인 미가용 — 무시 */
   }
 }
 

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -26,6 +26,8 @@ export interface LiquidGlassTabBarPlugin {
   setSelected(options: { key: string }): Promise<void>;
   setBadge(options: { key: string; count: number }): Promise<void>;
   setVisible(options: { visible: boolean }): Promise<void>;
+  /** 세션 토큰을 공유 App Group 에 기록 — NSE(채팅 아바타)의 /uploads 인증용. token="" 이면 제거. */
+  setSharedToken(options: { token: string; group?: string }): Promise<void>;
   /** 애플 기본 확인 시트(action sheet). 로그아웃 등 재확인용. */
   confirm(options: {
     title?: string;


### PR DESCRIPTION
## 증상
**아바타 NSE용 App Group 토큰 브리지 (코드 완성)**

새 기능을 추가합니다.

## 원인
프로필 아이콘(Communication Notification) NSE 가 /uploads 아바타를 인증해 받으려면
앱 세션 토큰을 공유 App Group 에 둬야 한다. 그 브리지를 코드로 완성:
- AppDelegate.swift: LiquidGlassTabBar 플러그인에 setSharedToken 메서드 추가(App Group 에 기록).
- authToken.ts: setAuthToken() 이 로그인/세션복원/로그아웃 때 자동 호출(네이티브 한정).
- liquidGlassTabBar.ts: 인터페이스에 setSharedToken 추가.
- README: '브리지 코드 완성, App Groups capability 만 켜면 됨' 으로 갱신.

additive·무해: App Group capability 미설정/구버전 네이티브면 suiteName nil → no-op.
남은 건 Xcode 작업뿐(NSE 타깃 추가 + App Groups·Communication Notifications capability + 빌드).

검증: client tsc -b ✅ · build ✅. ⚠️ Swift 는 Xcode 없어 컴파일 미검증(기존 플러그인 패턴 동일, 단순 additive).

## 수정
**작업 항목 (커밋 단위)**
- feat(notif): 아바타 NSE용 App Group 토큰 브리지 — 코드 완성(Xcode 설정만 남김)

**변경 대상 (4개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/ios/App/NotificationServiceExtension/README.md`
- `client/src/lib/authToken.ts`
- `client/src/lib/liquidGlassTabBar.ts`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #310** 에서 진행됩니다.

