### PR TITLE
🔀 :: (#370) 탭바 좌우 스크롤 안 되던 회귀

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -318,9 +318,14 @@ export default function AdminPage() {
         <StatCard label="직급" value={positions.length} sub="전사 직급 수" />
       </div>
 
-      {/* 탭 */}
-      <div className="mb-5 border-b border-ink-150 overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-        <div className="flex items-center gap-1 min-w-max">
+      {/* 탭 — 모바일에서 좌우 스와이프 스크롤. touch-action:pan-x 로 세로 페이지 스크롤과 충돌 차단,
+           -webkit-overflow-scrolling:touch 로 iOS momentum, scrollbar 숨겨 깔끔하게.
+           w-max 는 min-w-max 와 달리 inline 컨테이너에서도 안정적으로 자식 폭 확보. */}
+      <div
+        className="hinest-x-scroll mb-5 border-b border-ink-150 overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0"
+        style={{ touchAction: "pan-x", WebkitOverflowScrolling: "touch" }}
+      >
+        <div className="flex items-center gap-1 w-max">
           {TABS.map((t) => (
             <button
               key={t.key}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1359,3 +1359,18 @@ html.dark .nav-active svg { stroke: var(--c-brand-soft-fg); }
 body.hinest-chat-fs .hinest-preview-banner {
   visibility: hidden;
 }
+
+/* ============================================================ */
+/*  가로 스크롤 영역 — 좌우 탭바·필터 등 모바일 스와이프용.        */
+/*  scrollbar 숨김(가로 스크롤바가 세로 콘텐츠를 깎아내림 방지),  */
+/*  iOS momentum 활성화. 부모 정의: overflow-x-auto + w-max 자식. */
+/* ============================================================ */
+.hinest-x-scroll {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.hinest-x-scroll::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}


### PR DESCRIPTION
## 증상
**탭바 좌우 스크롤 안 되던 회귀**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
증상: 관리자 페이지 탭(구성원·초대키·팀·직급·출근 IP)이 모바일에서 좌우 스크롤 잘 안 됨.

원인:
- min-w-max 가 일부 Safari 에서 인라인 컨테이너 폭 확보를 놓침
- touch-action 미지정 → iOS 가 세로 페이지 스크롤로 빨아들여 가로 스와이프 무시
- WebkitOverflowScrolling momentum 미지정 → 손가락 떼면 즉시 멈춤

수정:
- min-w-max → w-max(인라인-flex 보다 안정)
- touch-action:pan-x — 가로 스와이프 전용 명시
- -webkit-overflow-scrolling:touch — momentum 활성화
- hinest-x-scroll 헬퍼 클래스 — scrollbar 숨김

## 수정
**작업 항목 (커밋 단위)**
- fix(admin): 탭바 좌우 스크롤 모바일 — touch-action:pan-x + w-max 자식
- style(css): hinest-x-scroll 헬퍼 — 가로 스크롤 영역 공통 스타일

**변경 대상 (2개 파일)**
- `client/src/pages/AdminPage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #370** 에서 진행됩니다.

