### PR TITLE
🔀 :: (#840) 야근(추가근무) 신청 + 승인 + 자동퇴근 연장 (C)

### DIFF
--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -431,6 +431,9 @@ export default function AttendancePage() {
         </div>
       )}
 
+      {/* 야근(추가근무) 신청 */}
+      <OvertimeSection isReviewer={isReviewer} />
+
       {/* 신청 모달 */}
       {open && (
         <Portal>
@@ -629,4 +632,123 @@ function dayDiff(a: string, b: string) {
 function formatRange(a: string, b: string) {
   if (a === b) return a;
   return `${a} ~ ${b}`;
+}
+
+/* ===== 야근(추가근무) 신청 ===== */
+type Overtime = {
+  id: string; date: string; extendedEnd: string; reason?: string | null;
+  status: string; user?: { name: string; team: string | null } | null;
+};
+function otTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
+  const [mine, setMine] = useState<Overtime[]>([]);
+  const [all, setAll] = useState<Overtime[]>([]);
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [endTime, setEndTime] = useState("21:00");
+  const [reason, setReason] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function load() {
+    try {
+      const m = await api<{ overtimes: Overtime[] }>("/api/attendance/overtime");
+      setMine(m.overtimes);
+      if (isReviewer) {
+        const a = await api<{ overtimes: Overtime[] }>("/api/attendance/overtime?all=1");
+        setAll(a.overtimes);
+      }
+    } catch { /* ignore */ }
+  }
+  useEffect(() => { load(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+
+  async function submit() {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const extendedEnd = `${date}T${endTime}:00+09:00`;
+      await api("/api/attendance/overtime", { method: "POST", json: { date, extendedEnd, reason: reason || undefined } });
+      setReason("");
+      await load();
+    } catch (e: any) {
+      alertAsync({ title: "신청 실패", description: e?.message ?? "야근 신청에 실패했어요" });
+    } finally { setSaving(false); }
+  }
+  async function review(id: string, status: string) {
+    try { await api(`/api/attendance/overtime/${id}`, { method: "PATCH", json: { status } }); await load(); }
+    catch (e: any) { alertAsync({ title: "처리 실패", description: e?.message ?? "처리에 실패했어요" }); }
+  }
+
+  return (
+    <div className="space-y-4 mt-4">
+      <div className="panel p-5">
+        <div className="text-[15px] font-extrabold text-ink-900 mb-3">야근(추가근무) 신청</div>
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-2.5">
+          <label className="text-[12px] text-ink-500 block">날짜
+            <input type="date" className="input mt-1" value={date} onChange={(e) => setDate(e.target.value)} />
+          </label>
+          <label className="text-[12px] text-ink-500 block">연장 종료시각
+            <input type="time" className="input mt-1" value={endTime} onChange={(e) => setEndTime(e.target.value)} />
+          </label>
+          <label className="text-[12px] text-ink-500 block sm:col-span-2">사유 (선택)
+            <input className="input mt-1" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="예: 배포 대응" maxLength={1000} />
+          </label>
+        </div>
+        <div className="flex justify-end mt-3">
+          <button className="btn-primary" onClick={submit} disabled={saving}>{saving ? "신청 중…" : "야근 신청"}</button>
+        </div>
+        <p className="text-[11.5px] text-ink-400 mt-2">승인되면 연장 종료시각까지 자동 퇴근이 미뤄지고, 사후 신청은 승인 시 그 날짜 근무시간에 가산돼요.</p>
+      </div>
+
+      <div className="panel p-0 overflow-hidden">
+        <div className="px-5 py-3.5 border-b border-ink-100 font-extrabold text-ink-900">내 야근 신청</div>
+        {mine.length === 0 ? (
+          <div className="px-5 py-8 text-center text-ink-400 text-[13px]">신청 내역이 없어요.</div>
+        ) : (
+          <div className="divide-y divide-ink-100">
+            {mine.map((o) => (
+              <div key={o.id} className="px-5 py-3 flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="font-bold text-ink-900">{o.date} <span className="text-ink-400 font-medium text-[12px]">→ {otTime(o.extendedEnd)}</span></div>
+                  {o.reason && <div className="text-[12px] text-ink-500 truncate">{o.reason}</div>}
+                </div>
+                <StatusChip status={o.status} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {isReviewer && (
+        <div className="panel p-0 overflow-hidden">
+          <div className="px-5 py-3.5 border-b border-ink-100 font-extrabold text-ink-900">
+            전체 야근 신청 <span className="text-ink-400 font-medium ml-1">대기 {all.filter((o) => o.status === "PENDING").length}</span>
+          </div>
+          {all.length === 0 ? (
+            <div className="px-5 py-8 text-center text-ink-400 text-[13px]">신청이 없어요.</div>
+          ) : (
+            <div className="divide-y divide-ink-100">
+              {all.map((o) => (
+                <div key={o.id} className="px-5 py-3 flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="font-bold text-ink-900">{o.user?.name} <span className="text-ink-400 font-medium text-[12px]">{o.date}</span></div>
+                    <div className="text-[12px] text-ink-500 truncate">→ {otTime(o.extendedEnd)}{o.reason ? ` · ${o.reason}` : ""}</div>
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <StatusChip status={o.status} />
+                    {o.status === "PENDING" && (
+                      <>
+                        <button className="btn-ghost btn-xs" onClick={() => review(o.id, "APPROVED")}>승인</button>
+                        <button className="btn-ghost btn-xs text-red-600" onClick={() => review(o.id, "REJECTED")}>반려</button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/server/prisma/migrations/20260609000000_overtime_request/migration.sql
+++ b/server/prisma/migrations/20260609000000_overtime_request/migration.sql
@@ -1,0 +1,21 @@
+-- 야근(추가근무) 신청 테이블. 새 테이블만 추가 — 비파괴적.
+CREATE TABLE "OvertimeRequest" (
+  "id" TEXT NOT NULL,
+  "companyId" TEXT,
+  "userId" TEXT NOT NULL,
+  "date" TEXT NOT NULL,
+  "extendedEnd" TIMESTAMP(3) NOT NULL,
+  "reason" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'PENDING',
+  "reviewer" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "OvertimeRequest_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "OvertimeRequest_userId_status_idx" ON "OvertimeRequest"("userId", "status");
+CREATE INDEX "OvertimeRequest_status_idx" ON "OvertimeRequest"("status");
+CREATE INDEX "OvertimeRequest_companyId_status_idx" ON "OvertimeRequest"("companyId", "status");
+
+ALTER TABLE "OvertimeRequest"
+  ADD CONSTRAINT "OvertimeRequest_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -77,6 +77,7 @@ model User {
   inviteKey               InviteKey?             @relation("UsedKey")
   events                  Event[]
   leaves                  Leave[]
+  overtimeRequests        OvertimeRequest[]
   attendances             Attendance[]
   journals                Journal[]
   notices                 Notice[]
@@ -453,6 +454,24 @@ model Leave {
   // nav.ts 에서 status="PENDING" 전체 카운트 — leading userId 없이 status 단독 스캔 가능하게.
   @@index([status])
   @@index([companyId])
+}
+
+/// 야근(추가근무) 신청 — 연장 종료시각까지 자동퇴근을 미루거나, 사후 승인 시 근태에 가산.
+model OvertimeRequest {
+  id          String    @id @default(cuid())
+  companyId   String?
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  date        String // YYYY-MM-DD (KST) — 야근한/할 날짜
+  extendedEnd DateTime // 연장 종료시각
+  reason      String?
+  status      String    @default("PENDING") // PENDING | APPROVED | REJECTED
+  reviewer    String? // 심사한 관리자 userId
+  createdAt   DateTime  @default(now())
+
+  @@index([userId, status])
+  @@index([status])
+  @@index([companyId, status])
 }
 
 model Attendance {

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -239,4 +239,112 @@ router.patch("/leave/:id", async (req, res) => {
   res.json({ leave });
 });
 
+/* ===== 야근(추가근무) 신청 =====
+ * 연장 종료시각 지정. 승인되면:
+ *  - (사전, 오늘+근무중) Attendance.overtimeUntil = 연장시각 → 자동퇴근을 그 시각까지 보류.
+ *  - (사후, 퇴근했거나 과거날짜) 연장 블록을 세션으로 추가해 그 날짜 근무시간에 가산.
+ */
+const overtimeSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD"),
+  extendedEnd: z.string().refine((s) => !Number.isNaN(new Date(s).getTime()), "유효한 일시가 아닙니다"),
+  reason: z.string().max(1000).optional(),
+});
+
+router.post("/overtime", async (req, res) => {
+  const parsed = overtimeSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const u = (req as any).user;
+  const d = parsed.data;
+  const ot = await prisma.overtimeRequest.create({
+    data: {
+      userId: u.id,
+      companyId: u.companyId ?? null,
+      date: d.date,
+      extendedEnd: new Date(d.extendedEnd),
+      reason: d.reason,
+    },
+  });
+  await writeLog(u.id, "OVERTIME_REQUEST", ot.id, `${d.date} → ${d.extendedEnd}`);
+  res.json({ overtime: ot });
+});
+
+router.get("/overtime", async (req, res) => {
+  const u = (req as any).user;
+  const all = req.query.all === "1" && (u.role === "ADMIN" || u.role === "MANAGER");
+  const where: any = all ? {} : { userId: u.id };
+  if (all && u.role === "MANAGER") {
+    const me = await prisma.user.findUnique({ where: { id: u.id }, select: { team: true } });
+    where.user = me?.team ? { team: me.team } : { id: "__none__" };
+  }
+  if (all) where.companyId = u.companyId ?? null; // 같은 회사로 한정
+  const list = await prisma.overtimeRequest.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    take: 500,
+    include: { user: { select: { name: true, team: true } } },
+  });
+  res.json({ overtimes: list });
+});
+
+router.patch("/overtime/:id", async (req, res) => {
+  const u = (req as any).user;
+  if (u.role !== "ADMIN" && u.role !== "MANAGER") return res.status(403).json({ error: "forbidden" });
+  const status = req.body?.status;
+  if (!["APPROVED", "REJECTED", "PENDING"].includes(status)) return res.status(400).json({ error: "invalid status" });
+  const ot = await prisma.overtimeRequest.findUnique({
+    where: { id: req.params.id },
+    include: { user: { select: { team: true, workEndTime: true } } },
+  });
+  if (!ot) return res.status(404).json({ error: "not found" });
+  if (ot.userId === u.id) return res.status(403).json({ error: "본인 신청은 직접 심사할 수 없어요" });
+  if (u.role === "MANAGER") {
+    const me = await prisma.user.findUnique({ where: { id: u.id }, select: { team: true } });
+    if (!me?.team || ot.user?.team !== me.team) return res.status(403).json({ error: "다른 팀 신청을 심사할 수 없어요" });
+  }
+
+  const updated = await prisma.overtimeRequest.update({
+    where: { id: ot.id }, data: { status, reviewer: u.id },
+  });
+
+  if (status === "APPROVED") {
+    const ext = new Date(ot.extendedEnd);
+    const wEnd = ot.user?.workEndTime || "18:00";
+    const base = new Date(`${ot.date}T${wEnd}:00+09:00`); // 해당 날짜 근무종료시각(KST)
+    const att = await prisma.attendance.findUnique({ where: { userId_date: { userId: ot.userId, date: ot.date } } });
+    const sessions = normalizeSessions(att);
+    const stillWorking = ot.date === todayStr() && hasOpenSession(sessions);
+    if (stillWorking && att) {
+      // 사전 승인 — 자동퇴근을 연장시각까지 미룬다(라이브 세션이 시간 계산).
+      await prisma.attendance.update({ where: { id: att.id }, data: { overtimeUntil: ext } });
+    } else {
+      // 사후 승인 — 연장 블록 세션 추가(기존 기록과 겹치지 않게 시작 보정).
+      const lastEnd = sessions.reduce((mx, s) => Math.max(mx, s.e ? new Date(s.e).getTime() : 0), 0);
+      const startMs = Math.max(base.getTime(), lastEnd);
+      if (ext.getTime() > startMs) {
+        sessions.push({ s: new Date(startMs).toISOString(), e: ext.toISOString(), src: "overtime" });
+        await prisma.attendance.upsert({
+          where: { userId_date: { userId: ot.userId, date: ot.date } },
+          update: { sessions: sessions as unknown as object, checkOut: ext },
+          create: {
+            userId: ot.userId, companyId: ot.companyId ?? null, date: ot.date, checkOut: ext,
+            sessions: [{ s: new Date(startMs).toISOString(), e: ext.toISOString(), src: "overtime" }] as unknown as object,
+          },
+        });
+      }
+    }
+  }
+
+  await writeLog(u.id, "OVERTIME_REVIEW", ot.id, status);
+  if ((status === "APPROVED" || status === "REJECTED") && ot.userId !== u.id) {
+    await notify({
+      userId: ot.userId,
+      type: "APPROVAL_REVIEW",
+      title: status === "APPROVED" ? "야근 신청이 승인됐어요" : "야근 신청이 반려됐어요",
+      linkUrl: "/attendance",
+      actorName: u.name,
+    });
+  }
+  res.json({ overtime: updated });
+});
+
 export default router;


### PR DESCRIPTION
## 증상
**야근(추가근무) 신청 + 승인 + 자동퇴근 연장 (C)**

새 기능을 추가합니다.

## 원인
야근 신청 — userId·date·extendedEnd·status·reviewer. User 역관계 추가.
새 테이블만 추가하는 비파괴적 마이그레이션.

## 수정
**작업 항목 (커밋 단위)**
- feat(attendance): OvertimeRequest 모델 + 마이그레이션
- feat(attendance): 야근 신청/조회/승인 엔드포인트
- feat(attendance): 야근 신청 UI (근태 페이지)

**변경 대상 (4개 파일)**
- `client/src/pages/AttendancePage.tsx`
- `server/prisma/migrations/20260609000000_overtime_request/migration.sql`
- `server/prisma/schema.prisma`
- `server/src/routes/attendance.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #840** 에서 진행됩니다.

