### PR TITLE
🔀 :: (#387) Xcode 빌드 오류 — uiStyle 호출 타입 수정

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -146,7 +146,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc func setInterfaceStyle(_ call: CAPPluginCall) {
         let mode = call.getString("style") ?? "light" // light | dark | system
         UserDefaults.standard.set(mode, forKey: "hinest.interfaceStyle")
-        let style = AppDelegate.uiStyle(from: mode)
+        let style = LiquidGlassTabBarPlugin.uiStyle(from: mode)
         DispatchQueue.main.async {
             self.bridge?.viewController?.view.window?.overrideUserInterfaceStyle = style
             self.tabBarView?.overrideUserInterfaceStyle = style
@@ -184,7 +184,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         // 탭바 트레잇을 앱 테마(저장값)에 맞춘다. 윈도우를 따라가도 되지만, addSubview 직후
         // 부모 트레잇을 즉시 반영하지 않는 미세한 frame 갭이 있어 명시적으로 같은 값을 박는다.
         // light→.light / dark→.dark / system→.unspecified(윈도우=OS 따라감).
-        tabBar.overrideUserInterfaceStyle = AppDelegate.uiStyle(from: UserDefaults.standard.string(forKey: "hinest.interfaceStyle"))
+        tabBar.overrideUserInterfaceStyle = LiquidGlassTabBarPlugin.uiStyle(from: UserDefaults.standard.string(forKey: "hinest.interfaceStyle"))
 
         var items: [UITabBarItem] = []
         for (i, tab) in tabs.enumerated() {


### PR DESCRIPTION
## 증상
**Xcode 빌드 오류 — uiStyle 호출 타입 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
PR #374(다크모드)에서 uiStyle 헬퍼를 LiquidGlassTabBarPlugin 의 static 메서드로 정의해놓고
호출은 AppDelegate.uiStyle 로 잘못 적었다 → 'Type AppDelegate has no member uiStyle' ×2.
정의된 타입(LiquidGlassTabBarPlugin)으로 호출 수정. 두 곳(setInterfaceStyle·build).

## 수정
**작업 항목 (커밋 단위)**
- fix(ios): 빌드 오류 — AppDelegate.uiStyle → LiquidGlassTabBarPlugin.uiStyle

**변경 대상 (1개 파일)**
- `client/ios/App/App/AppDelegate.swift`

## 검증
- `client` tsc 통과 + vite build ✓
- iOS 빌드/실기기 확인

---
🔗 이 작업은 **PR #387** 에서 진행됩니다.

