### PR TITLE
🔀 :: (#403) presigned URL 한글 파일명 S3 거부 긴급 수정

### DIFF
--- a/server/src/lib/storage.ts
+++ b/server/src/lib/storage.ts
@@ -177,8 +177,16 @@ export async function getSignedDownloadUrl(
   opts: { downloadName?: string | null; contentType?: string | null; expiresIn?: number } = {}
 ): Promise<string | null> {
   const expiresIn = opts.expiresIn ?? 300;
+  // ⚠️ Content-Disposition 헤더는 ISO-8859-1 만 허용한다(S3 가 한글 등 비-ASCII 가 들어가면
+  // InvalidArgument 로 거부). 따라서 plain filename="..." 은 ASCII 로 치환한 폴백을 쓰고, 실제 원본명은
+  // RFC 5987 filename*=UTF-8''<percent-encoded> 로 전달한다(최신 브라우저·OS 가 이걸 우선 사용).
   const disposition = opts.downloadName
-    ? `attachment; filename="${opts.downloadName.replace(/"/g, "")}"; filename*=UTF-8''${encodeURIComponent(opts.downloadName)}`
+    ? (() => {
+        const asciiFallback = opts.downloadName!
+          .replace(/[^\x20-\x7E]/g, "_") // 비-ASCII → _
+          .replace(/["\\]/g, "_");
+        return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeURIComponent(opts.downloadName!)}`;
+      })()
     : "inline";
 
   // 1) S3 presigned GET — ResponseContentDisposition 으로 파일명/inline 제어.


### PR DESCRIPTION
## 증상
**presigned URL 한글 파일명 S3 거부 긴급 수정**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
S3 가 response-content-disposition 헤더에 비-ASCII(한글) 가 들어가면 InvalidArgument 로 거부
('Header value cannot be represented using ISO-8859-1'). plain filename="..." 을 ASCII 폴백으로
치환하고, 원본명은 RFC5987 filename*=UTF-8'' 로만 전달(브라우저가 이걸 우선 사용).

## 수정
**작업 항목 (커밋 단위)**
- fix(storage): presigned Content-Disposition ASCII 안전화 — 한글 파일명 S3 거부 수정

**변경 대상 (1개 파일)**
- `server/src/lib/storage.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #403** 에서 진행됩니다.

