### PR TITLE
🔀 :: (#345) 서명·공증 env var 지원 — 시크릿 셋업하면 자동

### DIFF
--- a/.github/workflows/build-desktop-macos.yml
+++ b/.github/workflows/build-desktop-macos.yml
@@ -53,20 +53,25 @@ jobs:
       - name: Compile TypeScript
         run: npm run build
 
-      # 시크릿(서명·공증용) 존재 여부에 따라 빌드 옵션을 분기. 빈 시크릿은 GitHub Actions
-      # 에서 빈 문자열로 들어오므로 단순 비교로 분기 가능.
+      # 시크릿 풀스택(MAC_CSC_LINK + APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID)
+      # 존재 여부에 따라 빌드 옵션을 분기. 빈 시크릿은 GitHub Actions 에서 빈 문자열로 들어오므로
+      # 단순 비교로 분기 가능. afterSign.js 가 env var 방식을 지원하므로 시크릿이 다 있으면
+      # 공증까지 자동으로 들어간다.
       - name: Decide signing strategy
         id: signing
         run: |
           if [[ -n "${{ secrets.MAC_CSC_LINK }}" ]]; then
             echo "auto_discovery=true" >> $GITHUB_OUTPUT
             echo "extra_args=" >> $GITHUB_OUTPUT
-            # 시크릿 있으면 공증 시도(desktop/build/afterSign.js — keychain profile 방식).
-            # ⚠️ 단 keychain profile 'hinest-notary' 가 러너에 없으므로, 시크릿 셋업과 함께
-            #    afterSign.js 를 env var(APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD) 기반으로 바꾸는
-            #    별도 작업이 필요. 그 작업 완료 전엔 시크릿이 있어도 SKIP 으로 두는 게 안전.
-            echo "skip_notarize=1" >> $GITHUB_OUTPUT
-            echo "🔐 Code signing enabled (MAC_CSC_LINK secret found)"
+            # 서명 + 공증 풀스택 시크릿이 다 있을 때만 공증 ON. 하나라도 빠지면 서명만 하고
+            # 공증은 스킵(빌드 자체는 굴러감 — 사용자가 .dmg 첫 실행 시 경고가 약간 줄어듦).
+            if [[ -n "${{ secrets.APPLE_ID }}" && -n "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}" && -n "${{ secrets.APPLE_TEAM_ID }}" ]]; then
+              echo "skip_notarize=0" >> $GITHUB_OUTPUT
+              echo "🔐 Code signing + notarization enabled (all secrets present)"
+            else
+              echo "skip_notarize=1" >> $GITHUB_OUTPUT
+              echo "🔐 Code signing only (APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID missing → notarization skipped)"
+            fi
           else
             echo "auto_discovery=false" >> $GITHUB_OUTPUT
             # package.json 의 mac.identity 가 명시돼 있어 무서명 빌드 시 keychain 탐색이
@@ -89,8 +94,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # 시크릿 없으면 keychain 자동 탐색 끔(없는데 찾으려다 실패하는 거 방지).
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.signing.outputs.auto_discovery }}
-          # desktop/build/afterSign.js 가 keychain profile 'hinest-notary' 를 찾아 공증을
-          # 시도하는데 CI 러너에는 없다 → SKIP. 시크릿 + 공증 env var 셋업되면 별도 작업으로
-          # afterSign.js 를 env var 기반으로 전환하고 이 변수를 0 으로 토글.
+          # afterSign.js 가 env var(APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID) 방식 지원.
+          # 시크릿 풀스택이 셋업되면 signing step 이 skip_notarize=0 으로 토글해 자동 공증 수행.
           HINEST_SKIP_NOTARIZE: ${{ steps.signing.outputs.skip_notarize }}
         run: npx electron-builder --mac --publish always ${{ steps.signing.outputs.extra_args }}

--- a/desktop/build/afterSign.js
+++ b/desktop/build/afterSign.js
@@ -1,14 +1,16 @@
 // 서명 직후에 Apple notary 서비스로 제출 → 승인 대기 → app 에 스테이플.
 //
-// electron-builder 의 기본 notarize 옵션은 env var (APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD)
-// 에 의존하는데, 여기선 키체인 프로필(hinest-notary) 을 쓰고 있어서 afterSign 훅에서
-// notarytool 을 직접 돌린다.
+// 두 가지 자격 증명 방식을 모두 지원:
 //
