### PR TITLE
🔀 :: (#346) version 0.1.5 — 서명·공증 검증용 첫 release

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hinest-desktop",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "HiNest Desktop (Electron wrapper)",
   "main": "dist/main.js",


### PR DESCRIPTION
## 증상
**version 0.1.5 — 서명·공증 검증용 첫 release**

유지보수 작업을 진행합니다.

## 원인
Apple Developer ID Application 인증서(MAC_CSC_LINK) + 공증 자격(APPLE_ID 외 2개) 시크릿
5종 셋업 완료. 새 release(v0.1.5)로 첫 서명+공증된 .dmg 가 publish 되는지 검증.

## 수정
**작업 항목 (커밋 단위)**
- chore(desktop): version 0.1.4 → 0.1.5 — 서명·공증 풀스택 첫 release

**변경 대상 (1개 파일)**
- `desktop/package.json`

## 검증
- Electron 빌드 확인

---
🔗 이 작업은 **PR #346** 에서 진행됩니다.

