### PR TITLE
🔀 :: (#853) 직급 단위 사용자 숨김 — 디렉터리·조직도·픽커에서 제외

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -185,7 +185,7 @@ type Invite = {
   createdAt: string;
 };
 type Team = { id: string; name: string; createdAt: string };
-type Position = { id: string; name: string; rank: number; createdAt: string };
+type Position = { id: string; name: string; rank: number; hidden?: boolean; createdAt: string };
 
 type Tab = "users" | "invites" | "teams" | "positions" | "ip" | "attendance";
 
@@ -2037,6 +2037,15 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
     invalidateCache("/api/admin/positions");
     reload();
   }
+  async function toggleHidden(p: Position) {
+    try {
+      await api(`/api/admin/positions/${p.id}`, { method: "PATCH", json: { hidden: !p.hidden } });
+      invalidateCache("/api/admin/positions");
+      // 디렉터리/조직도가 보는 캐시도 무효화 — 즉시 반영.
+      invalidateCache("/api/user");
+      reload();
+    } catch (e: any) { alertAsync({ title: "변경 실패", description: e.message }); }
+  }
   async function remove(p: Position) {
     const ok = await confirmAsync({
       title: "직급 삭제",
@@ -2159,6 +2168,16 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
                     if (v && v !== p.name) rename(p, v);
                   }}
                 />
+                <button
+                  type="button"
+                  onClick={() => toggleHidden(p)}
+                  className="flex items-center gap-1.5 text-[11.5px] font-bold transition"
+                  style={{ color: p.hidden ? "#F59E0B" : "var(--c-text-3)" }}
+                  title={p.hidden ? "이 직급의 구성원이 디렉터리·조직도 등에서 숨겨집니다 (클릭해 표시로 전환)" : "이 직급을 숨김으로 전환 — 소속 구성원이 디렉터리·조직도 등에서 사라집니다 (본인은 계속 사용 가능)"}
+                >
+                  <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: p.hidden ? "#F59E0B" : "#94A3B8" }} />
+                  {p.hidden ? "숨김 직급" : "표시 직급"}
+                </button>
                 <div className="text-[11px] text-ink-500 tabular w-[88px] text-right hidden sm:block">
                   {new Date(p.createdAt).toLocaleDateString("ko-KR")}
                 </div>

