### PR TITLE
🔀 :: (#360) 전체 탭 iPad 화면 폭 가득 활용 — max-w 제거

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1309,9 +1309,10 @@ export function MobileMenuPage() {
   const res = filterByVisibility(RESOURCE_NAV);
 
   return (
-    <div className="max-w-lg sm:max-w-2xl mx-auto space-y-6">
-      {/* 프로필 카드 — 탭하면 내 프로필로. 컨테이너 폭: 폰 lg(512) → 640+ 2xl(672)
-          iPad portrait(834) 에서 좌우 여백 자연스러움. */}
+    <div className="space-y-6">
+      {/* 프로필 카드 — 탭하면 내 프로필로. 부모 main 컨테이너가 이미
+          max-w-[1400px] mx-auto px-4 로 정렬해주므로 여기서 추가 max-w 안 둠 — 그래야
+          iPad portrait(834) 에서 화면 폭 가득 활용(좁게 가운데 정렬 안 됨). */}
       <NavLink
         to="/profile"
         className="flex items-center gap-3 p-3.5 rounded-2xl bg-ink-50 border border-ink-150 hover:bg-ink-100 transition"


### PR DESCRIPTION
## 증상
**전체 탭 iPad 화면 폭 가득 활용 — max-w 제거**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
PR #359 의 max-w-2xl(672px) 가 부모 main(max-w-[1400px] mx-auto px-4)와 이중 가운데
정렬로 작용해 iPad portrait(834px)에서 좁게 모여 보였음. 자식의 max-w + mx-auto 제거 →
부모 컨테이너 폭 그대로 가득 채움(폰은 어차피 부모 폭 = 화면 폭, iPad 만 차이).

## 수정
**작업 항목 (커밋 단위)**
- fix(menu): 전체 탭 — max-w 제거해 iPad 화면 폭 가득 활용

**변경 대상 (1개 파일)**
- `client/src/components/AppLayout.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #360** 에서 진행됩니다.

