### PR TITLE
🔀 :: (#833) 전직원 근태 페이지 + 개발자 관리자 권한

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -67,7 +67,8 @@ function Protected({ children }: { children: React.ReactNode }) {
 
 function AdminOnly({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
-  if (user?.role !== "ADMIN") return <Navigate to="/" replace />;
+  // 회사 ADMIN + HiNest 개발자(콘솔로만 부여) 허용 — 개발자도 관리자 페이지 제어 가능.
+  if (user?.role !== "ADMIN" && !user?.isDeveloper) return <Navigate to="/" replace />;
   return <>{children}</>;
 }
 

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -843,7 +843,7 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
           <PinsSection />
           <ProjectsSection />
 
-          {user?.role === "ADMIN" && (
+          {(user?.role === "ADMIN" || user?.isDeveloper) && (
             <div>
               <SectionLabel>관리</SectionLabel>
               <NavLink
@@ -1365,7 +1365,7 @@ export function MobileMenuPage() {
       <PinsSection />
       <ProjectsSection />
 
-      {user?.role === "ADMIN" && (
+      {(user?.role === "ADMIN" || user?.isDeveloper) && (
         <div>
           <SectionLabel>관리</SectionLabel>
           <NavLink to="/admin" className={({ isActive }) => navClass(isActive)}>

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -187,7 +187,7 @@ type Invite = {
 type Team = { id: string; name: string; createdAt: string };
 type Position = { id: string; name: string; rank: number; createdAt: string };
 
-type Tab = "users" | "invites" | "teams" | "positions" | "ip";
+type Tab = "users" | "invites" | "teams" | "positions" | "ip" | "attendance";
 
 // 내보내기 버튼에 쓰는 작은 브랜드 로고들. 외부 에셋 없이 inline SVG 로 둬서
 // 번들 사이즈/네트워크 요청 영향 없음. 크기는 16px 고정 — 버튼 높이(32)에 맞춘 값.
@@ -293,6 +293,7 @@ export default function AdminPage() {
     { key: "teams", label: "팀", count: teams.length, icon: <TeamIcon /> },
     { key: "positions", label: "직급", count: positions.length, icon: <RankIcon /> },
     { key: "ip", label: "출근 IP", count: ipCount, icon: <RankIcon /> },
+    { key: "attendance", label: "근태", count: users.length, icon: <ClockIcon /> },
   ];
 
   return (
@@ -354,11 +355,12 @@ export default function AdminPage() {
       {tab === "teams" && <TeamsTab teams={teams} reload={loadCommon} />}
       {tab === "positions" && <PositionsTab positions={positions} reload={loadCommon} />}
       {tab === "ip" && <AttendanceIpTab onCountChange={setIpCount} />}
+      {tab === "attendance" && <AttendanceOverviewTab />}
     </div>
   );
 }
 
-function StatCard({ label, value, sub }: { label: string; value: number; sub: string }) {
+function StatCard({ label, value, sub }: { label: string; value: number | string; sub: string }) {
   return (
     <div className="panel p-4">
       <div className="text-[11px] font-bold text-ink-500 uppercase tracking-[0.06em]">{label}</div>
@@ -2219,6 +2221,109 @@ function RankIcon() {
   return <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M6 9 12 3l6 6" /><path d="M12 3v18" /><path d="M6 15l6 6 6-6" />
   </svg>;
+}
+function ClockIcon() {
+  return <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="9" /><path d="M12 7v5l3 2" />
+  </svg>;
+}
+
+/* ===== 근태 — 전 직원 출퇴근 + 이번주/이번달/총 근무시간 ===== */
+type OverviewRow = {
+  id: string; name: string; team: string | null; position: string | null;
+  avatarColor?: string; avatarUrl?: string | null;
+  workStartTime?: string | null; workEndTime?: string | null;
+  today: { checkIn: string | null; checkOut: string | null; worked: number } | null;
+  weekMinutes: number; monthMinutes: number; totalMinutes: number;
+};
+function fmtMin(min: number): string {
+  if (!min) return "0분";
+  const h = Math.floor(min / 60), m = min % 60;
+  return h ? (m ? `${h}시간 ${m}분` : `${h}시간`) : `${m}분`;
+}
+function fmtTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+function AttendanceOverviewTab() {
+  const [rows, setRows] = useState<OverviewRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    let alive = true;
+    api<{ rows: OverviewRow[] }>("/api/admin/attendance/overview")
+      .then((r) => { if (alive) setRows(r.rows || []); })
+      .catch(() => {})
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+  const workingNow = rows.filter((r) => r.today?.checkIn && !r.today?.checkOut).length;
+  const weekTotal = rows.reduce((a, r) => a + r.weekMinutes, 0);
+  const monthTotal = rows.reduce((a, r) => a + r.monthMinutes, 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard label="구성원" value={rows.length} sub={`근무 중 ${workingNow}명`} />
+        <StatCard label="이번 주 합계" value={`${Math.floor(weekTotal / 60)}h`} sub={`${rows.length}명 합산`} />
+        <StatCard label="이번 달 합계" value={`${Math.floor(monthTotal / 60)}h`} sub={`${rows.length}명 합산`} />
+        <StatCard label="평균(이번 달)" value={rows.length ? `${Math.floor(monthTotal / rows.length / 60)}h` : "0h"} sub="1인당" />
+      </div>
+      <div className="panel p-0 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-ink-100 flex items-center justify-between">
+          <span className="font-bold text-ink-900">직원별 근태 <span className="text-ink-400 font-medium ml-1">{rows.length}</span></span>
+          {loading && <span className="text-[12px] text-ink-400">불러오는 중…</span>}
+        </div>
+        <div className="overflow-x-auto hinest-x-scroll">
+          <table className="w-full text-[13px] whitespace-nowrap">
+            <thead>
+              <tr className="text-ink-500 border-b border-ink-100 text-[11.5px] uppercase tracking-wide">
+                <th className="text-left font-bold px-5 py-2.5 sticky left-0 bg-[var(--c-surface-1)]">구성원</th>
+                <th className="text-center font-bold px-3 py-2.5">오늘 출근</th>
+                <th className="text-center font-bold px-3 py-2.5">오늘 퇴근</th>
+                <th className="text-right font-bold px-3 py-2.5">오늘 근무</th>
+                <th className="text-right font-bold px-3 py-2.5">이번 주</th>
+                <th className="text-right font-bold px-3 py-2.5">이번 달</th>
+                <th className="text-right font-bold px-5 py-2.5">총 근무</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const working = !!r.today?.checkIn && !r.today?.checkOut;
+                return (
+                  <tr key={r.id} className="border-b border-ink-100">
+                    <td className="px-5 py-3 sticky left-0 bg-[var(--c-surface-1)]">
+                      <div className="flex items-center gap-2.5">
+                        <span className="grid place-items-center rounded-full text-white text-[11px] font-bold flex-shrink-0"
+                          style={{ width: 30, height: 30, background: r.avatarColor || "#64748B" }}>
+                          {r.name.slice(0, 1)}
+                        </span>
+                        <div className="min-w-0">
+                          <div className="font-bold text-ink-900 flex items-center gap-1.5">
+                            {r.name}
+                            {working && <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500" title="근무 중" />}
+                          </div>
+                          <div className="text-[11px] text-ink-400">{[r.team, r.position].filter(Boolean).join(" · ") || "—"}</div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="text-center px-3 py-3 tabular-nums text-ink-700">{fmtTime(r.today?.checkIn ?? null)}</td>
+                    <td className="text-center px-3 py-3 tabular-nums text-ink-700">{fmtTime(r.today?.checkOut ?? null)}</td>
+                    <td className="text-right px-3 py-3 tabular-nums font-semibold text-ink-900">{r.today ? fmtMin(r.today.worked) : "—"}</td>
+                    <td className="text-right px-3 py-3 tabular-nums text-ink-700">{fmtMin(r.weekMinutes)}</td>
+                    <td className="text-right px-3 py-3 tabular-nums text-ink-700">{fmtMin(r.monthMinutes)}</td>
+                    <td className="text-right px-5 py-3 tabular-nums font-bold text-ink-900">{fmtMin(r.totalMinutes)}</td>
+                  </tr>
+                );
+              })}
+              {!loading && rows.length === 0 && (
+                <tr><td colSpan={7} className="text-center py-10 text-ink-400">표시할 구성원이 없어요.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
 }
 function TrashIcon() {
   return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#DC2626" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -133,6 +133,9 @@ export interface AuthUser {
   companyId: string | null;
   // 플랫폼 운영자 — 테넌트를 가로지르는 최상위 권한 (회사 가입 승인 등).
   platformAdmin: boolean;
+  // HiNest 개발자 플래그 — 콘솔(superAdmin)에서만 부여되는 신뢰 designation.
+  // 회사 관리자 페이지 접근 + 역할 변경(ADMIN 부여)을 총관리자와 함께 허용한다.
+  isDeveloper: boolean;
 }
 
 export function signToken(
@@ -243,6 +246,7 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
       superAdmin: activeUser.superAdmin,
       companyId: activeUser.companyId ?? null,
       platformAdmin: activeUser.platformAdmin,
+      isDeveloper: activeUser.isDeveloper,
     } as AuthUser;
     // 핸들러에서 user row 가 또 필요하면 재조회하지 말고 이거 쓰기 — /api/me 처럼
     // 인증만 거치고 바로 user 필드를 되돌려주는 엔드포인트에서 DB 왕복 1번 절약.
@@ -263,7 +267,8 @@ export async function requireAuth(req: Request, res: Response, next: NextFunctio
 
 export function requireAdmin(req: Request, res: Response, next: NextFunction) {
   const u = (req as any).user as AuthUser | undefined;
-  if (!u || u.role !== "ADMIN") return res.status(403).json({ error: "forbidden" });
+  // 회사 ADMIN + HiNest 개발자(콘솔로만 부여) 허용 — 개발자도 관리자 페이지를 제어할 수 있게.
+  if (!u || (u.role !== "ADMIN" && !u.isDeveloper)) return res.status(403).json({ error: "forbidden" });
   next();
 }
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -11,6 +11,7 @@ import {
   signImpersonate, setImpCookie, clearImpCookie,
 } from "../lib/auth.js";
 import { todayStr } from "../lib/dates.js";
+import { normalizeSessions, workedMinutes } from "../lib/attendanceSessions.js";
 import { getLogs, type LogLevel, getErrorGroups, getErrorGroup, clearErrorGroups } from "../lib/logBuffer.js";
 import { evictNavVisibilityCache } from "./nav.js";
 
@@ -194,17 +195,25 @@ router.patch("/users/:id", async (req, res) => {
   // ADMIN 이 자신 또는 동료의 role 을 임의로 바꿀 수 없게 함.
   const isRoleChange = data.role !== undefined && data.role !== target.role;
   if (isRoleChange) {
-    if (!u.superAdmin) {
-      return res.status(403).json({ error: "역할 변경 권한이 없습니다 (총관리자 전용)" });
+    // 총관리자(superAdmin) + 개발자(isDeveloper) 가 역할(ADMIN 포함) 변경 가능.
+    // isDeveloper 는 콘솔(superAdmin)에서만 부여되는 신뢰 플래그라, 일반 ADMIN 의 자가 권한상승
+    // 경로가 되지 않는다(업데이트 스키마에 isDeveloper 없음).
+    const actorIsDev = !!(req as any).userRecord?.isDeveloper;
+    if (!u.superAdmin && !actorIsDev) {
+      return res.status(403).json({ error: "역할 변경 권한이 없습니다 (총관리자·개발자 전용)" });
     }
-    const v = verifySuperToken(req, u.id);
-    if (!v) {
-      return res.status(401).json({
-        error: "역할 변경 전에 비밀번호 재확인이 필요합니다",
-        code: "SUPER_STEPUP_REQUIRED",
-      });
+    // 총관리자는 step-up 재확인 필요(권한 에스컬레이션 보호). 개발자(superAdmin 아님)는
+    // super 쿠키를 발급받을 수 없으므로 step-up 면제 — 대신 신뢰 플래그로 게이트.
+    if (u.superAdmin) {
+      const v = verifySuperToken(req, u.id);
+      if (!v) {
+        return res.status(401).json({
+          error: "역할 변경 전에 비밀번호 재확인이 필요합니다",
+          code: "SUPER_STEPUP_REQUIRED",
+        });
+      }
     }
-    // 본인 역할 강등은 사고 방지용 차단 — 필요하면 다른 총관리자가 처리.
+    // 본인 역할 강등은 사고 방지용 차단 — 필요하면 다른 총관리자·개발자가 처리.
     if (target.id === u.id) {
       return res.status(400).json({ error: "본인 역할은 변경할 수 없습니다" });
     }
@@ -1473,6 +1482,67 @@ router.patch("/users/:id/attendance", async (req, res) => {
   // 출근 기록은 임금/평가 근거가 되는 민감 데이터 — 변경 감사 추적 필수.
   await writeLog(u.id, "ATTENDANCE_EDIT", id, `${date} in=${body.checkIn ?? "·"} out=${body.checkOut ?? "·"}`, req.ip);
   res.json({ attendance: rec });
+});
+
+/* ===== 전 직원 근태 한눈에 — 오늘 출퇴근 + 이번주/이번달/총 근무시간 합산 =====
+ * 회사 관리자(또는 개발자)용. 같은 회사 활성 사용자만. 근무시간은 세션 합산 기준. */
+router.get("/attendance/overview", async (req, res) => {
+  const u = (req as any).user;
+  const users = await prisma.user.findMany({
+    where: {
+      companyId: u.companyId ?? null,
+      active: true,
+      ...(u.superAdmin ? {} : { superAdmin: false }), // 일반 관리자에겐 총관리자 은닉
+    },
+    select: {
+      id: true, name: true, team: true, position: true,
+      avatarColor: true, avatarUrl: true, workStartTime: true, workEndTime: true,
+    },
+    orderBy: [{ team: "asc" }, { name: "asc" }],
+  });
+  if (users.length === 0) return res.json({ rows: [] });
+  const ids = users.map((x) => x.id);
+  const today = todayStr();
+  const monthPrefix = today.slice(0, 7); // YYYY-MM
+  // 이번 주 월요일(KST) — date 문자열 비교용(>= weekMonday).
+  const [yy, mm, dd] = today.split("-").map(Number);
+  const base = new Date(Date.UTC(yy, mm - 1, dd));
+  const dow = base.getUTCDay(); // 0=일
+  base.setUTCDate(base.getUTCDate() - (dow === 0 ? 6 : dow - 1));
+  const weekMonday = base.toISOString().slice(0, 10);
+
+  const att = await prisma.attendance.findMany({
+    where: { userId: { in: ids } },
+    select: { userId: true, date: true, checkIn: true, checkOut: true, sessions: true },
+  });
+  const byUser = new Map<string, typeof att>();
+  for (const a of att) {
+    const arr = byUser.get(a.userId) ?? [];
+    arr.push(a);
+    byUser.set(a.userId, arr);
+  }
+  const rows = users.map((usr) => {
+    const recs = byUser.get(usr.id) ?? [];
+    let week = 0, month = 0, total = 0;
+    let todayRec: (typeof att)[number] | undefined;
+    for (const r of recs) {
+      const w = workedMinutes(normalizeSessions(r));
+      total += w;
+      if (r.date.startsWith(monthPrefix)) month += w;
+      if (r.date >= weekMonday) week += w;
+      if (r.date === today) todayRec = r;
+    }
+    return {
+      id: usr.id, name: usr.name, team: usr.team, position: usr.position,
+      avatarColor: usr.avatarColor, avatarUrl: usr.avatarUrl,
+      workStartTime: usr.workStartTime, workEndTime: usr.workEndTime,
+      today: todayRec
+        ? { checkIn: todayRec.checkIn, checkOut: todayRec.checkOut, worked: workedMinutes(normalizeSessions(todayRec)) }
+        : null,
+      weekMinutes: week, monthMinutes: month, totalMinutes: total,
+    };
+  });
+  res.json({ rows, weekMonday, month: monthPrefix });
 });
 
 /* ===== Impersonation (사용자 대신 보기) =====


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 작업 개요
### 1. 전직원 근태 페이지 (관리자 → '근태' 탭)
직원별 **오늘 출/퇴근 · 이번 주 · 이번 달 · 총 근무시간**(세션 합산)을 표로. 근무 중 표시·요약 통계 포함.
- 서버: `GET /api/admin/attendance/overview` (회사 활성 직원, 이번주=월요일 기준)

### 2. 개발자(isDeveloper) 관리자 권한
총관리자(superAdmin)가 `consoleOnly` 라 회사 관리자 페이지에 못 들어가는 문제 →
**isDeveloper** 계정도 관리자 페이지 접근 + ADMIN 부여 가능하게.
- `requireAdmin`/`AdminOnly`/사이드바 링크에 isDeveloper 허용
- 역할변경 권한: superAdmin + isDeveloper (step-up 은 superAdmin 만; isDeveloper 는 콘솔로만 부여되는 신뢰 플래그라 안전)

### 검증
server tsc 0 · client tsc 0 · build ✓

Closes #833

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #833
