### PR TITLE
🔀 :: (#373) 일정 위젯 native SwiftUI 앱 — Phase 1: 코드 + 가이드

### DIFF
--- a/HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.entitlements
+++ b/HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- iOS NSE/widget 과 동일 그룹 — 같은 세션 토큰 키 공유 -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.hivits.hinest</string>
+	</array>
+	<!-- 위젯이 https 호출하려면 network client 필요(샌드박스) -->
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.swift
+++ b/HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.swift
@@ -1,0 +1,248 @@
+/**
+ * HiNest 일정 위젯 (macOS) — 알림센터/데스크톱에 다가오는 일정 표시.
+ *
+ * iOS 위젯과 거의 동일하지만 macOS 위젯 사이즈(systemSmall/Medium/Large)에 맞춰
+ * 여백·폰트만 미세 조정. 데이터 흐름은 같다 — App Group 의 세션 토큰으로
+ * /api/widget/schedule/today 호출.
+ *
+ * 토큰은 별도 HiNestWidgetApp(SwiftUI) 의 로그인 화면이 채워 넣는다 — 메인 Electron
+ * 앱과는 현재 독립적. (향후 Keychain 공유 또는 공유 파일로 자동 동기화 예정.)
+ */
+import WidgetKit
+import SwiftUI
+
+private let APP_GROUP = "group.com.hivits.hinest"
+private let API_BASE = "https://nest.hi-vits.com"
+private let TOKEN_KEY = "hinest.session.token"
+
+// MARK: - Models
+
+struct WidgetEvent: Codable, Identifiable {
+    let id: String
+    let title: String
+    let startAt: Date
+    let endAt: Date
+    let color: String
+    let category: String
+}
+
+private struct WidgetResponse: Codable {
+    let events: [WidgetEvent]
+    let nextRefreshAt: Date?
+}
+
+// MARK: - Timeline Provider
+
+struct ScheduleEntry: TimelineEntry {
+    let date: Date
+    let events: [WidgetEvent]
+    let signedIn: Bool
+}
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> ScheduleEntry {
+        ScheduleEntry(date: Date(), events: sampleEvents(), signedIn: true)
+    }
+    func getSnapshot(in context: Context, completion: @escaping (ScheduleEntry) -> Void) {
+        Task { completion(await fetchEntry()) }
+    }
+    func getTimeline(in context: Context, completion: @escaping (Timeline<ScheduleEntry>) -> Void) {
+        Task {
+            let entry = await fetchEntry()
+            let now = Date()
+            let nextHint = entry.events.first?.startAt ?? now.addingTimeInterval(15 * 60)
+            let fallback = now.addingTimeInterval(15 * 60)
+            let refresh = max(now.addingTimeInterval(60), min(nextHint, fallback))
+            completion(Timeline(entries: [entry], policy: .after(refresh)))
+        }
+    }
+    private func fetchEntry() async -> ScheduleEntry {
+        let defaults = UserDefaults(suiteName: APP_GROUP)
+        guard let token = defaults?.string(forKey: TOKEN_KEY), !token.isEmpty else {
+            return ScheduleEntry(date: Date(), events: [], signedIn: false)
+        }
+        guard let url = URL(string: "\(API_BASE)/api/widget/schedule/today") else {
+            return ScheduleEntry(date: Date(), events: [], signedIn: true)
+        }
+        var req = URLRequest(url: url)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.timeoutInterval = 8
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return ScheduleEntry(date: Date(), events: [], signedIn: true)
+            }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let body = try decoder.decode(WidgetResponse.self, from: data)
+            return ScheduleEntry(date: Date(), events: body.events, signedIn: true)
+        } catch {
+            return ScheduleEntry(date: Date(), events: [], signedIn: true)
+        }
+    }
+    private func sampleEvents() -> [WidgetEvent] {
+        let now = Date()
+        return [
+            WidgetEvent(id: "s1", title: "팀 스탠드업", startAt: now.addingTimeInterval(1800), endAt: now.addingTimeInterval(3600), color: "#3B5CF0", category: "MEETING"),
+            WidgetEvent(id: "s2", title: "디자인 리뷰", startAt: now.addingTimeInterval(7200), endAt: now.addingTimeInterval(10800), color: "#E11D48", category: "MEETING"),
+        ]
+    }
+}
+
+// MARK: - View
+
+struct HiNestScheduleWidgetEntryView: View {
+    var entry: Provider.Entry
+    @Environment(\.widgetFamily) var family
+    var body: some View {
+        switch family {
+        case .systemSmall:  SmallView(entry: entry)
+        case .systemMedium: MediumView(entry: entry)
+        case .systemLarge:  LargeView(entry: entry)
+        default:            MediumView(entry: entry)
+        }
+    }
+}
+
+private struct Header: View {
+    let date: Date
+    var body: some View {
+        HStack(spacing: 4) {
+            Text("HiNest")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(Color(red: 0.23, green: 0.36, blue: 0.94))
+            Text("·").font(.system(size: 11)).foregroundColor(.secondary)
+            Text(date, format: .dateTime.month().day().weekday(.abbreviated))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+private struct EmptyState: View {
+    let signedIn: Bool
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: signedIn ? "calendar.badge.checkmark" : "person.crop.circle.badge.exclamationmark")
+                .font(.system(size: 24, weight: .light))
+                .foregroundColor(.secondary)
+            Text(signedIn ? "다가오는 일정이 없어요" : "위젯 앱에 로그인하면 표시돼요")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct EventRow: View {
+    let event: WidgetEvent
+    let compact: Bool
+    var body: some View {
+        HStack(alignment: .top, spacing: 9) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(hex: event.color))
+                .frame(width: 3).frame(maxHeight: .infinity)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(event.title)
+                    .font(.system(size: compact ? 12 : 13, weight: .bold))
+                    .lineLimit(compact ? 1 : 2)
+                    .foregroundColor(.primary)
+                Text(timeRange(event))
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+    private func timeRange(_ e: WidgetEvent) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "a h:mm"
+        f.locale = Locale(identifier: "ko_KR")
+        return "\(f.string(from: e.startAt)) – \(f.string(from: e.endAt))"
+    }
+}
+
+private struct SmallView: View {
+    let entry: ScheduleEntry
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Header(date: entry.date)
+            if let first = entry.events.first {
+                EventRow(event: first, compact: false)
+                Spacer(minLength: 0)
+            } else {
+                EmptyState(signedIn: entry.signedIn)
+            }
+        }
+        .padding(13)
+        .containerBackground(for: .widget) { Color(.windowBackgroundColor) }
+    }
+}
+
+private struct MediumView: View {
+    let entry: ScheduleEntry
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Header(date: entry.date)
+            if entry.events.isEmpty {
+                EmptyState(signedIn: entry.signedIn)
+            } else {
+                ForEach(entry.events.prefix(3)) { e in
+                    EventRow(event: e, compact: true)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(13)
+        .containerBackground(for: .widget) { Color(.windowBackgroundColor) }
+    }
+}
+
+private struct LargeView: View {
+    let entry: ScheduleEntry
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Header(date: entry.date)
+            if entry.events.isEmpty {
+                EmptyState(signedIn: entry.signedIn)
+            } else {
+                ForEach(entry.events.prefix(7)) { e in
+                    EventRow(event: e, compact: true)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(15)
+        .containerBackground(for: .widget) { Color(.windowBackgroundColor) }
+    }
+}
+
+// MARK: - Widget Bundle
+
+@main
+struct HiNestScheduleWidget: Widget {
+    let kind: String = "HiNestScheduleWidget"
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            HiNestScheduleWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("일정")
+        .description("HiNest 의 다가오는 일정을 한눈에 확인하세요.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+// MARK: - Helpers
+
+private extension Color {
+    init(hex: String) {
+        let s = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        var rgb: UInt64 = 0
+        Scanner(string: s).scanHexInt64(&rgb)
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >> 8) & 0xFF) / 255.0
+        let b = Double(rgb & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/HiNest-MacOS-Widget/HiNestScheduleWidget/Info.plist
+++ b/HiNest-MacOS-Widget/HiNestScheduleWidget/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>ko</string>
+	<key>CFBundleDisplayName</key>
+	<string>HiNest 일정</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/HiNest-MacOS-Widget/HiNestWidgetApp/ContentView.swift
+++ b/HiNest-MacOS-Widget/HiNestWidgetApp/ContentView.swift
@@ -1,0 +1,134 @@
+/**
+ * HiNest 위젯 호스트 — 로그인/토큰 관리 화면.
+ *
+ * 동작:
+ *   - 로그인 안 됨: 이메일·비밀번호 입력 → POST /api/auth/login → 토큰을 App Group 에 저장
+ *   - 로그인 됨: '연결됨' 표시 + 위젯 재로드 버튼 + 로그아웃
+ *
+ * 향후 Electron 메인 앱과 토큰 자동 동기화 시 이 화면은 상태 확인용으로 축소.
+ */
+import SwiftUI
+import WidgetKit
+
+private let APP_GROUP = "group.com.hivits.hinest"
+private let API_BASE = "https://nest.hi-vits.com"
+private let TOKEN_KEY = "hinest.session.token"
+private let USER_NAME_KEY = "hinest.session.userName"
+
+struct ContentView: View {
+    @AppStorage(TOKEN_KEY, store: UserDefaults(suiteName: APP_GROUP))
+    private var token: String = ""
+    @AppStorage(USER_NAME_KEY, store: UserDefaults(suiteName: APP_GROUP))
+    private var userName: String = ""
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var loading = false
+    @State private var error: String? = nil
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "calendar.badge.clock")
+                .font(.system(size: 36, weight: .light))
+                .foregroundColor(.blue)
+            Text("HiNest 일정 위젯")
+                .font(.system(size: 16, weight: .bold))
+
+            if token.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("HiNest 계정으로 로그인하면 위젯에 일정이 표시돼요.")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity)
+                    TextField("이메일", text: $email)
+                        .textFieldStyle(.roundedBorder)
+                        .disableAutocorrection(true)
+                    SecureField("비밀번호", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                    if let error = error {
+                        Text(error).font(.system(size: 11)).foregroundColor(.red)
+                    }
+                    Button(action: { Task { await login() } }) {
+                        HStack {
+                            Spacer()
+                            Text(loading ? "로그인 중…" : "로그인").bold()
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(loading || email.isEmpty || password.isEmpty)
+                }
+            } else {
+                VStack(spacing: 8) {
+                    HStack(spacing: 6) {
+                        Circle().fill(Color.green).frame(width: 8, height: 8)
+                        Text("연결됨").font(.system(size: 13, weight: .semibold))
+                    }
+                    if !userName.isEmpty {
+                        Text(userName).font(.system(size: 12)).foregroundColor(.secondary)
+                    }
+                    Text("알림센터 → 위젯 편집 → 'HiNest 일정' 추가")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                    HStack {
+                        Button("위젯 새로고침") {
+                            WidgetCenter.shared.reloadTimelines(ofKind: "HiNestScheduleWidget")
+                        }
+                        Button("로그아웃") { logout() }
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            Spacer()
+        }
+        .padding(20)
+    }
+
+    private func login() async {
+        loading = true
+        error = nil
+        defer { loading = false }
+        guard let url = URL(string: "\(API_BASE)/api/auth/login") else { return }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = ["email": email, "password": password]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse else {
+                error = "응답을 처리할 수 없어요"
+                return
+            }
+            if http.statusCode != 200 {
+                error = "로그인 실패 (\(http.statusCode))"
+                return
+            }
+            if let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let t = obj["token"] as? String {
+                token = t
+                if let user = obj["user"] as? [String: Any], let name = user["name"] as? String {
+                    userName = name
+                }
+                WidgetCenter.shared.reloadTimelines(ofKind: "HiNestScheduleWidget")
+                password = ""
+            } else {
+                error = "토큰을 받지 못했어요"
+            }
+        } catch {
+            self.error = "연결 실패: \(error.localizedDescription)"
+        }
+    }
+
+    private func logout() {
+        token = ""
+        userName = ""
+        WidgetCenter.shared.reloadTimelines(ofKind: "HiNestScheduleWidget")
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/HiNest-MacOS-Widget/HiNestWidgetApp/HiNestWidgetApp.entitlements
+++ b/HiNest-MacOS-Widget/HiNestWidgetApp/HiNestWidgetApp.entitlements
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- 위젯 extension 과 동일 — 토큰을 같은 App Group UserDefaults 에 저장 -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.hivits.hinest</string>
+	</array>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/HiNest-MacOS-Widget/HiNestWidgetApp/HiNestWidgetApp.swift
+++ b/HiNest-MacOS-Widget/HiNestWidgetApp/HiNestWidgetApp.swift
@@ -1,0 +1,21 @@
+/**
+ * HiNest macOS 위젯 호스트 앱 — minimal SwiftUI 앱.
+ *
+ * 사용자가 보는 화면은 거의 없음. 위젯 갤러리에 "HiNest 일정" 이 등장하려면 호스트 앱이
+ * 적어도 1번 실행돼야 하고, 토큰 입력/관리 UI 만 작은 창으로 노출.
+ *
+ * 향후: Electron 메인 앱(HiNest-MacOS)과 토큰 자동 동기화 — 현재는 사용자가 1회 로그인.
+ */
+import SwiftUI
+import WidgetKit
+
+@main
+struct HiNestWidgetApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .frame(minWidth: 360, idealWidth: 420, minHeight: 320, idealHeight: 400)
+        }
+        .windowResizability(.contentSize)
+    }
+}

--- a/HiNest-MacOS-Widget/HiNestWidgetApp/Info.plist
+++ b/HiNest-MacOS-Widget/HiNestWidgetApp/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>ko</string>
+	<key>CFBundleDisplayName</key>
+	<string>HiNest 위젯</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<false/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>© HiNest</string>
+</dict>
+</plist>

--- a/HiNest-MacOS-Widget/README.md
+++ b/HiNest-MacOS-Widget/README.md
@@ -1,0 +1,76 @@
+# HiNest macOS 위젯 (SwiftUI)
+
+macOS 알림센터·데스크톱에 HiNest 일정 위젯을 표시하는 별도 native 앱.
+
+기존 Electron 기반 `HiNest-MacOS` 데스크탑 앱은 채팅·알림 메인 기능을 담당하고,
+**이 앱은 위젯 호스트 역할만** 합니다 (사용자 보기 화면은 거의 없음 — 위젯 갤러리에 등장하기 위해 minimal SwiftUI window 하나).
+
+## 구조
+
+```
+HiNest-MacOS-Widget/
+├── HiNestWidgetApp/          ← macOS 앱 (호스트, minimal UI)
+│   ├── HiNestWidgetApp.swift
+│   ├── ContentView.swift
+│   ├── Info.plist
+│   └── HiNestWidgetApp.entitlements
+├── HiNestScheduleWidget/     ← WidgetKit Extension
+│   ├── HiNestScheduleWidget.swift  (← iOS 와 거의 동일, 색·여백만 macOS 조정)
+│   ├── Info.plist
+│   └── HiNestScheduleWidget.entitlements
+└── Shared/                   ← iOS·macOS 공통(나중에 분리 시 사용)
+```
+
+## 데이터 흐름
+
+iOS 위젯과 동일한 패턴:
+
+```
+[Electron HiNest-MacOS]                    [App Group]              [SwiftUI HiNest-MacOS-Widget]
+로그인 토큰 ──► (개선 작업 필요: 토큰 ─►  group.com.hivits.hinest ◄──── 위젯 Provider
+              파일 또는 Keychain                                    ▼
+              으로 공유)                                          /api/widget/schedule/today
+```
+
+⚠️ **현재 한계**: Electron 앱과 macOS native 앱은 같은 sandbox 안에 있지 않아서, Electron 이 직접 App Group UserDefaults 에 쓸 수 없음. 두 가지 방법:
+
+### Option A — Keychain 공유 (권장)
+Electron 앱에서 `node-keytar` 로 시스템 Keychain 에 저장 → SwiftUI 위젯에서 `Security.framework` 로 같은 키 읽음. 같은 Team ID 이면 Keychain access group 으로 공유 가능.
+
+### Option B — 공유 파일
+Electron 이 `~/Library/Group Containers/group.com.hivits.hinest/token` 에 직접 쓰기 (entitlements 필요). 가장 간단.
+
+### Option C — 별도 로그인 (단순)
+SwiftUI 앱 안에서 사용자가 1회 로그인 → 그 토큰을 자체 Keychain 에 저장 → 위젯이 사용. Electron 과 무관.
+
+→ **현재 시작은 Option C**로 진행. 이후 Option A/B 로 자동 동기화 개선.
+
+## Xcode 프로젝트 만들기 (최초 1회)
+
+1. Xcode → File → New → Project → **macOS** 탭 → **App** → Next
+2. 필드:
+   - Product Name: **HiNest-MacOS-Widget**
+   - Team: 메인 앱과 동일
+   - Bundle Identifier: `com.hivits.hinest.widget`
+   - Interface: **SwiftUI**, Language: **Swift**, Testing: 끔
+   - Location: `/Users/seojiwan/Documents/Develop/HiNest/` (이 폴더가 자동 생성됨)
+3. 생성 직후, Xcode 가 만든 `HiNest-MacOS-Widget` 폴더 안의 템플릿 파일 삭제 후 본 폴더의 파일을 Add Files
+4. **+ 새 target → Widget Extension** (iOS 와 동일):
+   - Product Name: `HiNestScheduleWidget`
+   - Bundle ID: `com.hivits.hinest.widget.HiNestScheduleWidget`
+   - Platform: **macOS**
+   - Include Configuration Intent: ❌
+5. 두 target 모두:
+   - Signing & Capabilities → App Groups: `group.com.hivits.hinest`
+   - 이 폴더의 `.entitlements` 파일을 Code Signing Entitlements 에 지정
+6. Build & Run — 알림센터 우측 상단 → "위젯 편집" → "HiNest 일정" 추가
+
+## 빌드 / 배포
+
+- 개발: Xcode 에서 직접 빌드
+- 배포: 별도 .app 으로 만들어 Electron 메인 앱 인스톨러에 번들링 (`Contents/Library/Widgets/`) — electron-builder `extraResources` 에 추가
+
+## 주의
+
+- 이 SwiftUI 앱은 사용자가 "쓰는" 앱이 아니라 위젯 호스트. Dock 에 안 나오게 `LSUIElement = YES` 옵션 검토.
+- 토큰 동기화는 위 Option C 로 시작 → 추후 Electron 과 자동 동기화 개선.


### PR DESCRIPTION
## 증상
**일정 위젯 native SwiftUI 앱 — Phase 1: 코드 + 가이드**

새 기능을 추가합니다.

## 원인
기존 Electron HiNest-MacOS 에는 WidgetKit 을 못 넣어, 별도 minimal SwiftUI 앱으로
위젯 호스트. iOS 위젯과 동일한 데이터 흐름 — App Group(group.com.hivits.hinest) 의
세션 토큰으로 /api/widget/schedule/today 호출.

구조:
- HiNestWidgetApp/  — SwiftUI 호스트 (로그인·토큰 관리)
- HiNestScheduleWidget/ — WidgetKit extension (iOS 와 거의 동일, macOS 색·여백만 조정)
- README.md — Xcode 프로젝트 새로 만드는 단계 가이드

현재 한계:
- Electron 메인 앱과 토큰 자동 동기화 X — 사용자가 SwiftUI 앱에서 1회 직접 로그인
  (향후 Keychain access group 공유 또는 App Group 파일 공유로 자동 동기화 개선)

지원 사이즈: systemSmall/Medium/Large. 알림센터·데스크톱 모두 표시 가능.
LSUIElement=false — Dock 표시 유지(사용자 발견성). 향후 옵션으로 숨김 가능.

## 수정
**작업 항목 (커밋 단위)**
- feat(macos-widget): SwiftUI 호스트 앱 + WidgetKit 일정 위젯

**변경 대상 (8개 파일)**
- `HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.entitlements`
- `HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.swift`
- `HiNest-MacOS-Widget/HiNestScheduleWidget/Info.plist`
- `HiNest-MacOS-Widget/HiNestWidgetApp/ContentView.swift`
- `HiNest-MacOS-Widget/HiNestWidgetApp/HiNestWidgetApp.entitlements`
- `HiNest-MacOS-Widget/HiNestWidgetApp/HiNestWidgetApp.swift`
- `HiNest-MacOS-Widget/HiNestWidgetApp/Info.plist`
- `HiNest-MacOS-Widget/README.md`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #373** 에서 진행됩니다.

