### PR TITLE
🔀 :: (#367) attendance-ip 라우터 등록 순서 — adminRouter 보다 먼저

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -280,9 +280,11 @@ app.use("/api/download", desktopDownloadRouter);
 app.use("/api/auth", loginLimiter, authRouter);
 app.use("/api/me", meRouter);
 app.use("/api/feature-flags", featureFlagsRouter);
-app.use("/api/admin", adminRouter);
+// ⚠️ specific 한 sub-router 를 prefix-router 보다 먼저 마운트 — 안 그러면
+//    Express 가 /api/admin/attendance-ip 를 adminRouter 안에서 처리하려다 404 가 됨.
 // 회사 출근 IP 화이트리스트 — 회사 관리자(ADMIN) 전용. CRUD.
 app.use("/api/admin/attendance-ip", attendanceIpRestrictRouter);
+app.use("/api/admin", adminRouter);
 app.use("/api/platform", platformRouter);
 app.use("/api/users", usersRouter);
 app.use("/api/schedule", scheduleRouter);


### PR DESCRIPTION
## 증상
**attendance-ip 라우터 등록 순서 — adminRouter 보다 먼저**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
Express 는 app.use 등록 순서대로 시도. /api/admin prefix 라우터(adminRouter)가 먼저면
/api/admin/attendance-ip 가 거기 갇혀 404 가 반환됨(adminRouter 내부에 해당 path 없음).
specific sub-router 를 앞으로 옮겨 정상 라우팅.

## 수정
**작업 항목 (커밋 단위)**
- fix(server): attendance-ip 라우터를 adminRouter 보다 먼저 마운트 — 404 회피

**변경 대상 (1개 파일)**
- `server/src/index.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #367** 에서 진행됩니다.

