### PR TITLE
🔀 :: (#742) 채팅 알림 복구 — NSE 트리거(mutable-content) 임시 비활성

### DIFF
--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -45,6 +45,12 @@ const PRIMARY_HOST = PRODUCTION ? PROD_HOST : SANDBOX_HOST;
 const ALT_HOST = PRODUCTION ? SANDBOX_HOST : PROD_HOST;
 const HOST = PRIMARY_HOST; // 표시·진단용 기본 게이트웨이
 
+// 통신알림(발신자 아바타) 임시 스위치.
+// 현재 iOS 빌드의 NSE(mutable-content 처리)가 채팅 푸시를 가로채 알림이 표시되지 않는 문제가 있어,
+// 안정화 전까지 꺼 둔다 → mutable-content 를 싣지 않으므로 NSE 가 호출되지 않고 "일반 알림으로 정상 표시".
+// NSE 표시 문제(아바타 스타일) 해결 후 이 값을 true 로 되돌리면 통신알림(아바타)이 복구된다.
+const ENABLE_COMMUNICATION_PUSH = false;
+
 export function apnsEnabled(): boolean {
   return Boolean(KEY_RAW && KEY_ID && TEAM_ID);
 }
@@ -133,7 +139,8 @@ function sendOne(deviceToken: string, payload: ApnsPayload, host: string): Promi
     if (payload.groupId) aps["thread-id"] = payload.groupId;
     // Communication Notification — senderName 이 있으면(채팅) NSE 가 발신자 아바타로 알림을 재구성하도록
     // mutable-content 를 켜고, NSE 가 읽을 발신자 정보를 커스텀 키로 싣는다. NSE 미존재 시엔 일반 표시(무해).
-    if (payload.senderName) aps["mutable-content"] = 1;
+    // (ENABLE_COMMUNICATION_PUSH=false 동안은 mutable-content 를 끄고 일반 알림으로 표시 — 위 스위치 주석 참고)
+    if (ENABLE_COMMUNICATION_PUSH && payload.senderName) aps["mutable-content"] = 1;
     const bodyObj: Record<string, unknown> = { aps };
     if (payload.linkUrl) bodyObj.linkUrl = payload.linkUrl;
     if (payload.senderName) bodyObj.senderName = payload.senderName;


### PR DESCRIPTION
## 증상
채팅 DM 알림이 폰에 안 뜸. 단:
- `/api/push/diag` (mutable-content **없는** 단순 푸시) → 토큰 5개 전부 status 200 + 폰에 실제 도착 ✅
- `/api/notification` → DM 알림 **레코드는 정상 생성**됨 ✅ (notifyMany 동작, prefs/DND 정상)
- 즉 푸시 전달·알림 생성 다 정상인데 **mutable-content 가 실린 채팅 푸시만 미표시**

## 원인
채팅 푸시는 `mutable-content:1` 로 NSE(Notification Service Extension)를 깨우는데, 현재 iOS 빌드의 NSE 가 알림 표시를 가로채고 있음(아바타 통신알림 적용 단계). diag 는 mutable-content 가 없어 NSE 를 안 거쳐 정상 표시됨 → 차이가 NSE 로 좁혀짐.

## 조치 (즉시 복구)
`ENABLE_COMMUNICATION_PUSH = false` 스위치 추가 → mutable-content 를 싣지 않음 → NSE 미호출 → **일반 알림으로 정상 표시.**
- **iOS 재빌드 불필요** (현재 빌드 그대로, 서버 배포만으로 적용)
- `senderName`/`senderAvatarPath`/`thread-id` 는 그대로 실어둠(무해, 재활성 대비)

## 후속
NSE 표시 문제(아바타 스타일 + 전달 미차단) 해결 후 `ENABLE_COMMUNICATION_PUSH = true` 한 줄로 통신알림(아바타) 복구.

## 검증
`tsc --noEmit` 통과. 배포 후 실기기에서 채팅 알림 정상 표시 확인 필요.

Closes #742
