### PR TITLE
🔀 :: (#847) 비정상 총 근무시간(1100시간+) — 과거 열린 세션 자정 캡

### DIFF
--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -17,15 +17,24 @@ type Attendance = {
   sessions?: WorkSession[] | null;
 };
 
-/** 하루 근무 ms — 다중 세션 합산(갭 제외). sessions 없으면 checkIn/checkOut 단일(하위호환). */
+/** 하루 근무 ms — 다중 세션 합산(갭 제외). sessions 없으면 checkIn/checkOut 단일(하위호환).
+ *  닫히지 않은 과거 세션은 그날 자정으로 캡(옛날 데이터 손상 방어 — 1100시간+ 누적 버그 방지). */
 function attWorkedMs(r: Attendance): number {
   const sessions: WorkSession[] = Array.isArray(r.sessions)
     ? r.sessions
     : r.checkIn ? [{ s: r.checkIn, e: r.checkOut ?? null }] : [];
+  const today = new Date().toISOString().slice(0, 10); // UTC 라 KST 와 ±1 차이 가능하나 보수적
   let ms = 0;
   for (const s of sessions) {
     const start = new Date(s.s).getTime();
-    const end = s.e ? new Date(s.e).getTime() : Date.now();
+    let end: number;
+    if (s.e) {
+      end = new Date(s.e).getTime();
+    } else if (r.date && r.date < today) {
+      end = new Date(`${r.date}T23:59:59+09:00`).getTime();
+    } else {
+      end = Date.now();
+    }
     if (end > start) ms += end - start;
   }
   return ms;

--- a/server/src/lib/attendanceSessions.ts
+++ b/server/src/lib/attendanceSessions.ts
@@ -9,26 +9,45 @@
 export type WorkSession = { s: string; e: string | null; src?: string };
 
 type AttendanceLike = {
+  date?: string | null; // YYYY-MM-DD (KST). 닫히지 않은 과거 세션 캡에 사용.
   sessions?: unknown;
   checkIn?: Date | string | null;
   checkOut?: Date | string | null;
 };
 
-/** 레코드 → 정규화된 세션 배열. sessions 없으면 checkIn/checkOut 으로 단일 세션 구성. */
+/** 오늘 KST(YYYY-MM-DD). dates.ts 의 todayStr 과 동일 로직(순환 import 회피용 인라인). */
+function kstToday(): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul", year: "numeric", month: "2-digit", day: "2-digit" })
+    .format(new Date()).replaceAll("/", "-");
+}
+
+/** 닫히지 않은 과거 세션은 그날 KST 자정(23:59:59)으로 캡 — 옛날 자동퇴근 누락 데이터로 인해
+ *  workedMinutes 가 now 까지 누적돼 비정상 큰 값(예: 수백~수천 시간)이 나오는 걸 막는다. */
+function clampOpenEnd(s: WorkSession, rowDate: string | null | undefined): WorkSession {
+  if (s.e) return s;
+  if (!rowDate) return s;
+  if (rowDate < kstToday()) {
+    return { ...s, e: `${rowDate}T23:59:59+09:00` };
+  }
+  return s;
+}
+
+/** 레코드 → 정규화된 세션 배열. sessions 없으면 checkIn/checkOut 으로 단일 세션 구성.
+ *  과거 행에서 닫히지 않은 세션은 그날 자정으로 자동 캡(데이터 손상 방어). */
 export function normalizeSessions(rec: AttendanceLike | null | undefined): WorkSession[] {
   if (!rec) return [];
   const raw = rec.sessions;
   if (Array.isArray(raw)) {
     return raw
       .filter((x): x is WorkSession => !!x && typeof (x as any).s === "string")
-      .map((x) => ({ s: x.s, e: x.e ?? null, src: x.src }));
+      .map((x) => clampOpenEnd({ s: x.s, e: x.e ?? null, src: x.src }, rec.date));
   }
   if (rec.checkIn) {
-    return [{
+    return [clampOpenEnd({
       s: new Date(rec.checkIn).toISOString(),
       e: rec.checkOut ? new Date(rec.checkOut).toISOString() : null,
       src: "manual",
-    }];
+    }, rec.date)];
   }
   return [];
 }


### PR DESCRIPTION
## 증상
**비정상 총 근무시간(1100시간+) — 과거 열린 세션 자정 캡**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
옛 Attendance 행 중 checkIn 만 있고 checkOut 이 없는 채 남은 데이터(PR-A 이전 잔재)가
'계속 근무 중'으로 해석돼 며칠~몇 주치가 한 번에 누적되며 총 근무시간이 1100시간+ 같은
비정상 값으로 나오던 버그. 정규화 단계에서 '과거 날짜 + e=null' 세션을 그날 KST 자정
(23:59:59)으로 자동 캡해 누적 차단. server/client 양쪽 동일 로직.

Closes #847

## 수정
**작업 항목 (커밋 단위)**
- fix(attendance): 닫히지 않은 과거 세션을 자정 캡으로 보정

**변경 대상 (2개 파일)**
- `client/src/pages/AttendancePage.tsx`
- `server/src/lib/attendanceSessions.ts`

## 검증
- `server` tsc 통과
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #848** 에서 진행됩니다.

