### PR TITLE
🔀 :: (#374) 다크모드 사용자 탭바 라이트 고정 회귀 수정

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -10,7 +10,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        // 저장된 앱 테마(light/dark/system)를 첫 페인트 전에 윈도우에 적용 — 다크/라이트 깜빡임 방지.
+        // 이전엔 Info.plist 로 라이트를 '강제'해 다크모드 사용자의 탭바·상태바가 라이트로 고정됐다.
+        // 이제 마지막으로 저장된 사용자 테마를 읽어 윈도우 트레잇을 맞춘다(없으면 라이트 = 브랜드 기본).
+        //   light  → .light,  dark → .dark,  system → .unspecified(OS 설정 따라감)
+        let mode = UserDefaults.standard.string(forKey: "hinest.interfaceStyle") ?? "light"
+        switch mode {
+        case "dark": window?.overrideUserInterfaceStyle = .dark
+        case "system": window?.overrideUserInterfaceStyle = .unspecified
+        default: window?.overrideUserInterfaceStyle = .light
+        }
         return true
     }
 
@@ -82,6 +91,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "setVisible", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "confirm", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSharedToken", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setInterfaceStyle", returnType: CAPPluginReturnPromise),
     ]
 
     private var tabBarView: UITabBar?
@@ -119,6 +129,29 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         call.resolve()
     }
 
