### PR TITLE
🔀 :: (#344) version 0.1.4 — 새 release publish

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hinest-desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "HiNest Desktop (Electron wrapper)",
   "main": "dist/main.js",


### PR DESCRIPTION
## 증상
**version 0.1.4 — 새 release publish**

유지보수 작업을 진행합니다.

## 원인
#335 (macOS 알림 아바타) 및 그동안 누적된 변경을 새 release 로 publish 하기 위한 수동 버전 bump.
electron-builder 가 같은 버전이면 publish skip 하므로 새 release 가 만들어지지 않았다.
(release-please 자동 PR 도 매번 실패 중 — 별도 디버깅 필요).

## 수정
**작업 항목 (커밋 단위)**
- chore(desktop): version 0.1.3 → 0.1.4

**변경 대상 (1개 파일)**
- `desktop/package.json`

## 검증
- Electron 빌드 확인

---
🔗 이 작업은 **PR #344** 에서 진행됩니다.

