### PR TITLE
🔀 :: (#326) 알림 아바타 색=프로필 색(①) + 그룹방=방 아바타(⑤)

### DIFF
--- a/server/src/jobs/dispatchScheduled.ts
+++ b/server/src/jobs/dispatchScheduled.ts
@@ -46,6 +46,12 @@ async function dispatchOne(id: string): Promise<void> {
   // 알림 — 즉시 경로(chat.ts)와 동일 정책. DIRECT: 상대에게 DM / GROUP·TEAM: 멘션=MENTION, 그외=DM.
   const preview = (msg.content ?? "").trim() || (msg.fileName ? `📎 ${msg.fileName}` : "(첨부)");
   const roomName = msg.room.type === "DIRECT" ? `${msg.sender.name}님과의 1:1` : msg.room.name;
+  const groupColor = (seed: string) => {
+    let h = 0;
+    for (let i = 0; i < seed.length; i++) h = (Math.imul(h, 31) + seed.charCodeAt(i)) >>> 0;
+    const palette = ["#3D54C4", "#2F6FED", "#5B6BD6", "#3FA0E8", "#2E7FA8", "#4FB6A0", "#3FA65A", "#6FB13C", "#C7942E", "#C77E3A", "#D4622E", "#C8443A"];
+    return palette[h % palette.length];
+  };
   const mentions = (msg.mentions ?? "")
     .split(",")
     .map((s) => s.trim())
@@ -62,6 +68,7 @@ async function dispatchOne(id: string): Promise<void> {
         linkUrl: `/chat?room=${msg.roomId}`,
         actorName: msg.sender.name,
         actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
+        actorColor: msg.sender.avatarColor ?? undefined,
       })),
     );
   } else {
@@ -73,8 +80,9 @@ async function dispatchOne(id: string): Promise<void> {
         title: mentionSet.has(m.userId) ? `@${msg.sender.name} · ${roomName}` : roomName,
         body: `${msg.sender.name}: ${preview}`.slice(0, 140),
         linkUrl: `/chat?room=${msg.roomId}`,
-        actorName: msg.sender.name,
-        actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
+        actorName: roomName,
+        actorAvatarUrl: undefined,
+        actorColor: groupColor(msg.roomId),
       })),
     );
   }

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -553,6 +553,13 @@ router.post("/rooms/:id/messages", async (req, res) => {
   if (!scheduledAt) {
     const preview = (d.content ?? "").trim() || (d.fileName ? `📎 ${d.fileName}` : "(첨부)");
     const roomName = msg.room.type === "DIRECT" ? `${u.name}님과의 1:1` : msg.room.name;
+    // 그룹방은 방 사진이 없으므로, 방 id 로 일관된 색을 만들어 '방 이름 이니셜' 기본 아바타에 쓴다.
+    const groupColor = (seed: string) => {
+      let h = 0;
+      for (let i = 0; i < seed.length; i++) h = (Math.imul(h, 31) + seed.charCodeAt(i)) >>> 0;
+      const palette = ["#3D54C4", "#2F6FED", "#5B6BD6", "#3FA0E8", "#2E7FA8", "#4FB6A0", "#3FA65A", "#6FB13C", "#C7942E", "#C77E3A", "#D4622E", "#C8443A"];
+      return palette[h % palette.length];
+    };
 
     if (msg.room.type === "DIRECT") {
       const others = await prisma.roomMember.findMany({
@@ -568,6 +575,7 @@ router.post("/rooms/:id/messages", async (req, res) => {
           linkUrl: `/chat?room=${msg.roomId}`,
           actorName: u.name,
           actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
+          actorColor: msg.sender.avatarColor ?? undefined,
         }))
       );
     } else {
@@ -586,8 +594,10 @@ router.post("/rooms/:id/messages", async (req, res) => {
           title: mentionSet.has(m.userId) ? `@${u.name} · ${roomName}` : roomName,
           body: `${u.name}: ${preview}`.slice(0, 140),
           linkUrl: `/chat?room=${msg.roomId}`,
-          actorName: u.name,
-          actorAvatarUrl: msg.sender.avatarUrl ?? undefined,
+          // 그룹방은 발신자 개인 아바타 대신 '방'(이름 이니셜 + 방별 색)을 보여준다 — 카톡 단톡방처럼.
+          actorName: roomName,
+          actorAvatarUrl: undefined,
+          actorColor: groupColor(msg.roomId),
         }))
       );
     }


### PR DESCRIPTION
## 증상
**알림 아바타 색=프로필 색(①) + 그룹방=방 아바타(⑤)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
① 채팅 알림이 actorColor 를 안 실어 보내 사진 없는 발신자의 기본 아바타가 항상
   폴백색(파랑)으로 떴다. DIRECT·GROUP 알림에 actorColor=발신자 avatarColor 추가 →
   푸시 senderAvatarColor 로 전달돼 NSE 가 프로필과 같은 색으로 렌더.

⑤ 그룹(GROUP/TEAM)방 알림이 발신자 개인 아바타로 떴다. 카톡 단톡방처럼 '방'을 보이게:
   actorName=방 이름, actorAvatarUrl=없음, actorColor=방 id 기반 일관 색 → NSE 가
   방 이름 이니셜+방색 기본 아바타로 렌더. (ChatRoom 에 사진 필드가 없어 방 이름 이니셜
   기본 아바타 사용. body 는 기존대로 '발신자: 메시지'.)

즉시 경로(chat.ts) + 예약 경로(dispatchScheduled.ts) 동일 적용.

## 수정
**작업 항목 (커밋 단위)**
- fix(notif): 알림 아바타 색=발신자 프로필 색(①) + 그룹방은 방 아바타로(⑤)

**변경 대상 (2개 파일)**
- `server/src/jobs/dispatchScheduled.ts`
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #326** 에서 진행됩니다.

