### PR TITLE
🔀 :: (#838) IP 자동출근 + 실제 출근시간 위젯 (B·D)

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -90,18 +90,24 @@ export default function DashboardPage() {
   // 관리자 설정 기반 근무 시각 — 미설정 시 09:00/18:00 fallback.
   const startMin = parseHHmm(user?.workStartTime ?? "") ?? 9 * 60;
   const endMin = parseHHmm(user?.workEndTime ?? "") ?? 18 * 60;
-  const startLabel = formatHHmm(startMin);
+  // 실제 출근시간 반영 — 등록 출근시각(예: 9시)보다 일찍 출근(수동·IP자동)했다면, 그 날만
+  // 위젯 시작을 '실제 첫 출근시각'으로 한다(퍼센트도 그 기준). 늦게 출근은 등록 시각 유지.
+  const firstInMin = sessions.length
+    ? (() => { const d = new Date(sessions[0].s); return d.getHours() * 60 + d.getMinutes(); })()
+    : null;
+  const effStartMin = firstInMin != null && firstInMin < startMin ? firstInMin : startMin;
+  const startLabel = formatHHmm(effStartMin);
   const endLabel = formatHHmm(endMin);
   const dayProgress = useMemo(() => {
-    if (endMin <= startMin) return 0; // 잘못된 설정은 0%
-    // 데모(미리보기)는 방문 시각이 새벽일 수도 있어 09–18 절대시각 기준이면 0% 가 떠 자연스럽지 못함.
-    // 출근 후 경과 시간(workedMin) 을 근무 총 시간으로 나눠 '근무한 비율' 로 보여준다 — 항상 그럴듯한 값.
+    if (endMin <= effStartMin) return 0; // 잘못된 설정은 0%
+    // 데모(미리보기)는 방문 시각이 새벽일 수도 있어 절대시각 기준이면 0% 가 떠 자연스럽지 못함.
+    // 출근 후 경과 시간(workedMin) 을 근무 총 시간으로 나눠 '근무한 비율' 로 보여준다.
     if (isPreviewMode() && att?.checkIn) {
-      return Math.max(0, Math.min(1, workedMin / (endMin - startMin)));
+      return Math.max(0, Math.min(1, workedMin / (endMin - effStartMin)));
     }
     const m = now.getHours() * 60 + now.getMinutes();
-    return Math.max(0, Math.min(1, (m - startMin) / (endMin - startMin)));
-  }, [now, startMin, endMin, workedMin, att?.checkIn]);
+    return Math.max(0, Math.min(1, (m - effStartMin) / (endMin - effStartMin)));
+  }, [now, effStartMin, endMin, workedMin, att?.checkIn]);
 
   return (
     <div className="space-y-4">

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -11,12 +11,37 @@ const router = Router();
 router.use(requireAuth);
 
 // 오늘 출퇴근 상태 — sessions 합산 근무 분(workedMinutes)도 함께 내려준다.
+// IP 자동 출근: 회사가 IP 제한을 켰고(allowedIps 존재), 허용 IP 에서 접속했고, 오늘 아직 출근
+// 기록이 0건이면 출근 버튼 없이 자동 체크인(src="ip"). 하루 첫 접속 1회만(이후 세션 존재로 skip).
 router.get("/today", async (req, res) => {
   const u = (req as any).user;
-  const rec = await prisma.attendance.findUnique({
-    where: { userId_date: { userId: u.id, date: todayStr() } },
+  const date = todayStr();
+  let rec = await prisma.attendance.findUnique({
+    where: { userId_date: { userId: u.id, date } },
   });
-  const sessions = normalizeSessions(rec);
+  let sessions = normalizeSessions(rec);
+
+  if (sessions.length === 0 && u.companyId && !u.superAdmin && !u.platformAdmin) {
+    const company = await prisma.company.findUnique({
+      where: { id: u.companyId },
+      select: { attendanceIpRestrictEnabled: true, allowedIps: { select: { cidr: true } } },
+    });
+    if (company?.attendanceIpRestrictEnabled && company.allowedIps.length > 0) {
+      const clientIp = normalizeClientIp(req.ip);
+      if (clientIp && ipMatchesAny(clientIp, company.allowedIps.map((a) => a.cidr))) {
+        const now = new Date();
+        const ipSession = [{ s: now.toISOString(), e: null, src: "ip" }] as unknown as object;
+        rec = await prisma.attendance.upsert({
+          where: { userId_date: { userId: u.id, date } },
+          update: { sessions: ipSession, checkIn: now, checkOut: null },
+          create: { userId: u.id, companyId: u.companyId, date, checkIn: now, sessions: ipSession },
+        });
+        sessions = normalizeSessions(rec);
+        await writeLog(u.id, "CHECK_IN", date, "ip-auto");
+      }
+    }
+  }
+
   res.json({
     attendance: rec,
     workedMinutes: workedMinutes(sessions),


### PR DESCRIPTION
## 증상
**IP 자동출근 + 실제 출근시간 위젯 (B·D)**

새 기능을 추가합니다.

## 원인
회사가 IP 제한(attendanceIpRestrictEnabled + allowedIps)을 켰고, 허용 IP 에서
접속했고, 오늘 출근 기록이 0건이면 /today 호출 시 자동 체크인(세션 src=ip).
하루 첫 접속 1회만(이후 세션 존재로 skip) — 추가 쿼리 최소화.

## 수정
**작업 항목 (커밋 단위)**
- feat(attendance): IP 자동출근 — 허용 IP 접속 시 자동 체크인
- feat(attendance): 위젯에 실제 출근시간 반영

**변경 대상 (2개 파일)**
- `client/src/pages/DashboardPage.tsx`
- `server/src/routes/attendance.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #838** 에서 진행됩니다.

