### PR TITLE
🔀 :: (#416) 개발자 콘솔 회사별 분리 보기 (회사 선택 드롭다운)

### DIFF
--- a/client/src/components/superadmin/AuditPanel.tsx
+++ b/client/src/components/superadmin/AuditPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../../api";
+import { useConsoleCompany } from "./companyFilter";
 
 type Log = {
   id: string;
@@ -37,6 +38,8 @@ export default function AuditPanel() {
   const [filterAction, setFilterAction] = useState("");
   const [filterUserId, setFilterUserId] = useState("");
   const [q, setQ] = useState("");
+  // 회사 선택 드롭다운 값 — 있으면 해당 회사 감사 로그만 받는다.
+  const { companyId } = useConsoleCompany();
 
   async function load() {
     setLoading(true);
@@ -45,13 +48,14 @@ export default function AuditPanel() {
       if (filterAction) params.set("action", filterAction);
       if (filterUserId.trim()) params.set("userId", filterUserId.trim());
       if (q.trim()) params.set("q", q.trim());
+      if (companyId) params.set("companyId", companyId);
       const r = await api<{ logs: Log[] }>(`/api/admin/audit?${params}`);
       setLogs(r.logs);
     } finally {
       setLoading(false);
     }
   }
-  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [filterAction]);
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [filterAction, companyId]);
 
   useEffect(() => {
     api<{ actions: ActionRow[] }>("/api/admin/audit/actions").then((r) => setActions(r.actions));

--- a/client/src/components/superadmin/SessionsPanel.tsx
+++ b/client/src/components/superadmin/SessionsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync, alertAsync } from "../ConfirmHost";
+import { useConsoleCompany } from "./companyFilter";
 
 type Session = {
   id: string;
@@ -19,17 +20,21 @@ export default function SessionsPanel() {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [q, setQ] = useState("");
+  // 회사 선택 드롭다운 값 — 있으면 해당 회사 소속 유저의 세션만 받는다.
+  const { companyId } = useConsoleCompany();
 
   async function load() {
     setLoading(true);
     try {
-      const r = await api<{ sessions: Session[] }>("/api/admin/sessions?limit=300");
+      const params = new URLSearchParams({ limit: "300" });
+      if (companyId) params.set("companyId", companyId);
+      const r = await api<{ sessions: Session[] }>(`/api/admin/sessions?${params}`);
       setRows(r.sessions);
     } finally {
       setLoading(false);
     }
   }
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [companyId]);
 
   async function revokeOne(id: string, name: string) {
     if (!(await confirmAsync({ title: "이 세션 강제 로그아웃?", description: `${name} 의 디바이스 1개에서 즉시 로그아웃됩니다.` }))) return;

--- a/client/src/components/superadmin/TrashPanel.tsx
+++ b/client/src/components/superadmin/TrashPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync, alertAsync } from "../ConfirmHost";
+import { useConsoleCompany } from "./companyFilter";
 
 type Item = { id: string; title: string; deletedAt: string; deletedById: string | null; authorId: string; author: { name: string } | null };
 type Trash = { meeting: Item[]; document: Item[]; journal: Item[]; notice: Item[] };
@@ -18,13 +19,18 @@ export default function TrashPanel() {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [tab, setTab] = useState<keyof Trash>("meeting");
+  // 회사 선택 드롭다운 값 — 있으면 해당 회사의 휴지통만 받는다.
+  const { companyId } = useConsoleCompany();
 
   async function load() {
     setLoading(true);
-    try { setData(await api<Trash>("/api/admin/trash")); }
+    try {
+      const qs = companyId ? `?companyId=${encodeURIComponent(companyId)}` : "";
+      setData(await api<Trash>(`/api/admin/trash${qs}`));
+    }
     finally { setLoading(false); }
   }
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [companyId]);
 
   async function restore(type: keyof Trash, id: string, title: string) {
     if (!(await confirmAsync({ title: `"${title}" 복구?`, description: "원래 위치로 되돌립니다." }))) return;

--- a/client/src/components/superadmin/companyFilter.tsx
+++ b/client/src/components/superadmin/companyFilter.tsx
@@ -1,0 +1,125 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { useSearchParams } from "react-router-dom";
+import { api } from "../../api";
+
+/**
+ * 개발자 콘솔 — 회사 선택 드롭다운 공유 상태.
+ *
+ * 로그·감사·세션처럼 회사(companyId)로 나뉘는 탭들을 한 회사로 좁혀 볼 수 있게 한다.
+ * 선택값은 URL ?company=<id> 로 동기화 → 새로고침·탭 전환에도 유지되고, 링크 공유도 가능.
+ * "전체"(companyId=null)면 지금까지처럼 전 회사 데이터를 그대로 본다.
+ *
+ * 서버·에러·헬스·플래그처럼 회사 구분이 없는 전역 탭에서는 드롭다운을 숨긴다
+ * (COMPANY_SCOPED_TABS 로 판별).
+ */
+
+export type ConsoleCompany = {
+  id: string;
+  name: string;
+  slug: string | null;
+  status: string;
+};
+
+/** 회사 단위로 필터링을 지원하는 탭들. 여기 없는 탭은 전역 데이터로 간주해 드롭다운을 숨긴다. */
+export const COMPANY_SCOPED_TABS: ReadonlySet<string> = new Set(["logs", "audit", "sessions", "trash"]);
+export function isCompanyScoped(tab: string): boolean {
+  return COMPANY_SCOPED_TABS.has(tab);
+}
+
+type Ctx = {
+  companyId: string | null;
+  setCompanyId: (id: string | null) => void;
+  companies: ConsoleCompany[];
+  loading: boolean;
+};
+
+const ConsoleCompanyContext = createContext<Ctx>({
+  companyId: null,
+  setCompanyId: () => {},
+  companies: [],
+  loading: false,
+});
+
+export function useConsoleCompany(): Ctx {
+  return useContext(ConsoleCompanyContext);
+}
+
+/** 회사 fetch 쿼리스트링 헬퍼 — companyId 가 있으면 &companyId=... 를 덧붙인다. */
+export function appendCompanyParam(params: URLSearchParams, companyId: string | null): URLSearchParams {
+  if (companyId) params.set("companyId", companyId);
+  return params;
+}
+
+export function CompanyFilterProvider({ children }: { children: ReactNode }) {
+  const [sp, setSp] = useSearchParams();
+  const companyId = sp.get("company") || null;
+  const [companies, setCompanies] = useState<ConsoleCompany[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const setCompanyId = (id: string | null) => {
+    const next = new URLSearchParams(sp);
+    if (!id) next.delete("company");
+    else next.set("company", id);
+    setSp(next, { replace: true });
+  };
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    api<{ companies: ConsoleCompany[] }>("/api/admin/companies")
+      .then((r) => { if (alive) setCompanies(r.companies || []); })
+      .catch(() => { /* step-up 전이거나 권한 없음 — 드롭다운만 비고 패널은 정상 동작 */ })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  return (
+    <ConsoleCompanyContext.Provider value={{ companyId, setCompanyId, companies, loading }}>
+      {children}
+    </ConsoleCompanyContext.Provider>
+  );
+}
+
+/** 회사 선택 드롭다운 — 크롬 헤더 우측에 둔다. 회사 스코프 탭에서만 렌더하는 게 자연스럽다. */
+export function CompanyFilterDropdown({ accent = "#64748B" }: { accent?: string }) {
+  const { companyId, setCompanyId, companies, loading } = useConsoleCompany();
+  const selected = companies.find((c) => c.id === companyId) || null;
+
+  return (
+    <label className="inline-flex items-center gap-1.5 flex-shrink-0" title="회사별로 좁혀 보기">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke={accent} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M3 21h18" /><path d="M5 21V7l8-4v18" /><path d="M19 21V11l-6-4" />
+        <path d="M9 9v.01M9 12v.01M9 15v.01M9 18v.01" />
+      </svg>
+      <select
+        value={companyId ?? ""}
+        onChange={(e) => setCompanyId(e.target.value || null)}
+        disabled={loading && companies.length === 0}
+        className="input !py-1 !h-[30px] !text-[12px] max-w-[190px] font-semibold"
+        style={{ borderColor: companyId ? accent : undefined, color: companyId ? accent : undefined }}
+        aria-label="회사 선택"
+      >
+        <option value="">전체 회사</option>
+        {companies.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}{c.slug ? ` @${c.slug}` : ""}{c.status !== "ACTIVE" ? ` · ${c.status}` : ""}
+          </option>
+        ))}
+      </select>
+      {selected && (
+        <button
+          type="button"
+          onClick={() => setCompanyId(null)}
+          className="text-ink-400 hover:text-ink-700 transition"
+          title="전체 회사로"
+          aria-label="회사 필터 해제"
+          style={{ width: 20, height: 20, display: "grid", placeItems: "center", borderRadius: 999 }}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </label>
+  );
+}

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -17,6 +17,7 @@ import TokensPanel from "../components/superadmin/TokensPanel";
 import SecurityPanel from "../components/superadmin/SecurityPanel";
 import TwoFAPanel from "../components/superadmin/TwoFAPanel";
 import RolePermissionsPanel from "../components/superadmin/RolePermissionsPanel";
+import { CompanyFilterProvider, CompanyFilterDropdown, isCompanyScoped, useConsoleCompany } from "../components/superadmin/companyFilter";
 import Portal from "../components/Portal";
 
 type Log = {
@@ -186,7 +187,7 @@ function SuperConsoleInner() {
   const chat: ChatCtx = { unlocked: chatUnlocked, lock: lockChat };
 
   return (
-    <>
+    <CompanyFilterProvider>
       <Routes>
         <Route index element={<Navigate to="logs" replace />} />
         <Route path="logs" element={<GroupView group="logs" chat={chat} />} />
@@ -201,7 +202,7 @@ function SuperConsoleInner() {
           onSubmit={unlockChat}
         />
       )}
-    </>
+    </CompanyFilterProvider>
   );
 }
 
@@ -303,7 +304,10 @@ function LogsChrome({ tabs, tab, setTab, chat, meta }: ChromeProps) {
           <h1 className="text-[22px] font-extrabold text-ink-900 leading-tight">{meta.title}</h1>
           <p className="text-[12.5px] text-ink-500 mt-1">{meta.description}</p>
         </div>
-        <LogsGlyph />
+        <div className="flex flex-col items-end gap-2 flex-shrink-0">
+          {isCompanyScoped(tab) && <CompanyFilterDropdown accent={LOGS_ACCENT} />}
+          <LogsGlyph />
+        </div>
       </div>
       <div className="flex items-center gap-1 mb-4 border-b border-ink-150 overflow-x-auto whitespace-nowrap" style={{ scrollbarWidth: "thin" }}>
         {tabs.map((t) =>
@@ -349,19 +353,22 @@ function SystemChrome({ tabs, tab, setTab, meta }: ChromeProps) {
           </div>
         </div>
       </div>
-      <div className="inline-flex items-center gap-1 p-1 rounded-xl mb-4 bg-slate-100 max-w-full overflow-x-auto" style={{ scrollbarWidth: "thin" }}>
-        {tabs.map((t) => {
-          const active = tab === t;
-          return (
-            <button
-              key={t}
-              onClick={() => setTab(t)}
-              className={`px-3.5 h-[34px] rounded-lg text-[12.5px] font-semibold whitespace-nowrap transition flex-shrink-0 ${active ? "bg-white text-emerald-700 shadow-sm" : "text-ink-500 hover:text-ink-800"}`}
-            >
-              {TAB_LABEL[t]}
-            </button>
-          );
-        })}
+      <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+        <div className="inline-flex items-center gap-1 p-1 rounded-xl bg-slate-100 max-w-full overflow-x-auto" style={{ scrollbarWidth: "thin" }}>
+          {tabs.map((t) => {
+            const active = tab === t;
+            return (
+              <button
+                key={t}
+                onClick={() => setTab(t)}
+                className={`px-3.5 h-[34px] rounded-lg text-[12.5px] font-semibold whitespace-nowrap transition flex-shrink-0 ${active ? "bg-white text-emerald-700 shadow-sm" : "text-ink-500 hover:text-ink-800"}`}
+              >
+                {TAB_LABEL[t]}
+              </button>
+            );
+          })}
+        </div>
+        {isCompanyScoped(tab) && <CompanyFilterDropdown accent="#10B981" />}
       </div>
       <PanelArea tab={tab} />
     </div>
@@ -605,6 +612,8 @@ function LogsPanel() {
   const [logs, setLogs] = useState<Log[]>([]);
   const [q, setQ] = useState("");
   const [actionFilter, setActionFilter] = useState("");
+  // 회사 선택 드롭다운 값 — 있으면 해당 회사 활동만 서버에서 좁혀 받는다.
+  const { companyId } = useConsoleCompany();
   // 500개 로그를 필터할 때 한글 IME 입력이 끊기지 않도록 우선순위 낮춰 실행.
   const deferredQ = useDeferredValue(q);
 
@@ -618,14 +627,17 @@ function LogsPanel() {
 
   async function load() {
     const myToken = ++tokenRef.current;
-    const res = await api<{ logs: Log[] }>("/api/admin/logs?limit=500");
+    const params = new URLSearchParams({ limit: "500" });
+    if (companyId) params.set("companyId", companyId);
+    const res = await api<{ logs: Log[] }>(`/api/admin/logs?${params}`);
     if (!aliveRef.current || myToken !== tokenRef.current) return;
     setLogs(res.logs);
   }
 
   useEffect(() => {
     load();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [companyId]);
 
   const uniqueActions = useMemo(() => Array.from(new Set(logs.map((l) => l.action))).sort(), [logs]);
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1391,12 +1391,24 @@ ops.get("/server-logs", requireSuperAdminStepUp, async (req, res) => {
 
 ops.get("/logs", requireSuperAdminStepUp, async (req, res) => {
   const limit = Math.min(Number(req.query.limit ?? 200), 500);
+  // companyId 가 주어지면 해당 회사 활동만 — 개발자 콘솔의 회사 선택 드롭다운용.
+  const companyId = typeof req.query.companyId === "string" && req.query.companyId ? req.query.companyId : undefined;
   const logs = await prisma.auditLog.findMany({
+    where: companyId ? { companyId } : undefined,
     orderBy: { createdAt: "desc" },
     take: limit,
     include: { user: { select: { name: true, email: true } } },
   });
   res.json({ logs });
+});
+
+/** 회사 목록 — 개발자 콘솔의 회사 선택 드롭다운 채우기용(경량). */
+ops.get("/companies", requireSuperAdminStepUp, async (_req, res) => {
+  const companies = await prisma.company.findMany({
+    orderBy: { createdAt: "desc" },
+    select: { id: true, name: true, slug: true, status: true },
+  });
+  res.json({ companies });
 });
 
 /* ===== 출근 기록 조회 — 특정 유저의 특정 날짜 ===== */
@@ -1708,11 +1720,13 @@ ops.get("/audit", requireSuperAdminStepUp, async (req, res) => {
   const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
   const fromMs = req.query.from ? Number(req.query.from) : undefined;
   const toMs = req.query.to ? Number(req.query.to) : undefined;
+  const companyId = typeof req.query.companyId === "string" && req.query.companyId ? req.query.companyId : undefined;
   const limit = Math.min(500, Math.max(1, parseInt(String(req.query.limit ?? "200"), 10) || 200));
 
   const where: any = {};
   if (action) where.action = action;
   if (userId) where.userId = userId;
+  if (companyId) where.companyId = companyId;
   if (fromMs || toMs) {
     where.createdAt = {};
     if (fromMs) where.createdAt.gte = new Date(fromMs);
@@ -1753,30 +1767,33 @@ function trashModel(t: TrashType) {
   return ({ meeting: prisma.meeting, document: prisma.document, journal: prisma.journal, notice: prisma.notice } as const)[t];
 }
 
-ops.get("/trash", requireSuperAdminStepUp, async (_req, res) => {
+ops.get("/trash", requireSuperAdminStepUp, async (req, res) => {
   const include = { deletedBy: false }; // we resolve names below
   void include;
+  // companyId 가 주어지면 해당 회사의 휴지통만 — 개발자 콘솔의 회사 선택 드롭다운용.
+  const companyId = typeof req.query.companyId === "string" && req.query.companyId ? req.query.companyId : undefined;
+  const scope = companyId ? { companyId } : {};
   const [meetings, documents, journals, notices] = await Promise.all([
     prisma.meeting.findMany({
-      where: { deletedAt: { not: null } },
+      where: { deletedAt: { not: null }, ...scope },
       orderBy: { deletedAt: "desc" },
       take: 200,
       select: { id: true, title: true, deletedAt: true, deletedById: true, authorId: true, author: { select: { name: true } } },
     }),
     prisma.document.findMany({
-      where: { deletedAt: { not: null } },
+      where: { deletedAt: { not: null }, ...scope },
       orderBy: { deletedAt: "desc" },
       take: 200,
       select: { id: true, title: true, deletedAt: true, deletedById: true, authorId: true, author: { select: { name: true } } },
     }),
     prisma.journal.findMany({
-      where: { deletedAt: { not: null } },
+      where: { deletedAt: { not: null }, ...scope },
       orderBy: { deletedAt: "desc" },
       take: 200,
       select: { id: true, title: true, deletedAt: true, deletedById: true, userId: true, user: { select: { name: true } } },
     }),
     prisma.notice.findMany({
-      where: { deletedAt: { not: null } },
+      where: { deletedAt: { not: null }, ...scope },
       orderBy: { deletedAt: "desc" },
       take: 200,
       select: { id: true, title: true, deletedAt: true, deletedById: true, authorId: true, author: { select: { name: true } } },
@@ -1941,11 +1958,13 @@ ops.delete("/errors", requireSuperAdminStepUp, async (req, res) => {
 /** 활성 세션 목록. ?userId 로 특정 유저만, 기본은 전체 (최근 활동 순). */
 ops.get("/sessions", requireSuperAdminStepUp, async (req, res) => {
   const userId = typeof req.query.userId === "string" ? req.query.userId : undefined;
+  const companyId = typeof req.query.companyId === "string" && req.query.companyId ? req.query.companyId : undefined;
   const onlyActive = req.query.active !== "false";
   const limit = Math.min(500, parseInt(String(req.query.limit ?? "100"), 10) || 100);
   const sessions = await prisma.session.findMany({
     where: {
       ...(userId ? { userId } : {}),
+      ...(companyId ? { user: { companyId } } : {}),
       ...(onlyActive ? { revokedAt: null } : {}),
     },
     orderBy: { lastSeenAt: "desc" },


### PR DESCRIPTION
## 증상
**개발자 콘솔 회사별 분리 보기 (회사 선택 드롭다운)**

새 기능을 추가합니다.

## 원인
개발자 콘솔의 회사 선택 드롭다운용. companyId 쿼리가 오면 해당 회사로 좁히고,
없으면 종전처럼 전 회사 데이터를 반환(하위호환).
- GET /companies            드롭다운 채울 회사 목록(경량)
- GET /logs?companyId=       AuditLog.companyId
- GET /audit?companyId=      where.companyId
- GET /sessions?companyId=   where.user.companyId(관계 필터)
- GET /trash?companyId=      meeting·document·journal·notice 전부 회사 스코프

## 수정
**작업 항목 (커밋 단위)**
- feat(console): 로그·감사·세션·휴지통 엔드포인트에 companyId 필터
- feat(console): 회사 선택 드롭다운 — 3탭 회사별 분리 보기

**변경 대상 (6개 파일)**
- `client/src/components/superadmin/AuditPanel.tsx`
- `client/src/components/superadmin/SessionsPanel.tsx`
- `client/src/components/superadmin/TrashPanel.tsx`
- `client/src/components/superadmin/companyFilter.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/routes/admin.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #408** ↔ **이슈 #416** 로 연결됩니다.

Closes #416
