### PR TITLE
🔀 :: (#335) 데스크탑 알림 발신자 아바타(이니셜+색) 아이콘

### DIFF
--- a/HiNest-MacOS/src/main.ts
+++ b/HiNest-MacOS/src/main.ts
@@ -230,9 +230,11 @@ ipcMain.handle("hinest:flashFrame", () => {
   } catch {}
 });
 
-ipcMain.handle("hinest:showNotification", (_e, opts: { title: string; body?: string; silent?: boolean }) => {
+ipcMain.handle("hinest:showNotification", (_e, opts: { title: string; body?: string; silent?: boolean; icon?: string }) => {
   try {
-    const n = new Notification({ title: opts.title, body: opts.body, silent: opts.silent });
+    // 발신자 아바타(dataURL) 가 오면 알림 아이콘으로 사용. (macOS 에서 적용되는지 빌드로 검증)
+    const icon = opts.icon ? nativeImage.createFromDataURL(opts.icon) : undefined;
+    const n = new Notification({ title: opts.title, body: opts.body, silent: opts.silent, ...(icon && !icon.isEmpty() ? { icon } : {}) });
     n.on("click", () => showWindow());
     n.show();
   } catch {}

--- a/HiNest-MacOS/src/preload.ts
+++ b/HiNest-MacOS/src/preload.ts
@@ -17,7 +17,7 @@ contextBridge.exposeInMainWorld("hinest", {
   setBadge: (count: number) => ipcRenderer.invoke("hinest:setBadge", count),
   flashFrame: () => ipcRenderer.invoke("hinest:flashFrame"),
   openExternal: (url: string) => ipcRenderer.invoke("hinest:openExternal", url),
-  showNotification: (opts: { title: string; body?: string; silent?: boolean }) =>
+  showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) =>
     ipcRenderer.invoke("hinest:showNotification", opts),
   relaunch: () => ipcRenderer.invoke("hinest:relaunch"),
   canTouchID: () => ipcRenderer.invoke("hinest:canTouchID") as Promise<boolean>,

--- a/client/src/lib/desktopNotify.ts
+++ b/client/src/lib/desktopNotify.ts
@@ -94,6 +94,27 @@ export function alreadySeen(id: string) {
   return getSeen().has(id);
 }
 
+/** 발신자 기본 아바타(색 원형 + 이름 첫 글자)를 그려 dataURL 로. Electron 알림 아이콘용. */
+function avatarDataUrl(name?: string, color?: string): string | undefined {
+  if (typeof document === "undefined") return undefined;
+  try {
+    const size = 64;
+    const c = document.createElement("canvas");
+    c.width = size; c.height = size;
+    const ctx = c.getContext("2d");
+    if (!ctx) return undefined;
+    ctx.fillStyle = color || "#3D54C4";
+    ctx.beginPath(); ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = "#fff";
+    ctx.font = `bold ${Math.round(size * 0.44)}px -apple-system, system-ui, sans-serif`;
+    ctx.textAlign = "center"; ctx.textBaseline = "middle";
+    ctx.fillText(name?.[0] ?? "?", size / 2, size / 2 + 2);
+    return c.toDataURL("image/png");
+  } catch {
+    return undefined;
+  }
+}
+
 export function showDesktopNotification(opts: {
   id: string;
   title: string;
@@ -101,6 +122,8 @@ export function showDesktopNotification(opts: {
   url?: string;
   icon?: string;
   tag?: string;
+  actorName?: string;
+  actorColor?: string;
 }) {
   if (!isDesktopEnabled()) return;
   if (alreadySeen(opts.id)) return;
@@ -112,7 +135,9 @@ export function showDesktopNotification(opts: {
   // 데스크톱 앱은 창을 트레이로 숨겨두고 쓰는 일이 많아 포커스와 무관하게 항상 띄운다.
   if (isElectron()) {
     try {
-      void window.hinest?.showNotification?.({ title: opts.title, body: opts.body });
+      // 발신자 아바타(이니셜+색)를 알림 아이콘으로. 사진 URL 은 알림 데이터에 없어 기본 아바타.
+      const icon = opts.icon ?? avatarDataUrl(opts.actorName, opts.actorColor);
+      void window.hinest?.showNotification?.({ title: opts.title, body: opts.body, icon });
     } catch {}
     markSeen([opts.id]);
     return;
@@ -169,7 +194,7 @@ export function showDesktopNotification(opts: {
 
 /** 여러 개를 한 번에 처리. 테스트·초기 동기화 편의용. */
 export function deliverPendingNotifications(
-  items: { id: string; title: string; body?: string; linkUrl?: string }[]
+  items: { id: string; title: string; body?: string; linkUrl?: string; actorName?: string; actorColor?: string }[]
 ) {
   // 네이티브(Capacitor): WKWebView 는 Web Notification 미지원 → local-notifications 로 배너 표시.
   if (isCapacitorNative()) {
@@ -192,6 +217,6 @@ export function deliverPendingNotifications(
   if (!isDesktopEnabled()) return;
   for (const it of items) {
     if (alreadySeen(it.id)) continue;
-    showDesktopNotification({ id: it.id, title: it.title, body: it.body, url: it.linkUrl });
+    showDesktopNotification({ id: it.id, title: it.title, body: it.body, url: it.linkUrl, actorName: it.actorName, actorColor: it.actorColor });
   }
 }

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -15,6 +15,7 @@ export type Notif = {
   body?: string;
   linkUrl?: string;
   actorName?: string;
+  actorColor?: string;
   readAt?: string | null;
   createdAt: string;
 };
@@ -88,7 +89,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         // 가로막힌 항목은 벨/채팅 UI 에는 그대로 들어가지만 OS 토스트는 안 뜸.
         const allowed = unreadItems.filter((n) => shouldDeliverNotif(n));
         deliverPendingNotifications(
-          allowed.map((n) => ({ id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl }))
+          allowed.map((n) => ({ id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl, actorName: n.actorName, actorColor: n.actorColor }))
         );
       }
     } catch {}
@@ -194,7 +195,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
             // 동일 가드 — 음소거된 방의 SSE 푸시는 OS 알림 띄우지 않음.
             if (shouldDeliverNotif(n)) {
               deliverPendingNotifications([
-                { id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl },
+                { id: n.id, title: n.title, body: n.body, linkUrl: n.linkUrl, actorName: n.actorName, actorColor: n.actorColor },
               ]);
             }
             // (음소거·카테고리로 가로막힌 건 위 if 가 OS 배너만 생략 — 벨/미읽음은 이미 반영됨.)

--- a/client/src/types/hinest.d.ts
+++ b/client/src/types/hinest.d.ts
@@ -11,7 +11,7 @@ declare global {
       setBadge: (count: number) => Promise<void>;
       flashFrame: () => Promise<void>;
       openExternal: (url: string) => Promise<{ ok: boolean; error?: string }>;
-      showNotification: (opts: { title: string; body?: string; silent?: boolean }) => Promise<void>;
+      showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) => Promise<void>;
       relaunch: () => Promise<void>;
       onFullscreenChange: (cb: (isFs: boolean) => void) => () => void;
       // ─── macOS 네이티브 Touch ID ─────────────────────────────────

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -277,9 +277,11 @@ ipcMain.handle("hinest:flashFrame", () => {
   } catch {}
 });
 
-ipcMain.handle("hinest:showNotification", (_e, opts: { title: string; body?: string; silent?: boolean }) => {
+ipcMain.handle("hinest:showNotification", (_e, opts: { title: string; body?: string; silent?: boolean; icon?: string }) => {
   try {
-    const n = new Notification({ title: opts.title, body: opts.body, silent: opts.silent });
+    // 발신자 아바타(dataURL) 가 오면 알림 아이콘으로 사용. (Win/Linux 확실, macOS 는 빌드로 검증)
+    const icon = opts.icon ? nativeImage.createFromDataURL(opts.icon) : undefined;
+    const n = new Notification({ title: opts.title, body: opts.body, silent: opts.silent, ...(icon && !icon.isEmpty() ? { icon } : {}) });
     n.on("click", () => showWindow());
     n.show();
   } catch {}

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -12,7 +12,7 @@ contextBridge.exposeInMainWorld("hinest", {
   setBadge: (count: number) => ipcRenderer.invoke("hinest:setBadge", count),
   flashFrame: () => ipcRenderer.invoke("hinest:flashFrame"),
   openExternal: (url: string) => ipcRenderer.invoke("hinest:openExternal", url),
-  showNotification: (opts: { title: string; body?: string; silent?: boolean }) =>
+  showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) =>
     ipcRenderer.invoke("hinest:showNotification", opts),
   relaunch: () => ipcRenderer.invoke("hinest:relaunch"),
   canTouchID: () => ipcRenderer.invoke("hinest:canTouchID") as Promise<boolean>,


### PR DESCRIPTION
## 증상
**데스크탑 알림 발신자 아바타(이니셜+색) 아이콘**

새 기능을 추가합니다.

## 원인
hinest:showNotification 가 icon(dataURL) 옵션을 받아 nativeImage 로 알림 아이콘 설정.
preload·main 양쪽(desktop·HiNest-MacOS) 모두. icon 비거나 빈 이미지면 기존대로(앱 아이콘).
Windows/Linux 는 확실, macOS 적용 여부는 빌드받아 검증.

## 수정
**작업 항목 (커밋 단위)**
- feat(desktop): Electron 알림에 발신자 아바타 아이콘 수용
- feat(desktop): 데스크탑 알림에 발신자 기본 아바타(이니셜+색) 아이콘 전달

**변경 대상 (7개 파일)**
- `HiNest-MacOS/src/main.ts`
- `HiNest-MacOS/src/preload.ts`
- `client/src/lib/desktopNotify.ts`
- `client/src/notifications.tsx`
- `client/src/types/hinest.d.ts`
- `desktop/src/main.ts`
- `desktop/src/preload.ts`

## 검증
- `client` tsc 통과 + vite build ✓
- Electron 빌드 확인

---
🔗 이 작업은 **PR #335** 에서 진행됩니다.

