### PR TITLE
🔀 :: (#379) 커스텀 팝업 → 애플 네이티브 다이얼로그 (내용 동일)

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -92,6 +92,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "confirm", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSharedToken", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setInterfaceStyle", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "promptInput", returnType: CAPPluginReturnPromise),
     ]
 
     private var tabBarView: UITabBar?
@@ -250,18 +251,58 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         let confirmText = call.getString("confirmText") ?? "확인"
         let cancelText = call.getString("cancelText") ?? "취소"
         let destructive = call.getBool("destructive") ?? false
+        // alertOnly=true → 단일 버튼 알림(취소 없음). secondaryText → 3지선다 가운데 버튼.
+        let alertOnly = call.getBool("alertOnly") ?? false
+        let secondaryText = call.getString("secondaryText")
         DispatchQueue.main.async {
             guard let vc = self.bridge?.viewController else {
-                call.resolve(["confirmed": false]); return
+                call.resolve(["confirmed": false, "action": "cancel"]); return
             }
-            // .alert = 화면 중앙 다이얼로그(하단 액션시트 아님). 취소는 cancel 스타일로 왼쪽,
-            // 로그아웃은 destructive(빨강)로 오른쪽에 나란히 놓인다.
+            // .alert = 화면 중앙 다이얼로그(하단 액션시트 아님).
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: cancelText, style: .cancel) { _ in
-                call.resolve(["confirmed": false])
-            })
+            if !alertOnly {
+                alert.addAction(UIAlertAction(title: cancelText, style: .cancel) { _ in
+                    call.resolve(["confirmed": false, "action": "cancel"])
+                })
+            }
+            if let sec = secondaryText, !sec.isEmpty {
+                alert.addAction(UIAlertAction(title: sec, style: .default) { _ in
+                    call.resolve(["confirmed": false, "action": "secondary"])
+                })
+            }
             alert.addAction(UIAlertAction(title: confirmText, style: destructive ? .destructive : .default) { _ in
-                call.resolve(["confirmed": true])
+                call.resolve(["confirmed": true, "action": "confirm"])
+            })
+            vc.present(alert, animated: true)
+        }
+    }
+
+    /// 텍스트 입력 1개를 받는 애플 기본 다이얼로그(UIAlertController + textField).
+    /// resolve({ value, cancelled }). 취소/없음이면 cancelled:true.
+    @objc func promptInput(_ call: CAPPluginCall) {
+        let title = call.getString("title")
+        let message = call.getString("message")
+        let confirmText = call.getString("confirmText") ?? "확인"
+        let cancelText = call.getString("cancelText") ?? "취소"
+        let placeholder = call.getString("placeholder")
+        let defaultValue = call.getString("defaultValue") ?? ""
+        let secure = call.getBool("secure") ?? false
+        DispatchQueue.main.async {
+            guard let vc = self.bridge?.viewController else {
+                call.resolve(["cancelled": true]); return
+            }
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addTextField { tf in
+                tf.placeholder = placeholder
+                tf.text = defaultValue
+                tf.isSecureTextEntry = secure
+            }
+            alert.addAction(UIAlertAction(title: cancelText, style: .cancel) { _ in
+                call.resolve(["cancelled": true])
+            })
+            alert.addAction(UIAlertAction(title: confirmText, style: .default) { _ in
+                let v = alert.textFields?.first?.text ?? ""
+                call.resolve(["cancelled": false, "value": v])
             })
             vc.present(alert, animated: true)
         }

--- a/client/src/components/ConfirmHost.tsx
+++ b/client/src/components/ConfirmHost.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { nativePlatform } from "../lib/platform";
+import { LiquidGlassTabBar } from "../lib/liquidGlassTabBar";
 
 /**
  * 전역 확인/알림/입력 모달 호스트 — 네이티브 window.confirm/alert/prompt 를 대체한다.
@@ -79,7 +81,62 @@ function cancelPrevious() {
   else d.resolve(null);
 }
 
+// iOS/iPadOS(Capacitor) 에서는 커스텀 웹 모달 대신 애플 기본 UIAlertController 를 쓴다.
+// 내용(제목/본문/버튼 라벨)은 동일하게 전달 — 네이티브 룩앤필만 입힌다. 웹/데스크톱/안드로이드는
+// 기존 커스텀 모달 유지. 네이티브 호출 실패 시(플러그인 부재 등) 웹 모달로 폴백.
+function useNativeDialogs(): boolean {
+  return nativePlatform() === "ios"; // iPad 도 Capacitor 에선 "ios"
+}
+
 export function confirmAsync(opts: ConfirmOpts): Promise<ConfirmResult> {
+  if (useNativeDialogs()) {
+    return LiquidGlassTabBar.confirm({
+      title: opts.title,
+      message: opts.description,
+      confirmText: opts.confirmLabel,
+      cancelText: opts.cancelLabel,
+      destructive: opts.tone === "danger",
+      secondaryText: opts.secondaryLabel,
+    })
+      .then((r): ConfirmResult => (r.action === "secondary" ? "secondary" : !!r.confirmed))
+      .catch(() => webConfirm(opts));
+  }
+  return webConfirm(opts);
+}
+
+export function alertAsync(opts: AlertOpts): Promise<void> {
+  if (useNativeDialogs()) {
+    return LiquidGlassTabBar.confirm({
+      title: opts.title,
+      message: opts.description,
+      confirmText: opts.confirmLabel ?? "확인",
+      alertOnly: true,
+    })
+      .then(() => undefined)
+      .catch(() => webAlert(opts));
+  }
+  return webAlert(opts);
+}
+
+export function promptAsync(opts: PromptOpts): Promise<string | null> {
+  if (useNativeDialogs()) {
+    return LiquidGlassTabBar.promptInput({
+      title: opts.title,
+      message: opts.description,
+      confirmText: opts.confirmLabel,
+      cancelText: opts.cancelLabel,
+      placeholder: opts.placeholder,
+      defaultValue: opts.defaultValue,
+      secure: opts.inputType === "password",
+    })
+      .then((r) => (r.cancelled ? null : r.value ?? ""))
+      .catch(() => webPrompt(opts));
+  }
+  return webPrompt(opts);
+}
+
+// ── 웹/데스크톱/안드로이드용 커스텀 모달 구현(기존 동작) ───────────────────────────
+function webConfirm(opts: ConfirmOpts): Promise<ConfirmResult> {
   return new Promise((resolve) => {
     cancelPrevious();
     currentDialog = { kind: "confirm", opts, resolve };
@@ -87,7 +144,7 @@ export function confirmAsync(opts: ConfirmOpts): Promise<ConfirmResult> {
   });
 }
 
-export function alertAsync(opts: AlertOpts): Promise<void> {
+function webAlert(opts: AlertOpts): Promise<void> {
   return new Promise((resolve) => {
     cancelPrevious();
     currentDialog = { kind: "alert", opts, resolve };
@@ -95,7 +152,7 @@ export function alertAsync(opts: AlertOpts): Promise<void> {
   });
 }
 
-export function promptAsync(opts: PromptOpts): Promise<string | null> {
+function webPrompt(opts: PromptOpts): Promise<string | null> {
   return new Promise((resolve) => {
     cancelPrevious();
     currentDialog = { kind: "prompt", opts, resolve };

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -37,7 +37,21 @@ export interface LiquidGlassTabBarPlugin {
     confirmText?: string;
     cancelText?: string;
     destructive?: boolean;
-  }): Promise<{ confirmed: boolean }>;
+    /** true 면 취소 버튼 없는 단일 알림(alertAsync 용). */
+    alertOnly?: boolean;
+    /** 3지선다 가운데 버튼 라벨. 선택 시 action="secondary". */
+    secondaryText?: string;
+  }): Promise<{ confirmed: boolean; action?: "confirm" | "cancel" | "secondary" }>;
+  /** 텍스트 입력 1개를 받는 애플 기본 다이얼로그. */
+  promptInput(options: {
+    title?: string;
+    message?: string;
+    confirmText?: string;
+    cancelText?: string;
+    placeholder?: string;
+    defaultValue?: string;
+    secure?: boolean;
+  }): Promise<{ cancelled: boolean; value?: string }>;
   addListener(
     eventName: "tabSelected",
     listenerFunc: (data: { key: string }) => void,


### PR DESCRIPTION
## 증상
**커스텀 팝업 → 애플 네이티브 다이얼로그 (내용 동일)**

새 기능을 추가합니다.

## 원인
ConfirmHost 의 confirm/alert/prompt 를 애플 기본 UIAlertController 로 받기 위한 네이티브 확장.
- confirm: alertOnly(단일 버튼 알림)·secondaryText(3지선다 가운데)·action 반환 추가
- promptInput: textField 1개 받는 .alert (secure 지원) — promptAsync 용
하위호환: confirmed 도 그대로 반환.

## 수정
**작업 항목 (커밋 단위)**
- feat(ios): confirm 확장(alertOnly·secondary·action) + promptInput 추가
- feat(ui): iOS/iPadOS 커스텀 팝업 → 애플 네이티브 다이얼로그

**변경 대상 (3개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/src/components/ConfirmHost.tsx`
- `client/src/lib/liquidGlassTabBar.ts`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #379** 에서 진행됩니다.

