### PR TITLE
🔀 :: (#777) 네이티브 포그라운드 복귀 시 로컬알림 중복 토스트 제거

### DIFF
--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { api, apiUrl } from "./api";
 import { getAuthToken } from "./lib/authToken";
 import { deliverPendingNotifications, markSeen } from "./lib/desktopNotify";
+import { isCapacitorNative } from "./lib/platform";
 import { initNativeNotificationTaps } from "./lib/nativeNotify";
 import { shouldDeliverNotif } from "./lib/notifPrefs";
 
@@ -49,6 +50,9 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   const [items, setItems] = useState<Notif[]>([]);
   const [ready, setReady] = useState(false);
   const initialRef = useRef(true);
+  // 백→포그라운드 복귀(resume) 직전에 true 로 세팅 — 그 직후 reload 가 "쌓인 미읽음"을
+  // 라이브 알림처럼 토스트하지 않게(네이티브는 이미 APNs 로 표시됨) 구분하는 플래그.
+  const catchUpRef = useRef(false);
   const esRef = useRef<EventSource | null>(null);
 
   const bellItems = useMemo(() => items.filter((n) => !isChatType(n.type)), [items]);
@@ -62,6 +66,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   );
 
   const reload = useCallback(async () => {
+    // resume 직후의 reload 인지 await 전에 캡처 — 네이티브에서 백그라운드 동안 쌓인 미읽음을
+    // 다시 토스트하지 않기 위해. 폴링/일반 reload 는 false 라 평소대로 deliver.
+    const isResume = catchUpRef.current;
+    catchUpRef.current = false;
     try {
       const res = await api<{ notifications: Notif[]; unread: number }>("/api/notification");
       setItems(res.notifications);
@@ -69,6 +77,11 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       const unreadItems = res.notifications.filter((n) => !n.readAt);
       if (initialRef.current) {
         initialRef.current = false;
+        markSeen(unreadItems.map((n) => n.id));
+      } else if (isResume && isCapacitorNative()) {
+        // 네이티브 포그라운드 복귀: 쌓인 미읽음은 백그라운드 동안 이미 원격 APNs(+NSE 아바타)로
+        // 표시됐다. 여기서 로컬 배너로 또 토스트하면 "아바타 알림 → 로컬 알림" 중복이 된다.
+        // → 배너는 생략하고 seen 처리만(벨/미읽음 카운트는 setItems 로 이미 반영됨).
         markSeen(unreadItems.map((n) => n.id));
       } else {
         // 카테고리 토글 / 방별 음소거를 통과한 것만 OS 알림으로.
@@ -218,6 +231,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       // SSE 가 살아있으면 실시간 push 로 이미 동기화됨 — reload() 생략.
       // SSE 가 끊긴 상태(재연결 대기 중)에서만 전체 재조회.
       if (esRef.current && esRef.current.readyState !== EventSource.CLOSED) return;
+      // 이 reload 는 "복귀 직후 캐치업" — 네이티브에선 쌓인 미읽음을 다시 토스트하지 않게 표시.
+      catchUpRef.current = true;
       reload();
     }
     document.addEventListener("visibilitychange", onVisibility);


### PR DESCRIPTION
## 증상
아바타 알림(원격 APNs)으로 받은 걸, 앱을 다시 열면 **로컬 알림으로 또** 받는 중복.

## 원인
iOS 는 백그라운드에서 WKWebView JS 가 정지 → SSE 끊김. 포그라운드 복귀 시 `onVisibility` 가 `reload()` 를 호출하는데, 그 `reload` 의 `else` 분기가 **쌓인 미읽음을 `deliverPendingNotifications` 로 토스트**. 그 미읽음은 백그라운드 동안 이미 APNs(+NSE 아바타)로 표시된 것 → 중복.

## 수정
- resume 직전 `catchUpRef = true` 세팅, reload 가 await 전에 캡처.
- **네이티브 + resume** 이면 쌓인 미읽음은 `markSeen` 만 하고 배너 생략(이미 APNs 로 표시됨). 벨/카운트는 `setItems` 로 그대로 반영.
- 웹/데스크톱은 APNs 가 없으므로 기존대로 deliver(복귀 시 첫 토스트가 정상).
- #319(포그라운드 게이트)와 합쳐져, 백그라운드=APNs 아바타 / 포그라운드=로컬배너 / 복귀=중복없음.

## 검증
`tsc -b` 통과. (iOS 반영은 `npm run cap:ios` 필요)

Closes #777
