### PR TITLE
🔀 :: (#386) 공유 시트 목록 캐시 우선 + 보안·성능 점검 결과

### DIFF
--- a/client/src/components/ShareSheet.tsx
+++ b/client/src/components/ShareSheet.tsx
@@ -8,7 +8,7 @@
  * 모바일: 풀폭 바텀시트. 데스크톱: 가운데 중형 모달.
  */
 import { useEffect, useMemo, useState } from "react";
-import { api } from "../api";
+import { api, apiSWR } from "../api";
 import Portal from "./Portal";
 import { setNativeTabBarHidden } from "../lib/liquidGlassTabBar";
 
@@ -90,18 +90,21 @@ export default function ShareSheet({
     return () => setNativeTabBarHidden("share", false);
   }, [open]);
 
-  // 시트 열릴 때만 fetch — 닫힌 동안 네트워크 트래픽 0.
+  // 시트 열릴 때만 로드 — apiSWR 로 캐시 우선(즉시 표시) + 백그라운드 갱신.
+  // 반복해서 열어도 캐시가 있으면 즉시 뜨고 서버 호출은 갱신 1회로 절감(서버비 ↓).
   const [usersData, setUsersData] = useState<{ users: DirectoryUser[] } | null>(null);
   const [roomsData, setRoomsData] = useState<{ rooms: Room[] } | null>(null);
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    void api<{ users: DirectoryUser[] }>("/api/users").then((d) => {
-      if (!cancelled) setUsersData(d);
-    }).catch(() => {});
-    void api<{ rooms: Room[] }>("/api/chat/rooms").then((d) => {
-      if (!cancelled) setRoomsData(d);
-    }).catch(() => {});
+    void apiSWR<{ users: DirectoryUser[] }>("/api/users", {
+      onCached: (d) => { if (!cancelled) setUsersData(d); },
+      onFresh: (d) => { if (!cancelled) setUsersData(d); },
+    });
+    void apiSWR<{ rooms: Room[] }>("/api/chat/rooms", {
+      onCached: (d) => { if (!cancelled) setRoomsData(d); },
+      onFresh: (d) => { if (!cancelled) setRoomsData(d); },
+    });
     return () => { cancelled = true; };
   }, [open]);
 


### PR DESCRIPTION
## 증상
**공유 시트 목록 캐시 우선 + 보안·성능 점검 결과**

보안 취약점을 점검하고 보완합니다.

## 원인
공유 시트를 열 때마다 /api/users + /api/chat/rooms 를 매번 새로 요청하던 것을
apiSWR(캐시 우선 + 백그라운드 갱신)로 전환. 반복해서 열어도 캐시가 있으면 즉시 표시되고
서버 호출은 갱신 1회로 줄어든다(UX↑, 서버비↓).

[보안·성능·서버비 점검 결과]
- 추가 엔드포인트(widget/share/attendance-ip) 모두 requireAuth + zod 검증 + 결과 상한 보유.
- 핫 패스 findMany 는 take 상한(검색 80, 이벤트 2000, 휴가/예약 500 등) 또는 테넌트 크기로
  자연 제한(유저당 방·프로젝트당 멤버 등) → 무제한 스캔 DoS 위험 없음.
- 위젯 폴링은 iOS WidgetKit 예산으로 자연 스로틀 + Cache-Control 30s.
- 결론: 신규 기능발 치명적 보안/성능/서버비 이슈 없음. 본 캐시 개선만 적용.

## 수정
**작업 항목 (커밋 단위)**
- perf(share): ShareSheet 목록 캐시 우선 로드 — 서버 호출 절감

**변경 대상 (1개 파일)**
- `client/src/components/ShareSheet.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #386** 에서 진행됩니다.

