### PR TITLE
🔀 :: (#845) 근태 탭 클릭 시 구성원으로 되돌려지던 버그

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -242,7 +242,7 @@ function PdfLogo() {
 export default function AdminPage() {
   // 새로고침해도 현재 탭 유지되도록 URL 쿼리로 동기화.
   const [sp, setSp] = useSearchParams();
-  const tab = (["users", "invites", "teams", "positions", "ip"].includes(sp.get("tab") ?? "")
+  const tab = (["users", "invites", "teams", "positions", "ip", "attendance"].includes(sp.get("tab") ?? "")
     ? (sp.get("tab") as Tab)
     : "users") as Tab;
   const setTab = (t: Tab) => {


### PR DESCRIPTION
## 증상
**근태 탭 클릭 시 구성원으로 되돌려지던 버그**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
탭 URL 동기화 화이트리스트(?tab= validation)에 'attendance' 가 빠져 매번
fallback='users' 로 리셋되던 회귀. 화이트리스트에 추가.

Closes #845

## 수정
**작업 항목 (커밋 단위)**
- fix(admin): 근태 탭 클릭 시 구성원으로 되돌려지던 버그

**변경 대상 (1개 파일)**
- `client/src/pages/AdminPage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #846** 에서 진행됩니다.

