### PR TITLE
🔀 :: (#829) 다중 세션(재출근 보존) + 자동퇴근 workEndTime

### DIFF
--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -8,12 +8,28 @@ import Portal from "../components/Portal";
 import { alertAsync } from "../components/ConfirmHost";
 import { useModalDismiss } from "../lib/useModalDismiss";
 
+type WorkSession = { s: string; e: string | null; src?: string };
 type Attendance = {
   id: string;
   date: string;
   checkIn?: string;
   checkOut?: string;
+  sessions?: WorkSession[] | null;
 };
+
+/** 하루 근무 ms — 다중 세션 합산(갭 제외). sessions 없으면 checkIn/checkOut 단일(하위호환). */
+function attWorkedMs(r: Attendance): number {
+  const sessions: WorkSession[] = Array.isArray(r.sessions)
+    ? r.sessions
+    : r.checkIn ? [{ s: r.checkIn, e: r.checkOut ?? null }] : [];
+  let ms = 0;
+  for (const s of sessions) {
+    const start = new Date(s.s).getTime();
+    const end = s.e ? new Date(s.e).getTime() : Date.now();
+    if (end > start) ms += end - start;
+  }
+  return ms;
+}
 
 type Leave = {
   id: string;
@@ -145,10 +161,7 @@ export default function AttendancePage() {
   // === 통계 계산 ===
   const stats = useMemo(() => {
     const completed = records.filter((r) => r.checkIn && r.checkOut);
-    const totalMs = completed.reduce(
-      (acc, r) => acc + (new Date(r.checkOut!).getTime() - new Date(r.checkIn!).getTime()),
-      0,
-    );
+    const totalMs = completed.reduce((acc, r) => acc + attWorkedMs(r), 0);
     const avgMs = completed.length ? totalMs / completed.length : 0;
     const usedDays = leaves
       .filter((l) => l.status === "APPROVED")
@@ -297,7 +310,7 @@ export default function AttendancePage() {
                         </td>
                         <td data-label="근무시간" className="px-5 py-3 text-right">
                           {r.checkIn && r.checkOut ? (
-                            <span className="font-bold text-ink-900">{durationLabel(r.checkIn, r.checkOut)}</span>
+                            <span className="font-bold text-ink-900">{msToHM(attWorkedMs(r))}</span>
                           ) : (
                             <span className="text-ink-400">—</span>
                           )}

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -3,13 +3,14 @@ import { Link } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import InstallAppBanner from "../components/InstallAppBanner";
-import { confirmAsync, alertAsync } from "../components/ConfirmHost";
+import { alertAsync } from "../components/ConfirmHost";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { isPreviewMode } from "../lib/previewMock";
 
 type Notice = { id: string; title: string; content: string; createdAt: string; author: { name: string; isDeveloper?: boolean }; pinned: boolean };
 type Event = { id: string; title: string; startAt: string; endAt: string; scope: string; color: string };
-type Attendance = { checkIn?: string; checkOut?: string } | null;
+type WorkSession = { s: string; e: string | null; src?: string };
+type Attendance = { checkIn?: string; checkOut?: string; sessions?: WorkSession[] | null } | null;
 
 /**
  * 개요 — Toss 디자인 톤.
@@ -53,26 +54,13 @@ export default function DashboardPage() {
   useEffect(() => { load(); }, []);
 
   async function checkIn() {
+    // 다중 세션 — "다시 출근" 은 이전 기록을 보존하고 새 세션을 추가하므로 강제확인 불필요.
     try {
       await api("/api/attendance/check-in", { method: "POST" });
     } catch (err: any) {
-      if (err?.code === "ALREADY_CHECKED_OUT") {
-        const ok = await confirmAsync({
-          title: "재출근",
-          description: "오늘은 이미 퇴근 처리되었어요. 재출근으로 덮어쓸까요?\n(기존 퇴근 시각이 초기화됩니다)",
-          confirmLabel: "재출근",
-        });
-        if (!ok) return;
-        try {
-          await api("/api/attendance/check-in", { method: "POST", json: { force: true } });
-        } catch (e: any) {
-          alertAsync({ title: "출근 실패", description: e?.message ?? "출근 처리에 실패했어요" });
-          return;
-        }
-      } else {
-        alertAsync({ title: "출근 실패", description: err?.message ?? "출근 처리에 실패했어요" });
-        return;
-      }
+      const title = err?.code === "IP_NOT_ALLOWED" ? "출근 불가" : "출근 실패";
+      alertAsync({ title, description: err?.message ?? "출근 처리에 실패했어요" });
+      return;
     }
     load();
   }
@@ -87,10 +75,18 @@ export default function DashboardPage() {
   }
 
   const dateLabel = now.toLocaleDateString("ko-KR", { month: "long", day: "numeric", weekday: "long" });
-  const status: WorkStatus = att?.checkOut ? "OFF" : att?.checkIn ? "IN" : "NONE";
-  const workedMin = att?.checkIn
-    ? Math.max(0, Math.floor(((att.checkOut ? new Date(att.checkOut).getTime() : now.getTime()) - new Date(att.checkIn).getTime()) / 60000))
-    : 0;
+  // 다중 세션 — sessions 가 있으면 그대로, 없으면 checkIn/checkOut 단일 세션(하위호환).
+  const sessions: WorkSession[] = Array.isArray(att?.sessions)
+    ? att!.sessions!
+    : att?.checkIn ? [{ s: att.checkIn, e: att.checkOut ?? null }] : [];
+  const working = sessions.some((s) => !s.e); // 열린 세션 = 근무 중
+  const status: WorkStatus = working ? "IN" : sessions.length > 0 ? "OFF" : "NONE";
+  // 근무시간 = 모든 세션 합산(열린 세션은 now 까지). "다시 출근" 해도 누적된다.
+  const workedMin = sessions.reduce((acc, s) => {
+    const start = new Date(s.s).getTime();
+    const end = s.e ? new Date(s.e).getTime() : now.getTime();
+    return acc + (end > start ? Math.floor((end - start) / 60000) : 0);
+  }, 0);
   // 관리자 설정 기반 근무 시각 — 미설정 시 09:00/18:00 fallback.
   const startMin = parseHHmm(user?.workStartTime ?? "") ?? 9 * 60;
   const endMin = parseHHmm(user?.workEndTime ?? "") ?? 18 * 60;
@@ -133,25 +129,25 @@ export default function DashboardPage() {
             <div className="text-[13px] font-bold text-ink-500 mb-1">오늘 근무</div>
             <div className="flex items-baseline gap-1">
               <span className="text-[36px] sm:text-[40px] font-extrabold text-ink-900 tabular-nums" style={{ letterSpacing: "-0.03em" }}>
-                {att?.checkIn ? formatHours(workedMin) : "0"}
+                {sessions.length ? formatHours(workedMin) : "0"}
               </span>
-              <span className="text-[16px] font-bold text-ink-500">시간 {att?.checkIn ? formatMinutesPart(workedMin) : "0"}분</span>
+              <span className="text-[16px] font-bold text-ink-500">시간 {sessions.length ? formatMinutesPart(workedMin) : "0"}분</span>
             </div>
           </div>
           <div className="flex gap-2">
             <button
               type="button"
               onClick={checkIn}
-              disabled={!!att?.checkIn && !att?.checkOut}
+              disabled={working}
               className="px-5 py-2.5 rounded-xl text-[13.5px] font-extrabold transition disabled:opacity-40"
               style={{ background: "var(--c-brand)", color: "#fff" }}
             >
-              {att?.checkOut ? "다시 출근" : att?.checkIn ? "출근됨" : "출근하기"}
+              {working ? "출근됨" : sessions.length ? "다시 출근" : "출근하기"}
             </button>
             <button
               type="button"
               onClick={checkOut}
-              disabled={!att?.checkIn || !!att?.checkOut}
+              disabled={!working}
               className="px-5 py-2.5 rounded-xl text-[13.5px] font-extrabold transition disabled:opacity-40"
               style={{ background: "var(--c-surface-3)", color: "var(--c-text-1)" }}
             >

--- a/server/prisma/migrations/20260608000000_attendance_sessions/migration.sql
+++ b/server/prisma/migrations/20260608000000_attendance_sessions/migration.sql
@@ -1,0 +1,7 @@
+-- 근태 다중 세션 + 야근 연장.
+-- Attendance 에 sessions(JSONB, 다중 출퇴근 세션) + overtimeUntil(연장된 자동퇴근 시각) 추가.
+-- 둘 다 nullable → 기존 행에 NULL 이 채워지는 비파괴적 추가(테이블 락·재작성 없음).
+-- sessions 가 NULL 인 과거 행은 애플리케이션이 checkIn/checkOut 을 단일 세션으로 해석(하위호환).
+
+ALTER TABLE "Attendance" ADD COLUMN "sessions" JSONB;
+ALTER TABLE "Attendance" ADD COLUMN "overtimeUntil" TIMESTAMP(3);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -461,9 +461,16 @@ model Attendance {
   userId    String
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   date      String // YYYY-MM-DD
-  checkIn   DateTime?
-  checkOut  DateTime?
+  checkIn   DateTime? // 그날 첫 출근(요약). 다중 세션의 최초 시작 시각.
+  checkOut  DateTime? // 그날 마지막 퇴근(요약). 다중 세션의 최종 종료 시각.
   note      String?
+  // 다중 출퇴근 세션 — [{ s: ISO 시작, e: ISO 종료|null(근무중), src: "manual"|"ip"|"auto" }].
+  // 근무시간 = Σ((e ?? now) - s). "다시 출근" 해도 이전 세션을 보존·합산해 데이터 손실을 막는다.
+  // null 인 과거 레코드는 checkIn/checkOut 을 단일 세션으로 간주(하위호환).
+  sessions  Json?
+  // 야근(추가근무) 승인으로 연장된 자동퇴근 종료시각. 설정되면 그 시각까지 자동퇴근을 보류한다.
+  // (PR-C 야근 신청 기능에서 채워짐. PR-A 에선 컬럼만 추가 — 자동퇴근 잡이 미리 참조.)
+  overtimeUntil DateTime?
 
   @@unique([userId, date])
   // 디렉터리 페이지가 "오늘 date + userId IN (...)" 로 묶어 조회 →

--- a/server/src/jobs/autoClockOut.ts
+++ b/server/src/jobs/autoClockOut.ts
@@ -21,6 +21,10 @@
  */
 
 import { prisma } from "../lib/db.js";
+import { normalizeSessions, hasOpenSession, closeOpenSessions } from "../lib/attendanceSessions.js";
+
+/** 기본 퇴근시간 — workEndTime 미설정(null) 사용자에게 적용. */
+const DEFAULT_END = "18:00";
 
 /** KST 현재 시각을 { hhmm, ymd } 로 반환. */
 function nowInKst(): { hhmm: string; ymd: string } {
@@ -46,34 +50,37 @@ function nowInKst(): { hhmm: string; ymd: string } {
 async function tick() {
   try {
     const { hhmm, ymd } = nowInKst();
-    // 1) 자동 퇴근 대상 사용자
-    const users = await prisma.user.findMany({
-      where: {
-        active: true,
-        autoClockOutTime: hhmm,
-      },
-      select: { id: true },
-    });
+    // 1) 퇴근시간(workEndTime, 미설정 시 18:00)이 지금(hhmm)인 활성 사용자.
+    //    ※ 자동퇴근 기준을 별도 autoClockOutTime → workEndTime 으로 전환(설정 불일치로 엉뚱한
+    //       시각에 퇴근되던 버그 해결). 미설정 사용자는 기본 18:00 에 적용.
+    const where =
+      hhmm === DEFAULT_END
+        ? { active: true, OR: [{ workEndTime: DEFAULT_END }, { workEndTime: null }] }
+        : { active: true, workEndTime: hhmm };
+    const users = await prisma.user.findMany({ where, select: { id: true } });
     if (users.length === 0) return;
 
-    // 2) 각 사용자의 오늘 출근기록에 대해 checkOut 채움 — updateMany 로 단일 쿼리.
-    //    복합 unique(userId,date) 라 updateMany 는 통과하지만,
-    //    "checkIn 있고 checkOut 없음" 조건을 함께 걸어 멱등성 보장.
-    const now = new Date();
-    const result = await prisma.attendance.updateMany({
-      where: {
-        userId: { in: users.map((u) => u.id) },
-        date: ymd,
-        checkIn: { not: null },
-        checkOut: null,
-      },
-      data: { checkOut: now, note: "자동 퇴근" },
+    // 2) 그 사용자들의 오늘 근태 중 '열린 세션'이 있는 것만 닫아 자동 퇴근.
+    const recs = await prisma.attendance.findMany({
+      where: { userId: { in: users.map((u) => u.id) }, date: ymd },
     });
+    const now = new Date();
+    let count = 0;
+    for (const rec of recs) {
+      // 야근(추가근무) 승인으로 연장됐으면 그 시각까지 자동퇴근 보류.
+      if (rec.overtimeUntil && new Date(rec.overtimeUntil).getTime() > now.getTime()) continue;
+      const sessions = normalizeSessions(rec);
+      if (!hasOpenSession(sessions)) continue; // 이미 퇴근했거나 출근 안 함 → 건너뜀(멱등)
+      closeOpenSessions(sessions, now);
+      await prisma.attendance.update({
+        where: { id: rec.id },
+        data: { sessions: sessions as unknown as object, checkOut: now, note: "자동 퇴근" },
+      });
+      count++;
+    }
 
-    if (result.count > 0) {
-      console.log(
-        `[autoClockOut] ${ymd} ${hhmm} KST — 자동 퇴근 처리 ${result.count}건 (대상 ${users.length}명)`
-      );
+    if (count > 0) {
+      console.log(`[autoClockOut] ${ymd} ${hhmm} KST — 자동 퇴근 ${count}건 (대상 ${users.length}명)`);
     }
   } catch (e) {
     // 스케줄러는 절대 프로세스를 죽이지 않음 — 다음 tick 에서 재시도.

--- a/server/src/lib/attendanceSessions.ts
+++ b/server/src/lib/attendanceSessions.ts
@@ -1,0 +1,59 @@
+/**
+ * 근태 다중 세션 헬퍼.
+ *
+ * Attendance.sessions(Json) = [{ s: ISO 시작, e: ISO 종료|null(근무중), src }].
+ * "다시 출근" 시 이전 세션을 덮어쓰지 않고 새 세션을 추가 → 데이터 손실 방지 + 근무시간 합산.
+ * sessions 가 없는 과거 레코드는 checkIn/checkOut 을 단일 세션으로 간주(하위호환).
+ */
+
+export type WorkSession = { s: string; e: string | null; src?: string };
+
+type AttendanceLike = {
+  sessions?: unknown;
+  checkIn?: Date | string | null;
+  checkOut?: Date | string | null;
+};
+
+/** 레코드 → 정규화된 세션 배열. sessions 없으면 checkIn/checkOut 으로 단일 세션 구성. */
+export function normalizeSessions(rec: AttendanceLike | null | undefined): WorkSession[] {
+  if (!rec) return [];
+  const raw = rec.sessions;
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((x): x is WorkSession => !!x && typeof (x as any).s === "string")
+      .map((x) => ({ s: x.s, e: x.e ?? null, src: x.src }));
+  }
+  if (rec.checkIn) {
+    return [{
+      s: new Date(rec.checkIn).toISOString(),
+      e: rec.checkOut ? new Date(rec.checkOut).toISOString() : null,
+      src: "manual",
+    }];
+  }
+  return [];
+}
+
+/** 세션 합산 근무 분(分). 열린 세션은 now 까지 계산. */
+export function workedMinutes(sessions: WorkSession[], now: Date = new Date()): number {
+  let ms = 0;
+  for (const s of sessions) {
+    const start = new Date(s.s).getTime();
+    const end = s.e ? new Date(s.e).getTime() : now.getTime();
+    if (Number.isFinite(start) && Number.isFinite(end) && end > start) ms += end - start;
+  }
+  return Math.floor(ms / 60000);
+}
+
+/** 현재 근무 중(닫히지 않은 세션 존재)인가. */
+export function hasOpenSession(sessions: WorkSession[]): boolean {
+  return sessions.some((s) => !s.e);
+}
+
+/** 열린 세션을 모두 now 로 닫는다. 닫은 게 있으면 true. */
+export function closeOpenSessions(sessions: WorkSession[], now: Date = new Date()): boolean {
+  let closed = false;
+  for (const s of sessions) {
+    if (!s.e) { s.e = now.toISOString(); closed = true; }
+  }
+  return closed;
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1454,13 +1454,21 @@ router.patch("/users/:id/attendance", async (req, res) => {
   };
   const checkIn = parseTime(body.checkIn);
   const checkOut = parseTime(body.checkOut);
-  const data: { checkIn?: Date | null; checkOut?: Date | null } = {};
+  // 관리자 수정은 단일 세션으로 정규화 — sessions 합산 근무시간이 수정한 checkIn/checkOut 을
+  // 그대로 반영하게(기존 다중 세션은 덮어쓴다. 관리자가 입력한 값이 권위 있는 값).
+  const existing = await prisma.attendance.findUnique({ where: { userId_date: { userId: id, date } } });
+  const finalIn = checkIn !== undefined ? checkIn : (existing?.checkIn ?? null);
+  const finalOut = checkOut !== undefined ? checkOut : (existing?.checkOut ?? null);
+  const sessions = finalIn
+    ? [{ s: finalIn.toISOString(), e: finalOut ? finalOut.toISOString() : null, src: "edit" }]
+    : [];
+  const data: { checkIn?: Date | null; checkOut?: Date | null; sessions?: object } = { sessions };
   if (checkIn !== undefined) data.checkIn = checkIn;
   if (checkOut !== undefined) data.checkOut = checkOut;
   const rec = await prisma.attendance.upsert({
     where: { userId_date: { userId: id, date } },
     update: data,
-    create: { userId: id, date, checkIn: checkIn ?? null, checkOut: checkOut ?? null },
+    create: { userId: id, date, checkIn: checkIn ?? null, checkOut: checkOut ?? null, sessions: sessions as object },
   });
   // 출근 기록은 임금/평가 근거가 되는 민감 데이터 — 변경 감사 추적 필수.
   await writeLog(u.id, "ATTENDANCE_EDIT", id, `${date} in=${body.checkIn ?? "·"} out=${body.checkOut ?? "·"}`, req.ip);

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -5,29 +5,33 @@ import { requireAuth, writeLog } from "../lib/auth.js";
 import { notify } from "../lib/notify.js";
 import { todayStr } from "../lib/dates.js";
 import { ipMatchesAny, normalizeClientIp } from "../lib/ipMatch.js";
+import { normalizeSessions, workedMinutes, hasOpenSession, closeOpenSessions, type WorkSession } from "../lib/attendanceSessions.js";
 
 const router = Router();
 router.use(requireAuth);
 
-// 오늘 출퇴근 상태
+// 오늘 출퇴근 상태 — sessions 합산 근무 분(workedMinutes)도 함께 내려준다.
 router.get("/today", async (req, res) => {
   const u = (req as any).user;
   const rec = await prisma.attendance.findUnique({
     where: { userId_date: { userId: u.id, date: todayStr() } },
   });
-  res.json({ attendance: rec });
+  const sessions = normalizeSessions(rec);
+  res.json({
+    attendance: rec,
+    workedMinutes: workedMinutes(sessions),
+    working: hasOpenSession(sessions),
+  });
 });
 
-// 출근 — 하루에 여러 번 가능하지만, 이미 "출근 + 퇴근" 이 찍혀 있으면 한 번 더 확인을 받음.
-// 기존엔 checkOut 을 무조건 null 로 덮어써 퇴근 시각이 소실되는 데이터 손실 버그가 있었음.
-// 이제는:
-//   (a) 기록 없음 → 신규 생성
-//   (b) 출근만 있음 → checkIn 시각만 최신으로 덮어쓰기 (퇴근 기록은 건드리지 않음)
-//   (c) 출근 + 퇴근 둘 다 있음 → 409 Conflict 반환. 클라가 { force: true } 로 재요청 시에만 퇴근 시각 초기화.
+// 출근 — 다중 세션 방식. "다시 출근" 해도 이전 세션을 보존하고 새 세션을 추가한다.
+//   (a) 기록 없음 → 새 세션으로 생성
+//   (b) 이미 근무 중(열린 세션 존재) → 멱등(그대로 반환)
+//   (c) 퇴근 후 다시 출근 → 새 세션 추가(이전 세션·시간 보존), checkOut 요약만 초기화
+// 예전의 "checkOut 을 null 로 덮어써 퇴근 시각 소실" 버그 + 409 강제확인 흐름을 제거.
 router.post("/check-in", async (req, res) => {
   const u = (req as any).user;
   const date = todayStr();
-  const force = req.body?.force === true;
 
   // 회사 IP 화이트리스트 검사 — 관리자가 켜놓은 경우만. 매치 안 되면 403.
   // 슈퍼/플랫폼 어드민은 우회(원격 운영 편의). user 의 companyId 가 없으면(플랫폼 운영자) 우회.
@@ -56,40 +60,48 @@ router.post("/check-in", async (req, res) => {
   const existing = await prisma.attendance.findUnique({
     where: { userId_date: { userId: u.id, date } },
   });
-  if (existing?.checkOut && !force) {
-    return res.status(409).json({
-      code: "ALREADY_CHECKED_OUT",
-      error: "오늘은 이미 퇴근 처리가 되어 있어요. 정말 재출근으로 덮어쓸까요?",
-      attendance: existing,
-    });
+  const sessions = normalizeSessions(existing);
+
+  // 이미 근무 중이면 멱등 — 새 세션을 또 열지 않는다.
+  if (hasOpenSession(sessions)) {
+    return res.json({ attendance: existing, workedMinutes: workedMinutes(sessions), working: true });
   }
+
   const now = new Date();
+  sessions.push({ s: now.toISOString(), e: null, src: "manual" });
+  const firstCheckIn = existing?.checkIn ?? now; // 최초 출근 시각 보존
   const rec = await prisma.attendance.upsert({
     where: { userId_date: { userId: u.id, date } },
-    update: force
-      ? { checkIn: now, checkOut: null } // 명시적 동의 하에만 checkOut 초기화
-      : { checkIn: now },
-    create: { userId: u.id, date, checkIn: now },
+    update: { sessions: sessions as unknown as object, checkIn: firstCheckIn, checkOut: null },
+    create: {
+      userId: u.id,
+      companyId: u.companyId ?? null,
+      date,
+      checkIn: now,
+      sessions: [{ s: now.toISOString(), e: null, src: "manual" }] as unknown as object,
+    },
   });
-  await writeLog(u.id, "CHECK_IN", date, force ? "force" : undefined);
-  res.json({ attendance: rec });
+  await writeLog(u.id, "CHECK_IN", date, sessions.length > 1 ? "re-in" : undefined);
+  res.json({ attendance: rec, workedMinutes: workedMinutes(normalizeSessions(rec)), working: true });
 });
 
-// 퇴근
-// 출근 기록 없이 퇴근 눌러도 500 나지 않도록 upsert.
-// (앱 재설치 직후, 새벽 경계 타이밍, 관리자 수동 조정 등 엣지 케이스 대응)
-// create 시 checkIn 은 null 로 두고 checkOut 만 기록 — 리포트에서 "출근 누락 후 퇴근" 으로 보임.
+// 퇴근 — 열린 세션을 닫는다(다중 세션 합산 보존). 출근 기록 없이 눌러도 안전.
 router.post("/check-out", async (req, res) => {
   const u = (req as any).user;
   const date = todayStr();
   const now = new Date();
+  const existing = await prisma.attendance.findUnique({
+    where: { userId_date: { userId: u.id, date } },
+  });
+  const sessions = normalizeSessions(existing);
+  closeOpenSessions(sessions, now); // 열린 세션 종료
   const rec = await prisma.attendance.upsert({
     where: { userId_date: { userId: u.id, date } },
-    update: { checkOut: now },
-    create: { userId: u.id, date, checkOut: now },
+    update: { sessions: sessions as unknown as object, checkOut: now },
+    create: { userId: u.id, companyId: u.companyId ?? null, date, checkOut: now },
   });
   await writeLog(u.id, "CHECK_OUT", date);
-  res.json({ attendance: rec });
+  res.json({ attendance: rec, workedMinutes: workedMinutes(normalizeSessions(rec)), working: false });
 });
 
 // 월별 근태 기록


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 작업 개요
근태 버그 2건 수정 + 다중 세션 토대(근태 v2 PR-A).

### 버그 수정
1. **16:30 자동퇴근** — 자동퇴근을 별도 `autoClockOutTime` → **workEndTime(기본 18:00)** 기준으로. (autoClockOutTime 잔존값으로 엉뚱한 시각 퇴근되던 문제)
2. **재출근 시 이전 시간 증발** — `Attendance.sessions`(JSONB) 다중 세션으로 **보존·합산**. '다시 출근'은 새 세션을 추가하고 이전 기록을 보존.

### 변경
- 스키마: `sessions`·`overtimeUntil` 추가(비파괴 마이그레이션)
- check-in/out 다중 세션화, /today 합산, autoClockOut workEndTime+세션종료
- 관리자 수동 수정 시 sessions 동기화(급여 무결성)
- 위젯·월별 근태 근무시간 = 세션 합산

### 검증
server tsc 0 · client tsc 0 · build ✓. 마이그레이션은 배포 시 `migrate deploy` 자동 적용(additive).

Closes #829

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #829
