### PR TITLE
🔀 :: (#753) 미리보기 모바일 노치 회귀 — safe-area 흡수자 분기 수정

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -653,8 +653,12 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
   // 항상 "맨 위에 첫 번째로 보이는 요소" 만 흡수해서 더블 패딩 방지.
   const isPreview = isPreviewMode();
   const isImpersonating = !!impersonator;
+  // ⚠️ 네이티브(Capacitor)에선 PreviewBanner 가 렌더되지 않으므로(모바일 깔끔하게 가리는
+  //    요구사항, PreviewBanner.tsx 의 isCapacitorNative() 가드) 미리보기 모드라도 'preview'
+  //    슬롯을 쓰면 안 된다. 안 그러면 흡수자 없이 콘텐츠가 노치에 가려진다.
+  const previewBannerVisible = isPreview && !isCapacitorNative();
   const topSlot: "preview" | "impersonation" | "topbar" =
-    isPreview ? "preview" : isImpersonating ? "impersonation" : "topbar";
+    previewBannerVisible ? "preview" : isImpersonating ? "impersonation" : "topbar";
 
   useEffect(() => {
     if (!isMacDesktop || !window.hinest?.onFullscreenChange) return;


### PR DESCRIPTION
## 증상
미리보기 모바일에서 콘텐츠가 노치/다이내믹 아일랜드에 가려져 UI 깨짐.

## 원인
`topSlot` 가 `isPreview` 만 보고 'preview' 슬롯 배정 → PreviewBanner 가 safe-area-top 흡수 담당. 그런데 #338 에서 모바일에선 PreviewBanner 가 `null` 반환하게 했음(데모 마크 가리기 요구사항). → 흡수자 없는데 TopBar 도 `safeAreaTop=false` 로 받아서 아무도 노치 안 흡수 → 콘텐츠가 노치 안으로 깔림.

## 수정
`previewBannerVisible = isPreview && !isCapacitorNative()`. PreviewBanner 가 실제 렌더될 때만 'preview' 슬롯. 네이티브 미리보기는 'topbar' 로 떨어져 TopBar 가 정상 흡수.

## 적용
iOS Live Updates OTA — 앱 강제 종료 2회 후 적용. 웹은 Vercel 자동.

Closes #753