--- a/server/prisma/migrations/20260609010000_position_hidden/migration.sql
+++ b/server/prisma/migrations/20260609010000_position_hidden/migration.sql
@@ -1,0 +1,3 @@
+-- Position 에 hidden 플래그 추가. 이 직급에 속한 사용자는 디렉터리·조직도 등
+-- 사용자 목록에서 제외된다(본인 활동은 정상). NOT NULL + DEFAULT false 라 비파괴적.
+ALTER TABLE "Position" ADD COLUMN "hidden" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -829,6 +829,9 @@ model Position {
   companyId String?
   name      String
   rank      Int      @default(0)
+  /// 숨김 직급 — 이 직급에 속한 사용자는 디렉터리·조직도·picker 등 모든 사용자 목록 API 에서
+  /// 제외된다(본인은 자기 정보 정상 사용). 테스트 계정·외주 자리 등에 사용.
+  hidden    Boolean  @default(false)
   createdAt DateTime @default(now())
 
   @@unique([companyId, name])

--- a/server/src/lib/hiddenPositions.ts
+++ b/server/src/lib/hiddenPositions.ts
@@ -1,0 +1,59 @@
+/**
+ * 회사별 숨김 직급 이름 목록.
+ *
+ * Position.hidden=true 인 직급에 속한 사용자는 디렉터리·조직도·픽커 등 모든 사용자 목록
+ * API 에서 제외된다(본인은 자기 정보 정상 조회 가능). 회사당 직급 수가 보통 ~10개라 매번
+ * 조회해도 가벼우나, 사용자 목록 API 가 매 요청 호출되는 핫패스라 30초 메모리 캐시.
+ *
+ * 사용 예:
+ *   const hidden = await getHiddenPositions(u.companyId);
+ *   prisma.user.findMany({
+ *     where: { ...baseWhere, ...excludeHidden(hidden, { exceptId: u.id }) },
+ *   });
+ *
+ * 멀티 인스턴스(Fargate 확장) 환경에서도 안전 — 각 인스턴스가 자기 캐시를 가지고 TTL 안에
+ * 동기화. 30초 stale 은 직급 토글 즉시반영 측면에서 허용 범위.
+ */
+
+import { prisma } from "./db.js";
+
+const TTL_MS = 30_000;
+const cache = new Map<string, { at: number; names: string[] }>();
+
+/** 회사의 숨김 직급 이름 배열. 캐시 hit 시 즉시 반환. */
+export async function getHiddenPositions(companyId: string | null | undefined): Promise<string[]> {
+  const key = companyId ?? "__null__";
+  const hit = cache.get(key);
+  const now = Date.now();
+  if (hit && now - hit.at < TTL_MS) return hit.names;
+  const rows = await prisma.position.findMany({
+    where: { companyId: companyId ?? null, hidden: true },
+    select: { name: true },
+  });
+  const names = rows.map((r) => r.name);
+  cache.set(key, { at: now, names });
+  return names;
+}
+
+/** 회사 캐시 무효화 — Position 의 hidden 토글 시 즉시 반영. */
+export function evictHiddenPositions(companyId: string | null | undefined): void {
+  cache.delete(companyId ?? "__null__");
+}
+
+/**
+ * Prisma where 조각 — 숨김 직급 사용자 제외.
+ * - exceptId 지정 시 그 사용자 본인은 항상 포함(본인이 자기 자신을 picker 에서 보거나
+ *   본인 정보 API 가 영향받지 않게).
+ * - hidden 직급이 없으면 빈 객체 반환 → spread 해도 무영향.
+ */
+export function excludeHidden(
+  hiddenNames: string[],
+  opts?: { exceptId?: string | null },
+): Record<string, unknown> {
+  if (hiddenNames.length === 0) return {};
+  const notInHidden = { position: { notIn: hiddenNames } };
+  if (opts?.exceptId) {
+    return { OR: [notInHidden, { id: opts.exceptId }] };
+  }
+  return notInHidden;
+}

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -12,6 +12,7 @@ import {
 } from "../lib/auth.js";
 import { todayStr } from "../lib/dates.js";
 import { normalizeSessions, workedMinutes } from "../lib/attendanceSessions.js";
+import { evictHiddenPositions } from "../lib/hiddenPositions.js";
 import { getLogs, type LogLevel, getErrorGroups, getErrorGroup, clearErrorGroups } from "../lib/logBuffer.js";
 import { evictNavVisibilityCache } from "./nav.js";
 
@@ -661,17 +662,24 @@ router.post("/positions/reorder", async (req, res) => {
 router.patch("/positions/:id", async (req, res) => {
   const name = req.body?.name !== undefined ? capName(req.body.name) : undefined;
   const rank = req.body?.rank !== undefined ? Number(req.body.rank) : undefined;
+  const hidden = req.body?.hidden !== undefined ? !!req.body.hidden : undefined;
   const u = (req as any).user;
   const prev = await prisma.position.findUnique({ where: { id: req.params.id } });
   if (!prev) return res.status(404).json({ error: "not found" });
   const position = await prisma.position.update({
     where: { id: prev.id },
-    data: { ...(name !== undefined && { name }), ...(rank !== undefined && { rank }) },
+    data: {
+      ...(name !== undefined && { name }),
+      ...(rank !== undefined && { rank }),
+      ...(hidden !== undefined && { hidden }),
+    },
   });
   if (name && prev.name !== name) {
     await prisma.user.updateMany({ where: { position: prev.name }, data: { position: name } });
   }
-  await writeLog(u.id, "POSITION_UPDATE", position.id, `${prev.name} -> ${name ?? prev.name}`);
+  // hidden 토글되면 30초 캐시 즉시 무효화 — 다음 요청부터 반영.
+  if (hidden !== undefined && hidden !== prev.hidden) evictHiddenPositions(prev.companyId);
+  await writeLog(u.id, "POSITION_UPDATE", position.id, `${prev.name} -> ${name ?? prev.name}${hidden !== undefined ? ` hidden:${hidden}` : ""}`);
   res.json({ position });
 });
 

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { notifyMany } from "../lib/notify.js";
 import { allSameCompanyUsers } from "../lib/tenantValidate.js";
+import { getHiddenPositions, excludeHidden } from "../lib/hiddenPositions.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -144,8 +145,14 @@ router.get("/mentionable", async (req, res) => {
     if (authorId) allowedIds.add(authorId);
   }
 
+  // 숨김 직급(테스트 계정 등)은 멘션 후보에서 제외(본인은 항상 포함).
+  // allowedIds 가 있어도(특정 회의 viewer 픽커) 동일하게 — 회사 정책상 사용자 목록에 안 보임.
+  const hiddenP = await getHiddenPositions(u.companyId);
   const users = await prisma.user.findMany({
-    where: allowedIds ? { id: { in: Array.from(allowedIds) } } : {},
+    where: {
+      ...(allowedIds ? { id: { in: Array.from(allowedIds) } } : {}),
+      ...excludeHidden(hiddenP, { exceptId: u.id }),
+    },
     select: {
       id: true,
       name: true,

--- a/server/src/routes/schedule.ts
+++ b/server/src/routes/schedule.ts
@@ -4,6 +4,7 @@ import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
 import { notifyMany } from "../lib/notify.js";
 import { allSameCompanyUsers } from "../lib/tenantValidate.js";
+import { getHiddenPositions, excludeHidden } from "../lib/hiddenPositions.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -187,9 +188,12 @@ router.post("/", async (req, res) => {
   //  - TARGETED: 지정된 유저 + (선택) 본인 제외
   //  - PERSONAL: 없음
   let recipientIds: string[] = [];
+  // 숨김 직급(테스트 계정 등) 사용자는 회사 공지/팀 일정 수신자에서 제외 — 디렉터리에서
+  // 안 보이는 계정이 알림만 받는 모순을 막는다.
+  const hidden = await getHiddenPositions(u.companyId);
   if (d.scope === "COMPANY") {
     const users = await prisma.user.findMany({
-      where: { active: true, id: { not: u.id }, superAdmin: false },
+      where: { active: true, id: { not: u.id }, superAdmin: false, ...excludeHidden(hidden) },
       select: { id: true },
     });
     recipientIds = users.map((x) => x.id);
@@ -197,7 +201,7 @@ router.post("/", async (req, res) => {
     const team = d.team ?? me?.team;
     if (team) {
       const users = await prisma.user.findMany({
-        where: { active: true, team, id: { not: u.id } },
+        where: { active: true, team, id: { not: u.id }, ...excludeHidden(hidden) },
         select: { id: true },
       });
       recipientIds = users.map((x) => x.id);

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { prisma } from "../lib/db.js";
 import { requireAuth } from "../lib/auth.js";
+import { getHiddenPositions, excludeHidden } from "../lib/hiddenPositions.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -77,6 +78,8 @@ router.get("/", async (req, res) => {
         ],
       };
 
+  // 숨김 직급(테스트 계정 등) 사용자는 검색 결과에서 제외(본인은 항상 포함).
+  const hidden = await getHiddenPositions(u.companyId);
   const [people, notices, events, documents, messages, meetings, approvals, projects] = await Promise.all([
     prisma.user.findMany({
       where: {
@@ -92,6 +95,7 @@ router.get("/", async (req, res) => {
             ],
           },
         ],
+        ...excludeHidden(hidden, { exceptId: u.id }),
       },
       take: 8,
       select: { id: true, name: true, email: true, team: true, position: true, avatarColor: true, isDeveloper: true, avatarUrl: true },

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { prisma } from "../lib/db.js";
 import { requireAuth } from "../lib/auth.js";
 import { todayStr } from "../lib/dates.js";
+import { getHiddenPositions, excludeHidden } from "../lib/hiddenPositions.js";
 
 const router = Router();
 router.use(requireAuth);
@@ -13,9 +14,10 @@ router.get("/", async (req, res) => {
   const u = (req as any).user;
   // 종전엔 superAdmin 계정을 다른 사람에게 숨겼지만, \"HiNest 개발자\" 딱지가 별도 정체성으로 자리잡아
   // 더 이상 숨길 이유가 없음. 모든 활성 사용자를 노출하고 권한 표시는 칩으로.
-  void u;
+  // 숨김 직급(Position.hidden=true) 사용자는 디렉터리에서 제외(본인은 예외 — 자기 자신 보기 OK).
+  const hidden = await getHiddenPositions(u.companyId);
   const users = await prisma.user.findMany({
-    where: { active: true },
+    where: { active: true, ...excludeHidden(hidden, { exceptId: u.id }) },
     orderBy: { name: "asc" },
     take: 5000,
     select: {
@@ -81,14 +83,17 @@ router.get("/", async (req, res) => {
  * 경량 Presence 전용 엔드포인트 — ChatMiniApp 이 30초마다 폴링할 때 사용.
  * 전체 유저 목록 대신 id + presenceStatus + workStatus 만 반환 → 응답 크기 ~8x 감소.
  */
-router.get("/presence", async (_req, res) => {
+router.get("/presence", async (req, res) => {
+  const u = (req as any).user;
   const startOfToday = new Date(); startOfToday.setHours(0, 0, 0, 0);
   const endOfToday = new Date(startOfToday); endOfToday.setDate(endOfToday.getDate() + 1);
   const date = todayStr();
 
+  // 숨김 직급 사용자는 presence 폴링 결과에서도 제외(디렉터리 ↔ presence 일관).
+  const hidden = await getHiddenPositions(u.companyId);
   const [users, attendances, leaves] = await Promise.all([
     prisma.user.findMany({
-      where: { active: true, superAdmin: false },
+      where: { active: true, superAdmin: false, ...excludeHidden(hidden, { exceptId: u.id }) },
       select: { id: true, presenceStatus: true, presenceMessage: true },
       take: 5000,
     }),


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 작업 개요
관리자가 직급(예: '테스트 계정')을 숨김으로 토글하면 소속 사용자가 디렉터리·조직도·멘션·검색·공지 수신자 등 모든 사용자 목록 API 에서 제외됩니다. 본인은 자기 정보 정상 조회 + 활동 정상.

## 변경
- 스키마: `Position.hidden`(비파괴 마이그)
- 헬퍼: `getHiddenPositions(companyId)` 30초 캐시 + `excludeHidden(names, { exceptId })` Prisma where
- 적용 라우트: users(/, /presence) · schedule(공지 수신자) · meeting(mentionable) · search(people)
- 관리자 직급 탭: 행마다 '표시/숨김' 토글 (호박색)

## 검증
server tsc 0 · client tsc 0

Closes #853

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #853