+    /// 문자열 테마 모드 → UIUserInterfaceStyle 매핑.
+    static func uiStyle(from raw: String?) -> UIUserInterfaceStyle {
+        switch raw {
+        case "dark": return .dark
+        case "light": return .light
+        default: return .unspecified // "system" 또는 미설정 → OS 설정 따라감
+        }
+    }
+
+    /// 앱 테마를 네이티브 윈도우/탭바에 반영한다. JS(theme.tsx)가 테마 변경 시 호출.
+    /// - light/dark: 명시 고정. system: .unspecified 로 OS 설정 따라감(웹의 prefers-color-scheme 도 정상 동작).
+    /// 저장값은 다음 실행의 didFinishLaunching 가 읽어 첫 페인트부터 올바른 색을 그린다(깜빡임 방지).
+    @objc func setInterfaceStyle(_ call: CAPPluginCall) {
+        let mode = call.getString("style") ?? "light" // light | dark | system
+        UserDefaults.standard.set(mode, forKey: "hinest.interfaceStyle")
+        let style = AppDelegate.uiStyle(from: mode)
+        DispatchQueue.main.async {
+            self.bridge?.viewController?.view.window?.overrideUserInterfaceStyle = style
+            self.tabBarView?.overrideUserInterfaceStyle = style
+        }
+        call.resolve()
+    }
+
     @objc func configure(_ call: CAPPluginCall) {
         let tabs = call.getArray("tabs", JSObject.self) ?? []
         // 초기 선택 탭 키(현재 경로). 없으면 첫 탭으로 폴백.
@@ -146,10 +179,10 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         tabBar.translatesAutoresizingMaskIntoConstraints = false
         tabBar.delegate = self
         tabBar.tintColor = brandColor
-        // 라이트 모드 강제 — Info.plist 의 UIUserInterfaceStyle=Light 가 root window 에 적용되지만,
-        // UITabBar 가 추가될 때 부모 트레잇을 즉시 따라가지 않는 미세한 frame 이 있어 명시.
-        // 사용자가 시스템 다크 모드라도 탭바는 처음부터 라이트 글래스로 그려진다.
-        tabBar.overrideUserInterfaceStyle = .light
+        // 탭바 트레잇을 앱 테마(저장값)에 맞춘다. 윈도우를 따라가도 되지만, addSubview 직후
+        // 부모 트레잇을 즉시 반영하지 않는 미세한 frame 갭이 있어 명시적으로 같은 값을 박는다.
+        // light→.light / dark→.dark / system→.unspecified(윈도우=OS 따라감).
+        tabBar.overrideUserInterfaceStyle = AppDelegate.uiStyle(from: UserDefaults.standard.string(forKey: "hinest.interfaceStyle"))
 
         var items: [UITabBarItem] = []
         for (i, tab) in tabs.enumerated() {

--- a/client/ios/App/App/Info.plist
+++ b/client/ios/App/App/Info.plist
@@ -60,12 +60,11 @@
 	     applyNativeTheme() 가 StatusBar.setStyle(Light) 로 즉시 흰 글자로 전환. -->
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleDarkContent</string>
-	<!-- 앱 전체 UI 모드 라이트 강제 — 시스템 다크 모드여도 root window/UITabBar/액션시트 등
-	     모든 native UI 가 라이트로 그려진다. 이전엔 시스템 모드 따라 다크로 잠깐 그려졌다가
-	     React mount 후 applyNativeTheme() 가 라이트로 바꿔 깜빡임이 보였다. 사용자가 명시적으로
-	     다크 모드 켜면 applyNativeTheme() 가 window.overrideUserInterfaceStyle=.dark 로 동적
-	     전환(아래 nativeTheme.ts). 즉 정적 기본=라이트, 동적 전환만 다크. -->
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
+	<!-- ⚠️ UIUserInterfaceStyle 은 의도적으로 두지 않는다.
+	     여기에 Light 를 박으면 다크모드 사용자도 네이티브 탭바/상태바가 라이트로 고정되고,
+	     '시스템 설정 따라가기' 모드의 prefers-color-scheme 도 라이트로 고정돼 깨진다.
+	     대신 AppDelegate.didFinishLaunching 가 마지막 저장 테마(hinest.interfaceStyle)를 읽어
+	     첫 페인트 전에 window.overrideUserInterfaceStyle 을 설정한다(깜빡임 없음).
+	     이후 테마 변경은 setInterfaceStyle 플러그인이 윈도우+탭바에 즉시 반영. -->
 </dict>
 </plist>

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -28,6 +28,8 @@ export interface LiquidGlassTabBarPlugin {
   setVisible(options: { visible: boolean }): Promise<void>;
   /** 세션 토큰을 공유 App Group 에 기록 — NSE(채팅 아바타)의 /uploads 인증용. token="" 이면 제거. */
   setSharedToken(options: { token: string; group?: string }): Promise<void>;
+  /** 앱 테마를 네이티브 윈도우/탭바에 반영. light/dark/system. 저장돼 다음 실행 첫 페인트에도 적용. */
+  setInterfaceStyle(options: { style: "light" | "dark" | "system" }): Promise<void>;
   /** 애플 기본 확인 시트(action sheet). 로그아웃 등 재확인용. */
   confirm(options: {
     title?: string;

--- a/client/src/lib/nativeTheme.ts
+++ b/client/src/lib/nativeTheme.ts
@@ -25,3 +25,22 @@ export async function applyNativeTheme(resolved: "light" | "dark"): Promise<void
     await StatusBar.setStyle({ style: resolved === "dark" ? Style.Light : Style.Dark });
   } catch { /* StatusBar 플러그인 미설치 환경 — 조용히 무시 */ }
 }
+
+let _lastMode: "light" | "dark" | "system" | null = null;
+
+/**
+ * 앱 테마 모드(light/dark/system)를 네이티브 윈도우/탭바 트레잇에 반영한다.
+ *
+ * resolved(light|dark) 가 아니라 mode 를 받는 이유: system 모드는 .unspecified 로 둬야
+ * OS 설정을 따라가고 WebView 의 prefers-color-scheme 도 정상 동작한다. 명시(light/dark)
+ * 모드는 그 색으로 고정. 저장은 네이티브가 하므로 다음 실행 첫 페인트부터 올바른 색.
+ */
+export async function applyNativeInterfaceStyle(mode: "light" | "dark" | "system"): Promise<void> {
+  if (!isCapacitorNative()) return;
+  if (_lastMode === mode) return;
+  _lastMode = mode;
+  try {
+    const { LiquidGlassTabBar } = await import("./liquidGlassTabBar");
+    await LiquidGlassTabBar.setInterfaceStyle({ style: mode });
+  } catch { /* iOS<26 미지원/플러그인 부재 — 무해하게 무시 */ }
+}

--- a/client/src/theme.tsx
+++ b/client/src/theme.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { applyNativeTheme } from "./lib/nativeTheme";
+import { applyNativeTheme, applyNativeInterfaceStyle } from "./lib/nativeTheme";
 
 export type ThemeMode = "light" | "dark" | "system";
 
@@ -60,6 +60,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     void applyNativeTheme(resolved);
   }, [resolved]);
+
+  // mode 가 바뀔 때 네이티브 윈도우/탭바 트레잇도 동기화 — 다크모드 사용자의 탭바가
+  // 라이트로 고정되던 회귀 수정. system 모드는 OS 설정을 따라가도록 .unspecified 로 전달.
+  useEffect(() => {
+    void applyNativeInterfaceStyle(mode);
+  }, [mode]);
 
   const value = useMemo(() => ({ mode, resolved, setMode }), [mode, resolved, setMode]);
   return <ThemeCtx.Provider value={value}>{children}</ThemeCtx.Provider>;


### PR DESCRIPTION
## 증상
**다크모드 사용자 탭바 라이트 고정 회귀 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
문제: 직전 수정에서 Info.plist UIUserInterfaceStyle=Light + tabBar.overrideUserInterfaceStyle=.light
로 라이트를 '강제'해, 다크모드 설정 사용자는 다크 본문 + 라이트 탭바/상태바의 어색한 조합이 됐고
'시스템 설정 따라가기' 모드의 prefers-color-scheme 도 라이트로 고정돼 깨졌다.

수정:
- Info.plist 의 UIUserInterfaceStyle 제거(강제 해제)
- setInterfaceStyle 플러그인 메서드 추가 — light/dark/system 을 윈도우+탭바에 반영, 저장
- AppDelegate.didFinishLaunching 가 저장된 테마를 첫 페인트 전에 윈도우에 적용 → 깜빡임 없음
- 탭바도 저장 테마 따라 그려짐(.light 하드코딩 제거)
- system 모드는 .unspecified → OS 설정 따라감(웹 prefers-color-scheme 정상 동작)

결과: 라이트 사용자=라이트, 다크 사용자=다크, 시스템 사용자=OS 따라감. 모두 첫 페인트부터 일관, 깜빡임 없음.

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 네이티브 크롬이 앱 테마 따라가게 — 다크모드 회귀 수정
- feat(theme): mode 변경 시 네이티브 윈도우/탭바 트레잇 동기화

**변경 대상 (5개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/ios/App/App/Info.plist`
- `client/src/lib/liquidGlassTabBar.ts`
- `client/src/lib/nativeTheme.ts`
- `client/src/theme.tsx`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #374** 에서 진행됩니다.

