### PR TITLE
🔀 :: (#333) 1:1 대화 'per-user 숨김(나만 삭제)'

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -195,6 +195,24 @@ export default function ChatMiniApp({
       hydrateMutedFromServer(res.rooms);
     } catch {}
   };
+  // 1:1 대화 '나만 삭제'(per-user 숨김). 내 목록에서만 사라지고 상대에겐 유지. 새 메시지 오면 다시 나타남.
+  const hideRoom = async (r: Room) => {
+    const ok = await confirmAsync({
+      title: "대화 삭제",
+      description: "이 대화를 내 목록에서 삭제할까요?\n상대방에게는 그대로 남아있고, 새 메시지가 오면 다시 나타나요.",
+      tone: "danger",
+      confirmLabel: "삭제",
+    });
+    if (!ok) return;
+    // 낙관적 — 즉시 목록에서 제거. 실패하면 복원.
+    setRooms((prev) => prev.filter((x) => x.id !== r.id));
+    try {
+      await api(`/api/chat/rooms/${r.id}/hide`, { method: "POST" });
+    } catch (e: any) {
+      await alertAsync({ title: "삭제 실패", description: e?.message || "대화를 삭제하지 못했어요." });
+      loadRooms();
+    }
+  };
   // 메시지 로더.
   // - full=true: 전체 재조회 (방 진입/포커스 복귀/주기적 동기화)
   // - full=false: 마지막 메시지 이후만 증분 조회. 서버가 `?after=<id>` 로 새 메시지만 반환 →
@@ -720,6 +738,7 @@ export default function ChatMiniApp({
           q={q}
           setQ={setQ}
           onOpen={(id) => setActiveId(id)}
+          onHideRoom={hideRoom}
           messageHits={messageHits}
           searching={searching}
           roomSettings={roomSettings}
@@ -732,10 +751,11 @@ export default function ChatMiniApp({
 
 /* ======================= 목록 ======================= */
 function ListView({
-  rooms, meId, unread, q, setQ, onOpen, messageHits, searching, roomSettings, presenceMap,
+  rooms, meId, unread, q, setQ, onOpen, onHideRoom, messageHits, searching, roomSettings, presenceMap,
 }: {
   rooms: Room[]; meId: string; unread: Record<string, number>;
   q: string; setQ: (v: string) => void; onOpen: (id: string) => void;
+  onHideRoom: (r: Room) => void;
   messageHits: MessageHit[]; searching: boolean;
   roomSettings: Record<string, RoomLocalSetting>;
   presenceMap: Record<string, { presenceStatus: string | null; workStatus: string | null; presenceMessage: string | null }>;
@@ -836,6 +856,7 @@ function ListView({
             <ListRow
               key={r.id}
               onClick={() => onOpen(r.id)}
+              onDelete={r.type === "DIRECT" ? () => onHideRoom(r) : undefined}
               avatar={{ name: title, color: roomColor(r, meId), imageUrl: roomImageUrl(r, meId) }}
               title={title}
               titleHighlight={q}
@@ -908,9 +929,10 @@ function EmptyRow({ children }: { children: React.ReactNode }) {
 
 /* ===== 범용 리스트 행 ===== */
 function ListRow({
-  onClick, avatar, title, titleHighlight, subtitle, subtitleHighlight, subtitlePrefix, rightTop, unread, muted, presenceColor, presenceTitle, isGroup, memberCount,
+  onClick, onDelete, avatar, title, titleHighlight, subtitle, subtitleHighlight, subtitlePrefix, rightTop, unread, muted, presenceColor, presenceTitle, isGroup, memberCount,
 }: {
   onClick: () => void;
+  onDelete?: () => void;
   avatar: { name: string; color: string; imageUrl?: string | null };
   title: string;
   titleHighlight?: string;
@@ -925,9 +947,22 @@ function ListRow({
   isGroup?: boolean;
   memberCount?: number;
 }) {
+  // 길게 누르기(모바일) / 우클릭(데스크톱) → 삭제. 짧은 탭은 그대로 열기.
+  const pressTimer = useRef<number | null>(null);
+  const longPressed = useRef(false);
+  const startPress = () => {
+    if (!onDelete) return;
+    longPressed.current = false;
+    pressTimer.current = window.setTimeout(() => { longPressed.current = true; onDelete(); }, 500);
+  };
+  const cancelPress = () => { if (pressTimer.current) { clearTimeout(pressTimer.current); pressTimer.current = null; } };
   return (
     <button
-      onClick={onClick}
+      onClick={() => { if (longPressed.current) { longPressed.current = false; return; } onClick(); }}
+      onContextMenu={onDelete ? (e) => { e.preventDefault(); onDelete(); } : undefined}
+      onTouchStart={startPress}
+      onTouchEnd={cancelPress}
+      onTouchMove={cancelPress}
       style={{
         width: "100%",
         display: "flex", alignItems: "center", gap: 12,

--- a/server/prisma/migrations/20260606000000_room_member_hidden_at/migration.sql
+++ b/server/prisma/migrations/20260606000000_room_member_hidden_at/migration.sql
@@ -1,0 +1,4 @@
+-- 1:1 대화 'per-user 숨김(나만 삭제)'. RoomMember 에 hiddenAt 컬럼 추가.
+-- 가산형(ADD COLUMN, nullable) — PostgreSQL 11+ 에서 메타데이터 전용 연산이라
+-- 테이블 재작성/락 없이 즉시 적용된다. 기존 행은 NULL(숨김 안 함, 비파괴적).
+ALTER TABLE "RoomMember" ADD COLUMN "hiddenAt" TIMESTAMP(3);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -725,6 +725,10 @@ model RoomMember {
   // 방별 알림 음소거 — true 면 서버가 이 방 채팅 알림의 APNs(폰 푸시) 를 보내지 않음.
   // (알림 레코드·SSE·미읽음 뱃지는 유지 — 조용히 쌓이기만 함.) 기기 간 동기화를 위해 서버에 저장.
   muted      Boolean   @default(false)
+  // 1:1 대화 '나만 삭제'(per-user 숨김). A 가 숨기면 A 목록에선 사라지고, A 는 hiddenAt 이후
+  // 메시지만 본다(이전 기록은 안 보임). 상대(B)의 RoomMember 는 무관 → B 는 그대로 유지.
+  // 숨긴 뒤 새 메시지가 오면 방이 A 목록에 다시 나타난다(hiddenAt 이후 내용만).
+  hiddenAt   DateTime?
   room       ChatRoom  @relation(fields: [roomId], references: [id], onDelete: Cascade)
   user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -92,8 +92,34 @@ router.get("/rooms", async (req, res) => {
     take: auditMode ? 500 : 300,
   });
 
+  // per-user 숨김('나만 삭제') 적용 — 내가 숨긴 방은 목록에서 제외하되, hiddenAt 이후 새 메시지가
+  // 있으면 다시 보인다(상대가 새로 보냈을 때). audit 모드는 전체를 봐야 하므로 미적용.
+  const visible = auditMode
+    ? rooms
+    : rooms.filter((room) => {
+        const me = room.members.find((m) => m.userId === u.id);
+        if (!me?.hiddenAt) return true;
+        const last = room.messages[0];
+        return !!last && new Date(last.createdAt) > new Date(me.hiddenAt);
+      });
+
   if (auditMode) await writeLog(u.id, "CHAT_AUDIT_LIST", undefined, `count=${rooms.length}`);
-  res.json({ rooms, auditMode });
+  res.json({ rooms: visible, auditMode });
+});
+
+/**
+ * 1:1 대화 '나만 삭제'(per-user 숨김). 내 RoomMember.hiddenAt 만 갱신 → 내 목록에서 사라지고,
+ * 나는 이후 메시지만 보게 된다. 상대(B)의 RoomMember 는 무관 → 그대로 유지. 숨긴 뒤 상대가
+ * 새 메시지를 보내면(hiddenAt 이후) 방이 내 목록에 다시 나타난다.
+ */
+router.post("/rooms/:id/hide", async (req, res) => {
+  const u = (req as any).user;
+  const r = await prisma.roomMember.updateMany({
+    where: { roomId: req.params.id, userId: u.id },
+    data: { hiddenAt: new Date() },
+  });
+  if (r.count === 0) return res.status(404).json({ error: "참여 중인 방이 아닙니다" });
+  res.json({ ok: true });
 });
 
 /**

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -368,7 +368,7 @@ router.get("/rooms/:id/messages", async (req, res) => {
       select: {
         id: true,
         type: true,
-        members: { select: { userId: true, lastReadAt: true } },
+        members: { select: { userId: true, lastReadAt: true, hiddenAt: true } },
       },
     }),
     afterId
@@ -405,6 +405,14 @@ router.get("/rooms/:id/messages", async (req, res) => {
   // afterId 가 다른 방의 것을 가리키면 무시 — 클라이언트가 방을 막 전환한 상황
   if (after && after.roomId === room.id) {
     where.createdAt = { gt: after.createdAt };
+  }
+  // per-user 숨김: 내가 숨긴 방이면 hiddenAt 이전 메시지는 안 보인다('나만 삭제' 효과).
+  // afterId(페이지네이션 바닥)와 함께면 더 늦은 쪽이 실제 바닥.
+  const meMember = room.members.find((m) => m.userId === u.id);
+  if (meMember?.hiddenAt) {
+    const hid = new Date(meMember.hiddenAt);
+    const cur = where.createdAt?.gt ? new Date(where.createdAt.gt) : null;
+    where.createdAt = { gt: cur && cur > hid ? cur : hid };
   }
 
   const raw = await prisma.chatMessage.findMany({


### PR DESCRIPTION
## 증상
**1:1 대화 'per-user 숨김(나만 삭제)'**

새 기능을 추가합니다.

## 원인
A 가 1:1 대화를 '나만 삭제'하면 A 의 RoomMember.hiddenAt 에 시각 기록.
A 목록에선 사라지고 A 는 이후 메시지만 보게 되며, 상대(B)는 그대로 유지.
muted 와 동일한 비파괴적 ADD COLUMN(nullable) 마이그레이션.

## 수정
**작업 항목 (커밋 단위)**
- feat(chat): RoomMember.hiddenAt 추가 — 1:1 대화 per-user 숨김 스키마
- feat(chat): 1:1 대화 숨김 엔드포인트 + 방목록에서 숨긴 방 제외
- feat(chat): 숨긴 방은 hiddenAt 이후 메시지만 조회
- feat(chat): 채팅 목록에서 1:1 대화 삭제(나만 숨김) UI

**변경 대상 (4개 파일)**
- `client/src/components/ChatMiniApp.tsx`
- `server/prisma/migrations/20260606000000_room_member_hidden_at/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #333** 에서 진행됩니다.

