### PR TITLE
🔀 :: (#385) 근무시간+퍼센트 위젯 (iOS/iPadOS/macOS)

### DIFF
--- a/HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.swift
+++ b/HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.swift
@@ -220,7 +220,6 @@ private struct LargeView: View {
 
 // MARK: - Widget Bundle
 
-@main
 struct HiNestScheduleWidget: Widget {
     let kind: String = "HiNestScheduleWidget"
     var body: some WidgetConfiguration {
@@ -230,6 +229,192 @@ struct HiNestScheduleWidget: Widget {
         .configurationDisplayName("일정")
         .description("HiNest 의 다가오는 일정을 한눈에 확인하세요.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+@main
+struct HiNestWidgets: WidgetBundle {
+    var body: some Widget {
+        HiNestScheduleWidget()
+        WorkStatusWidget()
+    }
+}
+
+// ============================================================================
+// MARK: - 근무 현황 위젯 (근무시간 + 진행률)
+// ============================================================================
+
+private struct WorkResponse: Codable {
+    let status: String
+    let workedMin: Int
+    let targetMin: Int
+    let percent: Int
+    let startLabel: String?
+    let endLabel: String?
+}
+
+struct WorkEntry: TimelineEntry {
+    let date: Date
+    let signedIn: Bool
+    let status: String
+    let workedMin: Int
+    let percent: Int
+    let startLabel: String
+    let endLabel: String
+}
+
+struct WorkProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WorkEntry {
+        WorkEntry(date: Date(), signedIn: true, status: "IN", workedMin: 218, percent: 40, startLabel: "09:00", endLabel: "18:00")
+    }
+    func getSnapshot(in context: Context, completion: @escaping (WorkEntry) -> Void) {
+        Task { completion(await fetch()) }
+    }
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WorkEntry>) -> Void) {
+        Task {
+            let entry = await fetch()
+            let interval: TimeInterval = entry.status == "IN" ? 60 : 15 * 60
+            completion(Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(interval))))
+        }
+    }
+    private func fetch() async -> WorkEntry {
+        let defaults = UserDefaults(suiteName: APP_GROUP)
+        guard let token = defaults?.string(forKey: TOKEN_KEY), !token.isEmpty else {
+            return WorkEntry(date: Date(), signedIn: false, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+        }
+        guard let url = URL(string: "\(API_BASE)/api/widget/work-status") else {
+            return WorkEntry(date: Date(), signedIn: true, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+        }
+        var req = URLRequest(url: url)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.timeoutInterval = 8
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return WorkEntry(date: Date(), signedIn: true, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+            }
+            let b = try JSONDecoder().decode(WorkResponse.self, from: data)
+            return WorkEntry(date: Date(), signedIn: true, status: b.status, workedMin: b.workedMin, percent: b.percent, startLabel: b.startLabel ?? "09:00", endLabel: b.endLabel ?? "18:00")
+        } catch {
+            return WorkEntry(date: Date(), signedIn: true, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+        }
+    }
+}
+
+private func workedText(_ min: Int) -> String {
+    let h = min / 60, m = min % 60
+    if h > 0 { return "\(h)시간 \(m)분" }
+    return "\(m)분"
+}
+
+private struct WorkStatusView: View {
+    let entry: WorkEntry
+    @Environment(\.widgetFamily) var family
+    private let brand = Color(red: 0.23, green: 0.36, blue: 0.94)
+
+    var body: some View {
+        if !entry.signedIn {
+            VStack(spacing: 6) {
+                Image(systemName: "person.crop.circle.badge.exclamationmark")
+                    .font(.system(size: 22, weight: .light)).foregroundColor(.secondary)
+                Text("위젯 앱에 로그인하면 표시돼요")
+                    .font(.system(size: 11, weight: .semibold)).foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(13)
+            .containerBackground(for: .widget) { Color(.windowBackgroundColor) }
+        } else {
+            content
+                .padding(family == .systemSmall ? 13 : 15)
+                .containerBackground(for: .widget) { Color(.windowBackgroundColor) }
+        }
+    }
+
+    private var statusLabel: String {
+        switch entry.status { case "IN": return "근무 중"; case "OFF": return "퇴근"; default: return "미출근" }
+    }
+    private var statusColor: Color {
+        switch entry.status {
+        case "IN": return Color(red: 0.09, green: 0.64, blue: 0.29)
+        case "OFF": return .secondary
+        default: return Color(red: 0.85, green: 0.46, blue: 0.10)
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        if family == .systemSmall {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                Spacer(minLength: 6)
+                Text(workedText(entry.workedMin)).font(.system(size: 22, weight: .heavy))
+                    .foregroundColor(.primary).minimumScaleFactor(0.7).lineLimit(1)
+                Text("근무 \(entry.percent)%").font(.system(size: 11, weight: .bold)).foregroundColor(brand)
+                ProgressBar(percent: entry.percent, color: brand).frame(height: 6).padding(.top, 5)
+            }
+        } else {
+            HStack(spacing: 16) {
+                Ring(percent: entry.percent, color: brand).frame(width: 74, height: 74)
+                VStack(alignment: .leading, spacing: 3) {
+                    header
+                    Text(workedText(entry.workedMin)).font(.system(size: 22, weight: .heavy))
+                        .foregroundColor(.primary).minimumScaleFactor(0.7).lineLimit(1)
+                    Text("\(entry.startLabel) – \(entry.endLabel) 기준")
+                        .font(.system(size: 10, weight: .medium)).foregroundColor(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 4) {
+            Text("HiNest").font(.system(size: 10, weight: .bold)).foregroundColor(brand)
+            Text("·").font(.system(size: 10)).foregroundColor(.secondary)
+            HStack(spacing: 3) {
+                Circle().fill(statusColor).frame(width: 6, height: 6)
+                Text(statusLabel).font(.system(size: 10, weight: .bold)).foregroundColor(statusColor)
+            }
+        }
+    }
+}
+
+private struct ProgressBar: View {
+    let percent: Int
+    let color: Color
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(color.opacity(0.18))
+                Capsule().fill(color).frame(width: geo.size.width * CGFloat(min(100, max(0, percent))) / 100)
+            }
+        }
+    }
+}
+
+private struct Ring: View {
+    let percent: Int
+    let color: Color
+    var body: some View {
+        ZStack {
+            Circle().stroke(color.opacity(0.18), lineWidth: 8)
+            Circle().trim(from: 0, to: CGFloat(min(100, max(0, percent))) / 100)
+                .stroke(color, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+            Text("\(percent)%").font(.system(size: 17, weight: .heavy)).foregroundColor(.primary)
+        }
+    }
+}
+
+struct WorkStatusWidget: Widget {
+    let kind: String = "HiNestWorkStatusWidget"
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: WorkProvider()) { entry in
+            WorkStatusView(entry: entry)
+        }
+        .configurationDisplayName("근무 현황")
+        .description("오늘 근무시간과 진행률을 한눈에.")
+        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }
 

--- a/client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.swift
+++ b/client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.swift
@@ -243,7 +243,6 @@ private struct LargeView: View {
 
 // MARK: - Widget Entry
 
-@main
 struct HiNestScheduleWidget: Widget {
     let kind: String = "HiNestScheduleWidget"
     var body: some WidgetConfiguration {
@@ -253,6 +252,205 @@ struct HiNestScheduleWidget: Widget {
         .configurationDisplayName("일정")
         .description("다가오는 일정을 한눈에 확인하세요.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+// MARK: - 위젯 번들 (일정 + 근무 현황)
+
+@main
+struct HiNestWidgets: WidgetBundle {
+    var body: some Widget {
+        HiNestScheduleWidget()
+        WorkStatusWidget()
+    }
+}
+
+// ============================================================================
+// MARK: - 근무 현황 위젯 (근무시간 + 진행률)
+// ============================================================================
+
+private struct WorkResponse: Codable {
+    let status: String        // NONE | IN | OFF
+    let workedMin: Int
+    let targetMin: Int
+    let percent: Int
+    let startLabel: String?
+    let endLabel: String?
+}
+
+struct WorkEntry: TimelineEntry {
+    let date: Date
+    let signedIn: Bool
+    let status: String
+    let workedMin: Int
+    let percent: Int
+    let startLabel: String
+    let endLabel: String
+}
+
+struct WorkProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WorkEntry {
+        WorkEntry(date: Date(), signedIn: true, status: "IN", workedMin: 218, percent: 40, startLabel: "09:00", endLabel: "18:00")
+    }
+    func getSnapshot(in context: Context, completion: @escaping (WorkEntry) -> Void) {
+        Task { completion(await fetch()) }
+    }
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WorkEntry>) -> Void) {
+        Task {
+            let entry = await fetch()
+            // 근무 중이면 1분마다, 아니면 15분마다 갱신.
+            let interval: TimeInterval = entry.status == "IN" ? 60 : 15 * 60
+            let refresh = Date().addingTimeInterval(interval)
+            completion(Timeline(entries: [entry], policy: .after(refresh)))
+        }
+    }
+    private func fetch() async -> WorkEntry {
+        let defaults = UserDefaults(suiteName: APP_GROUP)
+        guard let token = defaults?.string(forKey: TOKEN_KEY), !token.isEmpty else {
+            return WorkEntry(date: Date(), signedIn: false, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+        }
+        guard let url = URL(string: "\(API_BASE)/api/widget/work-status") else {
+            return WorkEntry(date: Date(), signedIn: true, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+        }
+        var req = URLRequest(url: url)
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.timeoutInterval = 8
+        do {
+            let (data, response) = try await URLSession.shared.data(for: req)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return WorkEntry(date: Date(), signedIn: true, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+            }
+            let b = try JSONDecoder().decode(WorkResponse.self, from: data)
+            return WorkEntry(date: Date(), signedIn: true, status: b.status, workedMin: b.workedMin, percent: b.percent, startLabel: b.startLabel ?? "09:00", endLabel: b.endLabel ?? "18:00")
+        } catch {
+            return WorkEntry(date: Date(), signedIn: true, status: "NONE", workedMin: 0, percent: 0, startLabel: "09:00", endLabel: "18:00")
+        }
+    }
+}
+
+private func workedText(_ min: Int) -> String {
+    let h = min / 60, m = min % 60
+    if h > 0 { return "\(h)시간 \(m)분" }
+    return "\(m)분"
+}
+
+private struct WorkStatusView: View {
+    let entry: WorkEntry
+    @Environment(\.widgetFamily) var family
+    private let brand = Color(red: 0.23, green: 0.36, blue: 0.94)
+
+    var body: some View {
+        if !entry.signedIn {
+            VStack(spacing: 6) {
+                Image(systemName: "person.crop.circle.badge.exclamationmark")
+                    .font(.system(size: 22, weight: .light)).foregroundColor(.secondary)
+                Text("앱에 로그인하면 표시돼요")
+                    .font(.system(size: 11, weight: .semibold)).foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(12)
+            .containerBackground(for: .widget) { Color(.systemBackground) }
+        } else {
+            content
+                .padding(family == .systemSmall ? 12 : 14)
+                .containerBackground(for: .widget) { Color(.systemBackground) }
+        }
+    }
+
+    private var statusLabel: String {
+        switch entry.status {
+        case "IN": return "근무 중"
+        case "OFF": return "퇴근"
+        default: return "미출근"
+        }
+    }
+    private var statusColor: Color {
+        switch entry.status {
+        case "IN": return Color(red: 0.09, green: 0.64, blue: 0.29)
+        case "OFF": return .secondary
+        default: return Color(red: 0.85, green: 0.46, blue: 0.10)
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        if family == .systemSmall {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                Spacer(minLength: 6)
+                Text(workedText(entry.workedMin))
+                    .font(.system(size: 22, weight: .heavy))
+                    .foregroundColor(.primary)
+                    .minimumScaleFactor(0.7).lineLimit(1)
+                Text("근무 \(entry.percent)%")
+                    .font(.system(size: 11, weight: .bold)).foregroundColor(brand)
+                ProgressBar(percent: entry.percent, color: brand).frame(height: 6).padding(.top, 5)
+            }
+        } else {
+            HStack(spacing: 16) {
+                Ring(percent: entry.percent, color: brand).frame(width: 74, height: 74)
+                VStack(alignment: .leading, spacing: 3) {
+                    header
+                    Text(workedText(entry.workedMin))
+                        .font(.system(size: 22, weight: .heavy)).foregroundColor(.primary)
+                        .minimumScaleFactor(0.7).lineLimit(1)
+                    Text("\(entry.startLabel) – \(entry.endLabel) 기준")
+                        .font(.system(size: 10, weight: .medium)).foregroundColor(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 4) {
+            Text("HiNest").font(.system(size: 10, weight: .bold)).foregroundColor(brand)
+            Text("·").font(.system(size: 10)).foregroundColor(.secondary)
+            HStack(spacing: 3) {
+                Circle().fill(statusColor).frame(width: 6, height: 6)
+                Text(statusLabel).font(.system(size: 10, weight: .bold)).foregroundColor(statusColor)
+            }
+        }
+    }
+}
+
+private struct ProgressBar: View {
+    let percent: Int
+    let color: Color
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                Capsule().fill(color.opacity(0.18))
+                Capsule().fill(color).frame(width: geo.size.width * CGFloat(min(100, max(0, percent))) / 100)
+            }
+        }
+    }
+}
+
+private struct Ring: View {
+    let percent: Int
+    let color: Color
+    var body: some View {
+        ZStack {
+            Circle().stroke(color.opacity(0.18), lineWidth: 8)
+            Circle()
+                .trim(from: 0, to: CGFloat(min(100, max(0, percent))) / 100)
+                .stroke(color, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+            Text("\(percent)%").font(.system(size: 17, weight: .heavy)).foregroundColor(.primary)
+        }
+    }
+}
+
+struct WorkStatusWidget: Widget {
+    let kind: String = "HiNestWorkStatusWidget"
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: WorkProvider()) { entry in
+            WorkStatusView(entry: entry)
+        }
+        .configurationDisplayName("근무 현황")
+        .description("오늘 근무시간과 진행률을 한눈에.")
+        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }
 

--- a/server/src/routes/widget.ts
+++ b/server/src/routes/widget.ts
@@ -10,9 +10,24 @@
 import { Router } from "express";
 import { prisma } from "../lib/db.js";
 import { requireAuth } from "../lib/auth.js";
+import { todayStr } from "../lib/dates.js";
 
 const router = Router();
 router.use(requireAuth);
+
+/** "HH:mm" → 분(0~1439). 형식 안 맞으면 null. */
+function parseHHmm(s: string | null | undefined): number | null {
+  if (!s) return null;
+  const m = /^(\d{1,2}):(\d{2})$/.exec(s.trim());
+  if (!m) return null;
+  const h = Number(m[1]);
+  const min = Number(m[2]);
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null;
+  return h * 60 + min;
+}
+function fmtHHmm(min: number): string {
+  return `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`;
+}
 
 /**
  * GET /api/widget/schedule/today
@@ -68,6 +83,46 @@ router.get("/schedule/today", async (req, res) => {
     // 위젯 refresh 다음 시각 힌트 — 새 이벤트가 곧 시작하면 그 시각 직전에 갱신.
     nextRefreshAt: events[0]?.startAt ?? new Date(now.getTime() + 15 * 60 * 1000).toISOString(),
     generatedAt: now.toISOString(),
+  });
+});
+
+/**
+ * GET /api/widget/work-status
+ *   - 오늘 출퇴근 상태 + 근무 경과시간 + 9to6(또는 설정) 기준 진행률
+ *   - status: NONE(미출근) | IN(근무중) | OFF(퇴근)
+ *   - workedMin: 출근~지금(또는 퇴근) 경과 분. targetMin: 근무 목표 분(기본 540=9h).
+ *   - percent: workedMin/targetMin (0~100)
+ */
+router.get("/work-status", async (req, res) => {
+  const u = (req as any).user;
+  const date = todayStr();
+  const [rec, userRow] = await Promise.all([
+    prisma.attendance.findUnique({ where: { userId_date: { userId: u.id, date } } }),
+    prisma.user.findUnique({ where: { id: u.id }, select: { workStartTime: true, workEndTime: true } }),
+  ]);
+
+  const now = Date.now();
+  const checkIn = rec?.checkIn ? new Date(rec.checkIn).getTime() : null;
+  const checkOut = rec?.checkOut ? new Date(rec.checkOut).getTime() : null;
+  const workedMin = checkIn ? Math.max(0, Math.floor(((checkOut ?? now) - checkIn) / 60000)) : 0;
+
+  const startMin = parseHHmm(userRow?.workStartTime) ?? 9 * 60;
+  const endMin = parseHHmm(userRow?.workEndTime) ?? 18 * 60;
+  const targetMin = Math.max(1, endMin - startMin);
+  const percent = Math.max(0, Math.min(100, Math.round((workedMin / targetMin) * 100)));
+  const status = checkOut ? "OFF" : checkIn ? "IN" : "NONE";
+
+  res.set("Cache-Control", "private, max-age=30");
+  res.json({
+    status,
+    workedMin,
+    targetMin,
+    percent,
+    checkIn: rec?.checkIn ?? null,
+    checkOut: rec?.checkOut ?? null,
+    startLabel: fmtHHmm(startMin),
+    endLabel: fmtHHmm(endMin),
+    generatedAt: new Date(now).toISOString(),
   });
 });
 


### PR DESCRIPTION
## 증상
**근무시간+퍼센트 위젯 (iOS/iPadOS/macOS)**

새 기능을 추가합니다.

## 원인
오늘 출퇴근 상태(NONE/IN/OFF), 근무 경과시간(workedMin), 9to6(또는 사용자 설정
workStartTime/workEndTime) 기준 진행률(percent). DashboardPage 와 동일 계산식.
Cache-Control private max-age=30.

## 수정
**작업 항목 (커밋 단위)**
- feat(server): GET /api/widget/work-status — 근무시간+진행률 위젯 endpoint
- feat(ios): 근무 현황 위젯 추가 — WidgetBundle(일정+근무)
- feat(macos): 근무 현황 위젯 추가 — WidgetBundle(일정+근무)

**변경 대상 (3개 파일)**
- `HiNest-MacOS-Widget/HiNestScheduleWidget/HiNestScheduleWidget.swift`
- `client/ios/App/HiNestScheduleWidget/HiNestScheduleWidget.swift`
- `server/src/routes/widget.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #385** 에서 진행됩니다.

