### PR TITLE
🔀 :: (#377) 다운로드 파일명이 스토리지 키로 저장되던 문제

### DIFF
--- a/HiNest-MacOS/src/main.ts
+++ b/HiNest-MacOS/src/main.ts
@@ -77,6 +77,30 @@ function createWindow() {
 
   mainWindow.loadURL(DEFAULT_URL);
 
+  // 다운로드 파일명 = 업로드 원본명. Electron 에선 cross-origin(/uploads → api.*) 다운로드 시
+  // <a download> 속성이 무시되고 URL 마지막 경로(스토리지 키)가 파일명이 되는 문제가 있다.
+  // will-download 에서 ?name= → Content-Disposition → getFilename 순으로 원본명을 강제한다.
+  mainWindow.webContents.session.on("will-download", (_e, item) => {
+    try {
+      let name = "";
+      try {
+        const u = new URL(item.getURL());
+        const q = u.searchParams.get("name");
+        if (q) name = decodeURIComponent(q);
+      } catch {}
+      if (!name) {
+        const cd = item.getContentDisposition?.() || "";
+        const star = /filename\*=UTF-8''([^;]+)/i.exec(cd);
+        const plain = /filename="?([^";]+)"?/i.exec(cd);
+        if (star) name = decodeURIComponent(star[1]);
+        else if (plain) name = plain[1];
+      }
+      if (!name) name = item.getFilename();
+      name = name.replace(/[/\\]/g, "_").trim();
+      if (name) item.setSaveDialogOptions({ defaultPath: name });
+    } catch { /* 기본 동작으로 진행 */ }
+  });
+
   // 창 상태 변경 시 렌더러에 알려서 상단 여백을 동적으로 조정
   const sendFullscreenState = () => {
     try {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -73,6 +73,37 @@ function createWindow() {
 
   mainWindow.loadURL(DEFAULT_URL);
 
+  // 다운로드 파일명 = 업로드 원본명. 웹은 <a download="원본명"> 으로 저장하지만, Electron 에선
+  // cross-origin(/uploads → api.*) 다운로드 시 download 속성이 무시되고 URL 마지막 경로(스토리지 키,
+  // 예: 1780787010314-8a229...)가 파일명이 되는 문제가 있다. will-download 에서 직접 원본명을 강제한다.
+  //   우선순위: URL 의 ?name=<원본명>  →  Content-Disposition filename*  →  filename  →  기본(키)
+  mainWindow.webContents.session.on("will-download", (_e, item) => {
+    try {
+      let name = "";
+      // 1) ?name= 쿼리 (클라가 다운로드 URL 에 항상 붙임)
+      try {
+        const u = new URL(item.getURL());
+        const q = u.searchParams.get("name");
+        if (q) name = decodeURIComponent(q);
+      } catch {}
+      // 2) Content-Disposition (RFC5987 filename*=UTF-8'' 우선, 그다음 filename=)
+      if (!name) {
+        const cd = item.getContentDisposition?.() || "";
+        const star = /filename\*=UTF-8''([^;]+)/i.exec(cd);
+        const plain = /filename="?([^";]+)"?/i.exec(cd);
+        if (star) name = decodeURIComponent(star[1]);
+        else if (plain) name = plain[1];
+      }
+      // 3) 그래도 없으면 Electron 기본(getFilename)
+      if (!name) name = item.getFilename();
+      // 경로 구분자 제거(보안) 후 저장 대화상자 기본 파일명으로.
+      name = name.replace(/[/\\]/g, "_").trim();
+      if (name) item.setSaveDialogOptions({ defaultPath: name });
+    } catch {
+      /* 실패해도 Electron 기본 동작으로 진행 — 다운로드 자체는 막지 않는다 */
+    }
+  });
+
   // 창 상태 변경 시 렌더러에 알려서 상단 여백을 동적으로 조정
   const sendFullscreenState = () => {
     try {


### PR DESCRIPTION
## 증상
**다운로드 파일명이 스토리지 키로 저장되던 문제**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
증상: macOS 데스크톱에서 문서 다운로드 시 저장 파일명이 스토리지 키
(1780787010314-8a229...)로 나옴. 업로드 원본명(【 Rooti 2.0 】 개발계획.zip)이어야 함.

원인: 웹은 <a download='원본명'> 으로 저장하지만, Electron 은 cross-origin
(/uploads → api.*) 다운로드에서 download 속성을 무시하고 URL 마지막 경로(=키)를
파일명으로 쓴다.

수정: session 'will-download' 에서 원본명을 직접 강제.
  우선순위: URL ?name=<원본명> → Content-Disposition filename*/filename → getFilename.
  경로 구분자 제거 후 setSaveDialogOptions({defaultPath}) 로 저장 대화상자 기본명 지정.

## 수정
**작업 항목 (커밋 단위)**
- fix(desktop): 다운로드 파일명을 업로드 원본명으로 — will-download 핸들러
- fix(macos): will-download 핸들러로 다운로드 원본 파일명 강제 (desktop 과 동일)

**변경 대상 (2개 파일)**
- `HiNest-MacOS/src/main.ts`
- `desktop/src/main.ts`

## 검증
- Electron 빌드 확인

---
🔗 이 작업은 **PR #377** 에서 진행됩니다.

