### PR TITLE
🔀 :: (#414) 데스크톱 하단바 숨김 + chat log 비번 로그아웃 버그

### DIFF
--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -163,7 +163,7 @@ export default function ConsoleLayout() {
     <div className="flex bg-ink-50" style={{ height: "100dvh" }}>
       {/* ===== 데스크톱 사이드바 (어두운 운영 테마) ===== */}
       <aside
-        className="hidden md:flex w-[252px] flex-col flex-shrink-0 bg-ink-900 text-white"
+        className="console-sidebar hidden md:flex w-[252px] flex-col flex-shrink-0 bg-ink-900 text-white"
         style={{ paddingTop: "env(safe-area-inset-top)" }}
       >
         {/* 신호등 버튼용 드래그 가능 여백 — macOS 창모드에서만 */}
@@ -284,7 +284,7 @@ export default function ConsoleLayout() {
             데스크톱은 좌측 사이드바를 쓰므로 md:hidden. 콘솔은 AppLayout 과 분리된
             레이아웃이라 네이티브 탭바 플러그인을 쓰지 않고 동일한 --c-glass 토큰으로 맞춘다. */}
         <nav
-          className="md:hidden console-bottomnav"
+          className="console-bottomnav"
           style={{
             position: "fixed",
             left: "50%",
@@ -300,7 +300,6 @@ export default function ConsoleLayout() {
             border: "1px solid var(--c-glass-border)",
             boxShadow: "0 10px 30px rgba(16,18,27,0.22), inset 0 1px 0 rgba(255,255,255,0.22)",
             padding: "6px 4px",
-            display: "flex",
             alignItems: "stretch",
           }}
           aria-label="운영 콘솔 메뉴"

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -97,6 +97,10 @@ html.hinest-native-tabbar .console-bottomnav { display: none !important; }
    기기는 .hinest-desktop 이 안 붙어 기존 반응형 그대로. */
 html.hinest-desktop .app-sidebar { display: flex !important; }
 html.hinest-desktop .app-bottomnav { display: none !important; }
+/* 데스크톱은 운영 콘솔의 하단 탭바를 숨기고 좌측 사이드바를 강제 표시 — 창을 좁혀도 사이드바로 탐색
+   (앱 본체와 동일 정책). 사이드바는 hidden md:flex 라 좁은 창에서 숨으므로 여기서 다시 켠다. */
+html.hinest-desktop .console-bottomnav { display: none !important; }
+html.hinest-desktop .console-sidebar { display: flex !important; }
 
 /* 모달(.modal-safe 오버레이)이 열려 있는 동안 웹 하단 탭 바를 숨긴다 — 모달 풋터(저장·취소
    버튼 등)가 떠 있는 바와 겹쳐 가려지는 "UI 깨짐"을 막는다. iOS 네이티브는 .hinest-native-tabbar

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1243,14 +1243,18 @@ ops.post("/chat-audit/unlock", requireSuperAdminStepUp, async (req, res) => {
   // 길이가 다르면 즉시 false — timingSafeEqual 은 같은 길이만 받음.
   if (got.length !== expected.length) {
     await writeLog(u.id, "CHAT_AUDIT_UNLOCK_FAIL", undefined, undefined, req.ip).catch(() => {});
-    return res.status(401).json({ error: "암호 불일치" });
+    // 403 — 인증은 됐지만(슈퍼관리자 세션) 이 step-up 암호가 틀림. 401 로 주면 클라 api() 가
+    // '세션 만료' 로 오인해 전역 로그아웃시킨다(버그). 암호 오류는 forbidden 으로 분리.
+    return res.status(403).json({ code: "BAD_STEPUP_PW", error: "암호 불일치" });
   }
   const a = Buffer.from(got);
   const b = Buffer.from(expected);
   const ok = crypto.timingSafeEqual(a, b);
   if (!ok) {
     await writeLog(u.id, "CHAT_AUDIT_UNLOCK_FAIL", undefined, undefined, req.ip).catch(() => {});
-    return res.status(401).json({ error: "암호 불일치" });
+    // 403 — 인증은 됐지만(슈퍼관리자 세션) 이 step-up 암호가 틀림. 401 로 주면 클라 api() 가
+    // '세션 만료' 로 오인해 전역 로그아웃시킨다(버그). 암호 오류는 forbidden 으로 분리.
+    return res.status(403).json({ code: "BAD_STEPUP_PW", error: "암호 불일치" });
   }
   await writeLog(u.id, "CHAT_AUDIT_UNLOCK_OK", undefined, undefined, req.ip).catch(() => {});
   res.json({ ok: true, ttlMs: 30 * 60 * 1000 });


### PR DESCRIPTION
## 증상
**데스크톱 하단바 숨김 + chat log 비번 로그아웃 버그**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
데스크톱 앱에서 운영 콘솔 하단 탭바(회사/로그/시스템/보안/개발자)가 떠 있었다.
.hinest-desktop 에서 console-bottomnav 숨김 + console-sidebar(hidden md:flex 라 좁은 창에서
숨던 것) 강제 표시 → 창 좁혀도 좌측 사이드바로 탐색(앱 본체와 동일 정책).

## 수정
**작업 항목 (커밋 단위)**
- fix(console): 데스크톱에서 하단 탭바 숨김 + 사이드바 강제 표시
- fix(console): chat-audit 암호 오류를 401→403 — 로그아웃 회귀 수정

**변경 대상 (3개 파일)**
- `client/src/components/ConsoleLayout.tsx`
- `client/src/styles.css`
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #406** ↔ **이슈 #414** 로 연결됩니다.

Closes #414
