### PR TITLE
🔀 :: (#316) 일정 추가 버튼을 +아이콘만으로 줄여 월 네비 줄에 통합

### DIFF
--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -263,8 +263,14 @@ export default function SchedulePage() {
                 : `${weekDays[0].getMonth() + 1}.${weekDays[0].getDate()} – ${weekDays[6].getMonth() + 1}.${weekDays[6].getDate()}`}
             </div>
             <button className="btn-ghost" onClick={() => navCursor(1)}>→</button>
-            <button className="btn-primary sm:ml-3" onClick={() => setOpen(true)}>
-              + 일정 추가
+            <button
+              className="btn-primary"
+              style={{ width: 34, height: 34, padding: 0, fontSize: 22, fontWeight: 800, lineHeight: 1, display: "grid", placeItems: "center" }}
+              onClick={() => setOpen(true)}
+              aria-label="일정 추가"
+              title="일정 추가"
+            >
+              +
             </button>
           </div>
         }


### PR DESCRIPTION
## 증상
**일정 추가 버튼을 +아이콘만으로 줄여 월 네비 줄에 통합**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
'+ 일정 추가' 텍스트 버튼이 길어 모바일에서 flex-wrap 으로 다음 줄에 떨어져
어색했음. 텍스트를 빼고 34x34 compact '+' 아이콘 버튼으로 만들어 월/주 토글·
이전/다음 월 네비게이션과 같은 줄(오른쪽 끝)에 합침. aria-label/title='일정 추가'.

## 수정
**작업 항목 (커밋 단위)**
- fix(schedule): 일정 추가 버튼을 +아이콘만으로 줄여 월 네비 줄에 통합

**변경 대상 (1개 파일)**
- `client/src/pages/SchedulePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #316** 에서 진행됩니다.

