### PR TITLE
🔀 :: (#350) .gitignore 강화 — 시크릿/인증서/private key 광범위 차단

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,37 @@ dist
 # runtime uploads (user-generated)
 server/uploads/
 
-# envs
+# envs — 모든 dotenv 변형 제외(production/development/staging/test). .env.example 만 트래킹.
 .env
-.env.local
+.env.*
+!.env.example
+
+# 인증서 / 키 / 자격증명 — Apple Developer ID, RSA private key, AWS credential 등.
+# (어떤 파일이든 이 확장자면 절대 커밋되지 않음. 실수로 잘못 add 해도 ignore.)
+*.p12
+*.pfx
+*.key
+*.pem
+*.cer
+*.crt
+*.mobileprovision
+*.provisionprofile
+*.jks
+*.keystore
+id_rsa
+id_rsa.*
+id_ed25519
+id_ed25519.*
+.npmrc
+.netrc
+credentials.json
+secrets.json
+service-account*.json
+GoogleService-Info.plist
+
+# 운영 비밀 데이터 / 디버그 스크립트 (이미 untracked 상태이지만 명시적으로 차단)
+server/scripts/migrateSuperAdmin.ts
+server/scripts/superadmin*.ts
 
 # prisma / sqlite (레거시 — 개발 편의상 아직 로컬 dev.db 는 커밋 안 함)
 server/prisma/*.db


### PR DESCRIPTION
## 증상
**.gitignore 강화 — 시크릿/인증서/private key 광범위 차단**

보안 취약점을 점검하고 보완합니다.

## 원인
기존 .env + .env.local 만 막던 것을 전면 강화. 모든 dotenv 변형(.env.production
/.env.staging 등) + Apple Developer 인증서(.p12/.pfx/.cer/.mobileprovision) + 일반 private
key(.key/.pem/id_rsa/id_ed25519) + AWS/GCP 자격증명(.npmrc/.netrc/credentials.json/
service-account*.json/GoogleService-Info.plist) + 운영 비밀 스크립트
(server/scripts/migrateSuperAdmin.ts) 까지 차단.

.env.example 은 "!.env.example" 예외 패턴으로 트래킹 유지.

이번 시크릿 누출 점검에서 실제 누출 0건 확인됨 — 이건 미래 실수 방지용 선제 조치.

## 수정
**작업 항목 (커밋 단위)**
- chore(security): .gitignore 강화 — 시크릿/인증서/private key 광범위 차단

**변경 대상 (1개 파일)**
- `.gitignore`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #350** 에서 진행됩니다.

