### PR TITLE
🔀 :: (#372) 일정 위젯 (WidgetKit) — Phase 1: 코드 + 가이드

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -1,5 +1,8 @@
 import UIKit
 import Capacitor
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -102,6 +105,16 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
             } else {
                 defaults.set(token, forKey: "hinest.session.token")
             }
+        }
+        // 일정 위젯도 같은 토큰을 쓰니, 토큰 갱신 즉시 다음 타임라인 갱신을 요청한다.
+        // (로그인 직후 위젯이 '로그인 필요' 빈 상태에 머무르는 회귀 방지)
+        // WidgetCenter 는 iOS 14+ — Capacitor 8 의 deployment target 보다 훨씬 낮아 안전.
+        if #available(iOS 14.0, *) {
+            #if canImport(WidgetKit)
+            // 위젯 extension 이 빌드 타깃에 포함됐을 때만 컴파일.
+            // (아직 Xcode 에 widget target 안 추가됐어도 메인 앱 빌드는 통과)
+            WidgetCenter.shared.reloadTimelines(ofKind: "HiNestScheduleWidget")
+            #endif
         }
         call.resolve()
     }

--- a/client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.entitlements
+++ b/client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- 메인 앱(NSE 가 이미 쓰는 그룹) 와 동일 — 세션 토큰을 위젯이 읽어 API 호출 -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.hivits.hinest</string>
+	</array>
+</dict>
+</plist>

