### PR TITLE
🔀 :: (#338) 키보드 테마 동기화 + 새로고침 깜빡임/검정 하단 수정

### DIFF
--- a/client/capacitor.config.ts
+++ b/client/capacitor.config.ts
@@ -27,6 +27,16 @@ const config: CapacitorConfig = {
   // 안드로이드 기본 스킴을 https 로 — Secure 쿠키/Service Worker 가 정상 동작하도록.
   android: {
     allowMixedContent: false,
+    // 새로고침/페이지 전환 중 WebView 가 비어 보이는 순간을 앱 배경색으로 깔아 검은 깜빡임 차단.
+    backgroundColor: "#F5F6F8",
+  },
+  // iOS WebView 의 기본 배경(투명/검정)이 새로고침·전환 중 그대로 노출돼 하단바·세이프에어리어가
+  // 까맣게 깜빡이는 현상이 있다 → 라이트 테마 배경(--c-bg 와 동일) 로 채워 깔끔하게.
+  // 다크 모드에선 styles.css 의 background-color 가 위에 덮어 자연스럽게 동작한다.
+  ios: {
+    backgroundColor: "#F5F6F8",
+    // 키보드 등장 시 native contentInset 으로 자동 스크롤 — 네이티브 키보드 곡선과 같은 타이밍.
+    contentInset: "automatic",
   },
   server: {
     androidScheme: "https",
@@ -36,6 +46,13 @@ const config: CapacitorConfig = {
     // cleartext: false,
   },
   plugins: {
+    // 키보드 등장 애니메이션 — 'native' 리사이즈는 iOS 가 WebView 자체를 키보드 곡선에 맞춰
+    // 끌어올린다(CSS 트랜지션 없이도 부드러움). 'body' 보다 자연스럽고 입력 지연이 없다.
+    // resizeOnFullScreen=true → 안드로이드 전체화면에서도 동일 동작.
+    Keyboard: {
+      resize: "native",
+      resizeOnFullScreen: true,
+    },
     SplashScreen: {
       // 네이티브 스플래시는 솔리드 배경(앱 bg색) 이미지로 콜드 로드만 덮는다. 번들이 로드되면
       // main.tsx 가 즉시 hide() 하고 index.html 의 커스텀 인트로(배지 → 'HiNest' 슬라이드인)가

--- a/client/src/lib/nativeTheme.ts
+++ b/client/src/lib/nativeTheme.ts
@@ -1,0 +1,27 @@
+/**
+ * 네이티브(iOS/Android) 키보드·상태바 색을 앱 테마(light/dark) 에 맞춰 동기화한다.
+ *
+ * 기본적으로 iOS 키보드와 상태바는 OS 시스템 설정만 따라간다 — 그래서 앱 안에서 다크 테마를 켜도
+ * 키보드는 라이트(시스템 설정)로 떠 어색해진다. Capacitor Keyboard.setStyle / StatusBar.setStyle
+ * 을 명시 호출해 앱 테마를 따라가게 만든다.
+ *
+ * 웹/데스크톱은 플러그인이 없어 reject 되거나 no-op — try/catch 로 안전하게 무시한다.
+ */
+import { isCapacitorNative } from "./platform";
+
+let _last: "light" | "dark" | null = null;
+
+export async function applyNativeTheme(resolved: "light" | "dark"): Promise<void> {
+  if (!isCapacitorNative()) return;
+  if (_last === resolved) return; // 같은 값 중복 호출 방지(불필요한 IPC 절약)
+  _last = resolved;
+  try {
+    const { Keyboard, KeyboardStyle } = await import("@capacitor/keyboard");
+    await Keyboard.setStyle({ style: resolved === "dark" ? KeyboardStyle.Dark : KeyboardStyle.Light });
+  } catch { /* no-op on web/desktop */ }
+  try {
+    const { StatusBar, Style } = await import("@capacitor/status-bar");
+    // 다크 배경 위 → 흰 글자(Light), 라이트 배경 위 → 어두운 글자(Dark).
+    await StatusBar.setStyle({ style: resolved === "dark" ? Style.Light : Style.Dark });
+  } catch { /* StatusBar 플러그인 미설치 환경 — 조용히 무시 */ }
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -67,6 +67,13 @@
   }
 }
 
+/* 모든 환경에서 html/body 배경을 앱 배경색으로 — 새로고침/페이지 전환 중 WebView 가 비어
+   하단·세이프에어리어가 까맣게 깜빡이던 문제 방어(capacitor.config 의 backgroundColor 와 이중 안전망).
+   라이트/다크 자동 대응(:root / .dark 의 --c-bg). */
+html, body {
+  background-color: var(--c-bg);
+}
+
 /* iOS 네이티브(아이폰·아이패드): 폭과 무관하게 모바일 레이아웃(플로팅 글래스 하단 네비)을 쓴다.
    아이패드(≥768px)도 사이드바 대신 하단 글래스 바를 쓰도록 사이드바를 숨기고 하단 바를
    강제 노출한다. html.hinest-ios 는 iOS 네이티브에서만 붙으므로 웹·안드·데스크톱은 무영향. */

--- a/client/src/theme.tsx
+++ b/client/src/theme.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { applyNativeTheme } from "./lib/nativeTheme";
 
 export type ThemeMode = "light" | "dark" | "system";
 
@@ -53,6 +54,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     mq.addEventListener?.("change", handler);
     return () => mq.removeEventListener?.("change", handler);
   }, [mode]);
+
+  // resolved 가 바뀔 때마다 네이티브 키보드/상태바 색도 동기화 — iOS 가 시스템 설정만 따라가
+  // 앱에서 다크 테마를 켜도 키보드가 라이트로 뜨던 문제 해결.
+  useEffect(() => {
+    void applyNativeTheme(resolved);
+  }, [resolved]);
 
   const value = useMemo(() => ({ mode, resolved, setMode }), [mode, resolved, setMode]);
   return <ThemeCtx.Provider value={value}>{children}</ThemeCtx.Provider>;


### PR DESCRIPTION
## 증상
**키보드 테마 동기화 + 새로고침 깜빡임/검정 하단 수정**

새 기능을 추가합니다.

## 원인
iOS WebView 배경이 새로고침/페이지 전환 동안 그대로 노출돼 하단·세이프에어리어가 까맣게
깜빡이던 문제 → ios.backgroundColor=#F5F6F8(라이트 테마 --c-bg)로 채움. 다크 모드는 styles.css
가 위에 덮어 자연스럽게 동작.

Keyboard plugin: resize=native 명시 → iOS 가 WebView 자체를 키보드 곡선에 맞춰 끌어올려
CSS 트랜지션 없이도 부드럽게 슬라이드(기본값이지만 명시해 보장). android 도 backgroundColor 동일 적용.

## 수정
**작업 항목 (커밋 단위)**
- chore(capacitor): ios.backgroundColor + Keyboard resize=native
- feat(theme): 네이티브 키보드·상태바 색을 앱 테마(light/dark)에 동기화
- fix(styles): html/body 배경을 앱 배경색으로 — 새로고침 깜빡임 추가 방어

**변경 대상 (4개 파일)**
- `client/capacitor.config.ts`
- `client/src/lib/nativeTheme.ts`
- `client/src/styles.css`
- `client/src/theme.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #338** 에서 진행됩니다.

