### PR TITLE
🔀 :: (#318) 통신알림(발신자 아바타) 재활성 + NSE 견고화

### DIFF
--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -48,8 +48,10 @@ const HOST = PRIMARY_HOST; // 표시·진단용 기본 게이트웨이
 // 통신알림(발신자 아바타) 임시 스위치.
 // 현재 iOS 빌드의 NSE(mutable-content 처리)가 채팅 푸시를 가로채 알림이 표시되지 않는 문제가 있어,
 // 안정화 전까지 꺼 둔다 → mutable-content 를 싣지 않으므로 NSE 가 호출되지 않고 "일반 알림으로 정상 표시".
-// NSE 표시 문제(아바타 스타일) 해결 후 이 값을 true 로 되돌리면 통신알림(아바타)이 복구된다.
-const ENABLE_COMMUNICATION_PUSH = false;
+// 재활성화: "사진 있는 발신자 알림 0" 의 진짜 원인은 actorAvatarUrl createMany 버그(#315 수정)였고,
+// NSE 도 다운로드 실패 시 "알림 전달 + 실패표시 / 최대 재시도" 로 견고화됨(NotificationService.swift).
+// → true 로 되돌려 통신알림(발신자 아바타) 복구.
+const ENABLE_COMMUNICATION_PUSH = true;
 
 export function apnsEnabled(): boolean {
   return Boolean(KEY_RAW && KEY_ID && TEAM_ID);


### PR DESCRIPTION
## 증상
**통신알림(발신자 아바타) 재활성 + NSE 견고화**

새 기능을 추가합니다.

## 원인
'사진 있는 발신자 알림 0' 의 진짜 원인은 actorAvatarUrl createMany 버그(#315 수정)였음.
NSE 도 견고화됨(NotificationService.swift): 아바타 다운로드 실패해도 알림을 무조건 전달하고
부제목에 실패 표시 / 6s×3 재시도 + 200·유효이미지 검증으로 최대 성공률.
→ mutable-content 재발송하여 통신알림(발신자 아바타) 복구. (iOS 는 새 NSE 로 재빌드 필요.)

## 수정
**작업 항목 (커밋 단위)**
- feat(push): 통신알림(발신자 아바타) 재활성 — ENABLE_COMMUNICATION_PUSH=true

**변경 대상 (1개 파일)**
- `server/src/lib/apns.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #318** 에서 진행됩니다.

