### PR TITLE
🔀 :: (#750) 미정의 CSS 변수 --c-surface-1 정의 (투명 패널/모달 겹침 수정)

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -13,6 +13,7 @@
 
   --c-bg:         #F5F6F8;  /* app bg */
   --c-surface:    #FFFFFF;  /* card / panel */
+  --c-surface-1:  var(--c-surface);  /* = 기본 패널/카드 표면 별칭. 미정의 상태로 모달·탭 등 여러 곳에서 var(--c-surface-1) 를 써와 투명 배경 버그(회원탈퇴 모달이 뒤 페이지와 겹쳐 보임 등). --c-surface 별칭이라 라이트/다크 자동 대응. */
   --c-surface-2:  #FAFBFC;  /* subtle surface (hover, thead 등) */
   --c-surface-3:  #F2F4F6;
   --c-border:     #E6E8EC;


### PR DESCRIPTION
## 증상
회원탈퇴 확인 모달을 열면 패널이 **투명**해서 뒤 페이지(개발자 옵션·비밀번호 변경 폼)와 글자가 겹쳐 보임.

## 원인
`styles.css` 에 `--c-surface`, `--c-surface-2`, `--c-surface-3` 는 정의돼 있으나 **`--c-surface-1` 은 미정의.** `ProfilePage` 탈퇴 모달이 `background: var(--c-surface-1)` 를 쓰는데 미정의라 투명(`rgba(0,0,0,0)`)으로 폴백 → 패널이 비쳐 겹침. (Dashboard·Meetings·SecurityPanel·TrashPanel·ErrorsPanel·PreviewEntry 도 동일 변수 사용 → 함께 해결.)

## 수정
`--c-surface-1: var(--c-surface)` 별칭 정의(라이트/다크 자동 대응).

## 검증
프리뷰에서 `var(--c-surface-1)` 가 `rgba(0,0,0,0)`(투명) → `rgb(23,26,32)`(불투명) 으로 해결됨 확인.

Closes #750
