### PR TITLE
🔀 :: (#420) 하단 네비바 데스크톱 숨김 — 순수 CSS 반응형(md:hidden)

### DIFF
--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -286,7 +286,11 @@ export default function ConsoleLayout() {
             데스크톱은 좌측 사이드바를 쓰므로 md:hidden. 콘솔은 AppLayout 과 분리된
             레이아웃이라 네이티브 탭바 플러그인을 쓰지 않고 동일한 --c-glass 토큰으로 맞춘다. */}
         <nav
-          className="console-bottomnav"
+          // flex: 모바일에서 아이콘을 가로로 배치(예전엔 display 규칙이 없어 세로로 깨져 보였음).
+          // md:hidden: 데스크톱(≥1024px, 사이드바 md:flex 와 동일 분기)에선 JS 클래스와 무관하게
+          //            순수 CSS 로 숨긴다 — hinest-desktop 클래스가 안 붙는 경로(콘솔 전용 계정 등)
+          //            에서도 확실히 사라지도록. 좁은 데스크톱 창은 html.hinest-desktop 규칙이 보강.
+          className="console-bottomnav flex md:hidden"
           style={{
             position: "fixed",
             left: "50%",


### PR DESCRIPTION
## 증상
데스크톱 웹에서 콘솔 하단 네비게이션 바가 **계속** 노출 (이전 PR #406·#411 로도 안 잡힘).

## 근본 원인 (2개)
1. `.console-bottomnav` 에 `display:flex` 규칙이 **아예 없어** `display:block` 으로 깨진 세로 스택이 됨
   (스크린샷에서 아이콘이 세로로 쌓인 이유).
2. 데스크톱 숨김이 오직 `html.hinest-desktop`(JS로 붙는 클래스)에만 의존 — 회사 앱을 거치지 않는
   `consoleOnly` 계정 등에선 클래스가 안 붙어 안 사라짐. (JS 타이밍·포인터 감지에도 취약)

## 수정
`nav` className 에 `flex md:hidden` 추가:
- **flex** — 모바일에서 아이콘 가로 배치 정상화
- **md:hidden** — 데스크톱(≥1024px, 사이드바 `md:flex` 와 **동일 breakpoint**)에선 **JS 무관 순수 CSS** 로 숨김.
  사이드바와 자동으로 상호배타. 좁은 데스크톱 창은 기존 `html.hinest-desktop` 규칙이 보강.

이제 새로고침하면 데스크톱 웹/앱 모두에서 하단바가 즉시 사라지고 좌측 사이드바만 남음.

## 검증
client tsc 0 · vite build ✓

Closes #420
