### PR TITLE
🔀 :: (#392) 멀티에이전트 감사 — 서버비/성능 (가입 팬아웃 HIGH 등)

### DIFF
--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -203,10 +203,17 @@ export async function notifyMany(inputs: NotifyInput[]) {
 /** 전사 공지 — 총관리자 제외 모든 활성 유저에게 발송 */
 export async function notifyAllUsers(
   tpl: Omit<NotifyInput, "userId">,
-  excludeUserId?: string
+  excludeUserId?: string,
+  // 대상 회사 한정 — 명시하면 그 회사 활성 사용자에게만 팬아웃. 미인증 경로(회원가입)는 테넌트
+  // AsyncLocalStorage 컨텍스트가 없어 자동 스코프가 안 걸려 전 회사로 새어나가므로 반드시 넘겨야 함.
+  companyId?: string | null
 ) {
   const users = await prisma.user.findMany({
-    where: { active: true, ...(excludeUserId ? { id: { not: excludeUserId } } : {}) },
+    where: {
+      active: true,
+      ...(excludeUserId ? { id: { not: excludeUserId } } : {}),
+      ...(companyId ? { companyId } : {}),
+    },
     select: { id: true },
   });
   await notifyMany(

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -275,7 +275,7 @@ router.post("/signup", async (req, res) => {
     linkUrl: `/users/${user.id}`,
     actorName: user.name,
     actorColor: user.avatarColor,
-  }, user.id).catch((e) => console.error("[signup] notifyAllUsers failed", e));
+  }, user.id, user.companyId).catch((e) => console.error("[signup] notifyAllUsers failed", e));
 
   res.json({
     user: {

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -854,6 +854,24 @@ router.post("/share", async (req, res) => {
     where: { id: u.id },
     select: { name: true, avatarUrl: true, avatarColor: true },
   });
+
+  // 방 정보 + 수신자 멤버를 루프 전에 일괄 조회(N+1 제거 — 방마다 findUnique/findMany 하던 것을 2쿼리로).
+  const roomIdList = [...recipientRoomIds];
+  const roomInfos = await prisma.chatRoom.findMany({
+    where: { id: { in: roomIdList } },
+    select: { id: true, type: true, name: true },
+  });
+  const roomById = new Map(roomInfos.map((r) => [r.id, r]));
+  const allMembers = await prisma.roomMember.findMany({
+    where: { roomId: { in: roomIdList }, userId: { not: u.id } },
+    select: { roomId: true, userId: true },
+  });
+  const othersByRoom = new Map<string, string[]>();
+  for (const m of allMembers) {
+    if (!othersByRoom.has(m.roomId)) othersByRoom.set(m.roomId, []);
+    othersByRoom.get(m.roomId)!.push(m.userId);
+  }
+
   for (const roomId of recipientRoomIds) {
     const msg = await prisma.chatMessage.create({
       data: {
@@ -872,20 +890,14 @@ router.post("/share", async (req, res) => {
     // SSE 로 같은 방 멤버들에게 즉시 갱신.
     broadcastToRoom(roomId, "chat:update", { kind: "create", messageId: msg.id, roomId });
 
-    // 방 정보 — 알림 표시명 결정.
-    const room = await prisma.chatRoom.findUnique({
-      where: { id: roomId },
-      select: { type: true, name: true },
-    });
-    const others = await prisma.roomMember.findMany({
-      where: { roomId, userId: { not: u.id } },
-      select: { userId: true },
-    });
+    // 방 정보 — 알림 표시명 결정(루프 전 prefetch 한 맵 사용).
+    const room = roomById.get(roomId);
+    const others = othersByRoom.get(roomId) ?? [];
     if (!others.length) continue;
     if (room?.type === "DIRECT") {
       await notifyMany(
-        others.map((o) => ({
-          userId: o.userId,
+        others.map((userId) => ({
+          userId,
           type: "DM" as const,
           title: u.name,
           body: `📌 ${label} · ${d.title}`.slice(0, 140),
@@ -898,8 +910,8 @@ router.post("/share", async (req, res) => {
     } else {
       const roomName = room?.name ?? "대화방";
       await notifyMany(
-        others.map((o) => ({
-          userId: o.userId,
+        others.map((userId) => ({
+          userId,
           type: "DM" as const,
           title: roomName,
           body: `${u.name}: 📌 ${label} · ${d.title}`.slice(0, 140),

--- a/server/src/routes/folderShareLink.ts
+++ b/server/src/routes/folderShareLink.ts
@@ -133,18 +133,23 @@ export async function streamFolderZip(
   folderName: string,
   res: any,
 ) {
-  // 폴더 + 하위 폴더 전체 조회
-  const allFolders = await prisma.folder.findMany({ select: { id: true, name: true, parentId: true } });
-  const folderMap = new Map(allFolders.map((f) => [f.id, f]));
-
-  function collectIds(rootId: string): string[] {
-    const result = [rootId];
-    for (const f of allFolders) {
-      if (f.parentId === rootId) result.push(...collectIds(f.id));
-    }
-    return result;
+  // 하위 폴더를 BFS 로 수집(트리 깊이당 1쿼리, parentId 인덱스 사용) — 전 회사 Folder 테이블을
+  // 매 요청 통째로 로드하던 것 제거(공개 endpoint 라 테넌트 스코프도 없어 더 위험했음).
+  // document.ts /folders/:id/download 와 동일 패턴.
+  type FolderNode = { id: string; name: string; parentId: string | null };
+  const subtree: FolderNode[] = [];
+  let frontier: string[] = [folderId];
+  while (frontier.length) {
+    const children = await prisma.folder.findMany({
+      where: { parentId: { in: frontier } },
+      select: { id: true, name: true, parentId: true },
+    });
+    if (!children.length) break;
+    subtree.push(...children);
+    frontier = children.map((c) => c.id);
   }
-  const folderIds = collectIds(folderId);
+  const folderMap = new Map(subtree.map((f) => [f.id, f]));
+  const folderIds = [folderId, ...subtree.map((f) => f.id)];
 
   // 해당 폴더들에 속한 문서 — deletedAt:null 필수. 소프트 삭제(deletedAt 만 세팅, fileUrl/folderId 보존)된
   // 문서가 과거 발급된 공개 링크로 계속 다운로드되던 결함 차단(인증 경로 document.ts 와 동작 일치).

--- a/server/src/routes/notice.ts
+++ b/server/src/routes/notice.ts
@@ -91,6 +91,7 @@ router.post("/", async (req, res) => {
       actorName: u.name,
     },
     u.id,
+    u.companyId,
   );
   res.json({ notice: n });
 });

--- a/server/src/routes/widget.ts
+++ b/server/src/routes/widget.ts
@@ -96,10 +96,9 @@ router.get("/schedule/today", async (req, res) => {
 router.get("/work-status", async (req, res) => {
   const u = (req as any).user;
   const date = todayStr();
-  const [rec, userRow] = await Promise.all([
-    prisma.attendance.findUnique({ where: { userId_date: { userId: u.id, date } } }),
-    prisma.user.findUnique({ where: { id: u.id }, select: { workStartTime: true, workEndTime: true } }),
-  ]);
+  // requireAuth 가 캐시해 둔 전체 user row 재사용(workStartTime/workEndTime 포함) — 중복 user 조회 제거.
+  const userRow = (req as any).userRecord ?? null;
+  const rec = await prisma.attendance.findUnique({ where: { userId_date: { userId: u.id, date } } });
 
   const now = Date.now();
   const checkIn = rec?.checkIn ? new Date(rec.checkIn).getTime() : null;


### PR DESCRIPTION
## 증상
**멀티에이전트 감사 — 서버비/성능 (가입 팬아웃 HIGH 등)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
notifyAllUsers 가 미인증 경로(회원가입)에서 테넌트 컨텍스트 없이 돌아 전 회사 활성 사용자에게
'합류 알림'을 팬아웃하던 문제(서버비 + 멀티테넌트 누수). companyId 인자 추가 + 가입/공지 호출에
명시 전달 → 해당 회사 사용자에게만 발송.

## 수정
**작업 항목 (커밋 단위)**
- fix(server): 회원가입 알림 팬아웃을 가입 회사로 한정 (HIGH 서버비/테넌트)
- perf(server): 폴더 공유 ZIP 하위폴더 BFS — 전 회사 Folder 풀스캔 제거
- perf(server): /share 방·멤버 일괄 prefetch — N+1 제거
- perf(server): /work-status 중복 user 조회 제거 — requireAuth 캐시 재사용

**변경 대상 (6개 파일)**
- `server/src/lib/notify.ts`
- `server/src/routes/auth.ts`
- `server/src/routes/chat.ts`
- `server/src/routes/folderShareLink.ts`
- `server/src/routes/notice.ts`
- `server/src/routes/widget.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #392** 에서 진행됩니다.

