### PR TITLE
🔀 :: (#843) 활동 로그 시각 셀 줄바꿈으로 깨지던 UI

### DIFF
--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -673,7 +673,7 @@ function LogsPanel() {
           <button className="btn-ghost btn-xs" onClick={load}>새로고침</button>
         </div>
       </div>
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto hinest-x-scroll">
       <table className="pro pro-cards" style={{ minWidth: 820 }}>
         <thead>
           <tr>
@@ -688,7 +688,13 @@ function LogsPanel() {
         <tbody>
           {filtered.map((l) => (
             <tr key={l.id}>
-              <td className="cell-primary tabular text-[12px] font-semibold text-ink-800 sm:text-[11px] sm:font-normal sm:text-ink-600">{new Date(l.createdAt).toLocaleString("ko-KR")}</td>
+              <td className="cell-primary tabular whitespace-nowrap text-[12px] font-semibold text-ink-800 sm:text-[11px] sm:font-normal sm:text-ink-600">{(() => {
+                // 컴팩트 포맷 — 좁은 화면에서 "2026. 6. 9. 오전 10:29:51" 같은 한국어 로케일이
+                // 줄바꿈을 강제해 행 높이가 깨지던 문제. MM-DD HH:mm:ss 로 통일해 한 줄에 들어가게.
+                const d = new Date(l.createdAt);
+                const pad = (n: number) => String(n).padStart(2, "0");
+                return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+              })()}</td>
               <td data-label="사용자">{l.user?.name ?? "—"}</td>
               <td data-label="액션"><span className="chip-gray tabular">{l.action}</span></td>
               <td data-label="대상" className="tabular text-[11px] text-ink-600 sm:max-w-[180px] sm:truncate" title={l.target ?? ""}>{l.target ?? "—"}</td>


### PR DESCRIPTION
## 증상
**활동 로그 시각 셀 줄바꿈으로 깨지던 UI**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
긴 한국어 로케일 포맷('2026. 6. 9. 오전 10:29:51')이 좁은 컬럼에서 줄바꿈되며
행 높이가 들쭉날쭉해지고 가로 정렬이 흐트러지던 문제. 컴팩트 'MM-DD HH:mm:ss' +
whitespace-nowrap 으로 한 줄 고정. 가로 스크롤 컨테이너에 hinest-x-scroll(momentum) 추가.

Closes #843

## 수정
**작업 항목 (커밋 단위)**
- fix(console): 활동 로그 시각 셀 줄바꿈으로 깨지던 UI

**변경 대상 (1개 파일)**
- `client/src/pages/SuperAdminPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #844** 에서 진행됩니다.

