### PR TITLE
🔀 :: (#835) 사내 감사 조회를 감사 로그에서 제외

### DIFF
--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -103,7 +103,8 @@ router.get("/rooms", async (req, res) => {
         return !!last && new Date(last.createdAt) > new Date(me.hiddenAt);
       });
 
-  if (auditMode) await writeLog(u.id, "CHAT_AUDIT_LIST", undefined, `count=${rooms.length}`);
+  // 사내 감사(scope=audit) 조회 자체는 감사 로그에 남기지 않는다 — 허가된 인원만 접근하는
+  // 내부 감사 도구라, 조회 행위는 회사 정책상 기록 대상에서 제외(회사 결정).
   res.json({ rooms: visible, auditMode });
 });
 
@@ -389,8 +390,7 @@ router.get("/rooms/:id/messages", async (req, res) => {
         code: "SUPER_STEPUP_REQUIRED",
       });
     }
-    // 감사 로그는 반드시 content 를 내리기 전에 persist — compliance 요건.
-    await writeLog(u.id, "CHAT_AUDIT_READ", room.id, `type=${room.type}`);
+    // 사내 감사 조회(메시지 열람)는 감사 로그에 남기지 않는다 — 위 목록 조회와 동일 정책.
   }
 
   const now = new Date();


### PR DESCRIPTION
## 증상
**사내 감사 조회를 감사 로그에서 제외**

유지보수 작업을 진행합니다.

## 원인
회사 정책 — 허가된 인원만 접근하는 내부 감사 도구라, 조회 행위 자체는 기록하지 않는다.
- CHAT_AUDIT_LIST(감사용 방 목록 조회) writeLog 제거
- CHAT_AUDIT_READ(감사용 메시지 조회) writeLog 제거
접근 게이트(super step-up + CHAT_AUDIT_PW)는 그대로 유지.

Closes #835

## 수정
**작업 항목 (커밋 단위)**
- chore(chat): 사내 감사(scope=audit) 조회를 감사 로그에서 제외

**변경 대상 (1개 파일)**
- `server/src/routes/chat.ts`

## 검증
- `server` tsc 통과

---
🔗 이 작업은 **PR #836** 에서 진행됩니다.

