### PR TITLE
🔀 :: (#418) chat log 비번 입력 시 로그아웃되는 버그 (진짜 원인)

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -160,9 +160,15 @@ async function apiInner<T = any>(
     // 세션 만료/무효(401) — 인증 엔드포인트 자체(로그인 실패·세션 복원 등)가 아니면 전역으로
     // 알려 AuthProvider 가 로그아웃 처리(→ /login)하게 한다. 페이지 사용 중 세션이 끊겼는데
     // 호출부가 catch{} 로 삼켜 빈 화면·stale 데이터로 방치되던 문제를 근본 해결.
+    //
+    // 단, SUPER_STEPUP_REQUIRED(총관리자 재인증 필요)는 "세션 만료"가 아니라 "step-up 재인증
+    // 필요"다 — 예: 사내톡 감사 진입, 역할 변경. 이걸 로그아웃으로 처리하면 chat log 비번을 맞춰도
+    // step-up 쿠키가 만료/부재일 때 튕겨버린다. 이 코드의 401 은 전역 로그아웃에서 제외하고,
+    // 호출부(패널)가 자체적으로 재인증을 유도하도록 둔다.
     if (
       res.status === 401 &&
       typeof window !== "undefined" &&
+      code !== "SUPER_STEPUP_REQUIRED" &&
       !path.startsWith("/api/auth") &&
       !path.startsWith("/api/me")
     ) {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -6,6 +6,7 @@ import { prisma } from "../lib/db.js";
 import { runUnscoped } from "../lib/tenant.js";
 import {
   requireAdmin, requireAuth, requireSuperAdminStepUp, verifySuperToken,
+  signSuper, setSuperCookie, SUPER_TTL_SEC,
   writeLog, evictUserCache, evictSessionCache,
   signImpersonate, setImpCookie, clearImpCookie,
 } from "../lib/auth.js";
@@ -1336,7 +1337,12 @@ ops.post("/chat-audit/unlock", requireSuperAdminStepUp, async (req, res) => {
     return res.status(403).json({ code: "BAD_STEPUP_PW", error: "암호 불일치" });
   }
   await writeLog(u.id, "CHAT_AUDIT_UNLOCK_OK", undefined, undefined, req.ip).catch(() => {});
-  res.json({ ok: true, ttlMs: 30 * 60 * 1000 });
+  // 채팅 감사 API(/api/chat/rooms?scope=audit, .../messages)는 super step-up 쿠키(hinest_super)를
+  // verifySuperToken 으로 요구한다. CHAT_AUDIT_PW 가 맞았으니 여기서 그 쿠키를 함께 발급해야
+  // 패널 진입 시 401 이 나지 않는다. (예전엔 쿠키를 안 줘서 패널이 401 → api() 가 세션 만료로
+  // 오인하고 전역 로그아웃시키는 버그가 있었음.)
+  setSuperCookie(res, signSuper(u.id), req);
+  res.json({ ok: true, ttlMs: SUPER_TTL_SEC * 1000 });
 });
 
 /** 사이드바 메뉴 가시성 관리 (총관리자 전용).


### PR DESCRIPTION
## 증상
콘솔에서 `chat log` → 비밀번호 입력 → **자동 로그아웃**. (#406 으로 고쳤다 했지만 재발)

## 진짜 원인
- `requireSuperAdminStepUp` 은 step-up 요구를 제거(superAdmin 세션만으로 통과)했음.
- 그러나 **채팅 감사 API**(`/api/chat/rooms?scope=audit`, `.../messages`)는 여전히
  `verifySuperToken`(=`hinest_super` 쿠키)을 요구.
- `chat-audit/unlock` 은 `CHAT_AUDIT_PW` 만 검사하고 **그 쿠키를 발급하지 않음** → 비번이
  맞아도 패널 진입 시 audit API 가 **401** → `api()` 가 세션 만료로 오인 → **전역 로그아웃**.
- #406 은 핸들러의 '비번 불일치' 401→403 만 고쳤을 뿐, 이 패널-진입 경로(별도 401)는 못 잡음.

## 수정
1. **서버** — `chat-audit/unlock` 이 `CHAT_AUDIT_PW` 일치 시 `signSuper`+`setSuperCookie` 로
   super 쿠키를 함께 발급. 이제 패널이 정상 로드.
2. **클라(안전망)** — `SUPER_STEPUP_REQUIRED` 코드의 401 은 '재인증 필요'이므로 전역 로그아웃에서
   제외. 쿠키가 15분 만료된 뒤에도 튕기지 않고, 패널이 자체적으로 재인증을 유도.

## 검증
server tsc 0 · client tsc 0

Closes #418
