### PR TITLE
🔀 :: (#417) 콘솔 접근 제어 — 사내톡 감사 완전 은닉 + 개발자 전용 계정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -91,6 +91,17 @@ function ConsoleOnly({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+// 회사 앱(일반 페이지) 진입 가드 — 개발자 콘솔 전용 계정(consoleOnly)은 회사 앱에 들어올 수
+// 없고 자기 콘솔 홈으로 보낸다. superAdmin 이면 /super-admin, 아니면 /platform 으로 — 그래야
+// SuperOnly/PlatformOnly 게이트에 막혀 "/" 로 되돌아오는 리다이렉트 루프가 생기지 않는다.
+function CompanyAppGate({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  if (user?.consoleOnly) {
+    return <Navigate to={user.superAdmin ? "/super-admin" : "/platform"} replace />;
+  }
+  return <>{children}</>;
+}
+
 export default function App() {
   // 라우트 단위 ErrorBoundary 의 reset 트리거 — 다음 페이지로 이동하면 자동 초기화.
   // 이렇게 안 하면 한 페이지에서 에러 나면 다른 메뉴로 가도 fallback 이 계속 보임.
@@ -117,7 +128,9 @@ export default function App() {
           path="/"
           element={
             <Protected>
-              <AppLayout />
+              <CompanyAppGate>
+                <AppLayout />
+              </CompanyAppGate>
             </Protected>
           }
         >

--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -15,6 +15,8 @@ export type User = {
   avatarUrl?: string | null;
   superAdmin?: boolean;
   platformAdmin?: boolean;
+  /** 개발자 콘솔 전용 계정 — 회사 앱(일반 페이지) 접근 불가, /super-admin 만 사용. */
+  consoleOnly?: boolean;
   companyId?: string | null;
   isDeveloper?: boolean;
   employeeNo?: string | null;

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -103,7 +103,9 @@ export default function ConsoleLayout() {
 
   // 회사 소속이 있는 운영자만 서비스로 복귀 가능. 순수 플랫폼 운영자(companyId=null)는
   // 돌아갈 회사 앱이 없으므로 복귀 링크를 숨긴다.
-  const hasCompany = !!user?.companyId;
+  // 개발자 콘솔 전용 계정(consoleOnly)도 회사 앱 진입이 막혀 있어(복귀해도 즉시 콘솔로
+  // 튕겨 돌아옴) companyId 가 있어도 복귀 링크를 숨긴다.
+  const hasCompany = !!user?.companyId && !user?.consoleOnly;
 
   // 콘솔도 메인 앱과 동일한 실제 네이티브 리퀴드 글래스 탭바를 쓴다 — 콘솔 전용 탭으로
   // 재설정한다. 성공하면 .hinest-native-tabbar 가 붙어 아래 CSS 글래스 nav 는 숨고 네이티브

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -119,20 +119,13 @@ export default function SuperAdminPage() {
   );
 }
 
-/** 사내톡 감사 탭은 평소엔 UI 에서 가려두고, 콘솔의 \`chat log\` 명령 + 비밀번호로만 노출.
+/** 사내톡 감사 탭은 평소엔 UI 에서 완전히 가려두고, 콘솔의 \`chat log\` 명령 + 비밀번호로만 노출.
  *  서버 측 ChatAuditPanel API 들은 요청 자체에 super-stepup 게이트가 또 걸려있어 이중 가드.
- *  비밀번호 일치 시 30분 unlock — sessionStorage 사용으로 탭 닫으면 자동 잠금. */
+ *
+ *  unlock 상태는 **메모리(React state)에만** 둔다 — 새로고침/콘솔 재진입 시 무조건 재잠금되어,
+ *  탭은 매번 \`chat log\` + 비밀번호를 다시 입력해야만 나타난다. (이전엔 sessionStorage 로 30분
+ *  유지돼 "한 번 열면 계속 보이는" 문제가 있었음 — 보안상 노출 최소화로 변경.) */
 const CHAT_LOG_KEY = "hinest.chatAudit.unlock";
-
-function isChatAuditUnlocked(): boolean {
-  try {
-    const v = sessionStorage.getItem(CHAT_LOG_KEY);
-    if (!v) return false;
-    return Date.now() < Number(v);
-  } catch {
-    return false;
-  }
-}
 
 type ChatCtx = { unlocked: boolean; lock: () => void };
 
@@ -142,8 +135,14 @@ type ChatCtx = { unlocked: boolean; lock: () => void };
  */
 function SuperConsoleInner() {
   const nav = useNavigate();
-  const [chatUnlocked, setChatUnlocked] = useState<boolean>(() => isChatAuditUnlocked());
+  // 메모리 전용 — 콘솔 재진입/새로고침 시 항상 false 로 시작해 사내톡 감사 탭이 가려진다.
+  const [chatUnlocked, setChatUnlocked] = useState<boolean>(false);
   const [chatPwOpen, setChatPwOpen] = useState(false);
+
+  // 과거 sessionStorage 로 저장돼 있던 unlock 흔적이 남아있으면 정리(마운트 시 1회).
+  useEffect(() => {
+    try { sessionStorage.removeItem(CHAT_LOG_KEY); } catch {}
+  }, []);
 
   // 콘솔(개발자 도구)에서 \`chat log\` 명령 시 발사되는 이벤트 — 어느 그룹에 있든 받아서 모달 노출.
   useEffect(() => {
@@ -167,13 +166,11 @@ function SuperConsoleInner() {
 
   async function unlockChat(pw: string): Promise<boolean> {
     try {
-      const r = await api<{ ok: true; ttlMs: number }>("/api/admin/chat-audit/unlock", {
+      await api<{ ok: true; ttlMs: number }>("/api/admin/chat-audit/unlock", {
         method: "POST",
         json: { password: pw },
       });
-      try {
-        sessionStorage.setItem(CHAT_LOG_KEY, String(Date.now() + (r.ttlMs ?? 30 * 60 * 1000)));
-      } catch {}
+      // 메모리에만 유지 — 새로고침/재진입 시 다시 잠긴다(persist 안 함).
       setChatUnlocked(true);
       setChatPwOpen(false);
       // 사내톡 감사 탭은 로그·감사 그룹에 있으므로 그쪽으로 이동시켜 바로 보이게 한다.

--- a/server/src/lib/consoleOnly.ts
+++ b/server/src/lib/consoleOnly.ts
@@ -1,0 +1,39 @@
+/**
+ * 개발자 콘솔 전용 계정 판별.
+ *
+ * 일부 계정(예: xixn2@efface.dev)은 "진짜 개발자 페이지 전용" 계정이라, 회사 앱(일반 페이지:
+ * 팀원·공지·문서함 등)엔 들어가지 못하고 오직 운영 콘솔(/super-admin)만 사용해야 한다.
+ *
+ * 식별 기준 (둘 중 하나라도 매치 + 콘솔 권한 보유):
+ *   1) 이메일 allowlist      — CONSOLE_ONLY_EMAILS (쉼표 구분, 기본 비어있음)
+ *   2) 이메일 도메인 allowlist — CONSOLE_ONLY_DOMAINS (기본 "efface.dev" = 개발 스튜디오 도메인)
+ *
+ * 안전장치: superAdmin / platformAdmin 이 아닌 계정은 절대 콘솔 전용으로 묶지 않는다
+ * (혹시 일반 사용자가 같은 도메인 이메일을 쓰더라도 회사 앱에서 쫓겨나지 않도록).
+ *
+ * 환경변수로 덮어쓸 수 있어, 코드 수정/배포 없이 대상 계정을 추가/변경할 수 있다.
+ */
+
+function parseList(v: string | undefined, fallback: string): string[] {
+  return (v ?? fallback)
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+const CONSOLE_ONLY_EMAILS = parseList(process.env.CONSOLE_ONLY_EMAILS, "");
+const CONSOLE_ONLY_DOMAINS = parseList(process.env.CONSOLE_ONLY_DOMAINS, "efface.dev");
+
+export function isConsoleOnlyUser(u: {
+  email?: string | null;
+  superAdmin?: boolean | null;
+  platformAdmin?: boolean | null;
+}): boolean {
+  if (!u?.email) return false;
+  // 콘솔 권한이 없는 계정은 대상에서 제외 — 일반 사용자가 잘못 갇히는 일 방지.
+  if (!u.superAdmin && !u.platformAdmin) return false;
+  const email = u.email.toLowerCase();
+  if (CONSOLE_ONLY_EMAILS.includes(email)) return true;
+  const domain = email.split("@")[1] ?? "";
+  return CONSOLE_ONLY_DOMAINS.includes(domain);
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { notifyAllUsers } from "../lib/notify.js";
 import { sendEmail } from "../lib/email.js";
+import { isConsoleOnlyUser } from "../lib/consoleOnly.js";
 import {
   signToken,
   setAuthCookie,
@@ -157,6 +158,7 @@ router.post("/login", async (req, res) => {
       avatarColor: user.avatarColor,
       avatarUrl: user.avatarUrl,
       superAdmin: user.superAdmin,
+      consoleOnly: isConsoleOnlyUser(user),
     },
     // 네이티브 앱(Capacitor)은 cross-site 쿠키가 ITP 에 막혀 새로고침 시 세션이 끊긴다.
     // 네이티브 origin 일 때만 세션 JWT 를 본문으로 함께 내려, 클라가 저장해 Authorization
@@ -288,6 +290,7 @@ router.post("/signup", async (req, res) => {
       avatarColor: user.avatarColor,
       avatarUrl: user.avatarUrl,
       superAdmin: user.superAdmin,
+      consoleOnly: isConsoleOnlyUser(user),
     },
     // 로그인과 동일 — 네이티브 origin 에만 세션 토큰을 본문으로 함께 내린다.
     ...(isNativeOrigin(req) ? { token } : {}),

--- a/server/src/routes/me.ts
+++ b/server/src/routes/me.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { z } from "zod";
 import { requireAuth, clearImpCookie, writeLog } from "../lib/auth.js";
 import { prisma } from "../lib/db.js";
+import { isConsoleOnlyUser } from "../lib/consoleOnly.js";
 
 const router = Router();
 
@@ -29,6 +30,8 @@ router.get("/", requireAuth, async (req, res) => {
       avatarUrl: user.avatarUrl,
       superAdmin: user.superAdmin,
       platformAdmin: user.platformAdmin,
+      // 개발자 콘솔 전용 계정이면 회사 앱(일반 페이지) 접근을 막고 /super-admin 으로 보낸다.
+      consoleOnly: isConsoleOnlyUser(user),
       companyId: user.companyId ?? null,
       isDeveloper: user.isDeveloper,
       employeeNo: user.employeeNo,


### PR DESCRIPTION
## 증상
**콘솔 접근 제어 — 사내톡 감사 완전 은닉 + 개발자 전용 계정**

새 기능을 추가합니다.

## 원인
이전엔 sessionStorage 로 30분 유지돼 한 번 chat log+비번으로 열면 새로고침/재진입
후에도 탭이 계속 보였음. unlock 상태를 React state 에만 두어, 콘솔에 들어올 때마다
무조건 잠긴 채 시작 → 매번 'chat log' + 비밀번호를 다시 입력해야만 탭이 나타난다.
(서버 stepup 게이트는 그대로 — 이중 가드)

## 수정
**작업 항목 (커밋 단위)**
- fix(console): 사내톡 감사 탭 unlock 을 메모리 전용으로 — 새로고침 시 재잠금
- feat(auth): 개발자 콘솔 전용 계정 — 회사 앱 차단, /super-admin 만 허용

**변경 대상 (7개 파일)**
- `client/src/App.tsx`
- `client/src/auth.tsx`
- `client/src/components/ConsoleLayout.tsx`
- `client/src/pages/SuperAdminPage.tsx`
- `server/src/lib/consoleOnly.ts`
- `server/src/routes/auth.ts`
- `server/src/routes/me.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #409** ↔ **이슈 #417** 로 연결됩니다.

Closes #417
