### PR TITLE
🔀 :: (#396) 파일명 링크 클릭 시 다운로드 파일명 깨지던 문제

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1368,9 +1368,15 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                           {d.fileName} <span className="text-ink-300">(invalid)</span>
                         </span>
                       );
+                      // 파일명 링크도 ?name=<원본명> 을 붙인다 — 비-인라인 타입(.docx 등)이 다운로드될 때
+                      // 서버 Content-Disposition 이 스토리지 키 대신 원본명을 쓰게. (download=1 은 안 붙여
+                      // 이미지·PDF 는 인라인 프리뷰 유지 — 다운로드 아이콘만 강제 저장.)
+                      const named = d.fileName
+                        ? safe + (safe.includes("?") ? "&" : "?") + "name=" + encodeURIComponent(d.fileName)
+                        : safe;
                       return (
-                        <a href={safe} target="_blank" rel="noreferrer" title={d.fileName ?? undefined}
-                          onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(safe); if (u) void Browser.open({ url: u }); } }}
+                        <a href={named} target="_blank" rel="noreferrer" title={d.fileName ?? undefined}
+                          onClick={(e) => { if (isCapacitorNative()) { e.preventDefault(); const u = imgSrc(named); if (u) void Browser.open({ url: u }); } }}
                           className="inline-flex items-center gap-1 max-w-[180px] sm:max-w-[260px] align-middle text-[12px] font-bold text-brand-600 hover:underline tabular">
                           <span className="truncate">{d.fileName}</span>
                           <span className="text-ink-400 flex-shrink-0">({humanSize(d.fileSize ?? 0)})</span>
@@ -1455,8 +1461,10 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
             const meta = isMemo ? "메모" : `${(ext || "file").toUpperCase()} · ${humanSize(d.fileSize ?? 0)}`;
             const openDoc = () => {
               if (isMemo) { setMemoTarget(d); return; }
-              const safe = safeUploadUrl(d.fileUrl);
-              if (!safe) return;
+              const safe0 = safeUploadUrl(d.fileUrl);
+              if (!safe0) return;
+              // ?name=<원본명> — 다운로드되는 타입(.docx 등)이 스토리지 키 대신 원본명으로 저장되게.
+              const safe = d.fileName ? safe0 + (safe0.includes("?") ? "&" : "?") + "name=" + encodeURIComponent(d.fileName) : safe0;
               if (isCapacitorNative()) { const u = imgSrc(safe); if (u) void Browser.open({ url: u }); }
               else window.open(safe, "_blank", "noopener");
             };


### PR DESCRIPTION
## 증상
**파일명 링크 클릭 시 다운로드 파일명 깨지던 문제**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
다운로드 아이콘(downloadDoc)은 ?download=1&name=<원본명> 을 붙여 원본명으로 저장되지만,
파일명 텍스트 링크는 raw /uploads/<키> 를 열어 ?name= 이 없어 서버 Content-Disposition 이
스토리지 키를 파일명으로 내려줬다(.docx 등 비-인라인 타입).

수정: 파일명 링크(데스크톱 테이블 + 모바일 카드 openDoc)에 ?name=<원본명> 추가.
download=1 은 안 붙여 이미지·PDF 의 인라인 프리뷰는 그대로 유지(다운로드 아이콘만 강제 저장).

## 수정
**작업 항목 (커밋 단위)**
- fix(docs): 파일명 링크 클릭 시 다운로드 파일명이 스토리지 키로 저장되던 문제

**변경 대상 (1개 파일)**
- `client/src/pages/DocumentsPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #396** 에서 진행됩니다.

