### PR TITLE
🔀 :: (#327) 모바일 상단바 우측에 프로필 버튼 추가

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1678,6 +1678,7 @@ const BREADCRUMB: Record<string, string> = {
 function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggable?: boolean; onOpenNav?: () => void; safeAreaTop?: boolean }) {
   const loc = useLocation();
   const { chatUnread } = useNotifications();
+  const { user } = useAuth();
   const label = loc.pathname.startsWith("/projects/")
     ? "프로젝트"
     : BREADCRUMB[loc.pathname] ?? "";
@@ -1773,6 +1774,21 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
             )}
           </button>
           <NotificationBell />
+          {/* 내 프로필 — 모바일 전용(데스크톱은 사이드바에 있음). 맨 오른쪽. 탭하면 프로필. */}
+          <NavLink
+            to="/profile"
+            className="md:hidden grid place-items-center flex-shrink-0 ml-0.5"
+            title="내 프로필"
+            aria-label="내 프로필"
+          >
+            {user?.avatarUrl ? (
+              <img src={imgSrc(user.avatarUrl)} alt="프로필" className="w-8 h-8 rounded-full object-cover border border-ink-150" loading="lazy" decoding="async" />
+            ) : (
+              <span className="w-8 h-8 rounded-full grid place-items-center text-white text-[13px] font-extrabold flex-shrink-0" style={{ background: user?.avatarColor ?? "#3D54C4", letterSpacing: "-0.02em" }}>
+                {user?.name?.[0] ?? "?"}
+              </span>
+            )}
+          </NavLink>
         </div>
       </header>
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} />


### PR DESCRIPTION
## 증상
**모바일 상단바 우측에 프로필 버튼 추가**

새 기능을 추가합니다.

## 원인
상단바 우측에 사내톡·알림 버튼만 있어 프로필 접근이 없었다. 벨 옆 맨 오른쪽에 내
아바타 버튼 추가 → 탭하면 /profile. 모바일 전용(md:hidden) — 데스크톱은 사이드바에
프로필이 이미 있음. 사진 없으면 이니셜+아바타색 원형.

## 수정
**작업 항목 (커밋 단위)**
- feat(layout): 모바일 상단바 우측 맨 끝에 내 프로필 버튼 추가(⑦)

**변경 대상 (1개 파일)**
- `client/src/components/AppLayout.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #327** 에서 진행됩니다.

