### PR TITLE
🔀 :: (#339) Capacitor Live Updates Phase 1 — 셸 통합

### DIFF
--- a/client/capacitor.config.ts
+++ b/client/capacitor.config.ts
@@ -53,6 +53,22 @@ const config: CapacitorConfig = {
       resize: "native",
       resizeOnFullScreen: true,
     },
+    // Capacitor Live Updates (Capgo, MIT, self-hosted) — 셸은 App Store 한 번만 심사받고,
+    // 웹 번들(dist)은 우리 서버에서 OTA 로 받는다. Phase 1: 셸 통합만(autoUpdate=false). Phase 2
+    // 에서 진짜 zip 배포 자동화 들어가면 true 로 전환. autoUpdate 가 켜져 있으면 SDK 가
+    // 백그라운드에서 updateUrl 폴링 → 다음 콜드 스타트 때 새 번들로 교체.
+    //   updateUrl  : POST {device_id, app_id, version, bundle_id, channel} → 새 버전 JSON
+    //   statsUrl   : POST 통계(선택, 우선 비활성)
+    //   appReadyTimeout: notifyAppReady() 가 이 시간 안에 안 불리면 직전 정상 번들로 자동 롤백.
+    CapacitorUpdater: {
+      autoUpdate: false,
+      updateUrl: "https://nest.hi-vits.com/api/updates/check",
+      appReadyTimeout: 10000,
+      responseTimeout: 20,
+      autoDeleteFailed: true,
+      autoDeletePrevious: true,
+      resetWhenUpdate: true,
+    },
     SplashScreen: {
       // 네이티브 스플래시는 솔리드 배경(앱 bg색) 이미지로 콜드 로드만 덮는다. 번들이 로드되면
       // main.tsx 가 즉시 hide() 하고 index.html 의 커스텀 인트로(배지 → 'HiNest' 슬라이드인)가

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "@capacitor/push-notifications": "^8.1.1",
         "@capacitor/splash-screen": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
+        "@capgo/capacitor-updater": "^8.47.9",
         "@simplewebauthn/browser": "^13.3.0",
         "@tiptap/extension-color": "^3.22.4",
         "@tiptap/extension-highlight": "^3.22.4",
@@ -932,6 +933,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capgo/capacitor-updater": {
+      "version": "8.47.9",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-updater/-/capacitor-updater-8.47.9.tgz",
+      "integrity": "sha512-9HPiL143Qo+aHNQJ1hYN6p9X7zKGCK7/TfDqzX1/7ki8+Dwj6rUqlKK+hSsjiqiNzr2LYS6nTt975qN98EtRaA==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@capacitor/core": "^8.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@capacitor/push-notifications": "^8.1.1",
     "@capacitor/splash-screen": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
+    "@capgo/capacitor-updater": "^8.47.9",
     "@simplewebauthn/browser": "^13.3.0",
     "@tiptap/extension-color": "^3.22.4",
     "@tiptap/extension-highlight": "^3.22.4",

--- a/client/src/lib/liveUpdates.ts
+++ b/client/src/lib/liveUpdates.ts
@@ -1,0 +1,26 @@
+/**
+ * Capacitor Live Updates (Capgo, self-hosted) — 클라이언트 셸 통합.
+ *
+ * 동작 원리:
+ *  - 네이티브 셸은 App Store 한 번만 심사받고, 이후 dist(웹 번들)는 우리 서버에서 OTA 로 받는다.
+ *  - autoUpdate 가 켜져 있으면 SDK 가 백그라운드에서 updateUrl 을 폴링 → 새 버전이 있으면
+ *    다운로드해 두고, 다음 콜드 스타트(앱 재실행)부터 새 번들로 교체된다.
+ *  - 새 번들이 로드된 직후 10초 안에 notifyAppReady() 가 호출돼야 '정상 시작'으로 간주된다.
+ *    안 호출되면 직전 정상 번들로 자동 롤백 → 빌드가 깨져도 사용자가 "벽돌 앱" 을 만나지 않음.
+ *
+ * Phase:
+ *   1 (현재): notifyAppReady 만 호출. autoUpdate=false 라 실 OTA 는 아직. 셸/롤백 메커니즘 검증.
+ *   2 (예정): 서버 endpoint + zip 배포 자동화 들어가면 autoUpdate=true 로 전환해 실 OTA 시작.
+ */
+import { isCapacitorNative } from "./platform";
+
+/** 앱 진입점에서 가장 먼저 호출. 10초 안에 호출 못 하면 직전 번들로 자동 롤백. */
+export async function notifyLiveUpdateReady(): Promise<void> {
+  if (!isCapacitorNative()) return;
+  try {
+    const { CapacitorUpdater } = await import("@capgo/capacitor-updater");
+    await CapacitorUpdater.notifyAppReady();
+  } catch {
+    // 플러그인 미가용(웹/데스크톱) — 조용히 무시. 또는 첫 빌드라 네이티브 측 미반영.
+  }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,11 +5,16 @@ import App from "./App";
 import { AuthProvider } from "./auth";
 import { FeatureFlagsProvider } from "./lib/featureFlags";
 import { isPreviewMode } from "./lib/previewMock";
+import { notifyLiveUpdateReady } from "./lib/liveUpdates";
 import { ThemeProvider } from "./theme";
 import "./styles.css";
 
 // 미리보기 모드 부트스트랩 — 새로고침 후 fetch/EventSource 가 실제 서버로 새지 않게 가장 먼저 패치.
 isPreviewMode();
+
+// Capacitor Live Updates — 새 OTA 번들이 로드된 직후 10초 안에 호출돼야 '정상 시작' 으로 간주.
+// 안 호출되면 직전 정상 번들로 자동 롤백(벽돌 앱 방지). 네이티브가 아니면 no-op.
+void notifyLiveUpdateReady();
 
 // 네이티브 앱 스플래시 — 번들이 로드되면 네이티브 스플래시(솔리드 배경)를 내리고,
 // index.html 의 커스텀 인트로 애니메이션(배지 → 'HiNest' 슬라이드인, 2초)을 시작한다.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -21,6 +21,7 @@ import { isStorageEnabled, downloadFile } from "./lib/storage.js";
 import fs from "node:fs";
 import notificationRouter from "./routes/notification.js";
 import pushRouter from "./routes/push.js";
+import updatesRouter from "./routes/updates.js";
 import searchRouter from "./routes/search.js";
 import documentRouter from "./routes/document.js";
 import approvalRouter from "./routes/approval.js";
@@ -279,6 +280,9 @@ app.use("/api/expense", expenseRouter);
 app.use("/api/upload", uploadLimiter, uploadRouter);
 app.use("/api/notification", notificationRouter);
 app.use("/api/push", pushRouter);
+// Capacitor Live Updates (Capgo self-hosted) — 네이티브 셸이 OTA 새 번들 여부 확인.
+// Phase 1: 항상 'no_new_version_available' 응답(placeholder). Phase 2 에서 진짜 OTA 활성화.
+app.use("/api/updates", updatesRouter);
 app.use("/api/search", searchRouter);
 app.use("/api/document", documentRouter);
 // extras(templates/lines) 를 approval 보다 먼저 마운트 — approval 의 /:id 와 경로가 겹치는

--- a/server/src/routes/updates.ts
+++ b/server/src/routes/updates.ts
@@ -1,0 +1,32 @@
+import { Router } from "express";
+
+/**
+ * Capacitor Live Updates (Capgo) self-hosted endpoint.
+ *
+ * 셸(iOS/Android 네이티브 앱)이 정기적으로 이 endpoint 에 현재 번들 정보를 POST 해
+ * 새 버전이 있는지 묻는다. 응답 형식은 Capgo SDK 규약을 따른다:
+ *   업데이트 있음:   { version, url, checksum, sessionKey?, message? }
+ *   최신 상태:       { error: "no_new_version_available", message: "..." }
+ *
+ * Phase 1 (현재): 항상 "최신 상태" 응답 — 셸/네트워크 경로만 살려두고, 실제 OTA 배포는
+ *   Phase 2 에서 zip 배포 파이프라인이 들어간 뒤 활성화. 그때까지 클라 capacitor.config 도
+ *   autoUpdate=false 라 사실상 호출되지 않지만, 셸 환경 변화로 호출돼도 안전하도록 endpoint
+ *   자체는 살아있게 둔다.
+ *
+ * Phase 2 에서 할 일:
+ *   1) 빌드 산출물 dist/ 를 zip → S3/Vercel 정적 호스팅 위치에 업로드
+ *   2) 메타(version, checksum, url)를 DB/객체스토리지에 저장
+ *   3) 이 endpoint 가 (currentVersion, channel) 보고 새 메타 있으면 그걸 반환
+ *   4) (선택) /api/updates/stats — 다운로드/실패 통계 수집
+ */
+const router = Router();
+
+router.post("/check", (_req, res) => {
+  // Phase 1 placeholder — 새 번들 없음 응답.
+  res.json({
+    error: "no_new_version_available",
+    message: "No new version available (Live Updates Phase 1 — OTA pipeline not active yet).",
+  });
+});
+
+export default router;


### PR DESCRIPTION
## 증상
**Capacitor Live Updates Phase 1 — 셸 통합**

새 기능을 추가합니다.

## 원인
Capacitor Live Updates (Capgo MIT, self-hosted) 도입 — 셸은 App Store 한 번만 심사받고
웹 번들(dist)은 우리 서버에서 OTA 로 받는 구조. Phase 1 (이 커밋 포함 PR) 은 셸 통합만,
Phase 2 에서 zip 배포 자동화 들어가면 autoUpdate=true 로 전환.

- @capgo/capacitor-updater@^8.47.9 (Capacitor 8 호환)
- capacitor.config.ts plugins.CapacitorUpdater 등록 (autoUpdate=false, updateUrl 우리 서버,
  appReadyTimeout=10s 안에 notifyAppReady 미호출 시 자동 롤백).

## 수정
**작업 항목 (커밋 단위)**
- chore(deps): @capgo/capacitor-updater 설치 + capacitor.config 플러그인 등록
- feat(native): Live Updates notifyAppReady — 새 번들 로드 후 자동 롤백 보호
- feat(server): Live Updates check endpoint placeholder

**변경 대상 (7개 파일)**
- `client/capacitor.config.ts`
- `client/package-lock.json`
- `client/package.json`
- `client/src/lib/liveUpdates.ts`
- `client/src/main.tsx`
- `server/src/index.ts`
- `server/src/routes/updates.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #339** 에서 진행됩니다.

