### PR TITLE
🔀 :: (#361) 문서함/관리자/회의록 모바일 카드 — iPad 까지

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -298,8 +298,8 @@ export default function AdminPage() {
         description="구성원·초대키·팀·직급을 관리합니다."
       />
 
-      {/* 통계 — 모바일은 한 줄 요약, 데스크톱은 카드 */}
-      <div className="sm:hidden flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-ink-500 mb-4">
+      {/* 통계 — 모바일·iPad 는 한 줄 요약, 데스크톱은 카드 */}
+      <div className="md:hidden flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-ink-500 mb-4">
         <span className="font-bold text-ink-900">구성원 {users.length}</span>
         <span className="text-ink-300">·</span>
         <span>활성 <b className="text-ink-800 font-bold">{users.filter((u) => u.active).length}</b></span>
@@ -310,7 +310,7 @@ export default function AdminPage() {
         <span className="text-ink-300">·</span>
         <span>미사용 초대키 <b className="text-ink-800 font-bold">{invites.filter((k) => !k.used).length}</b></span>
       </div>
-      <div className="hidden sm:grid grid-cols-2 md:grid-cols-4 gap-3 mb-5">
+      <div className="hidden md:grid grid-cols-2 lg:grid-cols-4 gap-3 mb-5">
         <StatCard label="전체 구성원" value={users.length} sub={`활성 ${users.filter((u) => u.active).length}명`} />
         <StatCard label="미사용 초대키" value={invites.filter((k) => !k.used).length} sub={`총 ${invites.length}건 발급`} />
         <StatCard label="팀" value={teams.length} sub="전사 팀 수" />
@@ -543,8 +543,8 @@ function UsersTab({
         <DetailUserTable rows={filtered} positions={positions} update={update} remove={remove} />
       )}
       {view === "basic" && (<>
-      {/* 데스크톱: 인라인 편집 테이블 */}
-      <div className="overflow-x-auto hidden sm:block">
+      {/* 데스크톱(md+): 인라인 편집 테이블. iPad portrait 는 모바일 카드로 보낸다. */}
+      <div className="overflow-x-auto hidden md:block">
       <table className="pro" style={{ minWidth: 720 }}>
         <thead>
           <tr>
@@ -689,8 +689,8 @@ function UsersTab({
         </tbody>
       </table>
       </div>
-      {/* 모바일: 깔끔한 구성원 카드 — 탭하면 상세 편집(권한·상태 포함) */}
-      <div className="sm:hidden flex flex-col gap-2">
+      {/* 모바일·iPad(<md): 깔끔한 구성원 카드 — 탭하면 상세 편집(권한·상태 포함) */}
+      <div className="md:hidden flex flex-col gap-2">
         {filtered.map((u) => (
           <button
             key={u.id}

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1215,7 +1215,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                   <div className="text-[11px] text-ink-500 tabular">{new Date(f.createdAt).toLocaleDateString("ko-KR")}</div>
                 </div>
                 {/* 모바일: 폴더 열기 셰브론 (데스크톱은 우상단 호버 액션) */}
-                <svg className="sm:hidden text-ink-300 flex-shrink-0" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+                <svg className="md:hidden text-ink-300 flex-shrink-0" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
                 {/* 호버 액션은 absolute 오버레이 — 평소엔 레이아웃을 먹지 않아 이름·날짜 영역이 잘리지 않음. */}
                 <div className="touch-reveal-flex absolute top-2 right-2 hidden group-hover:flex items-center gap-0.5 bg-[color:var(--c-surface)]/95 backdrop-blur-sm rounded-lg px-1 py-0.5 shadow-sm border border-ink-100">
                   <button className="btn-icon" onClick={(e) => { e.stopPropagation(); downloadFolder(f); }} title="폴더 전체 다운로드 (ZIP)">
@@ -1263,8 +1263,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
         </div>
       ) : (
         <>
-        {/* 데스크톱: 인라인 테이블 */}
-        <div className="panel p-0 overflow-hidden overflow-x-auto hidden sm:block">
+        {/* 데스크톱(md+): 인라인 테이블. iPad portrait 는 이 너비를 못 받쳐 모바일 카드로 보낸다. */}
+        <div className="panel p-0 overflow-hidden overflow-x-auto hidden md:block">
           <table className="pro min-w-[760px]">
             <thead>
               <tr>
@@ -1435,8 +1435,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
             </tbody>
           </table>
         </div>
-        {/* 모바일: 깔끔한 문서 행 (탭하면 열기) */}
-        <div className="sm:hidden flex flex-col gap-2">
+        {/* 모바일·iPad(<md): 깔끔한 문서 행 (탭하면 열기) */}
+        <div className="md:hidden flex flex-col gap-2">
           {docs.map((d) => {
             const isMemo = d.content != null;
             const ext = (d.fileName?.split(".").pop() || "").toLowerCase();

--- a/client/src/pages/MeetingsPage.tsx
+++ b/client/src/pages/MeetingsPage.tsx
@@ -144,15 +144,15 @@ export default function MeetingsPage() {
         }
       />
 
-      {/* 통계 — 모바일은 한 줄 요약(레퍼런스), 데스크톱은 카드 */}
-      <div className="sm:hidden flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-ink-500 mb-4">
+      {/* 통계 — 모바일·iPad 는 한 줄 요약(레퍼런스), 데스크톱은 카드 */}
+      <div className="md:hidden flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-ink-500 mb-4">
         <span className="font-bold text-ink-900">전체 {stats.total}</span>
         <span className="text-ink-300">·</span>
         <span>이번 주 <b className="text-ink-800 font-bold">{stats.thisWeek}</b></span>
         <span className="text-ink-300">·</span>
         <span>내가 쓴 것 <b className="text-ink-800 font-bold">{stats.mine}</b></span>
       </div>
-      <div className="hidden sm:grid grid-cols-3 gap-3 mb-5">
+      <div className="hidden md:grid grid-cols-3 gap-3 mb-5">
         <StatCard
           label="전체 회의록"
           value={stats.total}


### PR DESCRIPTION
## 증상
**문서함/관리자/회의록 모바일 카드 — iPad 까지**

새 기능을 추가합니다.

## 원인
iPad portrait(834px)가 모바일 레이아웃을 받음(#358)에도 문서함은 sm:hidden 으로 모바일
카드를 안 보여줌. iPad 에서 좁은 데스크탑 테이블이 렌더되어 컬럼 폭이 작아지고 작성자
이름이 세로로 깨져 보였음. sm:hidden / hidden sm:block → md:hidden / hidden md:block.

## 수정
**작업 항목 (커밋 단위)**
- feat(documents): 문서함 sm:→md: — iPad 도 모바일 카드 (좁은 데스크탑 테이블 회피)
- feat(admin): 관리자 sm:→md: — iPad 도 모바일 카드/한 줄 통계
- feat(meetings): 회의록 통계 sm:→md: — iPad 도 한 줄 통계

**변경 대상 (3개 파일)**
- `client/src/pages/AdminPage.tsx`
- `client/src/pages/DocumentsPage.tsx`
- `client/src/pages/MeetingsPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #361** 에서 진행됩니다.

