### PR TITLE
🔀 :: (#334) 지금 보고 있는 방은 알림(APNs) 생략 (active-viewer)

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -312,6 +312,16 @@ export default function ChatMiniApp({
     return () => clearInterval(t);
   }, [activeId, isPanelOpen]);
 
+  // active-viewer 하트비트 — 방을 보는 동안(패널 열림 + 화면 보임) 15초마다 읽음을 갱신해,
+  // 서버가 'lastReadAt 신선 = 지금 보고 있음'으로 판정하게 한다(보는 방엔 APNs 푸시 X). 폴링과
+  // 별개의 전용 경로라 폴링 주기가 바뀌어도 active-viewer 판정이 안 깨진다. 닫거나 숨기면 멈춤.
+  useEffect(() => {
+    if (!activeId || !isPanelOpen) return;
+    const ping = () => { if (isChatVisible()) void markRead(activeId); };
+    const t = setInterval(ping, 15_000);
+    return () => clearInterval(t);
+  }, [activeId, isPanelOpen]);
+
   // SSE 수신 — NotificationProvider 의 EventSource 가 여기로 재방송한 chat:* 이벤트.
   // 대상 방이 현재 열려있는 방과 일치할 때만 상태에 반영. 아니면 rooms 목록만 갱신
   // (마지막 메시지 미리보기 / 미읽음 뱃지용).

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -78,6 +78,31 @@ async function mutedApnsSet(targets: { userId: string; linkUrl?: string | null }
   return new Set(muted.map((m) => `${m.userId}:${m.roomId}`));
 }
 
+/** 활성 시청자로 간주하는 lastReadAt 신선도 — 이 시간 안에 읽음이 갱신됐으면 "지금 그 방을 보고 있음". */
+const ACTIVE_VIEW_MS = 45_000;
+/**
+ * (userId, roomId) 쌍 중 "지금 그 방을 보고 있는" 조합을 `${userId}:${roomId}` Set 으로 반환.
+ * 보고 있는 방의 채팅 알림은 APNs(폰 푸시) 를 건너뛴다 — 화면에 떠 있으니 알림이 불필요(요구사항).
+ * 판정: RoomMember.lastReadAt 이 최근(ACTIVE_VIEW_MS 이내). 클라가 방을 보는 동안 읽음을 주기적으로
+ * 갱신(하트비트)하므로 보는 중엔 신선하게 유지된다. 레코드·SSE 는 그대로라 미읽음/채팅은 정상.
+ */
+async function activeViewerApnsSet(targets: { userId: string; linkUrl?: string | null }[]): Promise<Set<string>> {
+  const pairs = targets
+    .map((t) => ({ userId: t.userId, roomId: roomIdFromLink(t.linkUrl) }))
+    .filter((p): p is { userId: string; roomId: string } => !!p.roomId);
+  if (!pairs.length) return new Set();
+  const since = new Date(Date.now() - ACTIVE_VIEW_MS);
+  const active = await prisma.roomMember.findMany({
+    where: {
+      lastReadAt: { gte: since },
+      roomId: { in: Array.from(new Set(pairs.map((p) => p.roomId))) },
+      userId: { in: Array.from(new Set(pairs.map((p) => p.userId))) },
+    },
+    select: { roomId: true, userId: true },
+  });
+  return new Set(active.map((m) => `${m.userId}:${m.roomId}`));
+}
+
 export async function notify(input: NotifyInput) {
   try {
     const map = await resolveDelivery([input.userId], input.type);
@@ -142,6 +167,10 @@ export async function notifyMany(inputs: NotifyInput[]) {
     const mutedSet = await mutedApnsSet(
       created.map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
     );
+    // 지금 그 방을 보고 있는 사람에겐 APNs 생략(요구사항: 보는 방 알림 X). 레코드·SSE 는 그대로.
+    const activeSet = await activeViewerApnsSet(
+      created.map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
+    );
     // 아바타(actorAvatarUrl)는 Notification 컬럼이 아니라 입력에만 있으므로 id 로 되짚는다.
     const inputById = new Map(rows.map((r) => [r.id, r]));
     const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string; groupId?: string; senderName?: string; senderAvatarPath?: string; senderAvatarColor?: string } }[] = [];
@@ -149,7 +178,7 @@ export async function notifyMany(inputs: NotifyInput[]) {
       if (pushFlag.get(`${n.userId}:${n.type as NotifyType}`) === false) continue;
       publish(n.userId, "notification", n);
       const rid = roomIdFromLink(n.linkUrl);
-      if (!(rid && mutedSet.has(`${n.userId}:${rid}`))) {
+      if (!(rid && (mutedSet.has(`${n.userId}:${rid}`) || activeSet.has(`${n.userId}:${rid}`)))) {
         // 채팅(DM/MENTION)만 Communication Notification(발신자 아바타) 대상. 결재/공지 등은 일반 알림.
         const isChat = n.type === "DM" || n.type === "MENTION";
         const inp = inputById.get(n.id);


### PR DESCRIPTION
## 증상
**지금 보고 있는 방은 알림(APNs) 생략 (active-viewer)**

새 기능을 추가합니다.

## 원인
activeViewerApnsSet — RoomMember.lastReadAt 이 최근(45초 이내)인 (user,room)은 '지금
그 방을 보고 있음'으로 보고 채팅 APNs 를 건너뛴다. muted 스킵과 동일 패턴으로 notifyMany
에 적용(둘 중 하나라도 해당하면 푸시 생략). 알림 레코드·SSE 는 그대로라 미읽음/채팅목록은 정상.

## 수정
**작업 항목 (커밋 단위)**
- feat(notif): 지금 보고 있는 방은 APNs 푸시 생략 (서버 active-viewer)
- feat(chat): 보는 방 active-viewer 하트비트 — lastReadAt 신선 유지

**변경 대상 (2개 파일)**
- `client/src/components/ChatMiniApp.tsx`
- `server/src/lib/notify.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #334** 에서 진행됩니다.

