### PR TITLE
🔀 :: (#754) 프로필 사진 있는 발신자의 알림 전부 누락 — createMany 에서 actorAvatarUrl 제외

### DIFF
--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -83,7 +83,9 @@ export async function notify(input: NotifyInput) {
     const map = await resolveDelivery([input.userId], input.type);
     const d = map.get(input.userId);
     if (d && !d.allowed) return;
-    const created = await prisma.notification.create({ data: input });
+    // actorAvatarUrl 은 Notification 컬럼이 아님(푸시 전용) → create 데이터에서 제외(notifyMany 와 동일 이유).
+    const { actorAvatarUrl, ...createData } = input;
+    const created = await prisma.notification.create({ data: createData });
     if (!d || d.allowPush) {
       publish(input.userId, "notification", created);
       // 방 음소거 시 APNs(폰 푸시) 만 생략 — 레코드/SSE 는 위에서 이미 보냄.
@@ -131,7 +133,10 @@ export async function notifyMany(inputs: NotifyInput[]) {
     // 거의 동시에 온 두 알림 중 하나의 실시간 SSE/APNs 가 누락됐다(레코드는 남아 다음 새로고침엔 보임).
     // 근본 수정: 각 행의 id 를 미리 생성해 넣고, 그 id 들로 정확히 되짚어 "전부" 푸시한다.
     const rows = filtered.map((i) => ({ ...i, id: randomUUID() as string }));
-    await prisma.notification.createMany({ data: rows });
+    // actorAvatarUrl 은 Notification 컬럼이 아니라 푸시 페이로드 전용(아래 inputById 로만 사용) →
+    // createMany 데이터에서 제외해야 한다. 문자열이 섞이면 Prisma 가 unknown arg 로 throw 해
+    // createMany 전체가 실패 → "프로필 사진 있는 발신자"의 알림이 통째로 누락됐다(전 플랫폼).
+    await prisma.notification.createMany({ data: rows.map(({ actorAvatarUrl, ...row }) => row) });
     const created = await prisma.notification.findMany({ where: { id: { in: rows.map((r) => r.id) } } });
     // 음소거된 방의 채팅 알림은 APNs(폰 푸시) 만 생략 — 한 번에 조회.
     const mutedSet = await mutedApnsSet(


### PR DESCRIPTION
## 증상 (전 플랫폼)
발신자에게 **프로필 사진이 있으면** 그 사람의 메시지/알림이 **iOS·웹·데스크탑 어디서도 안 옴.** 사진 없으면 정상.

## 진짜 원인 (서버 — NSE 무관)
`actorAvatarUrl` 은 푸시 페이로드 전용이고 **Notification 컬럼이 아님**(스키마에 actorName·actorColor 만 존재). 그런데 `notifyMany` 가:
```ts
const rows = filtered.map(i => ({ ...i, id }));   // actorAvatarUrl 포함
await prisma.notification.createMany({ data: rows });  // ← 여기로 그대로 감
```
- 사진 **있음** → `actorAvatarUrl='/uploads/...'`(문자열) → Prisma 가 **unknown arg 로 throw** → createMany 실패 → catch("notifyMany failed") → **알림 레코드 미생성** → SSE·APNs·인앱 전부 0.
- 사진 **없음** → `undefined` → Prisma 가 무시 → 정상.

코드 주석도 "actorAvatarUrl 은 컬럼이 아니라 입력에만 있다"고 적어놓고 createMany 에서 빼는 걸 빠뜨림.

## 수정
create/createMany 데이터에서 `actorAvatarUrl` 을 destructure 로 제외(푸시용 inputById 에는 유지). 단건 notify() 도 방어.

## 영향
`#312`(NSE mutable-content off)가 못 고친 이유가 이거였음 — 레코드 생성 단계 버그라서. 이 수정으로 **사진 있는 발신자도 전 플랫폼 알림 정상.** iOS 재빌드 불필요(서버만). `tsc --noEmit` 통과.

Closes #754
