### PR TITLE
🔀 :: (#324) 사진 없는 발신자도 기본 아바타(이니셜+색)로 통신알림

### DIFF
--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -120,6 +120,8 @@ export interface ApnsPayload {
   senderName?: string;
   /** 발신자 아바타 /uploads 상대경로(예: /uploads/x.png). NSE 가 App Group 세션토큰으로 받아 이미지로. */
   senderAvatarPath?: string;
+  /** 발신자 아바타 색(hex, 예 "#3D54C4"). 사진이 없으면 NSE 가 이니셜+이 색 원형(앱 기본 아바타)을 그려 통신알림으로. */
+  senderAvatarColor?: string;
 }
 
 interface SendResult {
@@ -147,6 +149,7 @@ function sendOne(deviceToken: string, payload: ApnsPayload, host: string): Promi
     if (payload.linkUrl) bodyObj.linkUrl = payload.linkUrl;
     if (payload.senderName) bodyObj.senderName = payload.senderName;
     if (payload.senderAvatarPath) bodyObj.senderAvatarPath = payload.senderAvatarPath;
+    if (payload.senderAvatarColor) bodyObj.senderAvatarColor = payload.senderAvatarColor;
     const body = Buffer.from(JSON.stringify(bodyObj));
 
     let session: http2.ClientHttp2Session;

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -144,7 +144,7 @@ export async function notifyMany(inputs: NotifyInput[]) {
     );
     // 아바타(actorAvatarUrl)는 Notification 컬럼이 아니라 입력에만 있으므로 id 로 되짚는다.
     const inputById = new Map(rows.map((r) => [r.id, r]));
-    const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string; groupId?: string; senderName?: string; senderAvatarPath?: string } }[] = [];
+    const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string; groupId?: string; senderName?: string; senderAvatarPath?: string; senderAvatarColor?: string } }[] = [];
     for (const n of created) {
       if (pushFlag.get(`${n.userId}:${n.type as NotifyType}`) === false) continue;
       publish(n.userId, "notification", n);
@@ -157,7 +157,7 @@ export async function notifyMany(inputs: NotifyInput[]) {
           userId: n.userId,
           payload: {
             title: n.title, body: n.body ?? undefined, linkUrl: n.linkUrl ?? undefined, groupId: rid ?? undefined,
-            ...(isChat ? { senderName: n.actorName ?? undefined, senderAvatarPath: inp?.actorAvatarUrl ?? undefined } : {}),
+            ...(isChat ? { senderName: n.actorName ?? undefined, senderAvatarPath: inp?.actorAvatarUrl ?? undefined, senderAvatarColor: n.actorColor ?? undefined } : {}),
           },
         });
       }


### PR DESCRIPTION
## 증상
**사진 없는 발신자도 기본 아바타(이니셜+색)로 통신알림**

새 기능을 추가합니다.

## 원인
지금까진 발신자가 프로필 사진을 안 올렸으면 푸시에 아바타 경로가 없어 NSE 가 이미지를
못 만들고 → 통신알림 스타일 미적용(앱로고만) 됐다. 이제 발신자의 avatarColor 를 푸시에
실어(senderAvatarColor) NSE 가 '이니셜 + 색 원형'(앱 기본 아바타와 동일)을 직접 그려
INPerson 에 넣는다 → 사진이 없어도 항상 발신자 아바타로 표시된다.

서버: ApnsPayload.senderAvatarColor 추가 + 채팅 푸시에 n.actorColor 전달.
NSE(별도, ⌘R): defaultAvatarImage() 로 이니셜+색 원형 렌더, image ?? default 폴백.

## 수정
**작업 항목 (커밋 단위)**
- feat(notif): 사진 없는 발신자도 기본 아바타(이니셜+색)로 통신알림

**변경 대상 (2개 파일)**
- `server/src/lib/apns.ts`
- `server/src/lib/notify.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #324** 에서 진행됩니다.

