### PR TITLE
🔀 :: (#365) cap:ios:dev — 시뮬레이터 hot reload

### DIFF
--- a/client/capacitor.config.ts
+++ b/client/capacitor.config.ts
@@ -48,6 +48,14 @@ const config: CapacitorConfig = {
     // (B) 원격 URL 방식으로 빠르게 테스트하려면 아래 두 줄의 주석을 해제:
     // url: "https://nest.hi-vits.com",
     // cleartext: false,
+    //
+    // (C) Dev hot-reload — 개발 중 npm run cap:ios:dev 로 가면 이 분기가 켜진다.
+    //     시뮬레이터/실기기가 호스트 Mac 의 Vite dev 서버(http://localhost:1000)를 직접 로드 →
+    //     코드 저장 시 HMR 으로 즉시 반영(매번 cap:ios 불필요). cleartext=true 로 http 허용.
+    //     env var 가 없으면 평소대로 번들 자산 + Live Updates 흐름.
+    ...(process.env.HINEST_CAP_DEV_SERVER
+      ? { url: process.env.HINEST_CAP_DEV_SERVER, cleartext: true }
+      : {}),
   },
   plugins: {
     // 키보드 등장 애니메이션 — 'native' 리사이즈는 iOS 가 WebView 자체를 키보드 곡선에 맞춰

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,8 @@
     "cap:add:android": "cap add android",
     "cap:sync": "VITE_API_BASE=${VITE_API_BASE:-https://nest.hi-vits.com} npm run build && cap sync",
     "cap:ios": "VITE_API_BASE=${VITE_API_BASE:-https://nest.hi-vits.com} npm run build && cap sync ios && cap open ios",
+    "cap:ios:dev": "VITE_API_BASE=${VITE_API_BASE:-https://nest.hi-vits.com} HINEST_CAP_DEV_SERVER=${HINEST_CAP_DEV_SERVER:-http://localhost:1000} cap sync ios && cap open ios",
+    "cap:ios:dev:lan": "VITE_API_BASE=${VITE_API_BASE:-https://nest.hi-vits.com} HINEST_CAP_DEV_SERVER=http://$(ipconfig getifaddr en0):1000 cap sync ios && cap open ios",
     "cap:android": "VITE_API_BASE=${VITE_API_BASE:-https://nest.hi-vits.com} npm run build && cap sync android && cap open android"
   },
   "dependencies": {


### PR DESCRIPTION
## 증상
**cap:ios:dev — 시뮬레이터 hot reload**

새 기능을 추가합니다.

## 원인
매번 cap:ios 치는 이유는 시뮬레이터에 dist 동기화 때문이었음. capacitor.config 의
server.url 을 HINEST_CAP_DEV_SERVER env 로 동적 분기 → 셸이 호스트 Mac 의 Vite dev
서버(localhost:1000)를 직접 로드 → 코드 저장 시 HMR 으로 즉시 반영. 한 번 cap:ios:dev
한 후엔 자유.

npm scripts:
  · cap:ios:dev      → 시뮬레이터 (http://localhost:1000)
  · cap:ios:dev:lan  → 실기기 (Mac LAN IP 자동 감지, en0)
  · cap:ios          → 기존 운영 빌드 (영향 0)

운영 빌드: env var 없으면 분기가 무시되어 평소대로 번들 자산 + Live Updates 흐름 유지.
cleartext:true 는 dev 분기에서만 켜져 http://localhost 허용.

## 수정
**작업 항목 (커밋 단위)**
- feat(cap): cap:ios:dev — 시뮬레이터/실기기 hot-reload (cap:ios 매번 불필요)

**변경 대상 (2개 파일)**
- `client/capacitor.config.ts`
- `client/package.json`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #365** 에서 진행됩니다.

