### PR TITLE
🔀 :: (#347) afterAllArtifactBuild.js env var 지원 + v0.1.6

### DIFF
--- a/desktop/build/afterAllArtifactBuild.js
+++ b/desktop/build/afterAllArtifactBuild.js
@@ -3,6 +3,9 @@
 // 여기서 DMG 자체도 공증 + 스테이플 해준다.
 // (공증 서버는 이미 .app 을 인식하므로 DMG 만 새로 제출 → 티켓이 DMG 에 박혀 오프라인
 //  배포 시에도 Gatekeeper 가 네트워크 없이 검증 가능.)
+//
+// 자격 증명: afterSign.js 와 동일 — env var(APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID)
+// 우선, 없으면 keychain profile 'hinest-notary' fallback.
 
 const { execSync } = require("child_process");
 
@@ -15,14 +18,22 @@ module.exports = async function (context) {
     return context.artifactPaths;
   }
 
+  // 자격 증명 결정 — env var 우선, 그다음 keychain profile.
+  const appleId = process.env.APPLE_ID;
+  const appleAsPwd = process.env.APPLE_APP_SPECIFIC_PASSWORD;
+  const appleTeam = process.env.APPLE_TEAM_ID;
+  const useEnvCreds = !!(appleId && appleAsPwd && appleTeam);
+  const credsArgs = useEnvCreds
+    ? `--apple-id "${appleId}" --password "${appleAsPwd}" --team-id "${appleTeam}"`
+    : `--keychain-profile "${KEYCHAIN_PROFILE}"`;
+
   const dmgs = (context.artifactPaths || []).filter((p) => p.endsWith(".dmg"));
   for (const dmg of dmgs) {
-    console.log(`[afterAllArtifactBuild] notarytool submit DMG: ${dmg}`);
+    console.log(
+      `[afterAllArtifactBuild] notarytool submit DMG (${useEnvCreds ? "env vars" : `keychain profile '${KEYCHAIN_PROFILE}'`}): ${dmg}`
+    );
     try {
-      execSync(
-        `xcrun notarytool submit "${dmg}" --keychain-profile "${KEYCHAIN_PROFILE}" --wait`,
-        { stdio: "inherit" }
-      );
+      execSync(`xcrun notarytool submit "${dmg}" ${credsArgs} --wait`, { stdio: "inherit" });
       console.log(`[afterAllArtifactBuild] stapling ${dmg}`);
       execSync(`xcrun stapler staple "${dmg}"`, { stdio: "inherit" });
       console.log("[afterAllArtifactBuild] DMG stapled ✔");

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hinest-desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "HiNest Desktop (Electron wrapper)",
   "main": "dist/main.js",


### PR DESCRIPTION
## 증상
**afterAllArtifactBuild.js env var 지원 + v0.1.6**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
PR #345 에서 afterSign.js 만 env var 지원으로 전환했는데, DMG 자체 공증을 담당하는
afterAllArtifactBuild.js 는 그대로라 v0.1.5 빌드 마지막 단계에서 keychain profile
'hinest-notary' 를 찾으려다 실패. .app 서명+공증·DMG publish 까지 다 잘 됐고 마지막
DMG 공증만 실패한 상황.

같은 패턴으로 env var(APPLE_ID/APPLE_APP_SPECIFIC_PASSWORD/APPLE_TEAM_ID) 우선,
keychain profile fallback. HINEST_SKIP_NOTARIZE=1 도 그대로 존중.

## 수정
**작업 항목 (커밋 단위)**
- fix(desktop): afterAllArtifactBuild.js 도 env var 자격 증명 지원
- chore(desktop): version 0.1.5 → 0.1.6 — afterAllArtifactBuild fix 검증

**변경 대상 (2개 파일)**
- `desktop/build/afterAllArtifactBuild.js`
- `desktop/package.json`

## 검증
- Electron 빌드 확인

---
🔗 이 작업은 **PR #347** 에서 진행됩니다.

