### PR TITLE
🔀 :: (#371) 공지/회의록 공유 시트 — 인스타 스타일 바텀시트

### DIFF
--- a/client/src/components/ShareButton.tsx
+++ b/client/src/components/ShareButton.tsx
@@ -1,0 +1,64 @@
+/**
+ * 공유 트리거 버튼 — 공지/메모/회의록 등 게시물 페이지에 박는다.
+ *
+ * 누르면 <ShareSheet> 가 열리고 동료/그룹방을 선택해 채팅으로 카드 메시지 전송.
+ *
+ * 사용:
+ *   <ShareButton payload={{ kind: "ANNOUNCEMENT", title, snippet, href: "/notice/..." }} />
+ *
+ * variant:
+ *   - "icon"  : 아이콘 단독 (페이지 상단 액션바 등)
+ *   - "button": 라벨 포함 (게시물 하단 액션 영역)
+ */
+import { useState } from "react";
+import ShareSheet, { type SharePayload } from "./ShareSheet";
+import { useAuth } from "../auth";
+
+function ShareIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+    </svg>
+  );
+}
+
+export default function ShareButton({
+  payload,
+  variant = "button",
+  label = "공유",
+  className = "",
+}: {
+  payload: SharePayload;
+  variant?: "icon" | "button";
+  label?: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const { user } = useAuth();
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        aria-label="공유"
+        className={
+          variant === "icon"
+            ? `inline-flex items-center justify-center w-9 h-9 rounded-full hover:bg-ink-100 text-ink-600 ${className}`
+            : `inline-flex items-center gap-1.5 h-9 px-3 rounded-[10px] border border-ink-200 hover:bg-ink-50 text-[12px] font-bold text-ink-700 ${className}`
+        }
+      >
+        <ShareIcon size={variant === "icon" ? 18 : 15} />
+        {variant === "button" && <span>{label}</span>}
+      </button>
+      <ShareSheet open={open} onClose={() => setOpen(false)} payload={payload} meId={user?.id ?? null} />
+    </>
+  );
+}

