### PR TITLE
🔀 :: (#798) 다운로드 presigned URL 직행 — 속도+파일명+504 해소

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1033.0",
         "@aws-sdk/client-ses": "^3.1046.0",
+        "@aws-sdk/s3-request-presigner": "^3.1063.0",
         "@prisma/client": "^5.22.0",
         "@simplewebauthn/server": "^13.3.0",
         "@supabase/supabase-js": "^2.104.0",
@@ -343,16 +344,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.9.tgz",
-      "integrity": "sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ==",
+      "version": "3.974.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.18.tgz",
+      "integrity": "sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.23",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.11",
+        "@aws-sdk/xml-builder": "^3.972.28",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -737,16 +740,32 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz",
-      "integrity": "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1063.0.tgz",
+      "integrity": "sha512-uYDuWEbBYz/DfS0sEbDA3BeBCNNaLiE+dmblIRrmU02bhoqsotJb3qWfx0+I3JlukC7Vk8wRuyRgjZzq1FyXGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.32",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.32.tgz",
+      "integrity": "sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -771,12 +790,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.11.tgz",
+      "integrity": "sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -859,14 +878,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.23.tgz",
-      "integrity": "sha512-A0YmgYFv+hTI9c17Ntvd2hSehm9bmJfkb+ggADBwVKA8H/3+Jx94SzR2qOB9bAA9WFeDqnfz9PKKQ+D+YAKomA==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.28.tgz",
+      "integrity": "sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.2",
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1354,9 +1372,9 @@
       "license": "MIT"
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -1664,13 +1682,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.2.tgz",
-      "integrity": "sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2034,13 +2052,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.2.tgz",
-      "integrity": "sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2066,9 +2084,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3585,9 +3603,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -3597,7 +3615,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1033.0",
     "@aws-sdk/client-ses": "^3.1046.0",
+    "@aws-sdk/s3-request-presigner": "^3.1063.0",
     "@prisma/client": "^5.22.0",
     "@simplewebauthn/server": "^13.3.0",
     "@supabase/supabase-js": "^2.104.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,7 +18,7 @@ import noticeRouter from "./routes/notice.js";
 import chatRouter from "./routes/chat.js";
 import expenseRouter from "./routes/expense.js";
 import uploadRouter, { UPLOAD_DIR } from "./routes/upload.js";
-import { isStorageEnabled, downloadFile } from "./lib/storage.js";
+import { isStorageEnabled, downloadFile, getSignedDownloadUrl } from "./lib/storage.js";
 import fs from "node:fs";
 import notificationRouter from "./routes/notification.js";
 import pushRouter from "./routes/push.js";
@@ -404,13 +404,33 @@ app.use("/uploads", uploadsQueryToken, requireAuth, async (req, res) => {
   const rawName = typeof req.query.name === "string" ? req.query.name : undefined;
   const downloadName = rawName ? sanitizeDownloadName(rawName) : undefined;
 
-  // 1) Supabase Storage 우선 — 새 업로드는 여기 있음
+  // 1) 스토리지(S3/Supabase).
   if (isStorageEnabled()) {
+    const mt = String(mime.lookup(name) || "application/octet-stream");
+    const inline = INLINE_MIME_PREFIXES.some((p) => mt.startsWith(p));
+    const wantAttachment = forceDownload || !inline;
+
+    // 다운로드(첨부)는 presigned URL 로 302 리다이렉트 — 클라이언트가 스토리지(S3 CDN)에서 직접 받는다.
+    // ECS 가 전체 파일을 메모리로 버퍼링해 되넘기던 4-hop 경로 제거 → 속도 대폭 향상 + 504 타임아웃 해소 +
+    // ResponseContentDisposition 으로 원본 파일명 보장. (인라인 이미지/영상은 아래 버퍼+캐시 경로 유지 —
+    // 아바타 재요청 시 max-age 캐시 활용, 매 로드마다 리다이렉트 hop 이 생기지 않게.)
+    if (wantAttachment) {
+      const signed = await getSignedDownloadUrl(name, {
+        downloadName: downloadName || name,
+        contentType: mt,
+      });
+      if (signed) {
+        res.setHeader("Cache-Control", "no-store"); // 서명이 매번 달라 캐시 의미 없음
+        return res.redirect(302, signed);
+      }
+    }
+
+    // 인라인 이미지/영상, 또는 presigned 실패 → 기존 버퍼 스트림(+캐시).
     const file = await downloadFile(name);
     if (file) {
-      const mt = file.contentType || mime.lookup(name) || "application/octet-stream";
-      applyUploadSecurityHeaders(res, name, String(mt), forceDownload, downloadName);
-      res.setHeader("Content-Type", String(mt));
+      const fmt = file.contentType || mt;
+      applyUploadSecurityHeaders(res, name, String(fmt), forceDownload, downloadName);
+      res.setHeader("Content-Type", String(fmt));
       res.setHeader("Content-Length", String(file.size));
       res.setHeader("Cache-Control", "private, max-age=86400");
       return res.end(file.buffer);

--- a/server/src/lib/storage.ts
+++ b/server/src/lib/storage.ts
@@ -6,6 +6,7 @@ import {
   DeleteObjectCommand,
   NoSuchKey,
 } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import type { Readable } from "node:stream";
 
 /**
@@ -158,6 +159,51 @@ export async function downloadFile(key: string): Promise<{
       contentType: data.type || "application/octet-stream",
       size: ab.byteLength,
     };
+  }
+
+  return null;
+}
+
+/**
+ * 다운로드용 presigned URL — 클라이언트가 ECS 를 거치지 않고 스토리지(S3/Supabase CDN)에서 직접
+ * 받게 한다(서버 버퍼링·프록시 hop 제거로 속도 대폭 향상). 만료 짧게(기본 5분).
+ *
+ *  - downloadName 지정 시: 첨부(attachment)로 그 파일명 강제(Content-Disposition).
+ *  - downloadName 미지정 시: inline(브라우저 미리보기).
+ * 키가 어느 백엔드에도 없으면 null(호출부가 기존 버퍼 스트림으로 폴백).
+ */
+export async function getSignedDownloadUrl(
+  key: string,
+  opts: { downloadName?: string | null; contentType?: string | null; expiresIn?: number } = {}
+): Promise<string | null> {
+  const expiresIn = opts.expiresIn ?? 300;
+  const disposition = opts.downloadName
+    ? `attachment; filename="${opts.downloadName.replace(/"/g, "")}"; filename*=UTF-8''${encodeURIComponent(opts.downloadName)}`
+    : "inline";
+
+  // 1) S3 presigned GET — ResponseContentDisposition 으로 파일명/inline 제어.
+  if (s3) {
+    try {
+      const cmd = new GetObjectCommand({
+        Bucket: S3_BUCKET as string,
+        Key: key,
+        ResponseContentDisposition: disposition,
+        ...(opts.contentType ? { ResponseContentType: opts.contentType } : {}),
+      });
+      // s3 캐스팅 — client-s3 와 presigner 의 S3Client 타입이 중복 선언돼 TS 가 비호환으로 보지만
+      // 런타임은 동일 인스턴스라 안전(흔한 AWS SDK 버전 타입 이슈).
+      return await getSignedUrl(s3 as any, cmd as any, { expiresIn });
+    } catch {
+      /* 키 없음/실패 → Supabase 시도 */
+    }
+  }
+
+  // 2) Supabase signed URL — download 옵션에 파일명을 주면 attachment.
+  if (supabase) {
+    const { data, error } = await supabase.storage
+      .from(SB_BUCKET)
+      .createSignedUrl(key, expiresIn, opts.downloadName ? { download: opts.downloadName } : undefined);
+    if (!error && data?.signedUrl) return data.signedUrl;
   }
 
   return null;


### PR DESCRIPTION
## 증상
16KB 문서도 다운로드가 '한참' 걸림(클라→Vercel→ALB→ECS→S3 4-hop + ECS 전체 버퍼링), 큰 파일은 504, 데스크톱 파일명 깨짐.

## 수정
다운로드(첨부) 요청은 **스토리지 presigned URL(5분 만료)로 302 리다이렉트** → 클라가 **S3 CDN 에서 직접** 받음.
- 속도 대폭↑ (ECS 버퍼링·프록시 hop 제거)
- 504 타임아웃 해소
- `ResponseContentDisposition` = 원본 파일명 → **파일명 정확(네이티브 핸들러 불필요)**
- 인라인 이미지/영상은 기존 버퍼+캐시 유지(아바타 캐시 보존)

모든 클라(웹·데스크톱·iOS) 공통으로 빠르고 정확. 서버 tsc 통과.

Closes #798
