### PR TITLE
🔀 :: (#368) trust proxy 1→2 — Vercel hop 까지 신뢰

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,11 +58,14 @@ const PORT = Number(process.env.PORT ?? 4000);
 const IS_PROD = process.env.NODE_ENV === "production";
 const ORIGIN = process.env.CLIENT_ORIGIN ?? "http://localhost:1000";
 
-// ALB(및 Vercel) 뒤에 있으므로 첫 번째 프록시의 X-Forwarded-For 를 신뢰.
-// express-rate-limit 가 req.ip 로 실제 클라이언트 IP 를 식별하려면 필요.
-// "trust proxy" 를 true 로 두면 모든 프록시 헤더를 신뢰해 스푸핑 위험이 있음 → 1.
+// ALB + Vercel rewrite 두 hop 뒤에 있다(웹 + 네이티브 모두 nest.hi-vits.com → Vercel rewrite
+// → api.nest.hi-vits.com(ALB) → ECS). trust proxy=1 만 두면 마지막 Vercel hop 만 떼어내
+// req.ip 가 Vercel 인스턴스 IP(13.125.x.x / 43.203.x.x 같은 AWS Lambda IP) 로 잡힌다 →
+// 출근 IP 화이트리스트가 의도와 다르게 동작.
+// trust proxy=2 로 두 hop(ALB + Vercel) 신뢰 → X-Forwarded-For 의 가장 왼쪽 = 사용자 IP.
+// "true" 는 모든 프록시 신뢰라 스푸핑 위험 → 정확한 hop 수 명시.
 if (IS_PROD) {
-  app.set("trust proxy", 1);
+  app.set("trust proxy", 2);
 }
 
 // 기본 보안 헤더 — CSP 는 프런트 개발 편의상 기본만.

--- a/server/src/routes/attendanceIpRestrict.ts
+++ b/server/src/routes/attendanceIpRestrict.ts
@@ -44,6 +44,8 @@ router.get("/", async (req, res) => {
     enabled: !!company?.attendanceIpRestrictEnabled,
     allowedIps: company?.allowedIps ?? [],
     clientIp: normalizeClientIp(req.ip),
+    // 진단용 — X-Forwarded-For 의 가장 왼쪽이 진짜 클라 IP. trust proxy hop 수 검증에 사용.
+    xForwardedFor: String(req.headers["x-forwarded-for"] ?? ""),
   });
 });
 


### PR DESCRIPTION
## 증상
**trust proxy 1→2 — Vercel hop 까지 신뢰**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
증상: 출근 IP 등록 시 '내 IP' 가 매번 다른 AWS 서울 IP. Vercel rewrite proxy 의
AWS Lambda 인스턴스 IP — Vercel 인스턴스가 매번 바뀌니 사용자에겐 IP 변동처럼 보임.

흐름: 사용자 → Vercel(api rewrite) → AWS ALB → ECS. 2 hop. trust proxy=1 만 두면
마지막 1 hop 만 떼어내 Vercel IP 가 req.ip 로 잡힘. trust proxy=2 로 두 hop 모두 신뢰
→ X-Forwarded-For 의 가장 왼쪽(=진짜 사용자 IP)이 req.ip.

attendance-ip GET 응답에 xForwardedFor raw 도 포함(진단용).

## 수정
**작업 항목 (커밋 단위)**
- fix(server): trust proxy 1→2 — Vercel rewrite hop 까지 신뢰해 사용자 IP 추출

**변경 대상 (2개 파일)**
- `server/src/index.ts`
- `server/src/routes/attendanceIpRestrict.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #368** 에서 진행됩니다.

