### PR TITLE
🔀 :: (#357) 데모 진행률 — workedMin 기준 (방문 시각 무관)

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "../auth";
 import InstallAppBanner from "../components/InstallAppBanner";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
+import { isPreviewMode } from "../lib/previewMock";
 
 type Notice = { id: string; title: string; content: string; createdAt: string; author: { name: string; isDeveloper?: boolean }; pinned: boolean };
 type Event = { id: string; title: string; startAt: string; endAt: string; scope: string; color: string };
@@ -96,10 +97,15 @@ export default function DashboardPage() {
   const startLabel = formatHHmm(startMin);
   const endLabel = formatHHmm(endMin);
   const dayProgress = useMemo(() => {
-    const m = now.getHours() * 60 + now.getMinutes();
     if (endMin <= startMin) return 0; // 잘못된 설정은 0%
+    // 데모(미리보기)는 방문 시각이 새벽일 수도 있어 09–18 절대시각 기준이면 0% 가 떠 자연스럽지 못함.
+    // 출근 후 경과 시간(workedMin) 을 근무 총 시간으로 나눠 '근무한 비율' 로 보여준다 — 항상 그럴듯한 값.
+    if (isPreviewMode() && att?.checkIn) {
+      return Math.max(0, Math.min(1, workedMin / (endMin - startMin)));
+    }
+    const m = now.getHours() * 60 + now.getMinutes();
     return Math.max(0, Math.min(1, (m - startMin) / (endMin - startMin)));
-  }, [now, startMin, endMin]);
+  }, [now, startMin, endMin, workedMin, att?.checkIn]);
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## 증상
**데모 진행률 — workedMin 기준 (방문 시각 무관)**

유지보수 작업을 진행합니다.

## 원인
증상: 미리보기에서 진행률 게이지가 0% 로 떠있음 — 방문자가 새벽에 보면 09–18 절대시각
기준 진행률이 0 으로 떨어짐.

수정: 미리보기 모드 + 출근 상태면 workedMin(현재 3:38) / (endMin - startMin) 으로 계산.
→ 9-18 기준 3:38 = 약 40% 로 항상 그럴듯한 값. 일반 모드는 기존 절대시각 기준 유지.

## 수정
**작업 항목 (커밋 단위)**
- chore(preview): 데모 — 진행률 = workedMin/총근무시간 (방문 시각 무관)

**변경 대상 (1개 파일)**
- `client/src/pages/DashboardPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #357** 에서 진행됩니다.