--- a/client/src/components/ShareSheet.tsx
+++ b/client/src/components/ShareSheet.tsx
@@ -1,0 +1,352 @@
+/**
+ * 게시물 공유 바텀시트 — 공지/메모/회의록 등을 채팅으로 공유.
+ *
+ * 인스타그램 게시물 공유 패턴: 하단에서 시트가 올라오고, 동료(1:1)+그룹방 목록에서
+ * 다중 선택 후 "보내기" 누르면 각 대상의 채팅방으로 카드 메시지 1건씩 전송.
+ *
+ * 검색은 이름·방 이름 모두 부분 일치. 선택은 상단 칩으로 표시 → 다시 누르면 해제.
+ * 모바일: 풀폭 바텀시트. 데스크톱: 가운데 중형 모달.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../api";
+
+export type ShareKind = "ANNOUNCEMENT" | "MEMO" | "MEETING" | "DOCUMENT" | "JOURNAL";
+
+export type SharePayload = {
+  kind: ShareKind;
+  title: string;
+  snippet?: string;
+  /** 앱 내 라우트 경로 — 카드 클릭 시 이동 (예: "/notice/abc123") */
+  href: string;
+};
+
+type DirectoryUser = {
+  id: string;
+  name: string;
+  team?: string | null;
+  position?: string | null;
+  avatarUrl?: string | null;
+  avatarColor?: string | null;
+};
+
+type Room = {
+  id: string;
+  name: string;
+  type: "DIRECT" | "GROUP" | "TEAM" | string;
+  members?: { user: { id: string; name: string; avatarColor?: string | null } }[];
+};
+
+const KIND_LABEL: Record<ShareKind, string> = {
+  ANNOUNCEMENT: "공지",
+  MEMO: "메모",
+  MEETING: "회의록",
+  DOCUMENT: "문서",
+  JOURNAL: "업무일지",
+};
+
+export default function ShareSheet({
+  open,
+  onClose,
+  payload,
+  meId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  payload: SharePayload | null;
+  /** 본인 id — 동료 목록에서 본인 제외용. 없으면 응답을 신뢰. */
+  meId?: string | null;
+}) {
+  const [q, setQ] = useState("");
+  const [pickedUsers, setPickedUsers] = useState<Set<string>>(new Set());
+  const [pickedRooms, setPickedRooms] = useState<Set<string>>(new Set());
+  const [sending, setSending] = useState(false);
+
+  // 시트 열릴 때마다 선택 초기화 — 이전 공유의 잔상이 남지 않게.
+  useEffect(() => {
+    if (open) {
+      setQ("");
+      setPickedUsers(new Set());
+      setPickedRooms(new Set());
+    }
+  }, [open]);
+
+  // 시트 열릴 때만 fetch — 닫힌 동안 네트워크 트래픽 0.
+  const [usersData, setUsersData] = useState<{ users: DirectoryUser[] } | null>(null);
+  const [roomsData, setRoomsData] = useState<{ rooms: Room[] } | null>(null);
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void api<{ users: DirectoryUser[] }>("/api/users").then((d) => {
+      if (!cancelled) setUsersData(d);
+    }).catch(() => {});
+    void api<{ rooms: Room[] }>("/api/chat/rooms").then((d) => {
+      if (!cancelled) setRoomsData(d);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [open]);
+
+  const users: DirectoryUser[] = useMemo(() => {
+    const list = usersData?.users ?? [];
+    return list.filter((u: DirectoryUser) => (meId ? u.id !== meId : true));
+  }, [usersData, meId]);
+
+  // GROUP/TEAM 만 표시 — DIRECT 는 동료 목록에서 골라 보낸다(중복 방지).
+  const rooms: Room[] = useMemo(() => {
+    return (roomsData?.rooms ?? []).filter((r: Room) => r.type !== "DIRECT");
+  }, [roomsData]);
+
+  const filteredUsers = useMemo(() => {
+    const k = q.trim().toLowerCase();
+    if (!k) return users;
+    return users.filter((u) => u.name.toLowerCase().includes(k));
+  }, [users, q]);
+
+  const filteredRooms = useMemo(() => {
+    const k = q.trim().toLowerCase();
+    if (!k) return rooms;
+    return rooms.filter((r) => r.name.toLowerCase().includes(k));
+  }, [rooms, q]);
+
+  function toggleUser(id: string) {
+    setPickedUsers((s) => {
+      const next = new Set(s);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function toggleRoom(id: string) {
+    setPickedRooms((s) => {
+      const next = new Set(s);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const total = pickedUsers.size + pickedRooms.size;
+
+  async function send() {
+    if (!payload || !total || sending) return;
+    setSending(true);
+    try {
+      const r = await api<{ ok: boolean; count: number }>("/api/chat/share", {
+        method: "POST",
+        json: {
+          kind: payload.kind,
+          title: payload.title,
+          snippet: payload.snippet,
+          href: payload.href,
+          userIds: [...pickedUsers],
+          roomIds: [...pickedRooms],
+        },
+      });
+      if (r?.ok) {
+        // 가벼운 토스트 대신 시트 자체 닫음 — 이후 알림센터/채팅 갱신은 SSE 가 처리.
+        onClose();
+      }
+    } catch (e: any) {
+      window.alert(e?.message ?? "공유에 실패했어요");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (!open || !payload) return null;
+  const label = KIND_LABEL[payload.kind] ?? "공유";
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${label} 공유`}
+      className="modal-safe fixed inset-0 z-[1000] flex items-end md:items-center justify-center"
+      style={{ background: "rgba(15,18,28,0.45)" }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full md:max-w-md bg-white rounded-t-[20px] md:rounded-[18px] shadow-2xl flex flex-col"
+        style={{ maxHeight: "85vh" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 핸들바 — 모바일 시트 표시 */}
+        <div className="flex justify-center pt-2 md:hidden">
+          <div className="w-10 h-1.5 rounded-full bg-ink-200" />
+        </div>
+
+        {/* 헤더 */}
+        <div className="px-5 pt-3 pb-2 flex items-center justify-between">
+          <h3 className="text-[15px] font-bold text-ink-900">공유</h3>
+          <button
+            onClick={onClose}
+            aria-label="닫기"
+            className="text-ink-400 hover:text-ink-700 text-[20px] leading-none"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* 공유 카드 미리보기 */}
+        <div className="mx-5 mb-2 p-3 rounded-[12px] border border-ink-150 bg-ink-50/60">
+          <div className="text-[10px] font-bold text-brand-500 mb-0.5">📌 {label}</div>
+          <div className="text-[13px] font-bold text-ink-900 line-clamp-1">{payload.title}</div>
+          {payload.snippet && (
+            <div className="text-[11px] text-ink-500 line-clamp-2 mt-0.5">{payload.snippet}</div>
+          )}
+        </div>
+
+        {/* 검색 */}
+        <div className="px-5 pb-2">
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="이름 또는 대화방 검색"
+            className="w-full h-9 px-3 text-[13px] rounded-[10px] border border-ink-150 bg-white outline-none focus:border-brand-400"
+          />
+        </div>
+
+        {/* 선택된 칩 */}
+        {total > 0 && (
+          <div
+            className="hinest-x-scroll px-5 pb-2 flex gap-2 overflow-x-auto"
+            style={{ touchAction: "pan-x", WebkitOverflowScrolling: "touch" }}
+          >
+            {[...pickedUsers].map((id) => {
+              const u = users.find((x) => x.id === id);
+              if (!u) return null;
+              return (
+                <button
+                  key={`u:${id}`}
+                  onClick={() => toggleUser(id)}
+                  className="inline-flex items-center gap-1.5 px-2 h-7 rounded-full bg-brand-50 border border-brand-100 text-[12px] font-bold text-brand-700 whitespace-nowrap"
+                >
+                  {u.name}
+                  <span className="text-brand-400">×</span>
+                </button>
+              );
+            })}
+            {[...pickedRooms].map((id) => {
+              const r = rooms.find((x) => x.id === id);
+              if (!r) return null;
+              return (
+                <button
+                  key={`r:${id}`}
+                  onClick={() => toggleRoom(id)}
+                  className="inline-flex items-center gap-1.5 px-2 h-7 rounded-full bg-brand-50 border border-brand-100 text-[12px] font-bold text-brand-700 whitespace-nowrap"
+                >
+                  #{r.name}
+                  <span className="text-brand-400">×</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* 목록 */}
+        <div className="flex-1 overflow-y-auto px-2 pb-2">
+          {filteredRooms.length > 0 && (
+            <>
+              <div className="px-3 pt-2 pb-1 text-[10px] font-bold text-ink-400 uppercase tracking-wider">
+                대화방
+              </div>
+              {filteredRooms.map((r) => {
+                const picked = pickedRooms.has(r.id);
+                return (
+                  <button
+                    key={r.id}
+                    onClick={() => toggleRoom(r.id)}
+                    className={`w-full flex items-center gap-3 px-3 py-2 rounded-[10px] text-left ${
+                      picked ? "bg-brand-50" : "hover:bg-ink-50"
+                    }`}
+                  >
+                    <div
+                      className="w-9 h-9 rounded-full flex items-center justify-center text-[12px] font-bold text-white"
+                      style={{ background: "#4E5968" /* 그룹방 색 — 회의록 표준 슬레이트 */ }}
+                    >
+                      #{r.name.slice(0, 1)}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-[13px] font-bold text-ink-900 line-clamp-1">{r.name}</div>
+                      <div className="text-[11px] text-ink-500">{r.type === "TEAM" ? "팀방" : "그룹방"}</div>
+                    </div>
+                    <div
+                      className={`w-5 h-5 rounded-full border flex items-center justify-center ${
+                        picked ? "bg-brand-500 border-brand-500" : "border-ink-200"
+                      }`}
+                    >
+                      {picked && <span className="text-white text-[12px] leading-none">✓</span>}
+                    </div>
+                  </button>
+                );
+              })}
+            </>
+          )}
+
+          {filteredUsers.length > 0 && (
+            <>
+              <div className="px-3 pt-3 pb-1 text-[10px] font-bold text-ink-400 uppercase tracking-wider">
+                동료
+              </div>
+              {filteredUsers.map((u) => {
+                const picked = pickedUsers.has(u.id);
+                return (
+                  <button
+                    key={u.id}
+                    onClick={() => toggleUser(u.id)}
+                    className={`w-full flex items-center gap-3 px-3 py-2 rounded-[10px] text-left ${
+                      picked ? "bg-brand-50" : "hover:bg-ink-50"
+                    }`}
+                  >
+                    <div
+                      className="w-9 h-9 rounded-full flex items-center justify-center text-[12px] font-bold text-white overflow-hidden flex-shrink-0"
+                      style={{ background: u.avatarUrl ? "transparent" : u.avatarColor ?? "#3D54C4" }}
+                    >
+                      {u.avatarUrl ? (
+                        <img src={u.avatarUrl} alt={u.name} className="w-full h-full object-cover" />
+                      ) : (
+                        u.name.slice(0, 1)
+                      )}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-[13px] font-bold text-ink-900 line-clamp-1">{u.name}</div>
+                      {(u.team || u.position) && (
+                        <div className="text-[11px] text-ink-500 line-clamp-1">
+                          {[u.team, u.position].filter(Boolean).join(" · ")}
+                        </div>
+                      )}
+                    </div>
+                    <div
+                      className={`w-5 h-5 rounded-full border flex items-center justify-center ${
+                        picked ? "bg-brand-500 border-brand-500" : "border-ink-200"
+                      }`}
+                    >
+                      {picked && <span className="text-white text-[12px] leading-none">✓</span>}
+                    </div>
+                  </button>
+                );
+              })}
+            </>
+          )}
+
+          {!filteredRooms.length && !filteredUsers.length && (
+            <div className="text-center py-10 text-[12px] text-ink-400">검색 결과가 없어요</div>
+          )}
+        </div>
+
+        {/* 보내기 버튼 — safe-area inset bottom 흡수 */}
+        <div
+          className="px-5 pt-2 pb-3 border-t border-ink-100 bg-white rounded-b-[20px] md:rounded-b-[18px]"
+          style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 12px)" }}
+        >
+          <button
+            onClick={send}
+            disabled={!total || sending}
+            className="w-full h-11 rounded-[12px] bg-brand-500 text-white font-bold text-[14px] disabled:opacity-40 disabled:cursor-not-allowed transition active:scale-[0.98]"
+          >
+            {sending ? "보내는 중…" : total ? `${total}명에게 공유` : "받을 사람을 선택해 주세요"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -899,6 +899,12 @@ function MessageBubbleInner({ msg, mine }: { msg: Message; mine: boolean }) {
   const hasFile = !!fileUrl;
   const hasText = !!msg.content?.trim();
 
+  // 공유 카드 — 공지/메모/회의록 등. ShareSheet 가 보낸 메시지.
+  // fileType 은 "share:announcement" 같은 식별자, fileName 은 카드 제목, fileUrl 은 deep link.
+  if (msg.kind === "SHARE") {
+    return <ShareCardBubble msg={msg} mine={mine} />;
+  }
+
   // 이미지: 버블 없이 썸네일. 캡션은 아래 작은 버블.
   if (hasFile && msg.kind === "IMAGE") {
     return (
@@ -1036,6 +1042,67 @@ export const MessageBubble = memo(
   MessageBubbleInner,
   (a, b) => a.mine === b.mine && a.msg === b.msg
 );
+
+// 공유 카드 — kind="SHARE" 메시지. fileType="share:announcement|memo|meeting|document|journal" 분기.
+// 클릭 시 fileUrl 경로로 SPA 내 이동(react-router). 외부 링크가 들어와도 안전을 위해 same-origin 만.
+const SHARE_LABEL: Record<string, { label: string; icon: string }> = {
+  "share:announcement": { label: "공지", icon: "📣" },
+  "share:memo": { label: "메모", icon: "📝" },
+  "share:meeting": { label: "회의록", icon: "🗒️" },
+  "share:document": { label: "문서", icon: "📄" },
+  "share:journal": { label: "업무일지", icon: "🧾" },
+};
+
+function ShareCardBubble({ msg, mine }: { msg: Message; mine: boolean }) {
+  const meta = SHARE_LABEL[msg.fileType ?? ""] ?? { label: "공유", icon: "🔗" };
+  const href = msg.fileUrl ?? "#";
+  // SPA 라우트만 허용 — 외부 absolute URL 은 보안상 차단(피싱 방지).
+  const safe = href.startsWith("/") ? href : "#";
+  function navigate(e: React.MouseEvent) {
+    e.preventDefault();
+    if (safe === "#") return;
+    // SPA 라우터 — react-router 가 popstate 를 잡지 못하는 경우 대비 직접 navigate.
+    window.history.pushState({}, "", safe);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+  const bg = mine ? "rgba(255,255,255,0.95)" : "#FFFFFF";
+  const border = mine ? "rgba(255,255,255,0.4)" : "#E5E7EB";
+  return (
+    <a
+      href={safe}
+      onClick={navigate}
+      style={{
+        display: "block",
+        maxWidth: 320,
+        background: bg,
+        border: `1px solid ${border}`,
+        borderRadius: 14,
+        padding: "12px 14px",
+        textDecoration: "none",
+        color: "#0F172A",
+        boxShadow: "0 1px 2px rgba(15,23,42,0.04)",
+      }}
+    >
+      <div style={{ fontSize: 10, fontWeight: 700, color: "#3B5CF0", marginBottom: 4, letterSpacing: "-0.01em" }}>
+        {meta.icon} {meta.label}
+      </div>
+      <div style={{ fontSize: 14, fontWeight: 700, lineHeight: 1.35, marginBottom: 4, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+        {msg.fileName ?? "(제목 없음)"}
+      </div>
+      {msg.content && msg.content.trim() && msg.content !== msg.fileName && (
+        <div style={{ fontSize: 12, color: "#64748B", lineHeight: 1.4, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+          {/* content 가 "제목 — snippet" 포맷이라 제목 부분 제거 */}
+          {msg.content.startsWith(`${msg.fileName ?? ""} — `)
+            ? msg.content.slice((msg.fileName ?? "").length + 3)
+            : msg.content}
+        </div>
+      )}
+      <div style={{ marginTop: 8, paddingTop: 8, borderTop: "1px solid #F1F5F9", fontSize: 11, color: "#94A3B8", fontWeight: 600 }}>
+        탭해서 보기 →
+      </div>
+    </a>
+  );
+}
 
 // URL 자동 링크화 — http(s):// 또는 www. 로 시작하는 문자열을 <a> 로 변환.
 // 안전 조치: href 는 반드시 http/https 로만 구성하고, rel=noopener noreferrer + target=_blank.

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -15,7 +15,7 @@ export type Room = {
   messages: {
     content: string;
     createdAt: string;
-    kind?: "TEXT" | "IMAGE" | "VIDEO" | "FILE";
+    kind?: "TEXT" | "IMAGE" | "VIDEO" | "FILE" | "SHARE";
     fileName?: string | null;
     senderId?: string;
   }[];
@@ -33,7 +33,7 @@ export type Message = {
   // 페이로드엔 항상 포함 — 클라는 optional 로 읽고 활용.
   roomId?: string;
   content: string;
-  kind: "TEXT" | "IMAGE" | "VIDEO" | "FILE";
+  kind: "TEXT" | "IMAGE" | "VIDEO" | "FILE" | "SHARE";
   fileUrl?: string | null;
   fileName?: string | null;
   fileType?: string | null;

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -4,6 +4,7 @@ import { api, apiSWR, imgSrc, invalidateCache } from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
+import ShareButton from "../components/ShareButton";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
 import MeetingAttachments, { type MeetingAttachment } from "../components/MeetingAttachments";
 import { copyToClipboard, absoluteUrl } from "../lib/clipboard";
@@ -277,6 +278,14 @@ export default function MeetingDetailPage() {
             링크 복사
           </button>
           <PinButton type="MEETING" id={meeting.id} label={meeting.title} />
+          <ShareButton
+            variant="icon"
+            payload={{
+              kind: "MEETING",
+              title: meeting.title,
+              href: `/meetings/${meeting.id}`,
+            }}
+          />
           <button className="btn-ghost no-print" onClick={() => window.print()} title="A4 인쇄">인쇄</button>
           <button className="btn-ghost" onClick={() => setHistoryOpen(true)} title="버전 히스토리">히스토리</button>
           {canEdit && !edit && (

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -6,6 +6,7 @@ import { useNotifications } from "../notifications";
 import PageHeader from "../components/PageHeader";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
+import ShareButton from "../components/ShareButton";
 import Portal from "../components/Portal";
 import { copyToClipboard, absoluteUrl } from "../lib/clipboard";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
@@ -277,6 +278,15 @@ export default function NoticePage() {
                     링크 복사
                   </button>
                   <PinButton type="NOTICE" id={selected.id} label={selected.title} />
+                  <ShareButton
+                    variant="icon"
+                    payload={{
+                      kind: "ANNOUNCEMENT",
+                      title: selected.title,
+                      snippet: selected.content?.slice(0, 120) ?? undefined,
+                      href: `/notice?id=${selected.id}`,
+                    }}
+                  />
                   {canPost && (
                     <button
                       className="btn-ghost"

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -759,6 +759,162 @@ router.delete("/messages/:id", async (req, res) => {
 });
 
 /**
+ * 게시물 공유 — 공지/메모/회의록 등 앱 내 객체를 채팅 메시지로 보낸다.
+ *
+ * 1:1 (userIds) 와 그룹방 (roomIds) 둘 다 받는다. 1:1 은 기존 DIRECT 방 있으면 재사용,
+ * 없으면 새로 생성. 각 대상마다 kind="SHARE" 메시지 1건씩 만든다. 카드 표시 데이터는
+ * 기존 컬럼 재활용 — fileUrl=라우트 경로(deep link), fileName=제목, fileType=share:<kind>,
+ * content=fallback 표시 텍스트(브라우저 알림·검색 등에서 보일 때 사용).
+ *
+ * 보안:
+ *   - userIds 중 본인 회사가 아니면 무시 (공유 대상 제한)
+ *   - roomIds 중 본인이 멤버가 아닌 방은 무시 (외부 방 침입 차단)
+ *   - 본인 자신에게는 보내지 않음(중복 제거)
+ */
+const shareSchema = z.object({
+  kind: z.enum(["ANNOUNCEMENT", "MEMO", "MEETING", "DOCUMENT", "JOURNAL"]),
+  title: z.string().min(1).max(200),
+  snippet: z.string().max(300).optional(),
+  href: z.string().min(1).max(500),
+  userIds: z.array(z.string().max(50)).max(50).optional().default([]),
+  roomIds: z.array(z.string().max(50)).max(50).optional().default([]),
+});
+router.post("/share", async (req, res) => {
+  const u = (req as any).user;
+  const parsed = shareSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const d = parsed.data;
+  if (!d.userIds.length && !d.roomIds.length) {
+    return res.status(400).json({ error: "받을 대상을 한 명 이상 선택해 주세요" });
+  }
+
+  const recipientRoomIds = new Set<string>();
+
+  // 1) 그룹방 — 본인이 멤버여야만
+  for (const roomId of d.roomIds) {
+    const m = await prisma.roomMember.findUnique({
+      where: { roomId_userId: { roomId, userId: u.id } },
+      select: { id: true },
+    });
+    if (m) recipientRoomIds.add(roomId);
+  }
+
+  // 2) 1:1 — 각 userId 마다 DIRECT 방 찾거나 생성. 같은 회사만 허용.
+  for (const other of d.userIds) {
+    if (other === u.id) continue;
+    let room = await prisma.chatRoom.findFirst({
+      where: {
+        type: "DIRECT",
+        AND: [
+          { members: { some: { userId: u.id } } },
+          { members: { some: { userId: other } } },
+        ],
+      },
+      select: { id: true },
+    });
+    if (!room) {
+      const otherUser = await prisma.user.findUnique({
+        where: { id: other },
+        select: { id: true, companyId: true },
+      });
+      if (!otherUser) continue;
+      if (u.companyId && otherUser.companyId !== u.companyId) continue;
+      room = await prisma.chatRoom.create({
+        data: {
+          companyId: u.companyId ?? null,
+          name: `DM:${u.id}:${other}`,
+          type: "DIRECT",
+          createdById: u.id,
+          members: {
+            create: [
+              { companyId: u.companyId ?? null, userId: u.id },
+              { companyId: u.companyId ?? null, userId: other },
+            ],
+          },
+        },
+        select: { id: true },
+      });
+    }
+    recipientRoomIds.add(room.id);
+  }
+
+  // 3) 각 방에 SHARE 메시지 전송 + 알림
+  const fileType = `share:${d.kind.toLowerCase()}`;
+  const display = d.snippet ? `${d.title} — ${d.snippet}` : d.title;
+  const labelMap: Record<string, string> = {
+    ANNOUNCEMENT: "공지",
+    MEMO: "메모",
+    MEETING: "회의록",
+    DOCUMENT: "문서",
+    JOURNAL: "업무일지",
+  };
+  const label = labelMap[d.kind] ?? "공유";
+  const created: { roomId: string; messageId: string }[] = [];
+  const me = await prisma.user.findUnique({
+    where: { id: u.id },
+    select: { name: true, avatarUrl: true, avatarColor: true },
+  });
+  for (const roomId of recipientRoomIds) {
+    const msg = await prisma.chatMessage.create({
+      data: {
+        companyId: u.companyId ?? null,
+        roomId,
+        senderId: u.id,
+        content: display.slice(0, 8000),
+        kind: "SHARE",
+        fileUrl: d.href,
+        fileName: d.title,
+        fileType,
+      },
+      select: { id: true, roomId: true },
+    });
+    created.push({ roomId: msg.roomId, messageId: msg.id });
+    // SSE 로 같은 방 멤버들에게 즉시 갱신.
+    broadcastToRoom(roomId, "chat:update", { kind: "create", messageId: msg.id, roomId });
+
+    // 방 정보 — 알림 표시명 결정.
+    const room = await prisma.chatRoom.findUnique({
+      where: { id: roomId },
+      select: { type: true, name: true },
+    });
+    const others = await prisma.roomMember.findMany({
+      where: { roomId, userId: { not: u.id } },
+      select: { userId: true },
+    });
+    if (!others.length) continue;
+    if (room?.type === "DIRECT") {
+      await notifyMany(
+        others.map((o) => ({
+          userId: o.userId,
+          type: "DM" as const,
+          title: u.name,
+          body: `📌 ${label} · ${d.title}`.slice(0, 140),
+          linkUrl: `/chat?room=${roomId}`,
+          actorName: u.name,
+          actorAvatarUrl: me?.avatarUrl ?? undefined,
+          actorColor: me?.avatarColor ?? undefined,
+        }))
+      );
+    } else {
+      const roomName = room?.name ?? "대화방";
+      await notifyMany(
+        others.map((o) => ({
+          userId: o.userId,
+          type: "DM" as const,
+          title: roomName,
+          body: `${u.name}: 📌 ${label} · ${d.title}`.slice(0, 140),
+          linkUrl: `/chat?room=${roomId}`,
+          actorName: roomName,
+        }))
+      );
+    }
+  }
+
+  await writeLog(u.id, "SHARE", d.kind, `${recipientRoomIds.size}건:${d.title}`);
+  res.json({ ok: true, count: created.length, messages: created });
+});
+
+/**
  * 내 예약 메시지 목록
  */
 router.get("/scheduled", async (req, res) => {


### PR DESCRIPTION
## 증상
**공지/회의록 공유 시트 — 인스타 스타일 바텀시트**

새 기능을 추가합니다.

## 원인
공지·메모·회의록 같은 앱 내 객체를 채팅으로 공유하는 엔드포인트.
1:1(userIds) 와 그룹방(roomIds) 동시 지원, 1:1 은 기존 DIRECT 방 재사용 또는 생성.
각 대상마다 kind='SHARE' 메시지 1건. 카드 데이터는 기존 컬럼 재활용:
- fileUrl=라우트 경로(deep link)
- fileName=제목
- fileType=share:<kind> (announcement/memo/meeting/document/journal)
- content=fallback 표시 텍스트

보안:
- userIds 중 본인 회사 다른 사람은 무시
- roomIds 중 본인이 멤버 아닌 방은 무시
- 본인 자신 중복 제거

## 수정
**작업 항목 (커밋 단위)**
- feat(server): POST /api/chat/share — 게시물을 동료/그룹방에 공유
- feat(chat): 메시지 kind 에 SHARE 추가 + ShareCardBubble 렌더링
- feat(client): ShareSheet 바텀시트 + ShareButton 트리거
- feat(pages): 회의록/공지 상세에 ShareButton 통합

**변경 대상 (7개 파일)**
- `client/src/components/ShareButton.tsx`
- `client/src/components/ShareSheet.tsx`
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/components/chat/types.ts`
- `client/src/pages/MeetingDetailPage.tsx`
- `client/src/pages/NoticePage.tsx`
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #371** 에서 진행됩니다.

