### PR TITLE
🔀 :: (#745) active-viewer 동작 회귀 수정 — 보고있어도 알람 옴

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -253,12 +253,16 @@ export default function ChatMiniApp({
     } catch {}
   };
 
-  // 현재 채팅이 사용자에게 실제로 보이는지 — 창이 포커스 잃었거나 탭이 백그라운드면 읽음 처리 금지
+  // 현재 채팅이 사용자에게 실제로 보이는지 — 창이 포커스 잃었거나 탭이 백그라운드면 읽음 처리 금지.
+  // ⚠️ 네이티브(Capacitor WKWebView)에선 document.hasFocus() 가 키보드 표시·인풋 포커스 등
+  //    상호작용 중에 false 반환하는 케이스가 잦아, 사용자가 채팅창을 명백히 보고 있는 동안에도
+  //    하트비트 markRead 가 스킵되어 active-viewer APNs 스킵이 동작하지 않았다.
+  //    → 네이티브에선 hasFocus 의존성 제거(panel 열림 + visible 만 본다). 데스크톱 웹은 기존대로.
   const isChatVisible = () =>
     isPanelOpen &&
     typeof document !== "undefined" &&
     document.visibilityState === "visible" &&
-    (typeof document.hasFocus !== "function" || document.hasFocus());
+    (isCapacitorNative() || typeof document.hasFocus !== "function" || document.hasFocus());
 
   const markRead = async (roomId: string) => {
     try {

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -78,8 +78,9 @@ async function mutedApnsSet(targets: { userId: string; linkUrl?: string | null }
   return new Set(muted.map((m) => `${m.userId}:${m.roomId}`));
 }
 
-/** 활성 시청자로 간주하는 lastReadAt 신선도 — 이 시간 안에 읽음이 갱신됐으면 "지금 그 방을 보고 있음". */
-const ACTIVE_VIEW_MS = 45_000;
+/** 활성 시청자로 간주하는 lastReadAt 신선도 — 이 시간 안에 읽음이 갱신됐으면 "지금 그 방을 보고 있음".
+ *  클라 하트비트는 15초 주기이므로 6배 여유(네트워크 지연·하트비트 1~2회 실패 흡수). */
+const ACTIVE_VIEW_MS = 90_000;
 /**
  * (userId, roomId) 쌍 중 "지금 그 방을 보고 있는" 조합을 `${userId}:${roomId}` Set 으로 반환.
  * 보고 있는 방의 채팅 알림은 APNs(폰 푸시) 를 건너뛴다 — 화면에 떠 있으니 알림이 불필요(요구사항).


### PR DESCRIPTION
## 증상
채팅방 직접 열어둔 상태(메시지 화면에 보이는)에서도 알람이 옴 — PR #334 active-viewer 작동 안 함.

## 원인 + 수정 (2커밋)
1. **클라**: `isChatVisible()` 가 `document.hasFocus()` 까지 요구. iOS WKWebView 에선 키보드/인풋 포커스 중 hasFocus 가 false 반환 잦아 markRead 가 스킵 → lastReadAt 갱신 안 됨. 네이티브에선 hasFocus 빼고 `panel + visible` 만 판정.
2. **서버**: ACTIVE_VIEW_MS 45→90초 — 하트비트 1~2회 실패 흡수.

## 적용
서버 자동 배포 + iOS 는 Live Updates OTA(앱 콜드 스타트 시 자동).

Closes #745
