### PR TITLE
🔀 :: (#348) workflow_dispatch + 권한 토글 검증

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,8 @@ name: Release Please
 on:
   push:
     branches: [main]
+  # 수동 트리거 — 권한 토글 직후 등 즉시 검증/재실행이 필요할 때 사용.
+  workflow_dispatch:
 
 permissions:
   contents: write     # 태그 / 릴리스 / CHANGELOG 커밋


### PR DESCRIPTION
## 증상
**workflow_dispatch + 권한 토글 검증**

유지보수 작업을 진행합니다.

## 원인
권한 토글 직후 등에서 main push 없이도 즉시 release-please 를 돌릴 수 있게 한다.
GitHub Actions 권한(PR 생성/승인) 토글 완료 → 이 머지로 release-please 도 자동 트리거되어
검증이 한 번에 끝난다.

## 수정
**작업 항목 (커밋 단위)**
- ci(release-please): workflow_dispatch 트리거 추가 — 수동 검증/재실행 가능

**변경 대상 (1개 파일)**
- `.github/workflows/release-please.yml`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #348** 에서 진행됩니다.

