### PR TITLE
🔀 :: (#337) 상단바 간격 + 미리보기 모바일 가드 + 환영 화면 하단바

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1768,7 +1768,7 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
               이벤트로 ChatFab 패널을 토글한다(패널/리스너는 ChatFab 에 그대로 있음).
               데스크톱(md+)은 ChatFab 의 우하단 FAB 를 그대로 쓰므로 여기선 숨긴다. */}
           <button
-            className="btn-icon relative md:hidden !w-[40px] !h-[40px]"
+            className="btn-icon relative md:hidden !w-[40px] !h-[40px] -mr-1.5"
             onClick={() => window.dispatchEvent(new CustomEvent("chat:toggle"))}
             title="사내톡"
             aria-label={chatUnread > 0 ? `사내톡 · 안 읽은 메시지 ${chatUnread}건` : "사내톡"}

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -17,8 +17,8 @@ import { PinsProvider, usePins, pinLinkUrl } from "../pins";
 import { ROUTE_PREFETCH, loadProject } from "../routes";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
-import { isPreviewMode } from "../lib/previewMock";
-import { isInstalledApp, isDesktopApp, nativePlatform } from "../lib/platform";
+import { isPreviewMode, disablePreview } from "../lib/previewMock";
+import { isInstalledApp, isDesktopApp, nativePlatform, isCapacitorNative } from "../lib/platform";
 import { LiquidGlassTabBar, setNativeTabBarHidden, syncNativeTabBarVisibility } from "../lib/liquidGlassTabBar";
 import { confirmLogout } from "../lib/confirmLogout";
 
@@ -1385,10 +1385,19 @@ export function MobileMenuPage() {
         </div>
       )}
 
-      {/* 로그아웃 */}
+      {/* 로그아웃 — 미리보기 모드일 땐 '미리보기 종료'로 동작(데모 데이터 끄고 로그인 페이지로). */}
       <button
         type="button"
-        onClick={async () => { if (!(await confirmLogout())) return; await logout(); nav("/login"); }}
+        onClick={async () => {
+          if (isPreviewMode()) {
+            disablePreview();
+            window.location.replace("/login");
+            return;
+          }
+          if (!(await confirmLogout())) return;
+          await logout();
+          nav("/login");
+        }}
         className="w-full flex items-center justify-center gap-2 h-[46px] rounded-full border border-ink-150 text-[13px] font-bold text-ink-600 hover:bg-ink-100 hover:text-ink-900 transition"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -1396,7 +1405,7 @@ export function MobileMenuPage() {
           <path d="m16 17 5-5-5-5" />
           <path d="M21 12H9" />
         </svg>
-        <span>로그아웃</span>
+        <span>{isPreviewMode() ? "미리보기 종료" : "로그아웃"}</span>
       </button>
 
       {/* 법적 고지 — 로그인 후에도 메뉴에서 접근 가능하게(가입/로그인 화면 외 추가 노출). */}

--- a/client/src/components/PreviewBanner.tsx
+++ b/client/src/components/PreviewBanner.tsx
@@ -1,12 +1,17 @@
 import { isPreviewMode, disablePreview } from "../lib/previewMock";
+import { isCapacitorNative } from "../lib/platform";
 
 /**
  * 미리보기 모드 알림 배너 — 화면 최상단 고정. 클릭하면 가입 페이지로.
  * 모바일에서는 한 줄에 압축 (긴 텍스트는 줄임표), 데스크톱에서는 풀 메시지.
  * iOS 노치 영역(env(safe-area-inset-top))을 흡수해서 상태바와 자연스럽게 융합.
+ *
+ * 네이티브 앱(Capacitor) 에선 배너를 숨긴다 — '전체' 탭의 로그아웃 = 미리보기 종료.
+ * (모바일 화면을 데모 마크업 없이 깔끔하게 보여주려는 요구사항.)
  */
 export default function PreviewBanner({ safeAreaTop = true }: { safeAreaTop?: boolean }) {
   if (!isPreviewMode()) return null;
+  if (isCapacitorNative()) return null;
   return (
     <div
       className="hinest-preview-banner"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -96,6 +96,9 @@ html.hinest-desktop .app-bottomnav { display: none !important; }
    로 웹 바가 이미 숨겨져 있고(실제 네이티브 바는 AppLayout 의 modal 관찰자가 별도로 숨김), 이
    규칙은 웹·안드로이드·네이티브 폴백에서 동일하게 적용된다. :has() 는 iOS 15.4+/모던 브라우저 지원. */
 html:has(.modal-safe) .app-bottomnav { display: none !important; }
+/* 미리보기 환영(온보딩) 오버레이가 떠 있는 동안에도 하단바를 숨긴다 — 비치는 현상 +
+   하단바가 입력을 가로채 '건너뛰기' 버튼이 안 눌리던 문제를 함께 해결. */
+html:has(.hinest-onb-overlay) .app-bottomnav { display: none !important; }
 
 /* iOS 앱 — 상단바를 애플 리퀴드 글래스로. TopBar 를 본문 스크롤러(<main>) 위에 떠 있는
    반투명+blur 헤더(absolute)로 만들고, 본문은 그만큼 위쪽 패딩을 줘 헤더 아래에서 시작한다.


### PR DESCRIPTION
## 증상
**상단바 간격 + 미리보기 모바일 가드 + 환영 화면 하단바**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- PreviewBanner: isCapacitorNative 면 렌더 안 함(요구사항 — 모바일에서 데모 마크업 없이
  깔끔하게). 웹/데스크톱은 기존대로 표시.
- MobileMenuPage 로그아웃 버튼: 미리보기 모드면 라벨 '미리보기 종료' + disablePreview()
  호출 후 /login 으로(reload 없이 SPA 리로드 location.replace). 일반 모드는 기존 confirmLogout
  → logout → /login 그대로.

## 수정
**작업 항목 (커밋 단위)**
- feat(preview): 모바일 앱에서 미리보기 배너 숨김 + 전체 탭 로그아웃이 미리보기 종료
- fix(layout): 모바일 상단바 채팅-알람 간격 균일화
- fix(preview): 미리보기 환영 오버레이 동안 하단바 숨김 — 비침/건너뛰기 안 눌림 동시 해결

**변경 대상 (3개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/PreviewBanner.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #337** 에서 진행됩니다.

