### PR TITLE
🔀 :: (#363) OS 로그인 시 자동 시작 — 앱 종료돼도 알람 받기

### DIFF
--- a/HiNest-MacOS/src/main.ts
+++ b/HiNest-MacOS/src/main.ts
@@ -247,6 +247,27 @@ ipcMain.handle("hinest:relaunch", () => {
 });
 
 /**
+ * 자동 시작 (OS 로그인 시 트레이 상주) — 사용자 토글. 알람 항상 수신 목적.
+ * macOS LaunchAgent 등록. openAsHidden=true 로 윈도우 없이 트레이만 시작.
+ */
+ipcMain.handle("hinest:getAutoLaunch", () => {
+  try {
+    return app.getLoginItemSettings().openAtLogin;
+  } catch {
+    return false;
+  }
+});
+
+ipcMain.handle("hinest:setAutoLaunch", (_e, enabled: boolean) => {
+  try {
+    app.setLoginItemSettings({ openAtLogin: !!enabled, openAsHidden: true });
+    return { ok: true, enabled: app.getLoginItemSettings().openAtLogin };
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+});
+
+/**
  * 네이티브 Touch ID 프롬프트.
  * Electron 내부 Chromium 은 WebAuthn 플랫폼 인증기를 노출하지 않기 때문에
  * macOS Local Authentication 을 main 프로세스에서 직접 호출한다. (샌드박스에서 동작)

--- a/HiNest-MacOS/src/preload.ts
+++ b/HiNest-MacOS/src/preload.ts
@@ -20,6 +20,9 @@ contextBridge.exposeInMainWorld("hinest", {
   showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) =>
     ipcRenderer.invoke("hinest:showNotification", opts),
   relaunch: () => ipcRenderer.invoke("hinest:relaunch"),
+  getAutoLaunch: () => ipcRenderer.invoke("hinest:getAutoLaunch") as Promise<boolean>,
+  setAutoLaunch: (enabled: boolean) =>
+    ipcRenderer.invoke("hinest:setAutoLaunch", enabled) as Promise<{ ok: boolean; enabled?: boolean; error?: string }>,
   canTouchID: () => ipcRenderer.invoke("hinest:canTouchID") as Promise<boolean>,
   promptTouchID: (reason: string) =>
     ipcRenderer.invoke("hinest:promptTouchID", reason) as Promise<{ ok: boolean; error?: string }>,

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -665,6 +665,9 @@ function DesktopNotifyPanel() {
             />
           </label>
 
+          {/* 데스크탑 앱(Electron) 자동 시작 — 종료된 상태에서도 알람 받기 위해 OS 로그인 시 트레이 상주. */}
+          <AutoLaunchToggle />
+
           <NotifCategoryToggles disabled={!enabled} />
 
           <button type="button" className="btn-ghost" onClick={onTest}>
@@ -673,6 +676,50 @@ function DesktopNotifyPanel() {
         </div>
       )}
     </div>
+  );
+}
+
+/* ===== 데스크탑 앱 자동 시작 토글 — Electron 환경 + 자동시작 API 가용한 빌드에서만 노출 =====
+ * macOS/Windows: OS 로그인 시 트레이 상주(앱 자동 실행). 사용자가 명시 활성화. 다른 환경(웹/
+ * 미지원 구버전 셸)에선 컴포넌트 자체가 null 을 반환해 영향 없음. */
+function AutoLaunchToggle() {
+  const [supported, setSupported] = useState<boolean>(false);
+  const [enabled, setEnabled] = useState<boolean>(false);
+  const [pending, setPending] = useState<boolean>(false);
+  useEffect(() => {
+    const api = window.hinest;
+    if (!api?.getAutoLaunch || !api?.setAutoLaunch) return;
+    setSupported(true);
+    api.getAutoLaunch().then((v) => setEnabled(!!v)).catch(() => {});
+  }, []);
+  if (!supported) return null;
+  async function onToggle(next: boolean) {
+    setPending(true);
+    try {
+      const res = await window.hinest!.setAutoLaunch!(next);
+      if (res?.ok) setEnabled(!!res.enabled);
+      else if (!res?.ok && res?.error) window.alert(`자동 시작 변경 실패: ${res.error}`);
+    } finally {
+      setPending(false);
+    }
+  }
+  return (
+    <label className="flex items-center justify-between gap-3 p-3 rounded-lg bg-ink-25 border border-ink-150 cursor-pointer">
+      <div>
+        <div className="text-[13px] font-bold text-ink-900">OS 로그인 시 자동 시작</div>
+        <div className="text-[11.5px] text-ink-500 mt-0.5">
+          켜두면 컴퓨터를 켤 때마다 HiNest 가 트레이로 백그라운드 실행돼, 앱을 직접 켜지 않아도
+          새 알림을 받을 수 있어요.
+        </div>
+      </div>
+      <input
+        type="checkbox"
+        className="accent-brand-500 w-5 h-5 flex-shrink-0"
+        checked={enabled}
+        disabled={pending}
+        onChange={(e) => onToggle(e.target.checked)}
+      />
+    </label>
   );
 }
 

