### PR TITLE
🔀 :: (#313) 그룹/팀방 멤버 목록 (헤더 탭 → 설정)

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -1480,6 +1480,32 @@ function SettingsView({
         </div>
       </button>
 
+      {/* 멤버 — 그룹/팀방만 (DM 은 위 프로필 블록이 상대를 보여줌). 헤더(방 이름) 탭 → 설정 뷰에서 노출. */}
+      {room.type !== "DIRECT" && (
+        <>
+          <SectionLabel>멤버 {room.members.length}명</SectionLabel>
+          <div style={{ background: C.gray100, borderRadius: 12, padding: "4px 0", overflow: "hidden" }}>
+            {room.members.map((m) => {
+              const isMe = m.user.id === meId;
+              const isOwner = !!room.createdById && room.createdById === m.user.id;
+              return (
+                <div key={m.user.id} style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 14px" }}>
+                  <Avatar name={m.user.name} color={m.user.avatarColor ?? C.blue} imageUrl={m.user.avatarUrl ?? null} size={36} />
+                  <div style={{ flex: 1, minWidth: 0, fontSize: 14, fontWeight: 600, color: C.ink, letterSpacing: "-0.01em", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {m.user.name}{isMe ? " (나)" : ""}
+                  </div>
+                  {isOwner && (
+                    <span style={{ fontSize: 11, fontWeight: 700, color: C.blue, background: "color-mix(in srgb, var(--c-brand) 12%, transparent)", padding: "2px 8px", borderRadius: 999, flexShrink: 0 }}>
+                      방장
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
+
       <SharedMediaTabs messages={messages} />
 
       {canDeleteRoom && (


### PR DESCRIPTION
## 증상
**그룹/팀방 멤버 목록 (헤더 탭 → 설정)**

새 기능을 추가합니다.

## 원인
채팅방 헤더(방 이름)를 누르면 열리는 설정 뷰(SettingsView)에 멤버 목록 섹션을
추가. 그룹/팀방에서 각 멤버의 아바타+이름을 보여주고, 방장(createdById)·본인(나)을
표시. DM 은 기존 프로필 블록이 상대를 보여주므로 제외.

## 수정
**작업 항목 (커밋 단위)**
- feat(chat): 그룹/팀방 헤더 탭 → 설정 뷰에 멤버 목록 표시

**변경 대상 (1개 파일)**
- `client/src/components/ChatMiniApp.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #313** 에서 진행됩니다.

