### PR TITLE
🔀 :: (#359) 채팅 풀스크린 + 전체 탭 폭 — iPad 잔여 두 문제

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1309,8 +1309,9 @@ export function MobileMenuPage() {
   const res = filterByVisibility(RESOURCE_NAV);
 
   return (
-    <div className="max-w-lg mx-auto space-y-6">
-      {/* 프로필 카드 — 탭하면 내 프로필로 */}
+    <div className="max-w-lg sm:max-w-2xl mx-auto space-y-6">
+      {/* 프로필 카드 — 탭하면 내 프로필로. 컨테이너 폭: 폰 lg(512) → 640+ 2xl(672)
+          iPad portrait(834) 에서 좌우 여백 자연스러움. */}
       <NavLink
         to="/profile"
         className="flex items-center gap-3 p-3.5 rounded-2xl bg-ink-50 border border-ink-150 hover:bg-ink-100 transition"

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -56,14 +56,15 @@ export default function ChatFab() {
     setNativeTabBarHidden("chat", open);
     return () => setNativeTabBarHidden("chat", false);
   }, [open]);
-  // 모바일(≤640px) 에서는 사내톡을 풀스크린 페이지처럼 띄움.
-  // 뷰포트 크기 변화(회전/리사이즈) 시 갱신.
+  // 모바일·iPad portrait(<1024px) 에서는 사내톡을 풀스크린 페이지처럼 띄움(데스크탑은 우하단 팝업).
+  // Tailwind md=1024 와 동일 기준으로 'md 미만 = 풀스크린', 'md+ = 팝업' 분기. 회전/리사이즈 갱신.
+  const MOBILE_MQ = "(max-width: 1023.98px)";
   const [isMobile, setIsMobile] = useState<boolean>(
-    typeof window !== "undefined" ? window.matchMedia("(max-width: 640px)").matches : false
+    typeof window !== "undefined" ? window.matchMedia(MOBILE_MQ).matches : false
   );
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const mq = window.matchMedia("(max-width: 640px)");
+    const mq = window.matchMedia(MOBILE_MQ);
     const update = () => setIsMobile(mq.matches);
     mq.addEventListener?.("change", update);
     return () => mq.removeEventListener?.("change", update);


### PR DESCRIPTION
## 증상
**채팅 풀스크린 + 전체 탭 폭 — iPad 잔여 두 문제**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
ChatFab 의 모바일 판정이 max-width:640px 였어서 iPad portrait(834px)가
데스크탑으로 분류 → 우하단 팝업 채팅이 떴음. Tailwind md=1024 와 동일 기준으로
'<1024 = 풀스크린', '>=1024 = 팝업' 으로 통일.

## 수정
**작업 항목 (커밋 단위)**
- fix(chat): iPad portrait 도 풀스크린 채팅 — MQ 640 → 1023.98px
- fix(menu): MobileMenuPage 컨테이너 폭 — iPad 에서 좁게 가운데 정렬 회귀

**변경 대상 (2개 파일)**
- `client/src/components/AppLayout.tsx`
- `client/src/components/ChatFab.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #359** 에서 진행됩니다.

