### PR TITLE
🔀 :: (#376) 일정 — 퇴사/비활성 멤버 제외 + 날짜 줄바꿈 깨짐

### DIFF
--- a/client/src/components/DatePicker.tsx
+++ b/client/src/components/DatePicker.tsx
@@ -98,12 +98,13 @@ export default function DatePicker({
         disabled={disabled}
         className={
           variant === "input"
-            ? "input text-left tabular flex items-center justify-between disabled:opacity-60"
+            ? "input text-left tabular flex items-center justify-between gap-1 disabled:opacity-60"
             : "w-full min-w-0 bg-transparent border-0 focus:bg-[color:var(--c-surface)] text-[color:var(--c-text)] focus:outline-none focus:ring-1 focus:ring-brand-400 rounded text-[12px] px-1 py-1.5 tabular text-left hover:bg-[color:var(--c-surface-3)]"
         }
         onClick={() => !disabled && setOpen((v) => !v)}
       >
-        <span className={value ? "" : "text-ink-400"}>
+        {/* whitespace-nowrap — 좁은 칸에서 'YYYY-MM-DD' 가 'YYYY-/MM-DD' 로 줄바꿈되던 깨짐 방지 */}
+        <span className={`whitespace-nowrap overflow-hidden text-ellipsis ${value ? "" : "text-ink-400"}`}>
           {value || placeholder}
         </span>
         {variant === "input" && (

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -37,13 +37,17 @@ router.get("/:id", async (req, res) => {
     where: { id: req.params.id },
     include: {
       members: {
+        // 퇴사/비활성 멤버 제외 — 일정 담당자·필터칩에 더 이상 안 뜨게.
+        // (퇴사 처리 시 active=false 동시 설정되므로 active:true 면 둘 다 걸러짐.)
+        where: { user: { active: true } },
         include: { user: { select: { id: true, name: true, email: true, team: true, position: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
       },
       createdBy: { select: { id: true, name: true } },
     },
   });
   if (!p) return res.status(404).json({ error: "not found" });
-  // 멤버가 아니면 조회 불가 (ADMIN 제외)
+  // 멤버가 아니면 조회 불가 (ADMIN 제외). 위 where 로 비활성 멤버는 빠지지만,
+  // 로그인 사용자는 active=true 이므로 본인 멤버십 판정에는 영향 없음.
   const isMember = p.members.some((m) => m.userId === u.id);
   if (!isMember && u.role !== "ADMIN") return res.status(403).json({ error: "forbidden" });
   res.json({ project: p });


### PR DESCRIPTION
## 증상
**일정 — 퇴사/비활성 멤버 제외 + 날짜 줄바꿈 깨짐**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
일정 담당자 선택·필터칩이 프로젝트 멤버(project.members)에서 나오는데, 멤버가
퇴사/비활성 처리돼도 멤버십 레코드는 남아 계속 노출됐다.

/api/project/:id 의 members include 에 where:{user:{active:true}} 추가.
퇴사 처리 시 active=false 가 동시 설정되므로 비활성·퇴사 둘 다 한 번에 걸러진다.
로그인 사용자는 active=true 라 본인 멤버십 판정에는 영향 없음.

## 수정
**작업 항목 (커밋 단위)**
- fix(server): 프로젝트 멤버 조회 시 퇴사/비활성 사용자 제외
- fix(ui): 날짜 입력 줄바꿈 깨짐 — whitespace-nowrap

**변경 대상 (2개 파일)**
- `client/src/components/DatePicker.tsx`
- `server/src/routes/project.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #376** 에서 진행됩니다.

