### PR TITLE
🔀 :: (#362) 알람 latency + CloudWatch 비용 안전한 개선

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -147,7 +147,18 @@ function scrubUrl(raw: string): string {
 //   - GET /api/notification/stream 도 SSE long-poll 시작 핸드셰이크가 끊임없이 찍힘.
 //   - 위 두 경로는 정상 200/204 일 때만 스킵. 비정상 응답(5xx, 4xx)은 그대로 기록해야
 //     장애 진단이 가능.
-const ACCESS_LOG_SKIP_PATHS = new Set(["/api/health", "/api/notification/stream"]);
+// 정상(2xx/3xx) 응답만 스킵 — 비정상은 로그에 남겨 진단 가능. 추가 후보는 호출 빈도가 높은
+// 폴링·heartbeat 류로, 정상 응답 시 콘텐츠가 없거나 동일해 진단 가치가 낮은 것들.
+//   /api/health                  : ALB healthcheck (~30초 주기)
+//   /api/notification/stream     : SSE long-poll 핸드셰이크
+//   /api/updates/check           : Capgo Live Updates 폴링 (셸이 시작 시·간헐 호출)
+//   /api/version                 : 데스크탑/웹 버전 폴링 (UpdateBanner)
+const ACCESS_LOG_SKIP_PATHS = new Set([
+  "/api/health",
+  "/api/notification/stream",
+  "/api/updates/check",
+  "/api/version",
+]);
 app.use((req, res, next) => {
   const start = Date.now();
   res.on("finish", () => {

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -165,13 +165,14 @@ export async function notifyMany(inputs: NotifyInput[]) {
     await prisma.notification.createMany({ data: rows.map(({ actorAvatarUrl, ...row }) => row) });
     const created = await prisma.notification.findMany({ where: { id: { in: rows.map((r) => r.id) } } });
     // 음소거된 방의 채팅 알림은 APNs(폰 푸시) 만 생략 — 한 번에 조회.
-    const mutedSet = await mutedApnsSet(
-      created.map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
-    );
-    // 지금 그 방을 보고 있는 사람에겐 APNs 생략(요구사항: 보는 방 알림 X). 레코드·SSE 는 그대로.
-    const activeSet = await activeViewerApnsSet(
-      created.map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }))
-    );
+    // ⚡ 음소거 조회 + active-viewer 조회는 서로 독립적(다른 컬럼·다른 where) → 병렬로 묶어
+    //    매 알림마다 한 번의 DB 왕복(약 5-10ms) 줄임. publish(SSE) 가 이 둘 끝나야 트리거되므로
+    //    받는 사람 체감 latency 가 그만큼 단축된다.
+    const linkPairs = created.map((n) => ({ userId: n.userId, linkUrl: n.linkUrl }));
+    const [mutedSet, activeSet] = await Promise.all([
+      mutedApnsSet(linkPairs),
+      activeViewerApnsSet(linkPairs),
+    ]);
     // 아바타(actorAvatarUrl)는 Notification 컬럼이 아니라 입력에만 있으므로 id 로 되짚는다.
     const inputById = new Map(rows.map((r) => [r.id, r]));
     const apnsTargets: { userId: string; payload: { title: string; body?: string; linkUrl?: string; groupId?: string; senderName?: string; senderAvatarPath?: string; senderAvatarColor?: string } }[] = [];


### PR DESCRIPTION
## 증상
**알람 latency + CloudWatch 비용 안전한 개선**

성능을 개선합니다.

## 원인
현재 notifyMany 가 mutedApnsSet 과 activeViewerApnsSet 을 순차 await — 매 알림마다
DB 왕복 2회분 누적(~10ms). 둘은 서로 독립이라(다른 컬럼·다른 where) Promise.all 로 묶어
한 번에 처리. publish(SSE) 가 이 두 await 끝나야 트리거되므로 받는 사람 체감 latency
가 직접 단축됨. 페이로드/동작 무변경.

## 수정
**작업 항목 (커밋 단위)**
- perf(notify): mutedSet + activeViewerSet 병렬화 — 받는 사람 체감 latency 단축
- perf(log): access log 스킵에 폴링 endpoint 2개 추가 — CloudWatch 비용 절감

**변경 대상 (2개 파일)**
- `server/src/index.ts`
- `server/src/lib/notify.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #362** 에서 진행됩니다.