--- a/client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.swift
+++ b/client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.swift
@@ -1,0 +1,271 @@
+/**
+ * HiNest 일정 위젯 — 홈 화면에 다가오는 일정을 표시.
+ *
+ * 데이터 흐름:
+ *   1. 메인 앱이 로그인 시 App Group 의 UserDefaults 에 세션 토큰을 저장
+ *      (NSE 가 이미 그 토큰으로 채팅 아바타를 받는 것과 동일한 group).
+ *   2. 위젯 TimelineProvider 가 그 토큰으로 GET /api/widget/schedule/today 호출.
+ *   3. 응답을 Timeline 으로 만들어 WidgetKit 에 넘김 — refresh 는 next 일정 시작 시각
+ *      또는 15분 후 중 빠른 쪽.
+ *
+ * 크기:
+ *   - systemSmall (2x2) : 첫 1건만 큼직하게
+ *   - systemMedium (4x2): 다가오는 3–4건 리스트
+ *   - systemLarge (4x4) : 6–8건 + 시간 헤더 (iPad)
+ */
+import WidgetKit
+import SwiftUI
+
+private let APP_GROUP = "group.com.hivits.hinest"
+private let API_BASE = "https://nest.hi-vits.com" // 운영 Vercel 도메인 — 위젯도 동일 origin 사용
+private let TOKEN_KEY = "hinest.session.token"
+
+// MARK: - Models
+
+struct WidgetEvent: Codable, Identifiable {
+    let id: String
+    let title: String
+    let startAt: Date
+    let endAt: Date
+    let color: String
+    let category: String
+}
+
+private struct WidgetResponse: Codable {
+    let events: [WidgetEvent]
+    let nextRefreshAt: Date?
+}
+
+// MARK: - Timeline Provider
+
+struct ScheduleEntry: TimelineEntry {
+    let date: Date
+    let events: [WidgetEvent]
+    /// nil = 토큰 미설정(아직 로그인 안 함)
+    let signedIn: Bool
+}
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> ScheduleEntry {
+        ScheduleEntry(date: Date(), events: sampleEvents(), signedIn: true)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (ScheduleEntry) -> Void) {
+        Task {
+            let entry = await fetchEntry()
+            completion(entry)
+        }
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<ScheduleEntry>) -> Void) {
+        Task {
+            let entry = await fetchEntry()
+            // 다음 갱신 시점: nextRefreshAt or 15분 후(최소). next 가 너무 가까우면 1분 최소 보장.
+            let now = Date()
+            let nextHint = entry.events.first?.startAt ?? now.addingTimeInterval(15 * 60)
+            let fallback = now.addingTimeInterval(15 * 60)
+            let refresh = max(now.addingTimeInterval(60), min(nextHint, fallback))
+            completion(Timeline(entries: [entry], policy: .after(refresh)))
+        }
+    }
+
+    private func fetchEntry() async -> ScheduleEntry {
+        let defaults = UserDefaults(suiteName: APP_GROUP)
+        guard let token = defaults?.string(forKey: TOKEN_KEY), !token.isEmpty else {
+            return ScheduleEntry(date: Date(), events: [], signedIn: false)
+        }
+        guard let url = URL(string: "\(API_BASE)/api/widget/schedule/today") else {
+            return ScheduleEntry(date: Date(), events: [], signedIn: true)
+        }
+        var req = URLRequest(url: url)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.timeoutInterval = 8
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return ScheduleEntry(date: Date(), events: [], signedIn: true)
+            }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let body = try decoder.decode(WidgetResponse.self, from: data)
+            return ScheduleEntry(date: Date(), events: body.events, signedIn: true)
+        } catch {
+            return ScheduleEntry(date: Date(), events: [], signedIn: true)
+        }
+    }
+
+    private func sampleEvents() -> [WidgetEvent] {
+        let now = Date()
+        return [
+            WidgetEvent(id: "s1", title: "팀 스탠드업", startAt: now.addingTimeInterval(1800), endAt: now.addingTimeInterval(3600), color: "#3B5CF0", category: "MEETING"),
+            WidgetEvent(id: "s2", title: "디자인 리뷰", startAt: now.addingTimeInterval(7200), endAt: now.addingTimeInterval(10800), color: "#E11D48", category: "MEETING"),
+        ]
+    }
+}
+
+// MARK: - View
+
+struct HiNestScheduleWidgetEntryView: View {
+    var entry: Provider.Entry
+    @Environment(\.widgetFamily) var family
+
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            SmallView(entry: entry)
+        case .systemMedium:
+            MediumView(entry: entry)
+        case .systemLarge:
+            LargeView(entry: entry)
+        default:
+            MediumView(entry: entry)
+        }
+    }
+}
+
+private struct Header: View {
+    let date: Date
+    var body: some View {
+        HStack(spacing: 4) {
+            Text("HiNest")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(Color(red: 0.23, green: 0.36, blue: 0.94))
+            Text("·")
+                .font(.system(size: 10))
+                .foregroundColor(.secondary)
+            Text(date, format: .dateTime.month().day().weekday(.abbreviated))
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+private struct EmptyState: View {
+    let signedIn: Bool
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: signedIn ? "calendar.badge.checkmark" : "person.crop.circle.badge.exclamationmark")
+                .font(.system(size: 22, weight: .light))
+                .foregroundColor(.secondary)
+            Text(signedIn ? "다가오는 일정이 없어요" : "앱에 로그인하면 표시돼요")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct EventRow: View {
+    let event: WidgetEvent
+    let compact: Bool
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(hex: event.color))
+                .frame(width: 3)
+                .frame(maxHeight: .infinity)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(event.title)
+                    .font(.system(size: compact ? 12 : 13, weight: .bold))
+                    .lineLimit(compact ? 1 : 2)
+                    .foregroundColor(.primary)
+                Text(timeRange(event))
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+    private func timeRange(_ e: WidgetEvent) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "a h:mm"
+        f.locale = Locale(identifier: "ko_KR")
+        return "\(f.string(from: e.startAt)) – \(f.string(from: e.endAt))"
+    }
+}
+
+private struct SmallView: View {
+    let entry: ScheduleEntry
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Header(date: entry.date)
+            if let first = entry.events.first {
+                EventRow(event: first, compact: false)
+                Spacer(minLength: 0)
+            } else {
+                EmptyState(signedIn: entry.signedIn)
+            }
+        }
+        .padding(12)
+        .containerBackground(for: .widget) { Color(.systemBackground) }
+    }
+}
+
+private struct MediumView: View {
+    let entry: ScheduleEntry
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Header(date: entry.date)
+            if entry.events.isEmpty {
+                EmptyState(signedIn: entry.signedIn)
+            } else {
+                ForEach(entry.events.prefix(3)) { e in
+                    EventRow(event: e, compact: true)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(12)
+        .containerBackground(for: .widget) { Color(.systemBackground) }
+    }
+}
+
+private struct LargeView: View {
+    let entry: ScheduleEntry
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Header(date: entry.date)
+            if entry.events.isEmpty {
+                EmptyState(signedIn: entry.signedIn)
+            } else {
+                ForEach(entry.events.prefix(7)) { e in
+                    EventRow(event: e, compact: true)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(14)
+        .containerBackground(for: .widget) { Color(.systemBackground) }
+    }
+}
+
+// MARK: - Widget Entry
+
+@main
+struct HiNestScheduleWidget: Widget {
+    let kind: String = "HiNestScheduleWidget"
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            HiNestScheduleWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("일정")
+        .description("다가오는 일정을 한눈에 확인하세요.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+// MARK: - Helpers
+
+private extension Color {
+    init(hex: String) {
+        let s = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        var rgb: UInt64 = 0
+        Scanner(string: s).scanHexInt64(&rgb)
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >> 8) & 0xFF) / 255.0
+        let b = Double(rgb & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/client/ios/App/HiNestScheduleWidget/Info.plist
+++ b/client/ios/App/HiNestScheduleWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>ko</string>
+	<key>CFBundleDisplayName</key>
+	<string>HiNest 일정</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/client/ios/App/HiNestScheduleWidget/README.md
+++ b/client/ios/App/HiNestScheduleWidget/README.md
@@ -1,0 +1,73 @@
+# HiNest 일정 위젯 (iOS / iPadOS)
+
+홈 화면에 다가오는 일정을 보여주는 WidgetKit extension.
+
+## 데이터 흐름
+
+```
+[메인 앱]                        [App Group]                   [위젯]
+로그인 ──► setSharedToken(token) ─► UserDefaults ◄──── Provider.fetchEntry()
+                                  group.com.hivits.hinest                │
+                                  key: hinest.session.token              ▼
+                                                                GET /api/widget/schedule/today
+                                                                       │
+                                                                       ▼
+                                                                SwiftUI Timeline
+```
+
+- 메인 앱 로그인 시 `LiquidGlassTabBarPlugin.setSharedToken` 이 토큰을 App Group 에 저장
+  (이미 NSE — 알림 확장 — 이 같은 패턴으로 사용 중)
+- 위젯 Provider 가 그 토큰으로 `/api/widget/schedule/today` 호출
+- 토큰 갱신 시 `WidgetCenter.shared.reloadTimelines` 로 즉시 다시 그림
+
+## Xcode 에 target 등록 (최초 1회)
+
+이 폴더(`HiNestScheduleWidget`)는 소스만 포함. Xcode 프로젝트에 widget extension target 으로 등록은 **수동 1회** 작업.
+
+### 단계
+
+1. **Xcode 에서 `client/ios/App/App.xcworkspace` 열기**
+2. 좌측 트리에서 **App** 프로젝트 클릭 → 하단 **`+`** 버튼 → **Add Target**
+3. 템플릿: **iOS** 탭 → **Widget Extension** 선택 → Next
+4. 필드:
+   - **Product Name**: `HiNestScheduleWidget`
+   - **Team**: 기존 메인 앱과 동일
+   - **Bundle Identifier** (자동): `com.hivits.hinest.HiNestScheduleWidget`
+   - **Include Configuration Intent**: ❌ 끔 (Static configuration 사용)
+   - Finish → "Activate" 묻거든 **Activate**
+5. Xcode 가 자동 생성한 `HiNestScheduleWidget` 폴더 안의 파일(템플릿)을 **모두 삭제** (Move to Trash)
+6. 트리에서 `HiNestScheduleWidget` 그룹에 우클릭 → **Add Files to "App"** → 이 폴더의 `HiNestScheduleWidget.swift`, `Info.plist`, `HiNestScheduleWidget.entitlements`, `README.md` 선택 → **Add to targets: HiNestScheduleWidget** 체크 → Add
+7. **target 설정**:
+   - **Signing & Capabilities**: 메인 앱과 같은 Team 선택, **`+ Capability` → App Groups** → `group.com.hivits.hinest` 체크 (없으면 Apple Developer Portal 에서 같은 그룹 등록 후 새로 추가)
+   - **Build Settings → Code Signing Entitlements**: `HiNestScheduleWidget/HiNestScheduleWidget.entitlements`
+   - **Build Settings → Info.plist File**: `HiNestScheduleWidget/Info.plist`
+   - **Deployment Info → Minimum Deployments**: iOS 16.0 이상 (containerBackground 사용 — iOS 17+ 권장)
+8. **메인 앱 target → General → Frameworks, Libraries, and Embedded Content** → **`+`** → `HiNestScheduleWidget.appex` 선택 → "Embed Without Signing" 또는 default
+9. **Build & Run** — 시뮬레이터 홈 화면에서 길게 눌러 위젯 추가 → "HiNest" 검색
+
+### 확인
+
+- 로그인 한 상태에서 시뮬레이터 홈 → 위젯 갤러리 → "HiNest 일정" 추가
+- 일정이 표시됨 (없으면 "다가오는 일정이 없어요")
+- 로그아웃하면 다음 타임라인 갱신 시 "앱에 로그인하면 표시돼요"
+
+## 디버깅
+
+- 위젯 콘솔: Xcode → Debug → Attach to Process → `HiNestScheduleWidget`
+- 강제 reload: 메인 앱에서 로그인/로그아웃 → AppDelegate 의 `setSharedToken` 이 `WidgetCenter.shared.reloadTimelines` 호출
+- 데이터 확인: `defaults read group.com.hivits.hinest hinest.session.token` (시뮬레이터 Mac 터미널)
+
+## API
+
+`GET /api/widget/schedule/today` — 다음 36h 안의 일정 최대 12건, 최소 필드만.
+
+```json
+{
+  "events": [
+    { "id": "...", "title": "팀 스탠드업", "startAt": "2026-06-08T10:00:00.000Z",
+      "endAt": "2026-06-08T10:30:00.000Z", "color": "#3B5CF0", "category": "MEETING" }
+  ],
+  "nextRefreshAt": "2026-06-08T10:00:00.000Z",
+  "generatedAt": "2026-06-08T08:00:00.000Z"
+}
+```

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,7 @@ import authRouter from "./routes/auth.js";
 import adminRouter from "./routes/admin.js";
 import usersRouter from "./routes/users.js";
 import scheduleRouter from "./routes/schedule.js";
+import widgetRouter from "./routes/widget.js";
 import attendanceRouter from "./routes/attendance.js";
 import journalRouter from "./routes/journal.js";
 import noticeRouter from "./routes/notice.js";
@@ -291,6 +292,8 @@ app.use("/api/admin", adminRouter);
 app.use("/api/platform", platformRouter);
 app.use("/api/users", usersRouter);
 app.use("/api/schedule", scheduleRouter);
+// iOS/iPadOS/macOS WidgetKit 전용 — 위젯 페이로드 한계(~16KB) 고려한 가벼운 응답.
+app.use("/api/widget", widgetRouter);
 app.use("/api/attendance", attendanceRouter);
 app.use("/api/journal", journalRouter);
 app.use("/api/notice", noticeRouter);

--- a/server/src/routes/widget.ts
+++ b/server/src/routes/widget.ts
@@ -1,0 +1,74 @@
+/**
+ * 위젯 전용 가벼운 endpoint 모음 — iOS/iPadOS/macOS WidgetKit 에서 호출.
+ *
+ * WidgetKit 페이로드는 ~16KB 정도가 한계라 일반 API 응답(작성자·반응 등 풀 필드)을
+ * 그대로 쓰면 너무 크고 느림. 위젯은 최소 필드만 반환하는 별도 endpoint 가 깔끔.
+ *
+ * 인증: 일반 requireAuth — 메인 앱이 App Group 으로 토큰을 위젯과 공유.
+ *      위젯 timeline provider 가 그 토큰으로 직접 호출한다.
+ */
+import { Router } from "express";
+import { prisma } from "../lib/db.js";
+import { requireAuth } from "../lib/auth.js";
+
+const router = Router();
+router.use(requireAuth);
+
+/**
+ * GET /api/widget/schedule/today
+ *   - 지금부터 다음 24h 안에 시작하거나 진행 중인 일정 ~12건
+ *   - 최소 필드: id, title, startAt, endAt, color, category
+ *   - 정렬: startAt 오름차순
+ */
+router.get("/schedule/today", async (req, res) => {
+  const u = (req as any).user;
+  const meUser = (req as any).userRecord;
+  const now = new Date();
+  const next = new Date(now.getTime() + 36 * 3600 * 1000); // 살짝 여유 + 다음 날 일정 일부까지
+
+  const myProjects = await prisma.projectMember.findMany({
+    where: { userId: u.id },
+    select: { projectId: true },
+  });
+  const myProjectIds = myProjects.map((m) => m.projectId);
+
+  const orClauses: any[] = [
+    { scope: "COMPANY" },
+    { scope: "PERSONAL", createdBy: u.id },
+    { scope: "TARGETED", createdBy: u.id },
+    { scope: "TARGETED", targetUserIds: { contains: u.id } },
+  ];
+  if (meUser?.team) orClauses.push({ scope: "TEAM", team: meUser.team });
+  if (myProjectIds.length) orClauses.push({ scope: "PROJECT", projectId: { in: myProjectIds } });
+
+  const events = await prisma.event.findMany({
+    where: {
+      OR: orClauses,
+      AND: [
+        { endAt: { gte: now } },     // 이미 끝난 것 제외
+        { startAt: { lte: next } },  // 36h 안에 시작하는 것
+      ],
+    },
+    orderBy: { startAt: "asc" },
+    take: 12,
+    select: {
+      id: true,
+      title: true,
+      startAt: true,
+      endAt: true,
+      color: true,
+      category: true,
+    },
+  });
+
+  // 위젯 캐시 정책 — 30초간 stale OK. Cache-Control 은 사설 토큰 인증이라 private.
+  res.set("Cache-Control", "private, max-age=30");
+  res.json({
+    events,
+    // 위젯 refresh 다음 시각 힌트 — 새 이벤트가 곧 시작하면 그 시각 직전에 갱신.
+    nextRefreshAt: events[0]?.startAt ?? new Date(now.getTime() + 15 * 60 * 1000).toISOString(),
+    generatedAt: now.toISOString(),
+  });
+});
+
+export default router;


### PR DESCRIPTION
## 증상
**일정 위젯 (WidgetKit) — Phase 1: 코드 + 가이드**

새 기능을 추가합니다.

## 원인
iOS/iPadOS/macOS WidgetKit 페이로드 한계(~16KB) + 위젯 timeline 호출 빈도(~15분)
때문에 풀 일정 API 대신 별도 가벼운 endpoint.

응답: 다음 36h 안에 시작/진행 중인 일정 ~12건, 최소 필드(id/title/startAt/endAt/color/category).
힌트 필드: nextRefreshAt — 위젯이 다음 갱신 시각 결정에 사용.

Cache-Control: private, max-age=30 — 위젯 30초간 stale 허용.

## 수정
**작업 항목 (커밋 단위)**
- feat(server): GET /api/widget/schedule/today — 위젯 전용 가벼운 endpoint
- feat(ios): HiNestScheduleWidget extension 추가 — WidgetKit 일정 위젯
- feat(ios): 토큰 갱신 시 위젯 timeline 즉시 reload

**변경 대상 (7개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.entitlements`
- `client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.swift`
- `client/ios/App/HiNestScheduleWidget/Info.plist`
- `client/ios/App/HiNestScheduleWidget/README.md`
- `server/src/index.ts`
- `server/src/routes/widget.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #372** 에서 진행됩니다.

