### PR TITLE
🔀 :: (#391) 멀티에이전트 감사 — 보안 4건 (cross-tenant HIGH 포함)

### DIFF
--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -36,7 +36,7 @@ const TIMING_DUMMY_HASH = bcrypt.hashSync(
 
 const loginSchema = z.object({
   // 이메일 전용. 과거에는 사내 ID 도 허용했지만 정책 단순화로 이메일로만 로그인.
-  email: z.string().email().max(200),
+  email: z.string().email().max(200).transform((s) => s.trim().toLowerCase()),
   // bcrypt 는 72바이트 초과를 조용히 자르지만, 과도한 페이로드로 CPU 낭비 시키는
   // 슬로우 해시 DoS 를 막기 위해 128자 상한.
   password: z.string().min(1).max(128),
@@ -167,7 +167,7 @@ router.post("/login", async (req, res) => {
 
 const signupSchema = z.object({
   inviteKey: z.string().min(4).max(100),
-  email: z.string().email().max(200),
+  email: z.string().email().max(200).transform((s) => s.trim().toLowerCase()),
   name: z.string().min(1).max(200),
   // 8자 이상 — 6자는 현대 기준으로 너무 약함. 기존 계정은 그대로 사용 가능하고 다음 변경 시 8자 요구.
   // bcrypt 72바이트 한계 가이드 + 슬로우 해시 DoS 방지로 128자 상한.
@@ -301,7 +301,7 @@ router.post("/signup", async (req, res) => {
 const companySignupSchema = z.object({
   companyName: z.string().min(1).max(200),
   contactName: z.string().min(1).max(100),
-  email: z.string().email().max(200),
+  email: z.string().email().max(200).transform((s) => s.trim().toLowerCase()),
   password: z.string().min(8).max(128),
   contactPhone: z.string().max(40).optional(),
   bizRegNo: z.string().max(40).optional(),

--- a/server/src/routes/folderShareLink.ts
+++ b/server/src/routes/folderShareLink.ts
@@ -146,9 +146,10 @@ export async function streamFolderZip(
   }
   const folderIds = collectIds(folderId);
 
-  // 해당 폴더들에 속한 문서
+  // 해당 폴더들에 속한 문서 — deletedAt:null 필수. 소프트 삭제(deletedAt 만 세팅, fileUrl/folderId 보존)된
+  // 문서가 과거 발급된 공개 링크로 계속 다운로드되던 결함 차단(인증 경로 document.ts 와 동작 일치).
   const docs = await prisma.document.findMany({
-    where: { folderId: { in: folderIds }, fileUrl: { not: null } },
+    where: { folderId: { in: folderIds }, fileUrl: { not: null }, deletedAt: null },
     select: { id: true, title: true, fileName: true, fileUrl: true, folderId: true },
   });
 

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { notifyMany } from "../lib/notify.js";
+import { allSameCompanyUsers } from "../lib/tenantValidate.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -423,6 +424,15 @@ router.post("/", async (req, res) => {
     }
   }
 
+  // SPECIFIC 열람자(viewerIds)는 반드시 같은 회사 사용자여야 한다 — 안 그러면 타 회사 사용자에게
+  // 고아 MeetingViewer 행 + 알림/SSE/APNs 푸시가 주입되는 cross-tenant 결함(자동 스코프는 nested
+  // create·publish 를 막지 못함). chat.ts 등 다른 라우트와 동일하게 명시 검증.
+  if (d.visibility === "SPECIFIC" && d.viewerIds?.length) {
+    if (!(await allSameCompanyUsers(d.viewerIds))) {
+      return res.status(400).json({ error: "열람자 중 일부를 찾을 수 없습니다" });
+    }
+  }
+
   const meeting = await prisma.meeting.create({
     data: {
       title: d.title,
@@ -530,6 +540,13 @@ router.patch("/:id", async (req, res) => {
   const replaceViewers =
     d.viewerIds !== undefined &&
     ((d.visibility ?? existing.visibility) === "SPECIFIC");
+
+  // 교체될 viewerIds 는 반드시 같은 회사 사용자여야 함(POST 와 동일 — cross-tenant 알림 주입 차단).
+  if (replaceViewers && d.viewerIds?.length) {
+    if (!(await allSameCompanyUsers(d.viewerIds))) {
+      return res.status(400).json({ error: "열람자 중 일부를 찾을 수 없습니다" });
+    }
+  }
 
   // 교체 전 기존 열람자 스냅샷 — 트랜잭션 후 새로 추가된 사람에게만 공유 알림을 보내기 위함.
   const prevViewerIds = replaceViewers

--- a/server/src/routes/pin.ts
+++ b/server/src/routes/pin.ts
@@ -26,7 +26,10 @@ const createSchema = z.object({
  * 핀에 붙은 리소스의 최신 표시 정보를 한 번에 가져온다 — 리소스 삭제 후 핀만 남을 수 있어서
  * null 인 항목은 클라가 "[삭제된 항목]" 으로 표시 or 자동 제거 가능.
  */
-async function hydratePins(pins: { id: string; targetType: string; targetId: string; label: string | null; sortOrder: number; createdAt: Date }[]) {
+async function hydratePins(
+  pins: { id: string; targetType: string; targetId: string; label: string | null; sortOrder: number; createdAt: Date }[],
+  u: { id: string; role: string; team: string | null },
+) {
   const groups: Record<TargetType, string[]> = {
     DOCUMENT: [], MEETING: [], CHAT_ROOM: [], PROJECT: [], NOTICE: [],
   };
@@ -35,19 +38,42 @@ async function hydratePins(pins: { id: string; targetType: string; targetId: str
       groups[p.targetType as TargetType].push(p.targetId);
     }
   }
+  const isAdmin = u.role === "ADMIN";
+  // 접근통제(BAC): 핀은 임의 targetId 를 저장할 수 있으므로, 하이드레이션 단계에서 '현재 사용자가
+  // 실제로 볼 수 있는 것'만 이름을 조회한다. 접근 불가 항목은 nameBy 에 안 들어가 missing=true 로
+  // 떨어져 기존 '[삭제된 항목]' UX 로 흡수 → 비공개 리소스의 제목/이름이 새지 않음.
+  const docAcl = isAdmin
+    ? {}
+    : { OR: [
+        { scope: "ALL" },
+        { authorId: u.id },
+        ...(u.team ? [{ scope: "TEAM", scopeTeam: u.team }] : []),
+        { scope: "CUSTOM", scopeUserIds: { contains: u.id } },
+      ] };
+  const meetingAcl = isAdmin
+    ? {}
+    : { OR: [
+        { visibility: "ALL" },
+        { authorId: u.id },
+        { viewers: { some: { userId: u.id } } },
+        { visibility: "PROJECT", project: { members: { some: { userId: u.id } } } },
+      ] };
+  const projectAcl = isAdmin ? {} : { members: { some: { userId: u.id } } };
+
   const [docs, meetings, rooms, projects, notices] = await Promise.all([
     groups.DOCUMENT.length
-      ? prisma.document.findMany({ where: { id: { in: groups.DOCUMENT }, deletedAt: null }, select: { id: true, title: true } })
+      ? prisma.document.findMany({ where: { id: { in: groups.DOCUMENT }, deletedAt: null, ...docAcl }, select: { id: true, title: true } })
       : Promise.resolve([]),
     groups.MEETING.length
-      ? prisma.meeting.findMany({ where: { id: { in: groups.MEETING }, deletedAt: null }, select: { id: true, title: true } })
+      ? prisma.meeting.findMany({ where: { id: { in: groups.MEETING }, deletedAt: null, ...meetingAcl }, select: { id: true, title: true } })
       : Promise.resolve([]),
     groups.CHAT_ROOM.length
-      ? prisma.chatRoom.findMany({ where: { id: { in: groups.CHAT_ROOM } }, select: { id: true, name: true, type: true } })
+      ? prisma.chatRoom.findMany({ where: { id: { in: groups.CHAT_ROOM }, members: { some: { userId: u.id } } }, select: { id: true, name: true, type: true } })
       : Promise.resolve([]),
     groups.PROJECT.length
-      ? prisma.project.findMany({ where: { id: { in: groups.PROJECT } }, select: { id: true, name: true, color: true } })
+      ? prisma.project.findMany({ where: { id: { in: groups.PROJECT }, ...projectAcl }, select: { id: true, name: true, color: true } })
       : Promise.resolve([]),
+    // 공지는 회사 전체 공개 — companyId 자동 스코프로 충분(추가 ACL 불필요).
     groups.NOTICE.length
       ? prisma.notice.findMany({ where: { id: { in: groups.NOTICE }, deletedAt: null }, select: { id: true, title: true } })
       : Promise.resolve([]),
@@ -82,7 +108,7 @@ router.get("/", async (req, res) => {
     orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }],
     take: 100,
   });
-  const items = await hydratePins(pins);
+  const items = await hydratePins(pins, { id: u.id, role: u.role, team: u.team ?? null });
   res.json({ pins: items });
 });
 


### PR DESCRIPTION
## 증상
**멀티에이전트 감사 — 보안 4건 (cross-tenant HIGH 포함)**

보안 취약점을 점검하고 보완합니다.

## 원인
SPECIFIC 회의록의 viewerIds 가 같은 회사 사용자인지 검증되지 않아, 타 회사 사용자 id 를 넣으면
고아 MeetingViewer 행 + 알림/SSE/APNs 푸시가 그 피해자에게 주입되던 cross-tenant 결함.
( 자동 스코프는 nested create·publish 를 막지 못함.) POST·PATCH 모두 chat.ts 와 동일하게
allSameCompanyUsers() 가드 추가.

## 수정
**작업 항목 (커밋 단위)**
- fix(security): 회의록 viewerIds 같은 회사 검증 — cross-tenant 알림 주입 차단 (HIGH)
- fix(security): 공개 폴더 ZIP 이 소프트삭제 문서 내보내던 누출 차단
- fix(security): 이메일 정규화 통일 — 가입/로그인/재설정 소문자 일관화
- fix(security): 핀 하이드레이션에 접근통제 — 비공개 리소스 제목 노출 차단

**변경 대상 (4개 파일)**
- `server/src/routes/auth.ts`
- `server/src/routes/folderShareLink.ts`
- `server/src/routes/meeting.ts`
- `server/src/routes/pin.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #391** 에서 진행됩니다.

