### PR TITLE
🔀 :: (#323) 웹/데스크탑 SSE 백엔드 직결 (Vercel 우회) — 실시간 알림

### DIFF
--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -158,17 +158,27 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         window.dispatchEvent(new CustomEvent(name, { detail: payload }));
       } catch {}
     };
-    function connect() {
+    // 웹은 Vercel 이 SSE 를 버퍼/끊어 라이브 SSE 가 0 이라, 백엔드(api.*)로 직결한다. 직결엔
+    // ?token= 이 필요한데 웹은 JS 에 세션토큰이 없어(httpOnly 쿠키) 짧은 수명 SSE 티켓을 받아 쓴다.
+    // 네이티브는 기존처럼 자기 API_BASE + 저장된 토큰으로 직결(별도 티켓 불필요).
+    let useDirect = !isCapacitorNative();
+    let directOpened = false; // 직결이 한 번이라도 붙었나 — 첫 연결조차 실패하면 프록시로 폴백.
+    async function resolveStreamUrl(): Promise<string> {
+      if (useDirect) {
+        const { ticket } = await api<{ ticket: string }>("/api/notification/sse-ticket");
+        return `https://api.${location.hostname}/api/notification/stream?token=${encodeURIComponent(ticket)}`;
+      }
+      // 네이티브: 저장 토큰으로 ?token= 직결. 웹 폴백: 상대경로(Vercel 프록시)+쿠키.
+      const streamToken = getAuthToken();
+      return apiUrl("/api/notification/stream") + (streamToken ? `?token=${encodeURIComponent(streamToken)}` : "");
+    }
+    async function connect() {
       try {
-        // 네이티브 앱은 EventSource 가 헤더를 못 싣고 쿠키도 cross-site ITP 로 막혀 SSE 가 안 붙는다.
-        // 세션 토큰을 ?token= 쿼리로 보내 인증한다(서버 queryTokenAuth 가 Bearer 로 승격). 웹/데스크톱은
-        // 토큰이 없어 쿼리 없이 기존 쿠키 인증 그대로.
-        const streamToken = getAuthToken();
-        const streamUrl =
-          apiUrl("/api/notification/stream") + (streamToken ? `?token=${encodeURIComponent(streamToken)}` : "");
-        const es = new EventSource(streamUrl, { withCredentials: true });
+        const streamUrl = await resolveStreamUrl();
+        // 직결은 티켓(쿼리)으로 인증 → 쿠키 불필요. 프록시 폴백 경로는 기존 쿠키 인증 유지.
+        const es = new EventSource(streamUrl, { withCredentials: !useDirect });
         esRef.current = es;
-        es.onopen = () => { reconnectDelay = 3000; }; // 연결 성공 → 백오프 리셋
+        es.onopen = () => { reconnectDelay = 3000; if (useDirect) directOpened = true; }; // 연결 성공 → 백오프 리셋
         es.addEventListener("notification", (ev: MessageEvent) => {
           try {
             const n = JSON.parse(ev.data) as Notif;
@@ -207,13 +217,17 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         es.onerror = () => {
           es.close();
           esRef.current = null;
+          // 직결이 한 번도 못 붙으면(CORS/오리진/티켓 등) 프록시 경로로 영구 폴백.
+          if (useDirect && !directOpened) useDirect = false;
           scheduleReconnect();
         };
       } catch {
+        // 티켓 발급 실패 등 → 직결 포기하고 프록시(→폴링 폴백)로.
+        if (useDirect && !directOpened) useDirect = false;
         scheduleReconnect();
       }
     }
-    connect();
+    void connect();
 
     // SSE fallback 폴링. 단 웹은 Vercel 이 SSE 를 버퍼/끊어 라이브 SSE 가 사실상 0 이라
     // 이 폴링이 '주 동기화 경로'가 된다 → 미읽음 실시간성(①)을 위해 90초→20초로 단축.

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -142,6 +142,24 @@ export function signToken(
   return jwt.sign({ ...user, sid: sessionId }, SECRET, { expiresIn: "7d" });
 }
 
+/**
+ * 웹 전용 짧은 수명(2분) SSE 티켓.
+ *
+ * 웹은 보안상 JS 에 세션 토큰을 노출하지 않고 httpOnly 쿠키만 쓴다. 그런데 Vercel 이 SSE 를
+ * 버퍼/끊어 웹 라이브 SSE 가 0 이라, 백엔드(api.*)로 직결해야 한다. 직결 EventSource 는 커스텀
+ * 헤더를 못 싣고 cross-subdomain 쿠키도 안 가므로 `?token=` 이 유일한 인증 경로인데, 웹엔 쓸
+ * 토큰이 없다. → 쿠키 인증된 요청에서만 이 짧은 티켓을 발급해 EventSource 핸드셰이크에 1회 쓴다
+ * (연결 후엔 재검증되지 않으므로 2분이면 충분, 노출 창은 최소). sid 를 실어 강제 로그아웃/세션
+ * 무효화도 그대로 적용된다(requireAuth 가 sid 의 revokedAt 을 확인).
+ */
+export function signSseTicket(user: AuthUser, sid: string): string {
+  return jwt.sign(
+    { id: user.id, role: user.role, name: user.name, email: user.email, companyId: user.companyId ?? null, sid },
+    SECRET,
+    { expiresIn: "2m" },
+  );
+}
+
 /** 로그인 성공 시 호출 — 새 Session row 생성 후 sessionId 반환. JWT 에 박아두면
  *  서버에서 revokedAt 로 즉시 무효화 가능. */
 export async function createSession(userId: string, req: Request): Promise<string> {

--- a/server/src/routes/notification.ts
+++ b/server/src/routes/notification.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
-import { requireAuth, queryTokenAuth } from "../lib/auth.js";
+import { requireAuth, queryTokenAuth, signSseTicket } from "../lib/auth.js";
 import { addClient, removeClient } from "../lib/sse.js";
 
 const router = Router();
@@ -36,6 +36,14 @@ router.get("/stream", queryTokenAuth, requireAuth, async (req, res) => {
 });
 
 router.use(requireAuth);
+
+// 웹 전용: Vercel 이 SSE 를 버퍼/끊으므로, 짧은 수명 티켓을 받아 백엔드(api.*)로 직결한다.
+// 쿠키 인증(위 requireAuth) 통과한 요청만 발급 — sid 포함이라 세션 무효화도 그대로 적용.
+router.get("/sse-ticket", (req, res) => {
+  const sid = (req as any).sessionId as string | null;
+  if (!sid) return res.status(401).json({ error: "unauthorized" });
+  res.json({ ticket: signSseTicket((req as any).user, sid) });
+});
 
 router.get("/", async (req, res) => {
   const u = (req as any).user;


### PR DESCRIPTION
## 증상
**웹/데스크탑 SSE 백엔드 직결 (Vercel 우회) — 실시간 알림**

새 기능을 추가합니다.

## 원인
웹은 Vercel 이 SSE 를 버퍼/끊어 라이브 SSE 가 0 → 미읽음 실시간 갱신 안 됨(①),
데스크탑도 90초 폴링에만 의존. 백엔드(api.*)로 직결하면 해결되지만, 직결 EventSource
는 커스텀 헤더 불가 + cross-subdomain 쿠키 차단이라 ?token= 이 유일한 인증 경로인데
웹은 보안상 JS 에 세션토큰이 없다(httpOnly 쿠키).

해결: 쿠키 인증된 요청에만 짧은 수명(2분) SSE 티켓을 발급(GET /api/notification/sse-ticket).
웹은 이 티켓으로 https://api.<host>/api/notification/stream 에 직결한다. 티켓은 sid 를 실어
세션 무효화(강제 로그아웃)도 그대로 적용.

- 인증 전체 무변경(쿠키 도메인/CORS 건드리지 않음) — additive.
- 직결이 한 번도 못 붙으면(CORS/오리진/티켓 실패) 자동으로 기존 프록시 경로→폴링(20초)으로
  폴백 → 무회귀.
- 네이티브는 기존 API_BASE+저장토큰 직결 그대로(useDirect=false).
- CORS_ORIGINS 에 웹 오리진 포함돼 cross-origin EventSource 허용 확인.

## 수정
**작업 항목 (커밋 단위)**
- feat(notif): 웹/데스크탑 SSE 백엔드 직결 — Vercel 우회로 실시간 알림(①)

**변경 대상 (3개 파일)**
- `client/src/notifications.tsx`
- `server/src/lib/auth.ts`
- `server/src/routes/notification.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #323** 에서 진행됩니다.

