### PR TITLE
🔀 :: (#317) 일정 추가 버튼 반응형 — 모바일만 +아이콘, 데스크탑은 텍스트

### DIFF
--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -263,9 +263,14 @@ export default function SchedulePage() {
                 : `${weekDays[0].getMonth() + 1}.${weekDays[0].getDate()} – ${weekDays[6].getMonth() + 1}.${weekDays[6].getDate()}`}
             </div>
             <button className="btn-ghost" onClick={() => navCursor(1)}>→</button>
+            {/* 데스크탑(≥sm): 원래 텍스트 버튼 그대로 */}
+            <button className="btn-primary sm:ml-3 max-sm:hidden" onClick={() => setOpen(true)}>
+              + 일정 추가
+            </button>
+            {/* 모바일(<sm): + 아이콘만 — 헤더가 한 줄에 들어가게 */}
             <button
-              className="btn-primary"
-              style={{ width: 34, height: 34, padding: 0, fontSize: 22, fontWeight: 800, lineHeight: 1, display: "grid", placeItems: "center" }}
+              className="btn-primary sm:hidden"
+              style={{ width: 34, height: 34, padding: 0, fontSize: 22, fontWeight: 800, lineHeight: "34px", textAlign: "center" }}
               onClick={() => setOpen(true)}
               aria-label="일정 추가"
               title="일정 추가"


### PR DESCRIPTION
## 증상
**일정 추가 버튼 반응형 — 모바일만 +아이콘, 데스크탑은 텍스트**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
#316 에서 모든 화면에 컴팩트 + 를 적용했는데, 데스크탑 웹/앱은 원래
'+ 일정 추가' 텍스트 버튼이어야 함(모바일 기준으로만 아이콘화). 두 버튼으로 분리:
- 데스크탑(≥sm): 'btn-primary sm:ml-3 max-sm:hidden' → '+ 일정 추가'
- 모바일(<sm): 'btn-primary sm:hidden' 34x34 compact → '+'
프리뷰 검증: 375px 에서 +만(34px)·텍스트버튼 display:none / 1280px 에서 텍스트버튼·+ display:none.

## 수정
**작업 항목 (커밋 단위)**
- fix(schedule): 일정 추가 버튼 반응형 — 모바일만 +아이콘, 데스크탑은 텍스트 유지

**변경 대상 (1개 파일)**
- `client/src/pages/SchedulePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #317** 에서 진행됩니다.

