### PR TITLE
🔀 :: (#419) 데스크톱 콘솔 하단 네비바가 안 사라지던 회귀 (consoleOnly 경로)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { useAuth } from "./auth";
+import { isDesktopApp } from "./lib/platform";
 import UpdateBanner from "./components/UpdateBanner";
 import DesktopUpdateBanner from "./components/DesktopUpdateBanner";
 import ConfirmHost from "./components/ConfirmHost";
@@ -106,6 +107,19 @@ export default function App() {
   // 라우트 단위 ErrorBoundary 의 reset 트리거 — 다음 페이지로 이동하면 자동 초기화.
   // 이렇게 안 하면 한 페이지에서 에러 나면 다른 메뉴로 가도 fallback 이 계속 보임.
   const { pathname } = useLocation();
+
+  // 데스크톱 디바이스 클래스(.hinest-desktop)를 최상위에서 항상 보장한다.
+  // 예전엔 AppLayout 마운트 시에만 붙였는데, 콘솔(ConsoleLayout)은 AppLayout 과 분리된
+  // 라우트라 — 특히 회사 앱을 거치지 않고 바로 콘솔로 가는 consoleOnly 계정에선 — 클래스가
+  // 안 붙어 "콘솔 하단 네비바 숨김"(html.hinest-desktop .console-bottomnav) CSS 가 안 먹었다.
+  // 디바이스 사실(데스크톱 여부)이라 라우트와 무관하게 1회만 판정해 둔다.
+  useEffect(() => {
+    const isDesktopDevice =
+      isDesktopApp() ||
+      (typeof window !== "undefined" && !!window.matchMedia?.("(hover: hover) and (pointer: fine)").matches);
+    document.documentElement.classList.toggle("hinest-desktop", isDesktopDevice);
+  }, []);
+
   return (
     <>
     <UpdateBanner />


### PR DESCRIPTION
## 증상
데스크톱에서 콘솔 하단 네비게이션 바가 여전히 노출됨. (PR #406 에서 숨겼다고 했으나 재발)

## 원인
`.hinest-desktop` 클래스를 **AppLayout 마운트 시에만** 붙였음. 콘솔(`ConsoleLayout`)은 `AppLayout` 과
분리된 라우트라, 회사 앱을 거치지 않고 **바로 콘솔로 가는 `consoleOnly` 계정**(직전 작업으로 도입한
`xixn2@efface.dev`)에선 AppLayout 이 한 번도 안 떠서 클래스가 안 붙음 → `html.hinest-desktop
.console-bottomnav { display:none }` 이 적용 안 됨.

즉 직전 consoleOnly 변경이 만든 회귀.

## 수정
디바이스 클래스(`.hinest-desktop`) 판정을 **App 최상위 `useEffect`** 로 올려 라우트/레이아웃과 무관하게
항상 적용. 콘솔에서도 하단 네비바가 숨고 사이드바가 보임. (AppLayout 의 기존 토글은 같은 값이라 idempotent)

## 검증
client tsc 0 · vite build ✓

Closes #419
