### PR TITLE
🔀 :: (#356) 상태바 안 보임 — UIViewControllerBasedStatusBarAppearance false

### DIFF
--- a/client/ios/App/App/Info.plist
+++ b/client/ios/App/App/Info.plist
@@ -32,6 +32,10 @@
 	<string>동영상을 촬영해 첨부할 때 소리를 함께 녹음하기 위해 마이크를 사용합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>사진·동영상을 선택해 채팅·경비·프로필 등에 첨부하기 위해 사진 보관함에 접근합니다.</string>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>INSendMessageIntent</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -51,6 +55,10 @@
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<true/>
+	<false/>
+	<!-- 라이트 모드(흰 배경) 기본 — 다크 글자가 보이도록. 다크 테마 진입 시
+	     applyNativeTheme() 가 StatusBar.setStyle(Light) 로 즉시 흰 글자로 전환. -->
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleDarkContent</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 증상
**상태바 안 보임 — UIViewControllerBasedStatusBarAppearance false**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
증상: iOS 상단 상태바의 시간/배터리/시그널 아이콘이 안 보임 — 텍스트 색이 배경(흰색)과
동일해 가려진 상태.

원인: UIViewControllerBasedStatusBarAppearance=true 면 상태바 스타일을 ViewController 의
preferredStatusBarStyle 이 결정. Capacitor 의 StatusBar.setStyle() 호출이 무시됨.
nativeTheme.ts 가 테마에 맞춰 setStyle(Dark/Light) 를 호출하는데도 ViewController
override 로 적용 안 됨.

수정:
- UIViewControllerBasedStatusBarAppearance=false 로 변경 → StatusBar.setStyle 즉시 반영.
- UIStatusBarStyle=UIStatusBarStyleDarkContent 명시 → 초기 부팅 시 어두운 글자(라이트
  배경). 다크 테마 진입 시 applyNativeTheme 가 Light 로 즉시 전환.

⚠️ Info.plist 네이티브 변경이라 OTA 로 못 받음. cap:ios 빌드 필요.

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 상태바 글자 안 보임 — UIViewControllerBasedStatusBarAppearance false

**변경 대상 (1개 파일)**
- `client/ios/App/App/Info.plist`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #356** 에서 진행됩니다.

