### PR TITLE
🔀 :: (#841) 일반 총관리자도 로그인 후 회사 페이지로

### DIFF
--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -23,8 +23,10 @@ export default function LoginPage() {
   const [errCode, setErrCode] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // 총관리자(superAdmin)는 운영 콘솔로, 그 외 사용자는 회사 앱 홈으로.
-  if (user) return <Navigate to={user.superAdmin ? "/super-admin" : "/"} replace />;
+  // 콘솔 전용 계정(consoleOnly)만 운영 콘솔로 직행. 일반 총관리자(superAdmin) 는 회사 앱
+  // 홈으로 보낸 뒤, 사이드바의 '운영 콘솔' 링크로 왕복하게 한다. (총관리자도 평상시엔 회사
+  // 페이지를 쓰니, 로그인마다 강제로 콘솔에 던지지 않는 게 맞다.)
+  if (user) return <Navigate to={user.consoleOnly ? "/super-admin" : "/"} replace />;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -33,7 +35,7 @@ export default function LoginPage() {
     setLoading(true);
     try {
       const u = await login(email, password);
-      nav(u.superAdmin ? "/super-admin" : "/");
+      nav(u.consoleOnly ? "/super-admin" : "/");
     } catch (e: any) {
       setErr(e.message);
       // 서버가 ACCOUNT_LOCKED 같은 코드를 message JSON 에 포함하는 경우를 위해


### PR DESCRIPTION
## 증상
**일반 총관리자도 로그인 후 회사 페이지로**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
기존엔 superAdmin 면 무조건 /super-admin 으로 직행해, 회사 앱을 평상시 못 썼음.
consoleOnly 계정만 콘솔로 직행하도록 변경. 일반 총관리자는 회사 홈으로 가고,
사이드바의 '운영 콘솔' 링크(이미 존재)로 왕복.

Closes #841

## 수정
**작업 항목 (커밋 단위)**
- fix(auth): 일반 총관리자 로그인 후 회사 페이지로 (콘솔로 강제이동 안 함)

**변경 대상 (1개 파일)**
- `client/src/pages/LoginPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #842** 에서 진행됩니다.