--- a/client/src/types/hinest.d.ts
+++ b/client/src/types/hinest.d.ts
@@ -13,6 +13,9 @@ declare global {
       openExternal: (url: string) => Promise<{ ok: boolean; error?: string }>;
       showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) => Promise<void>;
       relaunch: () => Promise<void>;
+      // OS 로그인 시 자동 시작(트레이 상주). 미구현 빌드면 undefined.
+      getAutoLaunch?: () => Promise<boolean>;
+      setAutoLaunch?: (enabled: boolean) => Promise<{ ok: boolean; enabled?: boolean; error?: string }>;
       onFullscreenChange: (cb: (isFs: boolean) => void) => () => void;
       // ─── macOS 네이티브 Touch ID ─────────────────────────────────
       // Electron Chromium 이 WebAuthn 플랫폼 인증기를 노출하지 않아서

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -294,6 +294,33 @@ ipcMain.handle("hinest:relaunch", () => {
 });
 
 /**
+ * 자동 시작 (OS 로그인 시 트레이 상주) — 사용자 토글.
+ * macOS: 표준 LaunchAgent 등록(서명 무관). openAsHidden=true 로 윈도우 없이 트레이만 시작.
+ * Windows: 레지스트리 Run 키. AppData 의 \"squirrel-aware\" 옵션은 electron-builder NSIS 가 처리.
+ * 패키징 안 됐을 땐(dev) 동작 안 함 — 그래도 IPC 는 항상 응답해 렌더러가 깨지지 않게.
+ */
+ipcMain.handle("hinest:getAutoLaunch", () => {
+  try {
+    return app.getLoginItemSettings().openAtLogin;
+  } catch {
+    return false;
+  }
+});
+
+ipcMain.handle("hinest:setAutoLaunch", (_e, enabled: boolean) => {
+  try {
+    app.setLoginItemSettings({
+      openAtLogin: !!enabled,
+      // macOS: hidden 시작 = Dock 잠깐 안 보이고 트레이만(알림 수신 목적).
+      openAsHidden: true,
+    });
+    return { ok: true, enabled: app.getLoginItemSettings().openAtLogin };
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+});
+
+/**
  * 네이티브 Touch ID 프롬프트.
  * Electron 내부 Chromium 은 WebAuthn 플랫폼 인증기를 노출하지 않기 때문에
  * macOS Local Authentication 을 main 프로세스에서 직접 호출한다.

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -15,6 +15,10 @@ contextBridge.exposeInMainWorld("hinest", {
   showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) =>
     ipcRenderer.invoke("hinest:showNotification", opts),
   relaunch: () => ipcRenderer.invoke("hinest:relaunch"),
+  // OS 로그인 시 자동 시작(트레이 상주) — 알람 항상 수신 목적.
+  getAutoLaunch: () => ipcRenderer.invoke("hinest:getAutoLaunch") as Promise<boolean>,
+  setAutoLaunch: (enabled: boolean) =>
+    ipcRenderer.invoke("hinest:setAutoLaunch", enabled) as Promise<{ ok: boolean; enabled?: boolean; error?: string }>,
   canTouchID: () => ipcRenderer.invoke("hinest:canTouchID") as Promise<boolean>,
   promptTouchID: (reason: string) =>
     ipcRenderer.invoke("hinest:promptTouchID", reason) as Promise<{ ok: boolean; error?: string }>,


### PR DESCRIPTION
## 증상
**OS 로그인 시 자동 시작 — 앱 종료돼도 알람 받기**

새 기능을 추가합니다.

## 원인
OS 로그인 시 트레이 상주로 자동 시작해 앱이 켜져있지 않을 때도 알람을 받게 한다.
desktop·HiNest-MacOS 양쪽 main + preload 동일하게:
  · hinest:getAutoLaunch — app.getLoginItemSettings().openAtLogin
  · hinest:setAutoLaunch — setLoginItemSettings({openAtLogin, openAsHidden:true})

openAsHidden:true 로 자동 시작 시 윈도우 없이 트레이만 → 사용자 방해 없이 백그라운드 상주.
패키징 안 된 dev 빌드면 setLoginItemSettings 가 throw 가능 — try/catch 로 IPC 항상 응답.

## 수정
**작업 항목 (커밋 단위)**
- feat(desktop): Electron 자동 시작 IPC — getAutoLaunch/setAutoLaunch
- feat(client): 데스크탑 알림 패널에 'OS 로그인 시 자동 시작' 토글

**변경 대상 (6개 파일)**
- `HiNest-MacOS/src/main.ts`
- `HiNest-MacOS/src/preload.ts`
- `client/src/pages/ProfilePage.tsx`
- `client/src/types/hinest.d.ts`
- `desktop/src/main.ts`
- `desktop/src/preload.ts`

## 검증
- `client` tsc 통과 + vite build ✓
- Electron 빌드 확인

---
🔗 이 작업은 **PR #363** 에서 진행됩니다.

