### PR TITLE
🔀 :: (#531) 이슈 폼에 네이티브 Type 자동 설정

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: 🐛 버그 리포트
 description: 버그 · 오류 · 회귀를 신고합니다
 title: "fix: "
+type: Bug
 labels: ["type: fix"]
 assignees:
   - Xixn2

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: ✨ 기능 요청
 description: 새 기능 · 개선을 제안합니다
 title: "feat: "
+type: Feature
 labels: ["type: feat"]
 assignees:
   - Xixn2


### PR DESCRIPTION
## 증상
**이슈 폼에 네이티브 Type 자동 설정**

유지보수 작업을 진행합니다.

## 원인
폼으로 만든 이슈가 라벨·assignee 뿐 아니라 GitHub 네이티브 Type 필드도
자동으로 채워지도록 type 키 추가. (Priority 는 커스텀 org 필드라 폼 미지원 → API/수동)

Closes #531

## 수정
**작업 항목 (커밋 단위)**
- chore(ci): 이슈 폼에 네이티브 Type 자동 설정 (type: Bug/Feature)

**변경 대상 (2개 파일)**
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`

## 검증
- 코드·설정 검토

---
🔗 이 작업은 **PR #532** ↔ **이슈 #531** 로 연결됩니다.

Closes #531
