### PR TITLE
🔀 :: (#393) 멀티에이전트 감사 — 반응형/UI 13건 (320px~초광폭·다크모드)

### DIFF
--- a/client/src/components/DocMemoModal.tsx
+++ b/client/src/components/DocMemoModal.tsx
@@ -372,7 +372,7 @@ export default function DocMemoModal({
                   </svg>
                   <span className="text-[12px] font-bold text-ink-700">공개 범위</span>
                 </div>
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                <div className="grid grid-cols-1 min-[360px]:grid-cols-2 sm:grid-cols-4 gap-2">
                   {(["ALL", "TEAM", "PRIVATE", "CUSTOM"] as DocScope[]).map((s) => {
                     const active = scope === s;
                     return (

--- a/client/src/components/ProjectCalendar.tsx
+++ b/client/src/components/ProjectCalendar.tsx
@@ -390,7 +390,7 @@ export default function ProjectCalendar({
       {openCreate && (
         <Portal>
         <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setOpenCreate(false)}>
-          <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
+          <div className="card w-full max-w-md max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-bold mb-4">새 일정</h3>
             <form onSubmit={submitCreate} className="space-y-3">
               <div>
@@ -472,7 +472,7 @@ export default function ProjectCalendar({
       {selected && (
         <Portal>
         <div className="fixed inset-0 bg-slate-900/40 grid place-items-center modal-safe z-50" onClick={() => setSelected(null)}>
-          <div className="card w-full max-w-md" onClick={(e) => e.stopPropagation()}>
+          <div className="card w-full max-w-md max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center gap-2 mb-2">
               <span className="w-3 h-3 rounded-full" style={{ background: selected.color }} />
               <h3 className={`text-lg font-bold flex-1 ${selected.completed ? "line-through text-slate-400" : ""}`}>{selected.title}</h3>
@@ -930,9 +930,9 @@ function ListView({
         const isToday = sameDay(g.date, today);
         const weekday = ["일", "월", "화", "수", "목", "금", "토"][g.date.getDay()];
         return (
-          <div key={g.date.toISOString()} className="grid grid-cols-[110px_1fr] gap-4 px-4 py-3">
+          <div key={g.date.toISOString()} className="grid grid-cols-[64px_1fr] sm:grid-cols-[110px_1fr] gap-2 sm:gap-4 px-4 py-3">
             <div className="text-right">
-              <div className={`text-2xl font-bold tabular ${isToday ? "text-brand-600" : "text-slate-800"}`}>
+              <div className={`text-xl sm:text-2xl font-bold tabular ${isToday ? "text-brand-600" : "text-slate-800"}`}>
                 {g.date.getDate()}
               </div>
               <div className={`text-[11px] font-bold ${g.date.getDay() === 0 ? "text-rose-500" : g.date.getDay() === 6 ? "text-blue-500" : "text-slate-500"}`}>

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -247,7 +247,7 @@ export default function ExpensePage() {
 
       <div className="card p-0 overflow-hidden overflow-x-auto" style={{ WebkitOverflowScrolling: "touch" }}>
         <table className="pro-cards w-full text-sm min-w-[720px]">
-          <thead className="bg-slate-50 text-slate-500 text-xs">
+          <thead className="bg-[color:var(--c-surface-2)] text-[color:var(--c-text-3)] text-xs">
             <tr>
               <th className="text-left px-4 py-3">사용일시</th>
               {scope === "all" && <th className="text-left px-4 py-3">사용자</th>}
@@ -263,13 +263,13 @@ export default function ExpensePage() {
           <tbody>
             {list.length === 0 && (
               <tr>
-                <td colSpan={9} className="cell-full px-4 py-10 text-center text-slate-400">
+                <td colSpan={9} className="cell-full px-4 py-10 text-center text-ink-400">
                   등록된 사용내역이 없습니다.
                 </td>
               </tr>
             )}
             {list.map((e) => (
-              <tr key={e.id} className="border-t border-slate-100 hover:bg-slate-50/50">
+              <tr key={e.id} className="border-t border-[color:var(--c-border)] hover:bg-[color:var(--c-surface-2)]">
                 <td data-label="사용일시" className="px-4 py-3">
                   {new Date(e.usedAt).toLocaleString("ko-KR", {
                     month: "2-digit",
@@ -281,10 +281,10 @@ export default function ExpensePage() {
                 {scope === "all" && <td data-label="사용자" className="px-4 py-3">{e.user?.name}</td>}
                 <td className="cell-primary px-4 py-3 font-medium">{e.merchant}</td>
                 <td data-label="분류" className="px-4 py-3">
-                  <span className="chip bg-slate-100 text-slate-700">{e.category}</span>
+                  <span className="chip chip-gray">{e.category}</span>
                 </td>
                 <td data-label="금액" className="px-4 py-3 text-right font-semibold">{e.amount.toLocaleString()}원</td>
-                <td data-label="메모" className="px-4 py-3 text-slate-500">
+                <td data-label="메모" className="px-4 py-3 text-ink-500">
                   <span className="block truncate max-w-[160px] md:max-w-[200px]">{e.memo || "-"}</span>
                 </td>
                 <td data-label="영수증" className="px-4 py-3 text-center">
@@ -293,7 +293,7 @@ export default function ExpensePage() {
                       보기
                     </button>
                   ) : (
-                    <span className="text-slate-300 text-xs">-</span>
+                    <span className="text-ink-300 text-xs">-</span>
                   )}
                 </td>
                 <td data-label="상태" className="px-4 py-3 text-center">

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -385,12 +385,12 @@ export default function MeetingDetailPage() {
           공개 범위:
           {visibility === "ALL" && <span className="chip-green">전사</span>}
           {visibility === "PROJECT" && (
-            <span className="chip" style={{ background: "#DBEAFE", color: "#1E40AF" }}>
+            <span className="chip chip-blue">
               프로젝트 — {meeting.project?.name ?? "-"}
             </span>
           )}
           {visibility === "SPECIFIC" && (
-            <span className="chip" style={{ background: "#FEF3C7", color: "#92400E" }}>
+            <span className="chip chip-amber">
               특정 {meeting.viewers.length}명 + 작성자
             </span>
           )}
@@ -441,7 +441,7 @@ function VisBtn({ active, onClick, label, desc }: { active: boolean; onClick: ()
     <button
       type="button"
       onClick={onClick}
-      className={`flex-1 text-left p-3 rounded-lg border-2 transition ${active ? "border-brand-500 bg-brand-50" : "border-slate-200 hover:bg-slate-50"}`}
+      className={`flex-1 text-left p-3 rounded-lg border-2 transition ${active ? "border-brand-500 bg-brand-50 dark:bg-brand-900/30 dark:text-brand-200" : "border-ink-200 hover:bg-ink-50 dark:border-ink-700 dark:hover:bg-ink-800"}`}
     >
       <div className="text-[13px] font-bold">{label}</div>
       <div className="text-[11px] text-slate-500 mt-0.5">{desc}</div>

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -337,7 +337,7 @@ export default function NoticePage() {
                     </button>
                     {pickerOpen && (
                       <div
-                        className="absolute z-10 mt-2 left-0 bg-white border border-slate-200 shadow-lg rounded-lg p-1 flex gap-1"
+                        className="absolute z-10 mt-2 right-0 max-w-[calc(100vw-2rem)] bg-white border border-ink-150 shadow-lg rounded-lg p-1 flex flex-wrap gap-1"
                         onMouseLeave={() => setPickerOpen(false)}
                       >
                         {NOTICE_REACTION_EMOJI.map((e) => (

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -917,7 +917,7 @@ function InfoField({ label, value, tone, mono }: { label: string; value: string;
   return (
     <div>
       <div className="text-[11px] font-bold text-ink-500 uppercase tracking-[0.06em]">{label}</div>
-      <div className={`text-[13px] font-semibold mt-0.5 ${tone === "green" ? "text-emerald-600" : "text-ink-900"} ${mono ? "font-mono tracking-[0.02em]" : ""}`}>{value}</div>
+      <div className={`text-[13px] font-semibold mt-0.5 break-words ${tone === "green" ? "text-emerald-600" : "text-ink-900"} ${mono ? "font-mono tracking-[0.02em]" : ""}`} title={typeof value === "string" ? value : undefined}>{value}</div>
     </div>
   );
 }

--- a/client/src/pages/PublicSharePage.tsx
+++ b/client/src/pages/PublicSharePage.tsx
@@ -87,7 +87,7 @@ export default function PublicSharePage() {
               ) : (
                 <span className="text-2xl">📄</span>
               )}
-              <div className="text-lg font-bold text-ink-900">
+              <div className="text-lg font-bold text-ink-900 min-w-0 break-words">
                 {meta.document?.title ?? (meta.hasPassword ? "🔒 비밀번호로 보호된 파일" : "파일")}
               </div>
             </div>

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -392,7 +392,7 @@ export default function ServiceAccountsPage() {
   ];
 
   return (
-    <div className="container-narrow py-6">
+    <div className="max-w-[960px] mx-auto py-6">
       <PageHeader
         eyebrow="팀 리소스"
         title="계정 관리"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -415,14 +415,16 @@ textarea.input {
 /* iOS Safari 는 font-size < 16px 인 input 에 포커스 시 viewport 를 자동 확대함.
    모바일에서만 16px 로 고정해 자동 줌을 억제한다. */
 @media (max-width: 640px) {
-  .input { font-size: 16px; }
-  .filter-input { font-size: 16px; }
+  /* !important — 일부 입력칸이 Tailwind `!text-[12.5px]` 같은 important 유틸로 16px 규칙을
+     덮어써 iOS 자동 줌이 도로 발생하던 문제(감사 발견 JournalPage 등). 모바일에선 16px 강제. */
+  .input { font-size: 16px !important; }
+  .filter-input { font-size: 16px !important; }
 }
 /* 위 max-width:640px 은 세로 아이폰만 커버 → 아이패드·가로 아이폰(>640px) 은 여전히
    14px/12.5px 라 포커스 시 화면이 줌-점프한다. 호버 불가(=터치) 기기 전반에서 16px 로
    올려 자동 줌을 막는다. 마우스 데스크톱/Electron(pointer:fine) 은 기존 콤팩트 크기 유지. */
 @media (pointer: coarse) {
-  .input, textarea.input, .filter-input, select.filter-input, .ghost-select { font-size: 16px; }
+  .input, textarea.input, .filter-input, select.filter-input, .ghost-select { font-size: 16px !important; }
 }
 
 /* 터치(호버 불가) 기기에서는 hover 로만 드러나는 액션 버튼을 항상 보이게 한다.


### PR DESCRIPTION
## 증상
**멀티에이전트 감사 — 반응형/UI 13건 (320px~초광폭·다크모드)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
.input 의 모바일/coarse-pointer 16px 규칙이 Tailwind !text-[12.5px] 같은 important
유틸에 덮여 iOS 자동 줌이 도로 발생(감사: JournalPage 검색·제목 등). 규칙에 !important 부여로
모든 입력칸 일괄 방어.

## 수정
**작업 항목 (커밋 단위)**
- fix(ui): 모바일 입력칸 16px 강제(!important) — iOS 포커스 자동 줌 방지
- fix(ui): 일정 모달 스크롤 + 날짜컬럼·공개범위 반응형
- fix(ui): 다크모드 하드코딩색 제거 — 회의록 공개범위·경비 테이블
- fix(ui): 오버플로/폭 제한 — 드롭다운·긴 텍스트·container

**변경 대상 (9개 파일)**
- `client/src/components/DocMemoModal.tsx`
- `client/src/components/ProjectCalendar.tsx`
- `client/src/pages/ExpensePage.tsx`
- `client/src/pages/MeetingDetailPage.tsx`
- `client/src/pages/NoticePage.tsx`
- `client/src/pages/ProfilePage.tsx`
- `client/src/pages/PublicSharePage.tsx`
- `client/src/pages/ServiceAccountsPage.tsx`
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #393** 에서 진행됩니다.

