### PR TITLE
🔀 :: (#855) 활성 채팅방 시스템 알림 가드 (데스크탑·웹)

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -6,6 +6,7 @@ import { useNotifications } from "../notifications";
 import { resolvePresence } from "../lib/presence";
 import { downloadFromUrl } from "../lib/download";
 import { isCapacitorNative } from "../lib/platform";
+import { setActiveChatRoom } from "../lib/desktopNotify";
 import { Browser } from "@capacitor/browser";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
 import { SnippetSlashMenu, type SnippetSlashHandle } from "./chat/SnippetSlashMenu";
@@ -324,6 +325,27 @@ export default function ChatMiniApp({
     const ping = () => { if (isChatVisible()) void markRead(activeId); };
     const t = setInterval(ping, 15_000);
     return () => clearInterval(t);
+  }, [activeId, isPanelOpen]);
+
+  // 디바이스 로컬 active 방 추적 — desktopNotify 가 시스템 알림 띄우기 전에 참조해, 지금 보고
+  // 있는 방으로 향하는 알림은 OS 시스템 알림을 띄우지 않게 한다. 서버 active-viewer 게이트는
+  // APNs 만 막아주지만, 데스크탑/웹 시스템 알림은 디바이스 로컬 판단이 더 정확하다.
+  // (visibility 변경 / 패널 닫힘 시 즉시 해제.)
+  useEffect(() => {
+    const apply = () => {
+      const visible = typeof document !== "undefined" && document.visibilityState === "visible";
+      setActiveChatRoom(activeId && isPanelOpen && visible ? activeId : null);
+    };
+    apply();
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", apply);
+    }
+    return () => {
+      setActiveChatRoom(null);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", apply);
+      }
+    };
   }, [activeId, isPanelOpen]);
 
   // SSE 수신 — NotificationProvider 의 EventSource 가 여기로 재방송한 chat:* 이벤트.

--- a/client/src/lib/desktopNotify.ts
+++ b/client/src/lib/desktopNotify.ts
@@ -115,6 +115,24 @@ function avatarDataUrl(name?: string, color?: string): string | undefined {
   }
 }
 
+/** 지금 사용자가 보고 있는 채팅방 id. ChatMiniApp 이 활성 방을 setActiveChatRoom 으로
+ *  설정하면, 그 방으로 향하는 알림은 OS 시스템 알림을 띄우지 않는다(화면에 이미 떠 있으니
+ *  불필요). 전역 모듈 변수로 두는 이유: showDesktopNotification 이 React 트리 밖에서도 호출돼
+ *  React state 로는 동기적으로 못 읽음. */
+let __activeChatRoomId: string | null = null;
+export function setActiveChatRoom(roomId: string | null) {
+  __activeChatRoomId = roomId;
+}
+export function getActiveChatRoom(): string | null {
+  return __activeChatRoomId;
+}
+/** opts.url 이 채팅 룸 링크면 roomId 추출. /chat?room=X 또는 #room=X 둘 다 지원. */
+function chatRoomIdFromUrl(url: string | undefined): string | null {
+  if (!url) return null;
+  const m = /[?#&]room=([^&]+)/.exec(url);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
 export function showDesktopNotification(opts: {
   id: string;
   title: string;
@@ -127,6 +145,14 @@ export function showDesktopNotification(opts: {
 }) {
   if (!isDesktopEnabled()) return;
   if (alreadySeen(opts.id)) return;
+
+  // 사용자가 지금 보고 있는 채팅방으로 향하는 알림은 시스템 알림 스킵 — 화면에 이미 떠 있음.
+  // (서버 active-viewer 게이트가 APNs 만 막아 데스크탑/웹 알림이 새던 문제 보완.)
+  const rid = chatRoomIdFromUrl(opts.url);
+  if (rid && rid === __activeChatRoomId) {
+    markSeen([opts.id]);
+    return;
+  }
 
   // ── Electron(데스크톱 앱): 검증된 메인 프로세스 경로로 보낸다 ───────────────────
   // 렌더러의 Web Notification API 는 Mac App Store(샌드박스)+원격 URL 빌드에서


### PR DESCRIPTION
## 증상
**활성 채팅방 시스템 알림 가드 (데스크탑·웹)**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
서버 active-viewer 게이트는 APNs(폰 푸시)만 막아 데스크탑/웹 Electron·브라우저 시스템
알림은 그대로 떴음(스크린샷 재현). 디바이스 로컬 active room 추적 + 매칭 가드 추가.

- desktopNotify.ts: setActiveChatRoom/getActiveChatRoom + chatRoomIdFromUrl, opts.url 의
  roomId 가 active 면 시스템 알림 skip(markSeen 처리)
- ChatMiniApp.tsx: activeId·isPanelOpen·visibility 조합으로 setActiveChatRoom 호출(언마운트
  /숨김 시 즉시 해제)

iOS APNs 는 OS 가 직접 띄워 클라가 못 막음 → 서버 lastReadAt heartbeat 의존(별도 진단).

Closes #855

## 수정
**작업 항목 (커밋 단위)**
- fix(notify): 활성 채팅방 시스템 알림 가드 — 클라 로컬 판정

**변경 대상 (2개 파일)**
- `client/src/components/ChatMiniApp.tsx`
- `client/src/lib/desktopNotify.ts`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #856** 에서 진행됩니다.

