### PR TITLE
🔀 :: (#380) iOS/iPadOS 햅틱 전반 + 출근 IP 탭 카운트 버그 수정

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -93,6 +93,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "setSharedToken", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setInterfaceStyle", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "promptInput", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "haptic", returnType: CAPPluginReturnPromise),
     ]
 
     private var tabBarView: UITabBar?
@@ -277,6 +278,31 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    /// 햅틱 피드백 — JS(버튼·토글 탭 등)에서 호출. style: light|medium|heavy|selection|success|warning|error.
+    /// 메인 스레드에서 즉시 발생. 비지원 기기/시뮬레이터는 무음 no-op.
+    @objc func haptic(_ call: CAPPluginCall) {
+        let style = call.getString("style") ?? "light"
+        DispatchQueue.main.async {
+            switch style {
+            case "selection":
+                UISelectionFeedbackGenerator().selectionChanged()
+            case "success":
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            case "warning":
+                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            case "error":
+                UINotificationFeedbackGenerator().notificationOccurred(.error)
+            case "medium":
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            case "heavy":
+                UIImpactFeedbackGenerator(style: .heavy).impactOccurred()
+            default:
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            }
+        }
+        call.resolve()
+    }
+
     /// 텍스트 입력 1개를 받는 애플 기본 다이얼로그(UIAlertController + textField).
     /// resolve({ value, cancelled }). 취소/없음이면 cancelled:true.
     @objc func promptInput(_ call: CAPPluginCall) {
@@ -325,6 +351,9 @@ extension LiquidGlassTabBarPlugin: UITabBarDelegate {
     public func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
         let i = item.tag
         guard i >= 0, i < keys.count else { return }
+        // 탭 전환 시 선택 햅틱 — 네이티브 탭바 느낌. (실제 OS 탭바도 selection feedback 을 준다)
+        let gen = UISelectionFeedbackGenerator()
+        gen.selectionChanged()
         notifyListeners("tabSelected", data: ["key": keys[i]])
     }
 }

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -20,6 +20,7 @@ import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
 import { isPreviewMode, disablePreview } from "../lib/previewMock";
 import { isInstalledApp, isDesktopApp, nativePlatform, isCapacitorNative } from "../lib/platform";
 import { LiquidGlassTabBar, setNativeTabBarHidden, syncNativeTabBarVisibility } from "../lib/liquidGlassTabBar";
