### PR TITLE
🔀 :: (#831) 채팅 아이콘 가림 방지 — 하단 클리어런스

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -54,7 +54,10 @@
        위에서 끝나고 그 아래(safe-area)는 콘텐츠가 뒤로 지나가게 한다.
      · 모바일(<md)은 in-flow 하단 바가 safe-area 를 흡수하므로 본문엔 숨 쉴 여백(24px)만 —
        아래 미디어쿼리에서 덮어쓴다(바 패딩과 이중 여백 방지). */
-  --hinest-main-pb: max(24px, env(safe-area-inset-bottom));
+  /* 90px: 우하단 ChatFab(60px + bottom 20px = 상단 80px)에 마지막 콘텐츠(표 마지막 행의
+     '처리' 버튼 등)가 가리지 않도록 클리어런스 확보. FAB 는 md+ 에서만 뜨므로(아래 모바일
+     쿼리가 24px 로 덮어씀) 데스크톱·태블릿 웹에만 적용된다. */
+  --hinest-main-pb: max(90px, env(safe-area-inset-bottom));
 }
 
 /* Tailwind md 브레이크포인트(768px) 미만 = 사이드바가 드로어로 접히는 구간.


### PR DESCRIPTION
## 증상
**채팅 아이콘 가림 방지 — 하단 클리어런스**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
데스크톱 우하단 ChatFab(60px, bottom 20px→상단 80px) 뒤로 표 마지막 행의 '처리'
버튼 등이 가려 클릭 불가하던 문제. md+ 메인 하단패딩(--hinest-main-pb)을 24px→90px 로
올려 마지막 콘텐츠가 FAB 위로 스크롤되게 함. FAB 는 md+ 에서만 떠 모바일은 영향 없음.

Closes #831

## 수정
**작업 항목 (커밋 단위)**
- fix(layout): ChatFab 에 콘텐츠 가리지 않게 하단 클리어런스 추가

**변경 대상 (1개 파일)**
- `client/src/styles.css`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #832** 에서 진행됩니다.

