### PR TITLE
🔀 :: (#375) 공유 버튼 안 눌림 + 칩 잘림 + 프리뷰 색 + 카드 재디자인

### DIFF
--- a/client/src/components/ShareSheet.tsx
+++ b/client/src/components/ShareSheet.tsx
@@ -9,6 +9,8 @@
  */
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../api";
+import Portal from "./Portal";
+import { setNativeTabBarHidden } from "../lib/liquidGlassTabBar";
 
 export type ShareKind = "ANNOUNCEMENT" | "MEMO" | "MEETING" | "DOCUMENT" | "JOURNAL";
 
@@ -36,6 +38,14 @@ type Room = {
   members?: { user: { id: string; name: string; avatarColor?: string | null } }[];
 };
 
+/** 선택된 사람 수/방 수에 맞는 버튼 라벨. "1명에게 공유"가 방에도 쓰이던 오류 수정. */
+function shareTargetLabel(users: number, rooms: number): string {
+  const parts: string[] = [];
+  if (users) parts.push(`${users}명`);
+  if (rooms) parts.push(`${rooms}개 대화방`);
+  return `${parts.join(" · ")}에 공유`;
+}
+
 const KIND_LABEL: Record<ShareKind, string> = {
   ANNOUNCEMENT: "공지",
   MEMO: "메모",
@@ -60,6 +70,7 @@ export default function ShareSheet({
   const [pickedUsers, setPickedUsers] = useState<Set<string>>(new Set());
   const [pickedRooms, setPickedRooms] = useState<Set<string>>(new Set());
   const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
 
   // 시트 열릴 때마다 선택 초기화 — 이전 공유의 잔상이 남지 않게.
   useEffect(() => {
@@ -67,7 +78,16 @@ export default function ShareSheet({
       setQ("");
       setPickedUsers(new Set());
       setPickedRooms(new Set());
+      setSent(false);
     }
+  }, [open]);
+
+  // 시트가 열린 동안 네이티브 탭바(웹뷰 위에 떠 있는 UITabBar)를 확실히 숨긴다.
+  // 안 그러면 시트 하단의 '공유' 버튼이 네이티브 탭바에 가려 탭이 안 먹는다(=안 눌림).
+  useEffect(() => {
+    if (!open) return;
+    setNativeTabBarHidden("share", true);
+    return () => setNativeTabBarHidden("share", false);
   }, [open]);
 
   // 시트 열릴 때만 fetch — 닫힌 동안 네트워크 트래픽 0.
@@ -142,12 +162,12 @@ export default function ShareSheet({
         },
       });
       if (r?.ok) {
-        // 가벼운 토스트 대신 시트 자체 닫음 — 이후 알림센터/채팅 갱신은 SSE 가 처리.
-        onClose();
+        // 성공 체크 표시 후 살짝 뒤 닫음 — 사용자가 전송됐다는 걸 인지.
+        setSent(true);
+        setTimeout(() => onClose(), 700);
       }
     } catch (e: any) {
       window.alert(e?.message ?? "공유에 실패했어요");
-    } finally {
       setSending(false);
     }
   }
@@ -156,6 +176,7 @@ export default function ShareSheet({
   const label = KIND_LABEL[payload.kind] ?? "공유";
 
   return (
+   <Portal>
     <div
       role="dialog"
       aria-modal="true"
@@ -186,13 +207,19 @@ export default function ShareSheet({
           </button>
         </div>
 
-        {/* 공유 카드 미리보기 */}
-        <div className="mx-5 mb-2 p-3 rounded-[12px] border border-ink-150 bg-ink-50/60">
-          <div className="text-[10px] font-bold text-brand-500 mb-0.5">📌 {label}</div>
-          <div className="text-[13px] font-bold text-ink-900 line-clamp-1">{payload.title}</div>
-          {payload.snippet && (
-            <div className="text-[11px] text-ink-500 line-clamp-2 mt-0.5">{payload.snippet}</div>
-          )}
+        {/* 공유 카드 미리보기 — 다크/라이트 자동 대응(var 토큰), 브랜드 좌측 바 */}
+        <div
+          className="mx-5 mb-2 p-3 rounded-[12px] border flex gap-2.5"
+          style={{ background: "color-mix(in srgb, var(--c-brand, #3B5CF0) 7%, var(--c-surface))", borderColor: "var(--c-border)" }}
+        >
+          <div className="w-1 rounded-full self-stretch flex-shrink-0" style={{ background: "var(--c-brand, #3B5CF0)" }} />
+          <div className="min-w-0">
+            <div className="text-[10px] font-bold text-brand-500 mb-0.5">📌 {label}</div>
+            <div className="text-[13px] font-bold text-ink-900 line-clamp-1">{payload.title}</div>
+            {payload.snippet && (
+              <div className="text-[11px] text-ink-500 line-clamp-2 mt-0.5">{payload.snippet}</div>
+            )}
+          </div>
         </div>
 
         {/* 검색 */}
@@ -208,7 +235,7 @@ export default function ShareSheet({
         {/* 선택된 칩 */}
         {total > 0 && (
           <div
-            className="hinest-x-scroll px-5 pb-2 flex gap-2 overflow-x-auto"
+            className="hinest-x-scroll px-5 pt-1 pb-2.5 flex items-center gap-2 overflow-x-auto"
             style={{ touchAction: "pan-x", WebkitOverflowScrolling: "touch" }}
           >
             {[...pickedUsers].map((id) => {
@@ -340,13 +367,14 @@ export default function ShareSheet({
         >
           <button
             onClick={send}
-            disabled={!total || sending}
+            disabled={!total || sending || sent}
             className="w-full h-11 rounded-[12px] bg-brand-500 text-white font-bold text-[14px] disabled:opacity-40 disabled:cursor-not-allowed transition active:scale-[0.98]"
           >
-            {sending ? "보내는 중…" : total ? `${total}명에게 공유` : "받을 사람을 선택해 주세요"}
+            {sent ? "공유했어요 ✓" : sending ? "보내는 중…" : total ? `${shareTargetLabel(pickedUsers.size, pickedRooms.size)}` : "받을 사람을 선택해 주세요"}
           </button>
         </div>
       </div>
     </div>
+   </Portal>
   );
 }

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1065,40 +1065,50 @@ function ShareCardBubble({ msg, mine }: { msg: Message; mine: boolean }) {
     window.history.pushState({}, "", safe);
     window.dispatchEvent(new PopStateEvent("popstate"));
   }
-  const bg = mine ? "rgba(255,255,255,0.95)" : "#FFFFFF";
-  const border = mine ? "rgba(255,255,255,0.4)" : "#E5E7EB";
+  const snippet =
+    msg.content && msg.content.trim() && msg.content !== msg.fileName
+      ? (msg.content.startsWith(`${msg.fileName ?? ""} — `)
+          ? msg.content.slice((msg.fileName ?? "").length + 3)
+          : msg.content)
+      : "";
+  // 다크/라이트 자동 대응 — CSS 변수. 카드는 항상 표면색(버블색과 분리되어 또렷).
   return (
     <a
       href={safe}
       onClick={navigate}
       style={{
-        display: "block",
-        maxWidth: 320,
-        background: bg,
-        border: `1px solid ${border}`,
-        borderRadius: 14,
-        padding: "12px 14px",
+        display: "flex",
+        alignItems: "stretch",
+        gap: 0,
+        width: 264,
+        maxWidth: "78vw",
+        background: "var(--c-surface)",
+        border: "1px solid var(--c-border)",
+        borderRadius: 16,
+        overflow: "hidden",
         textDecoration: "none",
-        color: "#0F172A",
-        boxShadow: "0 1px 2px rgba(15,23,42,0.04)",
+        boxShadow: "0 1px 3px rgba(15,23,42,0.08)",
       }}
     >
-      <div style={{ fontSize: 10, fontWeight: 700, color: "#3B5CF0", marginBottom: 4, letterSpacing: "-0.01em" }}>
-        {meta.icon} {meta.label}
+      {/* 좌측 브랜드 컬러 바 + 아이콘 */}
+      <div style={{ width: 44, flexShrink: 0, background: "var(--c-brand-soft)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 19 }}>
+        {meta.icon}
       </div>
-      <div style={{ fontSize: 14, fontWeight: 700, lineHeight: 1.35, marginBottom: 4, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
-        {msg.fileName ?? "(제목 없음)"}
-      </div>
-      {msg.content && msg.content.trim() && msg.content !== msg.fileName && (
-        <div style={{ fontSize: 12, color: "#64748B", lineHeight: 1.4, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
-          {/* content 가 "제목 — snippet" 포맷이라 제목 부분 제거 */}
-          {msg.content.startsWith(`${msg.fileName ?? ""} — `)
-            ? msg.content.slice((msg.fileName ?? "").length + 3)
-            : msg.content}
+      <div style={{ flex: 1, minWidth: 0, padding: "11px 13px" }}>
+        <div style={{ fontSize: 10.5, fontWeight: 800, color: "var(--c-brand)", marginBottom: 3, letterSpacing: "0.02em" }}>
+          {meta.label}
         </div>
-      )}
-      <div style={{ marginTop: 8, paddingTop: 8, borderTop: "1px solid #F1F5F9", fontSize: 11, color: "#94A3B8", fontWeight: 600 }}>
-        탭해서 보기 →
+        <div style={{ fontSize: 14, fontWeight: 700, lineHeight: 1.3, color: "var(--c-text)", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+          {msg.fileName ?? "(제목 없음)"}
+        </div>
+        {snippet && (
+          <div style={{ fontSize: 12, color: "var(--c-text-3)", lineHeight: 1.4, marginTop: 3, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
+            {snippet}
+          </div>
+        )}
+        <div style={{ marginTop: 8, fontSize: 11, color: "var(--c-brand)", fontWeight: 700 }}>
+          탭해서 열기 →
+        </div>
       </div>
     </a>
   );

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -282,7 +282,7 @@ export default function MeetingDetailPage() {
             variant="icon"
             payload={{
               kind: "MEETING",
-              title: meeting.title,
+              title: meeting.title?.trim() || "제목 없는 회의록",
               href: `/meetings/${meeting.id}`,
             }}
           />

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -282,7 +282,7 @@ export default function NoticePage() {
                     variant="icon"
                     payload={{
                       kind: "ANNOUNCEMENT",
-                      title: selected.title,
+                      title: selected.title?.trim() || "제목 없는 공지",
                       snippet: selected.content?.slice(0, 120) ?? undefined,
                       href: `/notice?id=${selected.id}`,
                     }}


### PR DESCRIPTION
## 증상
**공유 버튼 안 눌림 + 칩 잘림 + 프리뷰 색 + 카드 재디자인**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
- 버튼 안 눌림: 네이티브 탭바(웹뷰 위 UITabBar)가 하단 '공유' 버튼을 덮고 있었음.
  Portal 로 body 레벨 렌더 + setNativeTabBarHidden('share') 로 시트 열린 동안 명시적 숨김.
- 선택 칩 잘림: 칩 컨테이너에 pt-1 pb-2.5 + items-center 로 상하 클리핑 제거.
- 프리뷰 카드 색 이상: bg-ink-50/60(다크 오버라이드 없어 허옇게)→ var(--c-surface) 기반
  브랜드 7% 틴트 + 좌측 브랜드 바. 다크/라이트 자동 대응.
- 버튼 라벨: '1명에게 공유'가 방에도 쓰이던 오류 → 'N명 · N개 대화방에 공유'.
- 성공 피드백: 전송 후 '공유했어요 ✓' 표시 후 닫힘.

## 수정
**작업 항목 (커밋 단위)**
- fix(share): 공유 버튼 안 눌림 + 칩 잘림 + 프리뷰 색 수정
- feat(chat): ShareCardBubble 재디자인 — 좌측 아이콘 바 + 다크 대응
- fix(share): 제목 빈 게시물 공유 시 fallback 제목 — 서버 400 방지

**변경 대상 (4개 파일)**
- `client/src/components/ShareSheet.tsx`
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/pages/MeetingDetailPage.tsx`
- `client/src/pages/NoticePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #375** 에서 진행됩니다.

