### PR TITLE
🔀 :: (#811) 앱 첫 부팅 시 네비게이션 바 다크→라이트 깜빡임 제거

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -133,6 +133,10 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         tabBar.translatesAutoresizingMaskIntoConstraints = false
         tabBar.delegate = self
         tabBar.tintColor = brandColor
+        // 라이트 모드 강제 — Info.plist 의 UIUserInterfaceStyle=Light 가 root window 에 적용되지만,
+        // UITabBar 가 추가될 때 부모 트레잇을 즉시 따라가지 않는 미세한 frame 이 있어 명시.
+        // 사용자가 시스템 다크 모드라도 탭바는 처음부터 라이트 글래스로 그려진다.
+        tabBar.overrideUserInterfaceStyle = .light
 
         var items: [UITabBarItem] = []
         for (i, tab) in tabs.enumerated() {

--- a/client/ios/App/App/Info.plist
+++ b/client/ios/App/App/Info.plist
@@ -60,5 +60,12 @@
 	     applyNativeTheme() 가 StatusBar.setStyle(Light) 로 즉시 흰 글자로 전환. -->
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDarkContent</string>
+	<!-- 앱 전체 UI 모드 라이트 강제 — 시스템 다크 모드여도 root window/UITabBar/액션시트 등
+	     모든 native UI 가 라이트로 그려진다. 이전엔 시스템 모드 따라 다크로 잠깐 그려졌다가
+	     React mount 후 applyNativeTheme() 가 라이트로 바꿔 깜빡임이 보였다. 사용자가 명시적으로
+	     다크 모드 켜면 applyNativeTheme() 가 window.overrideUserInterfaceStyle=.dark 로 동적
+	     전환(아래 nativeTheme.ts). 즉 정적 기본=라이트, 동적 전환만 다크. -->
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
## 증상
앱 켜자마자 하단 네비게이션 바(탭바)가 어두운 색으로 잠깐 보였다가 라이트 색으로 바뀜.

## 원인
- `Info.plist` 에 `UIUserInterfaceStyle` 미설정 → root window 가 시스템 모드 따라감
- 시스템 다크 모드 사용자: root window/UITabBar 가 첫 그리기에서 다크 글래스
- React mount 후 `applyNativeTheme()` 가 라이트 강제 → 깜빡임

## 수정
1. `Info.plist` 에 `UIUserInterfaceStyle=Light` 추가 → root window 부터 라이트 고정
2. `AppDelegate.swift` 의 `build()` 에서 `tabBar.overrideUserInterfaceStyle=.light` 명시 안전망

시스템 다크 모드 사용자도 HiNest 는 첫 paint 부터 라이트.

## 반영
**Native 변경이라 Live Updates 로 안 됩니다.** 다음 빌드부터 반영 — `cap:ios:dev` 로 시뮬레이터 hot reload 가능, 또는 `cap:ios` 후 Xcode 빌드.

Closes #811
