### PR TITLE
🔀 :: (#340) Capacitor Live Updates Phase 2 — 실 OTA 활성화

### DIFF
--- a/client/capacitor.config.ts
+++ b/client/capacitor.config.ts
@@ -54,14 +54,14 @@ const config: CapacitorConfig = {
       resizeOnFullScreen: true,
     },
     // Capacitor Live Updates (Capgo, MIT, self-hosted) — 셸은 App Store 한 번만 심사받고,
-    // 웹 번들(dist)은 우리 서버에서 OTA 로 받는다. Phase 1: 셸 통합만(autoUpdate=false). Phase 2
-    // 에서 진짜 zip 배포 자동화 들어가면 true 로 전환. autoUpdate 가 켜져 있으면 SDK 가
-    // 백그라운드에서 updateUrl 폴링 → 다음 콜드 스타트 때 새 번들로 교체.
-    //   updateUrl  : POST {device_id, app_id, version, bundle_id, channel} → 새 버전 JSON
-    //   statsUrl   : POST 통계(선택, 우선 비활성)
-    //   appReadyTimeout: notifyAppReady() 가 이 시간 안에 안 불리면 직전 정상 번들로 자동 롤백.
+    // 웹 번들(dist)은 우리 서버에서 OTA 로 받는다. autoUpdate=true ⇒ SDK 가 백그라운드에서
+    // updateUrl 폴링 → 새 버전이면 zip 다운로드 → 다음 콜드 스타트(앱 재실행) 때 새 번들로 교체.
+    //   updateUrl  : POST {device_id, app_id, version, bundle_id, channel} → 새 버전 JSON 응답
+    //                서버가 Vercel manifest.json 를 읽어 응답을 만든다(routes/updates.ts).
+    //   appReadyTimeout: 새 번들 부팅 후 notifyAppReady() 가 이 시간(ms) 안에 안 불리면 직전
+    //                정상 번들로 자동 롤백 → 빌드가 깨져도 사용자가 벽돌 앱을 만나지 않음.
     CapacitorUpdater: {
-      autoUpdate: false,
+      autoUpdate: true,
       updateUrl: "https://nest.hi-vits.com/api/updates/check",
       appReadyTimeout: 10000,
       responseTimeout: 20,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -48,6 +48,7 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
+        "adm-zip": "^0.5.17",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.14",
@@ -2964,6 +2965,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ansi-regex": {

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/build-live-update.mjs",
     "preview": "vite preview --port 1000",
     "cap:add:ios": "cap add ios",
     "cap:add:android": "cap add android",
@@ -54,6 +54,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",
+    "adm-zip": "^0.5.17",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",

--- a/client/scripts/build-live-update.mjs
+++ b/client/scripts/build-live-update.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Live Updates 번들 생성기 — vite build 직후 자동 실행.
+ *
+ *   입력: client/dist/  (vite 결과물)
+ *   출력: client/dist/live-updates/bundle-<sha>.zip + manifest.json
+ *
+ * Vercel 이 client/dist 를 그대로 정적 호스팅하므로, 출력물이 자동으로
+ *   https://nest.hi-vits.com/live-updates/manifest.json
+ *   https://nest.hi-vits.com/live-updates/bundle-<sha>.zip
+ * 로 노출된다 (추가 인프라/CI 0).
+ *
+ * 버전:
+ *   - 짧은 git SHA (예: a3f9c2) — 결정적, 유니크. Capgo SDK 는 version 문자열 비교만 하므로
+ *     SHA 가 다르면 새 버전으로 본다. 같은 코드 = 같은 SHA = 동일 버전 (사용자 재다운로드 X).
+ *   - git 정보가 없는 환경(CI 외)에선 Date.now() 폴백 — 결정성 깨지지만 동작은 보장.
+ *
+ * 안전:
+ *   - live-updates/ 디렉토리 자체는 zip 대상에서 제외 (재귀 zip 방지).
+ *   - 빌드가 깨졌어도 SDK 의 notifyAppReady 타임아웃(10초)이 자동 롤백 보장.
+ */
+import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const AdmZip = require("adm-zip"); // adm-zip 은 CJS
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, "..", "dist");
+const outDir = path.join(distDir, "live-updates");
+
+async function main() {
+  await mkdir(outDir, { recursive: true });
+
+  let version;
+  try {
+    version = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    version = String(Date.now()); // CI 외 환경 fallback
+  }
+
+  const zipName = `bundle-${version}.zip`;
+  const zipPath = path.join(outDir, zipName);
+
+  // dist 통째 zip — live-updates/ 자체는 제외(재귀 방지).
+  // adm-zip 은 폴더 통째 추가 + 필터 가능.
+  const zip = new AdmZip();
+  zip.addLocalFolder(distDir, "", (filename) => {
+    // 제외 패턴: 자기 자신(live-updates/) + macOS 메타.
+    if (filename.startsWith("live-updates/") || filename === "live-updates") return false;
+    if (filename.endsWith(".DS_Store")) return false;
+    return true;
+  });
+  zip.writeZip(zipPath);
+
+  const buf = readFileSync(zipPath);
+  const checksum = "sha256-" + createHash("sha256").update(buf).digest("hex");
+
+  const manifest = {
+    version,
+    url: `/live-updates/${zipName}`,
+    checksum,
+    size: buf.length,
+    createdAt: new Date().toISOString(),
+  };
+  await writeFile(
+    path.join(outDir, "manifest.json"),
+    JSON.stringify(manifest, null, 2) + "\n",
+  );
+
+  const kb = (buf.length / 1024).toFixed(1);
+  console.log(`✅ live-update bundle ${version} — ${kb} KB`);
+  console.log(`   manifest:  ${path.relative(process.cwd(), path.join(outDir, "manifest.json"))}`);
+  console.log(`   bundle:    ${path.relative(process.cwd(), zipPath)}`);
+}
+
+main().catch((e) => {
+  console.error("[build-live-update] failed:", e);
+  process.exit(1);
+});

--- a/server/src/routes/updates.ts
+++ b/server/src/routes/updates.ts
@@ -3,29 +3,79 @@ import { Router } from "express";
 /**
  * Capacitor Live Updates (Capgo) self-hosted endpoint.
  *
- * 셸(iOS/Android 네이티브 앱)이 정기적으로 이 endpoint 에 현재 번들 정보를 POST 해
- * 새 버전이 있는지 묻는다. 응답 형식은 Capgo SDK 규약을 따른다:
- *   업데이트 있음:   { version, url, checksum, sessionKey?, message? }
+ * 동작:
+ *   1) 셸이 POST /api/updates/check { version, ... } 로 현재 번들 정보를 보낸다.
+ *   2) 서버는 https://nest.hi-vits.com/live-updates/manifest.json 을 GET 해 최신 메타를 가져온다
+ *      (Vercel 정적 호스팅 — vite build 직후 build-live-update.mjs 가 자동 생성·갱신).
+ *   3) manifest.version 이 셸의 version 과 다르면 새 번들 정보 반환, 같으면 'no_new_version_available'.
+ *
+ * 응답 형식(Capgo SDK 규약):
+ *   업데이트 있음:   { version, url(절대 URL), checksum, message? }
  *   최신 상태:       { error: "no_new_version_available", message: "..." }
  *
- * Phase 1 (현재): 항상 "최신 상태" 응답 — 셸/네트워크 경로만 살려두고, 실제 OTA 배포는
- *   Phase 2 에서 zip 배포 파이프라인이 들어간 뒤 활성화. 그때까지 클라 capacitor.config 도
- *   autoUpdate=false 라 사실상 호출되지 않지만, 셸 환경 변화로 호출돼도 안전하도록 endpoint
- *   자체는 살아있게 둔다.
- *
- * Phase 2 에서 할 일:
- *   1) 빌드 산출물 dist/ 를 zip → S3/Vercel 정적 호스팅 위치에 업로드
- *   2) 메타(version, checksum, url)를 DB/객체스토리지에 저장
- *   3) 이 endpoint 가 (currentVersion, channel) 보고 새 메타 있으면 그걸 반환
- *   4) (선택) /api/updates/stats — 다운로드/실패 통계 수집
+ * 캐시: manifest 는 자주 안 바뀌므로 60 초 메모리 캐시. 빌드 직후 빠른 전파를 위해 짧게 잡음.
  */
 const router = Router();
 
-router.post("/check", (_req, res) => {
-  // Phase 1 placeholder — 새 번들 없음 응답.
-  res.json({
-    error: "no_new_version_available",
-    message: "No new version available (Live Updates Phase 1 — OTA pipeline not active yet).",
+const MANIFEST_URL =
+  process.env.LIVE_UPDATE_MANIFEST_URL ?? "https://nest.hi-vits.com/live-updates/manifest.json";
+const PUBLIC_ORIGIN =
+  process.env.LIVE_UPDATE_PUBLIC_ORIGIN ?? "https://nest.hi-vits.com";
+const CACHE_TTL_MS = 60_000;
+
+type Manifest = {
+  version: string;
+  url: string; // 보통 상대경로 (예: /live-updates/bundle-abc.zip)
+  checksum: string;
+  size?: number;
+  createdAt?: string;
+};
+
+let _cache: { at: number; manifest: Manifest | null } | null = null;
+
+async function getManifest(): Promise<Manifest | null> {
+  const now = Date.now();
+  if (_cache && now - _cache.at < CACHE_TTL_MS) return _cache.manifest;
+  try {
+    const r = await fetch(MANIFEST_URL, { headers: { "cache-control": "no-cache" } });
+    if (!r.ok) {
+      _cache = { at: now, manifest: null };
+      return null;
+    }
+    const m = (await r.json()) as Manifest;
+    _cache = { at: now, manifest: m };
+    return m;
+  } catch {
+    _cache = { at: now, manifest: null };
+    return null;
+  }
+}
+
+router.post("/check", async (req, res) => {
+  const body = (req.body ?? {}) as { version?: string };
+  const manifest = await getManifest();
+  if (!manifest || !manifest.version) {
+    // 아직 manifest 가 없거나 fetch 실패 — 안전하게 '최신' 응답(앱 정상 동작).
+    return res.json({
+      error: "no_new_version_available",
+      message: "Manifest not available yet.",
+    });
+  }
+  if (body.version === manifest.version) {
+    return res.json({
+      error: "no_new_version_available",
+      message: `Already on ${manifest.version}.`,
+    });
+  }
+  // 새 버전 — 다운로드 URL 을 절대 URL 로 노출 (셸이 그대로 fetch).
+  const absoluteUrl = manifest.url.startsWith("http")
+    ? manifest.url
+    : `${PUBLIC_ORIGIN}${manifest.url}`;
+  return res.json({
+    version: manifest.version,
+    url: absoluteUrl,
+    checksum: manifest.checksum,
+    message: `Update to ${manifest.version}`,
   });
 });
 


### PR DESCRIPTION
## 증상
**Capacitor Live Updates Phase 2 — 실 OTA 활성화**

새 기능을 추가합니다.

## 원인
vite build 직후 자동으로 dist/live-updates/bundle-<sha>.zip + manifest.json 생성.
Vercel 이 client/dist 를 그대로 정적 호스팅하므로 결과물이 자동으로
https://nest.hi-vits.com/live-updates/{manifest.json, bundle-<sha>.zip} 노출 — 추가 CI 0.

- scripts/build-live-update.mjs: adm-zip 으로 dist 통째 zip(live-updates/ 재귀 제외) +
  짧은 git SHA 버전 + sha256 checksum.
- package.json: build = tsc -b && vite build && node scripts/build-live-update.mjs.
- adm-zip 추가(devDep). archiver v8 은 ESM-only 로 호출 API 가 모호해 더 단순한 adm-zip 선택.

로컬 실행 검증: bundle-f224ed1.zip 1.2MB + manifest.json 정상 생성.

## 수정
**작업 항목 (커밋 단위)**
- chore(build): Live Updates 번들 생성 자동화 (adm-zip)
- feat(server): /api/updates/check 가 Vercel manifest 읽어 새 버전 응답
- chore(capacitor): CapacitorUpdater autoUpdate=true — 실 OTA 활성화

**변경 대상 (5개 파일)**
- `client/capacitor.config.ts`
- `client/package-lock.json`
- `client/package.json`
- `client/scripts/build-live-update.mjs`
- `server/src/routes/updates.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #340** 에서 진행됩니다.

