### PR TITLE
🔀 :: (#366) 회사 출근 IP 화이트리스트 — 관리자 토글 + CIDR 다중

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -187,7 +187,7 @@ type Invite = {
 type Team = { id: string; name: string; createdAt: string };
 type Position = { id: string; name: string; rank: number; createdAt: string };
 
-type Tab = "users" | "invites" | "teams" | "positions";
+type Tab = "users" | "invites" | "teams" | "positions" | "ip";
 
 // 내보내기 버튼에 쓰는 작은 브랜드 로고들. 외부 에셋 없이 inline SVG 로 둬서
 // 번들 사이즈/네트워크 요청 영향 없음. 크기는 16px 고정 — 버튼 높이(32)에 맞춘 값.
@@ -242,7 +242,7 @@ function PdfLogo() {
 export default function AdminPage() {
   // 새로고침해도 현재 탭 유지되도록 URL 쿼리로 동기화.
   const [sp, setSp] = useSearchParams();
-  const tab = (["users", "invites", "teams", "positions"].includes(sp.get("tab") ?? "")
+  const tab = (["users", "invites", "teams", "positions", "ip"].includes(sp.get("tab") ?? "")
     ? (sp.get("tab") as Tab)
     : "users") as Tab;
   const setTab = (t: Tab) => {
@@ -288,6 +288,7 @@ export default function AdminPage() {
     { key: "invites", label: "초대키", count: invites.filter((k) => !k.used).length, icon: <KeyIcon /> },
     { key: "teams", label: "팀", count: teams.length, icon: <TeamIcon /> },
     { key: "positions", label: "직급", count: positions.length, icon: <RankIcon /> },
+    { key: "ip", label: "출근 IP", count: 0, icon: <RankIcon /> },
   ];
 
   return (
@@ -343,6 +344,7 @@ export default function AdminPage() {
       {tab === "invites" && <InvitesTab invites={invites} teams={teams} positions={positions} reload={loadCommon} />}
       {tab === "teams" && <TeamsTab teams={teams} reload={loadCommon} />}
       {tab === "positions" && <PositionsTab positions={positions} reload={loadCommon} />}
+      {tab === "ip" && <AttendanceIpTab />}
     </div>
   );
 }
@@ -2307,6 +2309,152 @@ function SecurityBlock({ user, onChanged }: { user: UserRow; onChanged: () => vo
           </button>
         </div>
       </form>
+    </div>
+  );
+}
+
+
+/* ===================== Attendance IP Restrict ===================== */
+function AttendanceIpTab() {
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+  const [items, setItems] = useState<{ id: string; cidr: string; label: string | null; createdAt: string }[]>([]);
+  const [clientIp, setClientIp] = useState<string | null>(null);
+  const [cidrInput, setCidrInput] = useState("");
+  const [labelInput, setLabelInput] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const res = await api<{
+        enabled: boolean;
+        allowedIps: { id: string; cidr: string; label: string | null; createdAt: string }[];
+        clientIp: string | null;
+      }>("/api/admin/attendance-ip");
+      setEnabled(res.enabled);
+      setItems(res.allowedIps);
+      setClientIp(res.clientIp);
+    } catch (e: any) {
+      alertAsync({ title: "불러오기 실패", description: e?.message ?? String(e) });
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => { load(); }, []);
+
+  async function toggle(next: boolean) {
+    setEnabled(next);
+    try {
+      await api("/api/admin/attendance-ip", { method: "PATCH", json: { enabled: next } });
+    } catch (e: any) {
+      setEnabled(!next);
+      alertAsync({ title: "변경 실패", description: e?.message ?? String(e) });
+    }
+  }
+
+  async function add(useMyIp = false) {
+    const cidr = useMyIp ? (clientIp ? `${clientIp}/32` : "") : cidrInput.trim();
+    if (!cidr) { alertAsync({ title: "IP 를 입력하세요", description: "예: 203.241.45.67 또는 192.168.1.0/24" }); return; }
+    setAdding(true);
+    try {
+      const res = await api<{ ok: boolean; item: typeof items[number] }>("/api/admin/attendance-ip", {
+        method: "POST",
+        json: { cidr, label: useMyIp ? "내 현재 위치" : (labelInput.trim() || undefined) },
+      });
+      setItems((arr) => [...arr, res.item]);
+      setCidrInput(""); setLabelInput("");
+    } catch (e: any) {
+      alertAsync({ title: "추가 실패", description: e?.message ?? String(e) });
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function remove(id: string) {
+    const ok = await confirmAsync({
+      title: "이 IP 를 화이트리스트에서 제거할까요?",
+      description: "이 IP 에서는 더 이상 출근 처리가 안 돼요.",
+      tone: "danger",
+      confirmLabel: "제거",
+    });
+    if (!ok) return;
+    const prev = items;
+    setItems((arr) => arr.filter((x) => x.id !== id));
+    try { await api(`/api/admin/attendance-ip/${id}`, { method: "DELETE" }); }
+    catch (e: any) { setItems(prev); alertAsync({ title: "제거 실패", description: e?.message ?? String(e) }); }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="panel p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[15px] font-extrabold text-ink-900">출근 IP 제한</div>
+            <div className="text-[12.5px] text-ink-500 mt-1 leading-relaxed">
+              켜면 등록한 IP 에서만 출근 처리할 수 있어요. 사무실 인터넷에서만 출근을 허용하고 싶을 때 사용.
+              플랫폼/슈퍼 관리자는 이 제한과 무관하게 출근 가능합니다.
+            </div>
+          </div>
+          <label className="flex items-center gap-2 select-none cursor-pointer">
+            <input type="checkbox" className="accent-brand-500 w-5 h-5" checked={enabled}
+              onChange={(e) => toggle(e.target.checked)} disabled={loading} />
+            <span className="text-[13px] font-bold text-ink-800">사용</span>
+          </label>
+        </div>
+      </div>
+
+      <div className="panel p-5">
+        <div className="text-[13px] font-bold text-ink-800 mb-3">허용 IP 추가</div>
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex-1 min-w-[200px]">
+            <label className="field-label">IP 또는 CIDR</label>
+            <input className="input" placeholder="203.241.45.67 또는 192.168.1.0/24"
+              value={cidrInput} onChange={(e) => setCidrInput(e.target.value)} maxLength={64} />
+          </div>
+          <div className="flex-1 min-w-[160px]">
+            <label className="field-label">라벨 (선택)</label>
+            <input className="input" placeholder="예: 본사 사무실"
+              value={labelInput} onChange={(e) => setLabelInput(e.target.value)} maxLength={60} />
+          </div>
+          <button className="btn-primary" disabled={adding || !cidrInput.trim()} onClick={() => add(false)}>추가</button>
+          {clientIp && (
+            <button className="btn-ghost" disabled={adding} onClick={() => add(true)} title={`현재 ${clientIp}`}>
+              내 현재 IP 추가 ({clientIp})
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="panel p-0 overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-ink-100">
+          <div className="text-[13px] font-bold text-ink-800">허용 IP 목록 <span className="text-ink-400 tabular ml-1">{items.length}</span></div>
+          {!enabled && <span className="chip-amber text-[11px]">사용 꺼짐</span>}
+        </div>
+        {loading ? (
+          <div className="px-4 py-8 text-center text-[13px] text-ink-500">불러오는 중…</div>
+        ) : items.length === 0 ? (
+          <div className="px-4 py-10 text-center text-[13px] text-ink-500">
+            등록된 IP 가 없어요. 위에서 추가하세요.
+          </div>
+        ) : (
+          <ul className="divide-y divide-ink-100">
+            {items.map((it) => (
+              <li key={it.id} className="px-4 py-3 flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="text-[13px] font-bold text-ink-900 truncate">{it.cidr}</div>
+                  <div className="text-[11.5px] text-ink-500 truncate">
+                    {it.label ? <span>{it.label} · </span> : null}{new Date(it.createdAt).toLocaleString("ko-KR")}
+                  </div>
+                </div>
+                <button className="btn-icon" title="삭제" onClick={() => remove(it.id)}>
+                  <TrashIcon />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 }

--- a/server/prisma/migrations/20260607000000_company_attendance_ip_restrict/migration.sql
+++ b/server/prisma/migrations/20260607000000_company_attendance_ip_restrict/migration.sql
@@ -1,0 +1,18 @@
+-- 회사 출근 IP 화이트리스트.
+-- Company 에 attendanceIpRestrictEnabled(기본 false) + 새 모델 CompanyAttendanceAllowedIp.
+-- 비파괴적: ADD COLUMN NOT NULL DEFAULT 는 PG 11+ 에서 메타데이터 전용 연산, 테이블 재작성·락 없음.
+
+ALTER TABLE "Company" ADD COLUMN "attendanceIpRestrictEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE "CompanyAttendanceAllowedIp" (
+  "id" TEXT NOT NULL,
+  "companyId" TEXT NOT NULL,
+  "cidr" TEXT NOT NULL,
+  "label" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdById" TEXT,
+  CONSTRAINT "CompanyAttendanceAllowedIp_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "CompanyAttendanceAllowedIp_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "CompanyAttendanceAllowedIp_companyId_idx" ON "CompanyAttendanceAllowedIp"("companyId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -128,6 +128,10 @@ model User {
 model Company {
   id             String    @id @default(cuid())
   name           String // 회사명 (표시용)
+  // 출근 IP 화이트리스트 모드. 켜져있으면 attendance/check-in 시 클라 IP 가
+  // CompanyAttendanceAllowedIp(CIDR 다중) 중 하나에 매치돼야 한다. 꺼져있으면 어디서든 OK.
+  attendanceIpRestrictEnabled Boolean @default(false)
+  allowedIps     CompanyAttendanceAllowedIp[]
   slug           String?   @unique // URL/식별용 (선택)
   status         String    @default("PENDING") // PENDING | ACTIVE | SUSPENDED | REJECTED
   // ── 가입 신청자 정보 (스냅샷) ──
@@ -1266,6 +1270,20 @@ model FeatureFlag {
   description String?
   updatedAt   DateTime @updatedAt
   updatedById String?
+}
+
+/// 회사 출근 화이트리스트 IP (CIDR). Company.attendanceIpRestrictEnabled=true 일 때만 의미.
+/// 단일 IP 는 "/32" (또는 IPv6 "/128") 로 저장. 여러 개 등록 가능, OR 매칭(하나라도 매치되면 통과).
+model CompanyAttendanceAllowedIp {
+  id        String   @id @default(cuid())
+  companyId String
+  company   Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  cidr      String // 예: "203.241.45.67/32" 또는 "192.168.1.0/24"
+  label     String? // 메모용 (예: "본사 사무실", "도쿄 지점")
+  createdAt DateTime @default(now())
+  createdById String?
+
+  @@index([companyId])
 }
 
 /// 사이드바 메뉴 항목 표시 여부 (전사 단위) — 총관리자 토글로 즉시 숨김/노출.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,6 +22,7 @@ import fs from "node:fs";
 import notificationRouter from "./routes/notification.js";
 import pushRouter from "./routes/push.js";
 import updatesRouter from "./routes/updates.js";
+import attendanceIpRestrictRouter from "./routes/attendanceIpRestrict.js";
 import searchRouter from "./routes/search.js";
 import documentRouter from "./routes/document.js";
 import approvalRouter from "./routes/approval.js";
@@ -280,6 +281,8 @@ app.use("/api/auth", loginLimiter, authRouter);
 app.use("/api/me", meRouter);
 app.use("/api/feature-flags", featureFlagsRouter);
 app.use("/api/admin", adminRouter);
+// 회사 출근 IP 화이트리스트 — 회사 관리자(ADMIN) 전용. CRUD.
+app.use("/api/admin/attendance-ip", attendanceIpRestrictRouter);
 app.use("/api/platform", platformRouter);
 app.use("/api/users", usersRouter);
 app.use("/api/schedule", scheduleRouter);

--- a/server/src/lib/ipMatch.ts
+++ b/server/src/lib/ipMatch.ts
@@ -1,0 +1,119 @@
+/**
+ * IP 주소 ↔ CIDR 매칭 유틸 — 회사 출근 IP 화이트리스트 검사용.
+ *
+ * 의존성 없이 IPv4/IPv6 둘 다 처리. 단일 IP 도 "/32"(IPv4) / "/128"(IPv6) 로 정규화해 동일 코드패스.
+ * trust proxy=1 환경에서 req.ip 는 ALB X-Forwarded-For 의 첫 클라이언트 IP — 이걸 normalize 후 매칭.
+ */
+
+/** "::ffff:1.2.3.4" 같은 IPv4-mapped IPv6 를 순수 IPv4 로 푼다. 아니면 그대로. */
+export function normalizeClientIp(ip: string | undefined | null): string | null {
+  if (!ip) return null;
+  const s = ip.trim();
+  if (!s) return null;
+  // IPv4-mapped IPv6
+  const m = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(s);
+  if (m) return m[1];
+  return s;
+}
+
+/** "192.168.1.0/24" → { kind:'v4', addr:Uint8Array, prefix:24 } */
+type CIDR =
+  | { kind: "v4"; bytes: Uint8Array; prefix: number }
+  | { kind: "v6"; bytes: Uint8Array; prefix: number };
+
+function ipv4ToBytes(ip: string): Uint8Array | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  const out = new Uint8Array(4);
+  for (let i = 0; i < 4; i++) {
+    const n = Number(parts[i]);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+    out[i] = n;
+  }
+  return out;
+}
+
+function ipv6ToBytes(ip: string): Uint8Array | null {
+  // 매우 단순 파서 — :: 압축 + 16비트 그룹. embedded IPv4 (예: ::ffff:1.2.3.4) 도 처리.
+  try {
+    let s = ip.toLowerCase();
+    // IPv4-embedded 변환 — "::ffff:1.2.3.4" 의 끝 IPv4 를 2개 16진 그룹으로
+    const tail = /(\d+\.\d+\.\d+\.\d+)$/.exec(s);
+    if (tail) {
+      const b = ipv4ToBytes(tail[1]);
+      if (!b) return null;
+      const hi = (b[0] << 8) | b[1];
+      const lo = (b[2] << 8) | b[3];
+      s = s.slice(0, tail.index) + hi.toString(16) + ":" + lo.toString(16);
+    }
+    const parts = s.split("::");
+    if (parts.length > 2) return null;
+    const left = parts[0] ? parts[0].split(":") : [];
+    const right = parts.length === 2 && parts[1] ? parts[1].split(":") : [];
+    const zerosNeeded = 8 - (left.length + right.length);
+    if (zerosNeeded < 0) return null;
+    const groups = [...left, ...new Array(zerosNeeded).fill("0"), ...right];
+    if (groups.length !== 8) return null;
+    const out = new Uint8Array(16);
+    for (let i = 0; i < 8; i++) {
+      const n = parseInt(groups[i] || "0", 16);
+      if (!Number.isInteger(n) || n < 0 || n > 0xffff) return null;
+      out[i * 2] = (n >> 8) & 0xff;
+      out[i * 2 + 1] = n & 0xff;
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+/** CIDR 문자열을 파싱 — 잘못된 형식이면 null. 단일 IP 도 허용(=/32 또는 /128). */
+export function parseCidr(input: string): CIDR | null {
+  const s = input.trim();
+  if (!s) return null;
+  const [addr, maskStr] = s.includes("/") ? s.split("/") : [s, ""];
+  if (addr.includes(".")) {
+    const bytes = ipv4ToBytes(addr);
+    if (!bytes) return null;
+    const prefix = maskStr === "" ? 32 : Number(maskStr);
+    if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) return null;
+    return { kind: "v4", bytes, prefix };
+  }
+  if (addr.includes(":")) {
+    const bytes = ipv6ToBytes(addr);
+    if (!bytes) return null;
+    const prefix = maskStr === "" ? 128 : Number(maskStr);
+    if (!Number.isInteger(prefix) || prefix < 0 || prefix > 128) return null;
+    return { kind: "v6", bytes, prefix };
+  }
+  return null;
+}
+
+/** 사용자 입력 CIDR 검증(유효성만). */
+export function isValidCidr(input: string): boolean {
+  return parseCidr(input) !== null;
+}
+
+/** ip(평문) 가 CIDR 안에 속하는가. */
+function ipInCidr(ip: string, c: CIDR): boolean {
+  const bytes = c.kind === "v4" ? ipv4ToBytes(ip) : ipv6ToBytes(ip);
+  if (!bytes || bytes.length !== c.bytes.length) return false;
+  let bitsLeft = c.prefix;
+  for (let i = 0; i < bytes.length && bitsLeft > 0; i++) {
+    const take = Math.min(8, bitsLeft);
+    const mask = take === 8 ? 0xff : (0xff << (8 - take)) & 0xff;
+    if ((bytes[i] & mask) !== (c.bytes[i] & mask)) return false;
+    bitsLeft -= take;
+  }
+  return true;
+}
+
+/** ip 가 cidrs 중 하나라도 매치되면 true. cidrs 가 비어있으면 false(통과 안 함). */
+export function ipMatchesAny(ip: string, cidrs: string[]): boolean {
+  if (!cidrs.length) return false;
+  for (const raw of cidrs) {
+    const c = parseCidr(raw);
+    if (c && ipInCidr(ip, c)) return true;
+  }
+  return false;
+}

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { notify } from "../lib/notify.js";
 import { todayStr } from "../lib/dates.js";
+import { ipMatchesAny, normalizeClientIp } from "../lib/ipMatch.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -27,6 +28,31 @@ router.post("/check-in", async (req, res) => {
   const u = (req as any).user;
   const date = todayStr();
   const force = req.body?.force === true;
+
+  // 회사 IP 화이트리스트 검사 — 관리자가 켜놓은 경우만. 매치 안 되면 403.
+  // 슈퍼/플랫폼 어드민은 우회(원격 운영 편의). user 의 companyId 가 없으면(플랫폼 운영자) 우회.
+  if (u.companyId && !u.superAdmin && !u.platformAdmin) {
+    const company = await prisma.company.findUnique({
+      where: { id: u.companyId },
+      select: {
+        attendanceIpRestrictEnabled: true,
+        allowedIps: { select: { cidr: true } },
+      },
+    });
+    if (company?.attendanceIpRestrictEnabled) {
+      const clientIp = normalizeClientIp(req.ip);
+      const allowed = !!clientIp && ipMatchesAny(clientIp, company.allowedIps.map((a) => a.cidr));
+      if (!allowed) {
+        await writeLog(u.id, "CHECK_IN_DENIED_IP", date, clientIp ?? "(no-ip)");
+        return res.status(403).json({
+          code: "IP_NOT_ALLOWED",
+          error: "회사에서 허용한 IP 에서만 출근할 수 있어요. 사무실 네트워크에 연결됐는지 확인해 주세요.",
+          clientIp,
+        });
+      }
+    }
+  }
+
   const existing = await prisma.attendance.findUnique({
     where: { userId_date: { userId: u.id, date } },
   });

--- a/server/src/routes/attendanceIpRestrict.ts
+++ b/server/src/routes/attendanceIpRestrict.ts
@@ -1,0 +1,102 @@
+/**
+ * 회사 출근 IP 제한 관리 — 회사 관리자(ADMIN) 전용 CRUD.
+ *
+ * 라우터:
+ *   GET    /api/admin/attendance-ip          현재 설정 + 화이트리스트 목록 + 내 현재 IP
+ *   PATCH  /api/admin/attendance-ip          enabled toggle
+ *   POST   /api/admin/attendance-ip          항목 추가 (CIDR + label)
+ *   DELETE /api/admin/attendance-ip/:id      항목 삭제
+ *
+ * 슈퍼/플랫폼 어드민은 super-admin 콘솔에서 별도 관리. 여기는 회사 단위.
+ */
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../lib/db.js";
+import { requireAuth, writeLog } from "../lib/auth.js";
+import { isValidCidr, normalizeClientIp } from "../lib/ipMatch.js";
+
+const router = Router();
+router.use(requireAuth);
+
+function requireCompanyAdmin(req: any, res: any) {
+  const u = req.user;
+  if (!u || u.role !== "ADMIN" || !u.companyId) {
+    res.status(403).json({ error: "회사 관리자 권한이 필요합니다." });
+    return null;
+  }
+  return u;
+}
+
+router.get("/", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  const company = await prisma.company.findUnique({
+    where: { id: u.companyId },
+    select: {
+      attendanceIpRestrictEnabled: true,
+      allowedIps: {
+        select: { id: true, cidr: true, label: true, createdAt: true, createdById: true },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+  res.json({
+    enabled: !!company?.attendanceIpRestrictEnabled,
+    allowedIps: company?.allowedIps ?? [],
+    clientIp: normalizeClientIp(req.ip),
+  });
+});
+
+const patchSchema = z.object({ enabled: z.boolean() });
+router.patch("/", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  const parsed = patchSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  await prisma.company.update({
+    where: { id: u.companyId },
+    data: { attendanceIpRestrictEnabled: parsed.data.enabled },
+  });
+  await writeLog(u.id, "ATTENDANCE_IP_RESTRICT_TOGGLE", u.companyId, String(parsed.data.enabled));
+  res.json({ ok: true, enabled: parsed.data.enabled });
+});
+
+const postSchema = z.object({
+  cidr: z.string().trim().min(1).max(64),
+  label: z.string().max(60).optional(),
+});
+router.post("/", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  const parsed = postSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const cidr = parsed.data.cidr.trim();
+  if (!isValidCidr(cidr)) {
+    return res.status(400).json({ error: "올바른 IP 또는 CIDR 형식이 아닙니다 (예: 203.241.45.67 또는 192.168.1.0/24)." });
+  }
+  const created = await prisma.companyAttendanceAllowedIp.create({
+    data: {
+      companyId: u.companyId,
+      cidr,
+      label: parsed.data.label?.trim() || null,
+      createdById: u.id,
+    },
+    select: { id: true, cidr: true, label: true, createdAt: true, createdById: true },
+  });
+  await writeLog(u.id, "ATTENDANCE_IP_RESTRICT_ADD", u.companyId, `${cidr}${parsed.data.label ? ` (${parsed.data.label})` : ""}`);
+  res.json({ ok: true, item: created });
+});
+
+router.delete("/:id", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  // 다른 회사 항목 삭제 차단 — companyId 필터.
+  const result = await prisma.companyAttendanceAllowedIp.deleteMany({
+    where: { id: req.params.id, companyId: u.companyId },
+  });
+  if (result.count === 0) return res.status(404).json({ error: "not found" });
+  await writeLog(u.id, "ATTENDANCE_IP_RESTRICT_REMOVE", u.companyId, req.params.id);
+  res.json({ ok: true });
+});
+
+export default router;


### PR DESCRIPTION
## 증상
**회사 출근 IP 화이트리스트 — 관리자 토글 + CIDR 다중**

새 기능을 추가합니다.

## 원인
…mpanyAttendanceAllowedIp(CIDR)

회사 단위 ON/OFF 토글 + 화이트리스트(CIDR 다중). 매치되는 IP 에서만 출근 가능.
비파괴적 마이그레이션(ADD COLUMN NOT NULL DEFAULT false + 새 테이블).

## 수정
**작업 항목 (커밋 단위)**
- feat(schema): 출근 IP 화이트리스트 — Company.attendanceIpRestrictEnabled + Co…
- feat(server): 출근 IP 제한 검사 + 관리자 CRUD
- feat(admin): 관리자 페이지에 '출근 IP' 탭 — 토글 + CIDR 추가/삭제 + 내 현재 IP 추가

**변경 대상 (7개 파일)**
- `client/src/pages/AdminPage.tsx`
- `server/prisma/migrations/20260607000000_company_attendance_ip_restrict/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/index.ts`
- `server/src/lib/ipMatch.ts`
- `server/src/routes/attendance.ts`
- `server/src/routes/attendanceIpRestrict.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #366** 에서 진행됩니다.

