### PR TITLE
🔀 :: (#815) 파일명 인코딩 robust 처리 (다운로드 원본 이름)

### DIFF
--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -22,8 +22,14 @@ if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR, { recursive: true });
 // multer는 multipart 파일명을 latin1로 해석해서 한글이 깨짐 → UTF-8로 복원
 function fixName(name: string) {
   if (!name) return name;
+  // multer/busboy 는 파일명을 브라우저가 보낸 방식에 따라 latin1(구식 `filename=`) 또는
+  // UTF-8(`filename*=UTF-8''`, 모던 브라우저)로 디코딩한다. 전자만 latin1→utf8 복원이 필요하고,
+  // 후자(이미 올바른 한글)에 복원을 또 하면 "ë³´ê³ ì„œ" 처럼 깨진다(다운로드 이름이 이상해지는 원인).
+  // → latin1 상위바이트(0x80–0xFF)가 있고 UTF-8 재해석이 유효할 때만 복원, 아니면 원본 유지.
   try {
-    return Buffer.from(name, "latin1").toString("utf8");
+    if (!/[-ÿ]/.test(name)) return name; // ASCII / 이미 정상 UTF-8(코드포인트>0xFF) → 그대로
+    const decoded = Buffer.from(name, "latin1").toString("utf8");
+    return decoded.includes("�") ? name : decoded; // 복원 결과가 깨지면 원본 유지
   } catch {
     return name;
   }


### PR DESCRIPTION
## 증상
문서함 파일 다운로드 시 업로드 당시 원본 이름이 아니라 깨진 이름으로 받아짐.

## 원인
`fixName` 이 **무조건 latin1→utf8 복원**. multer/busboy 는 모던 브라우저가 보내는 `filename*=UTF-8''` 는 **이미 UTF-8 로** 디코딩하는데, 거기에 또 복원을 걸어 **이중 인코딩으로 한글이 깨짐**('ë³´ê³ ì„œ.pdf'). 서버 Content-Disposition·클라 download 속성은 모두 정상이라, 깨진 건 저장된 이름이었다.

## 수정
latin1 상위바이트(0x80–0xFF)가 있고 UTF-8 재해석이 유효할 때만 복원, 아니면 원본 유지. → latin1 인코딩본은 복원, 이미 정상 UTF-8/ASCII 는 그대로.

## 검증
node 로 3케이스(UTF-8 그대로 / latin1 복원 / ASCII 그대로) 확인 + server `tsc` 통과.
※ 이미 저장된 파일은 이름이 깨진 채라 재업로드 시 정상화.

Closes #815