+import { attachGlobalHaptics } from "../lib/haptics";
 import { confirmLogout } from "../lib/confirmLogout";
 
 /**
@@ -747,6 +748,11 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     const hideOnRoutes: string[] = [];
     setNativeTabBarHidden("route", hideOnRoutes.some((r) => pathname === r || pathname.startsWith(r + "/")));
   }, [pathname]);
+
+  // iOS/iPadOS 전역 햅틱 — 버튼·토글·탭 탭 시 light/selection 피드백. 웹/데스크톱은 no-op.
+  useEffect(() => {
+    return attachGlobalHaptics();
+  }, []);
 
   // 모달이 열려 있는 동안 네이티브 바 숨김. 모달 오버레이는 .modal-safe 로 표시돼 있으므로
   // DOM 에 그게 존재하는지 관찰한다. (채팅 풀스크린은 ChatFab 이 별도로 'chat' 사유로 숨김.)

--- a/client/src/lib/haptics.ts
+++ b/client/src/lib/haptics.ts
@@ -1,0 +1,67 @@
+/**
+ * 햅틱 피드백 헬퍼 — iOS/iPadOS 네이티브에서만 동작, 그 외(웹/데스크톱/안드로이드)는 no-op.
+ *
+ * 네이티브 LiquidGlassTabBar.haptic 을 호출(추가 Capacitor 플러그인 의존성 없음).
+ * 탭바 전환은 Swift 쪽 UITabBarDelegate 가 직접 selection 햅틱을 주고, 웹 DOM 의 버튼·토글
+ * 탭은 AppLayout 의 전역 pointerdown 리스너가 light 햅틱을 준다(아래 attachGlobalHaptics).
+ */
+import { nativePlatform } from "./platform";
+
+type HapticStyle = "light" | "medium" | "heavy" | "selection" | "success" | "warning" | "error";
+
+let _plugin: typeof import("./liquidGlassTabBar").LiquidGlassTabBar | null = null;
+
+function isNative(): boolean {
+  return nativePlatform() === "ios"; // iPad 도 Capacitor 에선 "ios"
+}
+
+export function haptic(style: HapticStyle = "light"): void {
+  if (!isNative()) return;
+  try {
+    if (!_plugin) {
+      // 동기 import 캐시 — 첫 호출 시 모듈 로드.
+      void import("./liquidGlassTabBar").then((m) => {
+        _plugin = m.LiquidGlassTabBar;
+        _plugin.haptic({ style }).catch(() => {});
+      });
+      return;
+    }
+    void _plugin.haptic({ style }).catch(() => {});
+  } catch {
+    /* no-op */
+  }
+}
+
+/**
+ * 전역 햅틱 — 버튼·토글·링크·체크박스 탭에 light 햅틱을 자동으로 건다.
+ * AppLayout 마운트 시 1회 호출. 반환된 함수로 해제.
+ *
+ * pointerdown 으로 누르는 순간 즉시 반응(클릭 완료까지 안 기다림 = 더 native 한 느낌).
+ * 텍스트 입력/스크롤 영역은 제외해 오발 방지. 비활성(disabled) 요소도 제외.
+ */
+export function attachGlobalHaptics(): () => void {
+  if (!isNative()) return () => {};
+  const SELECTOR =
+    'button, [role="button"], [role="switch"], [role="tab"], a[href], ' +
+    'input[type="checkbox"], input[type="radio"], label[data-haptic], [data-haptic]';
+  const handler = (e: PointerEvent) => {
+    const t = e.target as HTMLElement | null;
+    if (!t) return;
+    const el = t.closest(SELECTOR) as HTMLElement | null;
+    if (!el) return;
+    // 비활성 요소·data-no-haptic 은 제외.
+    if (el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true") return;
+    if (el.closest("[data-no-haptic]")) return;
+    // 스위치/체크박스/탭은 selection, 나머지는 light.
+    const role = el.getAttribute("role");
+    const isToggle =
+      role === "switch" ||
+      role === "tab" ||
+      (el as HTMLInputElement).type === "checkbox" ||
+      (el as HTMLInputElement).type === "radio";
+    haptic(isToggle ? "selection" : "light");
+  };
+  // passive — 스크롤 성능 영향 없음. capture 로 자식이 stopPropagation 해도 잡음.
+  document.addEventListener("pointerdown", handler, { passive: true, capture: true });
+  return () => document.removeEventListener("pointerdown", handler, { capture: true } as any);
+}

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -30,6 +30,8 @@ export interface LiquidGlassTabBarPlugin {
   setSharedToken(options: { token: string; group?: string }): Promise<void>;
   /** 앱 테마를 네이티브 윈도우/탭바에 반영. light/dark/system. 저장돼 다음 실행 첫 페인트에도 적용. */
   setInterfaceStyle(options: { style: "light" | "dark" | "system" }): Promise<void>;
+  /** 햅틱 피드백 — 버튼·토글 탭 등. style 기본 light. */
+  haptic(options: { style?: "light" | "medium" | "heavy" | "selection" | "success" | "warning" | "error" }): Promise<void>;
   /** 애플 기본 확인 시트(action sheet). 로그아웃 등 재확인용. */
   confirm(options: {
     title?: string;

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -255,6 +255,7 @@ export default function AdminPage() {
   const [invites, setInvites] = useState<Invite[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
   const [positions, setPositions] = useState<Position[]>([]);
+  const [ipCount, setIpCount] = useState(0);
 
   // 권한/팀 변경 연타 시 이전 reload() 응답이 나중에 도착해 최신 상태를 덮는 레이스 방지.
   // 언마운트 후 setState 호출도 동시에 막음.
@@ -267,11 +268,13 @@ export default function AdminPage() {
 
   async function loadCommon() {
     const myToken = ++reloadTokenRef.current;
-    const [u, i, t, p] = await Promise.all([
+    const [u, i, t, p, ip] = await Promise.all([
       api<{ users: UserRow[] }>("/api/admin/users"),
       api<{ keys: Invite[] }>("/api/admin/invites"),
       api<{ teams: Team[] }>("/api/admin/teams"),
       api<{ positions: Position[] }>("/api/admin/positions"),
+      // 출근 IP 탭 배지 카운트용 — 실패해도 다른 탭에 영향 없게 catch.
+      api<{ allowedIps: unknown[] }>("/api/admin/attendance-ip").catch(() => ({ allowedIps: [] as unknown[] })),
     ]);
     // 최신 호출이 아니거나 언마운트됐으면 무시.
     if (!aliveRef.current || myToken !== reloadTokenRef.current) return;
@@ -279,6 +282,7 @@ export default function AdminPage() {
     setInvites(i.keys);
     setTeams(t.teams);
     setPositions(p.positions);
+    setIpCount(Array.isArray(ip?.allowedIps) ? ip.allowedIps.length : 0);
   }
 
   useEffect(() => { loadCommon(); }, []);
@@ -288,7 +292,7 @@ export default function AdminPage() {
     { key: "invites", label: "초대키", count: invites.filter((k) => !k.used).length, icon: <KeyIcon /> },
     { key: "teams", label: "팀", count: teams.length, icon: <TeamIcon /> },
     { key: "positions", label: "직급", count: positions.length, icon: <RankIcon /> },
-    { key: "ip", label: "출근 IP", count: 0, icon: <RankIcon /> },
+    { key: "ip", label: "출근 IP", count: ipCount, icon: <RankIcon /> },
   ];
 
   return (
@@ -349,7 +353,7 @@ export default function AdminPage() {
       {tab === "invites" && <InvitesTab invites={invites} teams={teams} positions={positions} reload={loadCommon} />}
       {tab === "teams" && <TeamsTab teams={teams} reload={loadCommon} />}
       {tab === "positions" && <PositionsTab positions={positions} reload={loadCommon} />}
-      {tab === "ip" && <AttendanceIpTab />}
+      {tab === "ip" && <AttendanceIpTab onCountChange={setIpCount} />}
     </div>
   );
 }
@@ -2320,7 +2324,7 @@ function SecurityBlock({ user, onChanged }: { user: UserRow; onChanged: () => vo
 
 
 /* ===================== Attendance IP Restrict ===================== */
-function AttendanceIpTab() {
+function AttendanceIpTab({ onCountChange }: { onCountChange?: (n: number) => void }) {
   const [loading, setLoading] = useState(true);
   const [enabled, setEnabled] = useState(false);
   const [items, setItems] = useState<{ id: string; cidr: string; label: string | null; createdAt: string }[]>([]);
@@ -2328,6 +2332,9 @@ function AttendanceIpTab() {
   const [cidrInput, setCidrInput] = useState("");
   const [labelInput, setLabelInput] = useState("");
   const [adding, setAdding] = useState(false);
+
+  // 목록 길이가 바뀔 때마다 상위 탭 배지 카운트 동기화(추가/삭제 즉시 반영).
+  useEffect(() => { onCountChange?.(items.length); }, [items.length, onCountChange]);
 
   async function load() {
     setLoading(true);


### PR DESCRIPTION
## 증상
**iOS/iPadOS 햅틱 전반 + 출근 IP 탭 카운트 버그 수정**

새 기능을 추가합니다.

## 원인
- 네이티브 탭바(UITabBarDelegate didSelect): selection 햅틱 — 네이티브 탭 전환 느낌.
- LiquidGlassTabBar.haptic(style) 플러그인 메서드 추가(light/medium/heavy/selection/
  success/warning/error) — UIImpactFeedbackGenerator 등. 추가 Capacitor 의존성 없음.
- lib/haptics.ts: haptic() 헬퍼 + attachGlobalHaptics() — AppLayout 에서 1회 부착.
  pointerdown(capture,passive) 위임 리스너로 button/switch/tab/checkbox/link 탭 시
  light(또는 토글류는 selection) 햅틱. data-no-haptic 로 제외 가능. disabled 제외.
- 웹/데스크톱/안드로이드는 no-op.

## 수정
**작업 항목 (커밋 단위)**
- feat(ios): 햅틱 — 탭바 전환 + 버튼/토글 탭 전반
- fix(admin): 출근 IP 탭 배지 카운트 0 고정 버그

**변경 대상 (5개 파일)**
- `client/ios/App/App/AppDelegate.swift`
- `client/src/components/AppLayout.tsx`
- `client/src/lib/haptics.ts`
- `client/src/lib/liquidGlassTabBar.ts`
- `client/src/pages/AdminPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #380** 에서 진행됩니다.

