### PR TITLE
🔀 :: (#395) 공유 카드 이동 + 메모 공유 추가

### DIFF
--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -129,13 +129,16 @@ export default function ChatFab() {
       setOpen(true);
       setOpenRoomReq((prev) => ({ id: (prev?.id ?? 0) + 1, roomId: rid }));
     };
+    const onCloseEvt = () => setOpen(false);
     window.addEventListener("chat:toggle", onToggle);
     window.addEventListener("chat:open", onOpen);
     window.addEventListener("chat:open-room", onOpenRoom);
+    window.addEventListener("chat:close", onCloseEvt);
     return () => {
       window.removeEventListener("chat:toggle", onToggle);
       window.removeEventListener("chat:open", onOpen);
       window.removeEventListener("chat:open-room", onOpenRoom);
+      window.removeEventListener("chat:close", onCloseEvt);
     };
   }, []);
 

--- a/client/src/components/DocMemoModal.tsx
+++ b/client/src/components/DocMemoModal.tsx
@@ -11,6 +11,7 @@ import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useSta
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync } from "./ConfirmHost";
+import ShareButton from "./ShareButton";
 
 const MeetingEditor = lazy(() => import("./MeetingEditor"));
 
@@ -42,6 +43,19 @@ type Props = {
   onSaved: (doc: MemoDoc) => void;
   onDeleted?: (id: string) => void;
 };
+
+/** TipTap JSON 콘텐츠에서 앞부분 텍스트만 뽑아 공유 카드 미리보기로 쓴다(최대 120자). */
+function memoTextSnippet(node: any, limit = 120): string {
+  if (!node) return "";
+  let out = "";
+  const walk = (n: any) => {
+    if (out.length >= limit || !n) return;
+    if (typeof n.text === "string") out += n.text;
+    if (Array.isArray(n.content)) { for (const c of n.content) { walk(c); if (out.length >= limit) break; } }
+  };
+  walk(node);
+  return out.trim().slice(0, limit);
+}
 
 const SCOPE_LABEL: Record<DocScope, string> = {
   ALL: "전체 공개",
@@ -257,23 +271,37 @@ export default function DocMemoModal({
                 </button>
               </>
             ) : (
-              isMine && (
-                <>
-                  {doc && (
-                    <button
-                      className="btn-ghost btn-sm text-rose-600 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-900/30"
-                      onClick={handleDelete}
-                      disabled={deleting}
-                      title="메모 삭제"
-                    >
-                      {deleting ? "삭제 중…" : "삭제"}
+              <>
+                {/* 공유 — 열람 가능한 사람이면 누구나 사내 동료/대화방으로 공유 */}
+                {doc && (
+                  <ShareButton
+                    variant="icon"
+                    payload={{
+                      kind: "MEMO",
+                      title: title?.trim() || "제목 없는 메모",
+                      snippet: memoTextSnippet(doc.content),
+                      href: `/memos?memo=${doc.id}`,
+                    }}
+                  />
+                )}
+                {isMine && (
+                  <>
+                    {doc && (
+                      <button
+                        className="btn-ghost btn-sm text-rose-600 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-900/30"
+                        onClick={handleDelete}
+                        disabled={deleting}
+                        title="메모 삭제"
+                      >
+                        {deleting ? "삭제 중…" : "삭제"}
+                      </button>
+                    )}
+                    <button className="btn-ghost btn-sm" onClick={() => setEditMode(true)} disabled={deleting}>
+                      편집
                     </button>
-                  )}
-                  <button className="btn-ghost btn-sm" onClick={() => setEditMode(true)} disabled={deleting}>
-                    편집
-                  </button>
-                </>
-              )
+                  </>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
 import { C, FONT, formatBytes } from "./theme";
 import type { Attachment, Message, Reaction } from "./types";
 import { api, imgSrc } from "../../api";
@@ -1054,6 +1055,7 @@ const SHARE_LABEL: Record<string, { label: string; icon: string }> = {
 };
 
 function ShareCardBubble({ msg, mine }: { msg: Message; mine: boolean }) {
+  const nav = useNavigate();
   const meta = SHARE_LABEL[msg.fileType ?? ""] ?? { label: "공유", icon: "🔗" };
   const href = msg.fileUrl ?? "#";
   // SPA 라우트만 허용 — 외부 absolute URL 은 보안상 차단(피싱 방지).
@@ -1061,9 +1063,10 @@ function ShareCardBubble({ msg, mine }: { msg: Message; mine: boolean }) {
   function navigate(e: React.MouseEvent) {
     e.preventDefault();
     if (safe === "#") return;
-    // SPA 라우터 — react-router 가 popstate 를 잡지 못하는 경우 대비 직접 navigate.
-    window.history.pushState({}, "", safe);
-    window.dispatchEvent(new PopStateEvent("popstate"));
+    // 채팅 오버레이를 먼저 닫고(전체화면이라 안 닫으면 이동해도 가려짐) react-router 로 이동.
+    // 이전엔 pushState+popstate 로 직접 바꿔 react-router location 이 갱신을 놓쳐 이동이 안 됐다.
+    window.dispatchEvent(new CustomEvent("chat:close"));
+    nav(safe);
   }
   const snippet =
     msg.content && msg.content.trim() && msg.content !== msg.fileName

--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
@@ -183,6 +184,20 @@ export default function MemosPage() {
   const [debouncedQ, setDebouncedQ] = useState("");
   const [memoTarget, setMemoTarget] = useState<Memo | "new" | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const [sp, setSp] = useSearchParams();
+
+  // 공유 카드("탭해서 열기") 등에서 /memos?memo=<id> 로 진입하면 해당 메모를 자동으로 연다.
+  // 목록 로드 후 매칭되면 1회 열고 쿼리를 제거(새로고침·뒤로가기 시 재오픈 방지).
+  useEffect(() => {
+    const id = sp.get("memo");
+    if (!id || loading) return;
+    const found = memos.find((m) => m.id === id);
+    if (found) {
+      setMemoTarget(found);
+      sp.delete("memo");
+      setSp(sp, { replace: true });
+    }
+  }, [sp, memos, loading, setSp]);
 
   // q 디바운스 300ms
   useEffect(() => {


### PR DESCRIPTION
## 증상
**공유 카드 이동 + 메모 공유 추가**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
ShareCardBubble 이 pushState+popstate 로 직접 URL 을 바꿔 react-router location 갱신을
놓쳐 이동이 안 됐다. useNavigate() 로 교체 + chat:close 이벤트로 전체화면 채팅 오버레이를
먼저 닫는다(안 닫으면 이동해도 채팅에 가려짐). ChatFab 에 chat:close 리스너 추가.

## 수정
**작업 항목 (커밋 단위)**
- fix(chat): 공유 카드 '탭해서 열기' 이동 안 되던 문제
- feat(memo): 메모 공유 추가 + /memos?memo=<id> 딥링크

**변경 대상 (4개 파일)**
- `client/src/components/ChatFab.tsx`
- `client/src/components/DocMemoModal.tsx`
- `client/src/components/chat/MessageBubble.tsx`
- `client/src/pages/MemosPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #395** 에서 진행됩니다.

