### PR TITLE
🔀 :: (#328) 그룹방 알림 색을 앱 roomColor 와 일치

### DIFF
--- a/server/src/jobs/dispatchScheduled.ts
+++ b/server/src/jobs/dispatchScheduled.ts
@@ -46,12 +46,8 @@ async function dispatchOne(id: string): Promise<void> {
   // 알림 — 즉시 경로(chat.ts)와 동일 정책. DIRECT: 상대에게 DM / GROUP·TEAM: 멘션=MENTION, 그외=DM.
   const preview = (msg.content ?? "").trim() || (msg.fileName ? `📎 ${msg.fileName}` : "(첨부)");
   const roomName = msg.room.type === "DIRECT" ? `${msg.sender.name}님과의 1:1` : msg.room.name;
-  const groupColor = (seed: string) => {
-    let h = 0;
-    for (let i = 0; i < seed.length; i++) h = (Math.imul(h, 31) + seed.charCodeAt(i)) >>> 0;
-    const palette = ["#3D54C4", "#2F6FED", "#5B6BD6", "#3FA0E8", "#2E7FA8", "#4FB6A0", "#3FA65A", "#6FB13C", "#C7942E", "#C77E3A", "#D4622E", "#C8443A"];
-    return palette[h % palette.length];
-  };
+  // 그룹/팀방 아바타 색 — 클라 roomColor 와 동일(TEAM=청록 #00C4B4, 그 외 그룹=슬레이트 #4E5968).
+  const roomAvatarColor = msg.room.type === "TEAM" ? "#00C4B4" : "#4E5968";
   const mentions = (msg.mentions ?? "")
     .split(",")
     .map((s) => s.trim())
@@ -82,7 +78,7 @@ async function dispatchOne(id: string): Promise<void> {
         linkUrl: `/chat?room=${msg.roomId}`,
         actorName: roomName,
         actorAvatarUrl: undefined,
-        actorColor: groupColor(msg.roomId),
+        actorColor: roomAvatarColor,
       })),
     );
   }

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -553,13 +553,9 @@ router.post("/rooms/:id/messages", async (req, res) => {
   if (!scheduledAt) {
     const preview = (d.content ?? "").trim() || (d.fileName ? `📎 ${d.fileName}` : "(첨부)");
     const roomName = msg.room.type === "DIRECT" ? `${u.name}님과의 1:1` : msg.room.name;
-    // 그룹방은 방 사진이 없으므로, 방 id 로 일관된 색을 만들어 '방 이름 이니셜' 기본 아바타에 쓴다.
-    const groupColor = (seed: string) => {
-      let h = 0;
-      for (let i = 0; i < seed.length; i++) h = (Math.imul(h, 31) + seed.charCodeAt(i)) >>> 0;
-      const palette = ["#3D54C4", "#2F6FED", "#5B6BD6", "#3FA0E8", "#2E7FA8", "#4FB6A0", "#3FA65A", "#6FB13C", "#C7942E", "#C77E3A", "#D4622E", "#C8443A"];
-      return palette[h % palette.length];
-    };
+    // 그룹/팀방 아바타 색 — 클라 roomColor(components/chat/theme.tsx)와 동일하게 맞춘다.
+    // TEAM=청록(#00C4B4), 그 외 그룹=슬레이트(#4E5968). 방 사진이 없어 '방 이름 이니셜+이 색' 기본 아바타.
+    const roomAvatarColor = msg.room.type === "TEAM" ? "#00C4B4" : "#4E5968";
 
     if (msg.room.type === "DIRECT") {
       const others = await prisma.roomMember.findMany({
@@ -597,7 +593,7 @@ router.post("/rooms/:id/messages", async (req, res) => {
           // 그룹방은 발신자 개인 아바타 대신 '방'(이름 이니셜 + 방별 색)을 보여준다 — 카톡 단톡방처럼.
           actorName: roomName,
           actorAvatarUrl: undefined,
-          actorColor: groupColor(msg.roomId),
+          actorColor: roomAvatarColor,
         }))
       );
     }


### PR DESCRIPTION
## 증상
**그룹방 알림 색을 앱 roomColor 와 일치**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
#326 에서 그룹 알림 색을 방 id 해시 팔레트로 만들었는데, 앱(components/chat/theme.tsx
roomColor)은 TEAM=#00C4B4, 그 외 그룹=#4E5968(슬레이트) 고정색을 쓴다. 알림이 앱의
그룹방 아바타(회색)와 다른 색(파랑)으로 떠서 어색했다. 서버도 동일하게 타입별 고정색을
쓰도록 변경(즉시 경로 chat.ts + 예약 경로 dispatchScheduled.ts).

## 수정
**작업 항목 (커밋 단위)**
- fix(notif): 그룹방 알림 아바타 색을 앱 roomColor 와 일치(TEAM=청록·GROUP=슬레이트)

**변경 대상 (2개 파일)**
- `server/src/jobs/dispatchScheduled.ts`
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #328** 에서 진행됩니다.

