### PR TITLE
🔀 :: (#857) 자동 시작 토글 노출 — 알림 권한 무관

### DIFF
--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -665,9 +665,6 @@ function DesktopNotifyPanel() {
             />
           </label>
 
-          {/* 데스크탑 앱(Electron) 자동 시작 — 종료된 상태에서도 알람 받기 위해 OS 로그인 시 트레이 상주. */}
-          <AutoLaunchToggle />
-
           <NotifCategoryToggles disabled={!enabled} />
 
           <button type="button" className="btn-ghost" onClick={onTest}>
@@ -675,6 +672,13 @@ function DesktopNotifyPanel() {
           </button>
         </div>
       )}
+
+      {/* 데스크탑 앱(Electron) 자동 시작 — 알림 권한과 무관(트레이 상주만 토글). 권한이 default
+       *  /denied 라도 토글이 보이도록 perm 블록 밖에 둔다. 컴포넌트 자체가 Electron 환경이
+       *  아니면 null 을 반환해 웹/모바일에선 무영향. */}
+      <div className="mt-4">
+        <AutoLaunchToggle />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 증상
**자동 시작 토글 노출 — 알림 권한 무관**

현재 동작에 문제가 있어 이를 해결합니다.

## 원인
AutoLaunchToggle 이 perm==='granted' 분기 안에 있어 알림 권한이 default/denied 면
컴포넌트 자체가 렌더 안 됨. 자동 시작은 OS 로그인 트레이 상주 토글일 뿐 알림 권한과
무관하므로 분기 밖으로 이동. AutoLaunchToggle 내부에 이미 window.hinest 미노출 시
null 반환 가드가 있어 웹/모바일에선 무영향.

Closes #857

## 수정
**작업 항목 (커밋 단위)**
- fix(profile): 데스크탑 자동 시작 토글을 알림 권한 블록 밖으로

**변경 대상 (1개 파일)**
- `client/src/pages/ProfilePage.tsx`

## 검증
- `client` tsc 통과 + vite build ✓

---
🔗 이 작업은 **PR #858** 에서 진행됩니다.

