### PR TITLE
🔀 :: (#383) 네이티브 앱처럼 동작 — 링크프리뷰·모멘텀·키보드 보정

### DIFF
--- a/client/capacitor.config.ts
+++ b/client/capacitor.config.ts
@@ -41,6 +41,8 @@ const config: CapacitorConfig = {
     //   콘텐츠가 두 배 아래로 밀려 상단바 위 큰 빈 공간이 생긴다(#338 도입 회귀).
     //   키보드 부드러운 슬라이드는 별도의 Capacitor Keyboard plugin(resize:'native')이 처리.
     contentInset: "never",
+    // 링크 롱프레스 시 뜨는 사파리식 미리보기(peek/pop) 비활성화 — 네이티브 앱엔 없는 웹 팝업.
+    allowsLinkPreview: false,
   },
   server: {
     androidScheme: "https",

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -21,6 +21,7 @@ import { isPreviewMode, disablePreview } from "../lib/previewMock";
 import { isInstalledApp, isDesktopApp, nativePlatform, isCapacitorNative } from "../lib/platform";
 import { LiquidGlassTabBar, setNativeTabBarHidden, syncNativeTabBarVisibility } from "../lib/liquidGlassTabBar";
 import { attachGlobalHaptics } from "../lib/haptics";
+import { attachNativeKeyboard } from "../lib/nativeKeyboard";
 import { confirmLogout } from "../lib/confirmLogout";
 
 /**
@@ -752,6 +753,11 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
   // iOS/iPadOS 전역 햅틱 — 버튼·토글·탭 탭 시 light/selection 피드백. 웹/데스크톱은 no-op.
   useEffect(() => {
     return attachGlobalHaptics();
+  }, []);
+
+  // iOS/iPadOS 키보드 보정 — 입력 포커스 시 키보드 위로 scroll-into-view. 웹/데스크톱은 no-op.
+  useEffect(() => {
+    return attachNativeKeyboard();
   }, []);
 
   // 모달이 열려 있는 동안 네이티브 바 숨김. 모달 오버레이는 .modal-safe 로 표시돼 있으므로

--- a/client/src/lib/nativeKeyboard.ts
+++ b/client/src/lib/nativeKeyboard.ts
@@ -1,0 +1,64 @@
+/**
+ * 네이티브 키보드 동작 보정 — iOS/iPadOS 에서 입력 포커스 시 키보드가 입력칸을 가리지 않게
+ * 포커스된 요소를 보이는 영역으로 스크롤한다.
+ *
+ * Keyboard.resize="native" 는 WebView 자체를 키보드 높이만큼 줄여주지만, 스크롤 컨테이너
+ * 깊숙한 곳의 입력칸은 여전히 키보드 뒤에 남을 수 있다(특히 화면 하단 폼). 키보드가 다 올라온
+ * 뒤 scrollIntoView 로 한 번 더 끌어올려 '웹처럼 입력칸이 가려지는' 문제를 없앤다.
+ *
+ * 웹/데스크톱/안드로이드는 no-op.
+ */
+import { nativePlatform } from "./platform";
+
+function isNative(): boolean {
+  return nativePlatform() === "ios";
+}
+
+export function attachNativeKeyboard(): () => void {
+  if (!isNative()) return () => {};
+
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // 포커스된 입력칸을 보이는 영역 가운데로. block:"center" 가 키보드 위로 충분히 띄운다.
+  const scrollFocusedIntoView = () => {
+    const el = document.activeElement as HTMLElement | null;
+    if (!el) return;
+    const tag = el.tagName;
+    const editable =
+      tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+    if (!editable) return;
+    try {
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+    } catch {
+      el.scrollIntoView();
+    }
+  };
+
+  // focusin: 입력칸에 포커스가 들어오면, 키보드 등장 애니메이션(약 300ms)이 끝난 뒤 스크롤.
+  const onFocusIn = (e: FocusEvent) => {
+    const t = e.target as HTMLElement | null;
+    if (!t) return;
+    const tag = t.tagName;
+    if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT" && !t.isContentEditable) return;
+    if (pendingTimer) clearTimeout(pendingTimer);
+    pendingTimer = setTimeout(scrollFocusedIntoView, 320);
+  };
+
+  // 키보드 플러그인 이벤트로도 보정 — 기기/버전별 키보드 높이 확정 시점에 한 번 더.
+  let removeKbListener: (() => void) | null = null;
+  void import("@capacitor/keyboard")
+    .then(({ Keyboard }) => {
+      Keyboard.addListener("keyboardDidShow", scrollFocusedIntoView).then((h) => {
+        removeKbListener = () => { try { void h.remove(); } catch {} };
+      });
+    })
+    .catch(() => {});
+
+  document.addEventListener("focusin", onFocusIn, { passive: true });
+
+  return () => {
+    document.removeEventListener("focusin", onFocusIn);
+    if (pendingTimer) clearTimeout(pendingTimer);
+    removeKbListener?.();
+  };
+}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -121,6 +121,10 @@ html.hinest-ios .app-topbar {
 }
 html.hinest-ios .app-main-scroll {
   padding-top: calc(56px + env(safe-area-inset-top));
+  /* 네이티브 모멘텀 스크롤 — 손가락을 떼도 관성으로 부드럽게 이어진다(웹틱한 즉시 정지 방지). */
+  -webkit-overflow-scrolling: touch;
+  /* 스크롤 끝에서 부모/문서로 스크롤이 새지 않게(고무줄 '뚫림' 방지). */
+  overscroll-behavior-y: contain;
 }
 
 html.dark {


### PR DESCRIPTION
## 증상
**네이티브 앱처럼 동작 — 링크프리뷰·모멘텀·키보드 보정**

새 기능을 추가합니다.

## 원인
네이티브 앱엔 없는 사파리식 링크 미리보기 팝업을 끈다. 링크를 길게 눌러도 웹틱한
프리뷰가 안 뜨고 네이티브처럼 동작.

## 수정
**작업 항목 (커밋 단위)**
- feat(ios): 링크 롱프레스 미리보기(peek/pop) 비활성화 — allowsLinkPreview=false
- style(ios): 메인 스크롤러 모멘텀 + overscroll-contain
- feat(ios): 입력 포커스 시 키보드 위로 scroll-into-view

**변경 대상 (4개 파일)**
- `client/capacitor.config.ts`
- `client/src/components/AppLayout.tsx`
- `client/src/lib/nativeKeyboard.ts`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #383** 에서 진행됩니다.