-// 사전 준비 (최초 1회):
-//   xcrun notarytool store-credentials hinest-notary \
-//     --apple-id <dev apple id> --team-id 3NVCLTSP9V --password <app-specific password>
+//  1) env var 방식 (CI 권장) — APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID 세 개가
+//     모두 있으면 그걸로 notarytool 호출. GitHub Actions 등 신규 환경에 권장.
 //
-// 이후부터는 `npm run dist:mac` 한 줄로 서명 + 공증 + 스테이플 전부 끝.
+//  2) keychain profile 방식 (로컬 권장) — env var 가 없으면 keychain profile "hinest-notary"
+//     에 미리 저장된 자격 증명을 사용. 로컬 개발자 본인 맥에 한 번만 셋업:
+//       xcrun notarytool store-credentials hinest-notary \
+//         --apple-id <dev apple id> --team-id 3NVCLTSP9V --password <app-specific password>
+//
+// 어느 쪽도 안 되거나 HINEST_SKIP_NOTARIZE=1 이면 공증 스킵(무서명 빌드/빠른 로컬 테스트용).
 // DMG 자체는 electron-builder 가 후속 단계에서 만들고 자동 스테이플 해준다 (afterAllArtifactBuild).
 
 const { execSync } = require("child_process");
@@ -20,11 +22,17 @@ const KEYCHAIN_PROFILE = "hinest-notary";
 module.exports = async function (context) {
   if (context.electronPlatformName !== "darwin") return;
 
-  // HINEST_SKIP_NOTARIZE=1 로 공증 스킵 (로컬 빠른 테스트용)
+  // HINEST_SKIP_NOTARIZE=1 로 공증 스킵 (로컬 빠른 테스트용 / CI 무서명 빌드)
   if (process.env.HINEST_SKIP_NOTARIZE === "1") {
     console.log("[afterSign] HINEST_SKIP_NOTARIZE=1 — 공증 스킵");
     return;
   }
+
+  // 자격 증명 결정 — env var 우선, 그다음 keychain profile.
+  const appleId = process.env.APPLE_ID;
+  const appleAsPwd = process.env.APPLE_APP_SPECIFIC_PASSWORD;
+  const appleTeam = process.env.APPLE_TEAM_ID;
+  const useEnvCreds = !!(appleId && appleAsPwd && appleTeam);
 
   const appPath = path.join(
     context.appOutDir,
@@ -42,12 +50,14 @@ module.exports = async function (context) {
     throw e;
   }
 
-  console.log(`[afterSign] notarytool submit: ${zipPath}`);
+  const credsArgs = useEnvCreds
+    ? `--apple-id "${appleId}" --password "${appleAsPwd}" --team-id "${appleTeam}"`
+    : `--keychain-profile "${KEYCHAIN_PROFILE}"`;
+  console.log(
+    `[afterSign] notarytool submit (${useEnvCreds ? "env vars" : `keychain profile '${KEYCHAIN_PROFILE}'`}): ${zipPath}`
+  );
   try {
-    execSync(
-      `xcrun notarytool submit "${zipPath}" --keychain-profile "${KEYCHAIN_PROFILE}" --wait`,
-      { stdio: "inherit" }
-    );
+    execSync(`xcrun notarytool submit "${zipPath}" ${credsArgs} --wait`, { stdio: "inherit" });
     console.log("[afterSign] notarize accepted — stapling app");
     execSync(`xcrun stapler staple "${appPath}"`, { stdio: "inherit" });
     console.log("[afterSign] app stapled ✔");


### PR DESCRIPTION
## 증상
**서명·공증 env var 지원 — 시크릿 셋업하면 자동**

새 기능을 추가합니다.

## 원인
기존엔 keychain profile 'hinest-notary' 만 지원해 CI 러너에선 항상 실패했다.

이제 두 방식 모두 지원:
- env var (CI 권장): APPLE_ID + APPLE_APP_SPECIFIC_PASSWORD + APPLE_TEAM_ID 셋 다 있으면 사용
- keychain profile (로컬 권장): env var 없으면 'hinest-notary' fallback

어느 쪽도 없거나 HINEST_SKIP_NOTARIZE=1 이면 공증 스킵(무서명 빌드).

## 수정
**작업 항목 (커밋 단위)**
- feat(desktop): afterSign.js env var 자격 증명 지원 — CI 공증 가능
- feat(ci): macOS 워크플로우 — 시크릿 풀스택 있으면 공증 자동 활성화

**변경 대상 (2개 파일)**
- `.github/workflows/build-desktop-macos.yml`
- `desktop/build/afterSign.js`

## 검증
- Electron 빌드 확인

---
🔗 이 작업은 **PR #345** 에서 진행됩니다.

