### PR TITLE
🔀 :: (#859) 키보드 분리감·네비바 따라옴 해결

### DIFF
--- a/client/src/lib/nativeKeyboard.ts
+++ b/client/src/lib/nativeKeyboard.ts
@@ -45,12 +45,32 @@ export function attachNativeKeyboard(): () => void {
   };
 
   // 키보드 플러그인 이벤트로도 보정 — 기기/버전별 키보드 높이 확정 시점에 한 번 더.
-  let removeKbListener: (() => void) | null = null;
+  // + 키보드 표시/숨김에 따라 html 에 `hinest-keyboard-open` 클래스 + CSS 변수
+  //   `--hinest-keyboard-h` 를 노출해, 하단 네비바를 숨기거나 로그인 폼을 키보드 위로
+  //   끌어올리는 등 네이티브 같은 동작이 CSS 만으로 가능하게 한다.
+  const removeKbListeners: Array<() => void> = [];
+  const setKbOpen = (h: number) => {
+    document.documentElement.classList.add("hinest-keyboard-open");
+    document.documentElement.style.setProperty("--hinest-keyboard-h", `${Math.max(0, Math.round(h))}px`);
+  };
+  const setKbClosed = () => {
+    document.documentElement.classList.remove("hinest-keyboard-open");
+    document.documentElement.style.setProperty("--hinest-keyboard-h", "0px");
+  };
+  setKbClosed();
   void import("@capacitor/keyboard")
     .then(({ Keyboard }) => {
-      Keyboard.addListener("keyboardDidShow", scrollFocusedIntoView).then((h) => {
-        removeKbListener = () => { try { void h.remove(); } catch {} };
-      });
+      const reg = (ev: string, fn: (info?: { keyboardHeight: number }) => void) => {
+        Keyboard.addListener(ev as never, fn as never).then((h) => {
+          removeKbListeners.push(() => { try { void h.remove(); } catch {} });
+        });
+      };
+      // willShow 가 더 빠름(애니메이션 시작 직전) — 네비바 숨김·인셋 적용을 미리 시작해
+      // 키보드가 올라오는 동안 jank 가 없다. didShow 에선 정확한 높이로 확정.
+      reg("keyboardWillShow", (info) => setKbOpen(info?.keyboardHeight ?? 0));
+      reg("keyboardDidShow", (info) => { setKbOpen(info?.keyboardHeight ?? 0); scrollFocusedIntoView(); });
+      reg("keyboardWillHide", () => setKbClosed());
+      reg("keyboardDidHide", () => setKbClosed());
     })
     .catch(() => {});
 
@@ -59,6 +79,7 @@ export function attachNativeKeyboard(): () => void {
   return () => {
     document.removeEventListener("focusin", onFocusIn);
     if (pendingTimer) clearTimeout(pendingTimer);
-    removeKbListener?.();
+    removeKbListeners.forEach((fn) => fn());
+    setKbClosed();
   };
 }

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -62,7 +62,17 @@ export default function LoginPage() {
       </header>
 
       {/* 본문 — 중앙 정렬, 한 단 */}
-      <main className="flex-1 flex items-center justify-center px-6 pb-32">
+      <main
+        className="flex-1 flex items-center justify-center px-6"
+        style={{
+          // 키보드가 열리면 폼이 키보드 바로 위까지 자연스럽게 따라 올라온다(WebView resize
+          // 만으로는 폼이 화면 가운데 정렬돼서 키보드와 사이에 큰 빈 공간이 생겨 '웹스러운'
+          // 느낌이 났다). --hinest-keyboard-h 는 nativeKeyboard 가 keyboardWillShow 에서
+          // 실제 키보드 높이로 갱신, 닫힐 때 0 으로 리셋.
+          paddingBottom: "calc(8rem + var(--hinest-keyboard-h, 0px))",
+          transition: "padding-bottom 220ms cubic-bezier(.4, 0, .2, 1)",
+        }}
+      >
         <div className="w-full max-w-[360px]">
           {/* 인사말 */}
           <div className="mb-9">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -114,6 +114,13 @@ html:has(.modal-safe) .app-bottomnav { display: none !important; }
    하단바가 입력을 가로채 '건너뛰기' 버튼이 안 눌리던 문제를 함께 해결. */
 html:has(.hinest-onb-overlay) .app-bottomnav { display: none !important; }
 
+/* 키보드가 열려 있는 동안 하단 네비게이션 바를 숨긴다. 이전엔 iOS Keyboard resize='native'
+   가 WebView 만 줄여 하단 바가 키보드와 같이 위로 끌려 올라오는 현상이 있었다(사용자 신고).
+   keyboardWillShow 이벤트에서 html 에 .hinest-keyboard-open 이 붙으면, 같은 :has 패턴으로
+   탭 바·콘솔 바를 함께 숨겨 입력 화면이 깨끗하게 보이도록 한다. (iOS / 안드로이드 공통) */
+html.hinest-keyboard-open .app-bottomnav,
+html.hinest-keyboard-open .console-bottomnav { display: none !important; }
+
 /* iOS 앱 — 상단바를 애플 리퀴드 글래스로. TopBar 를 본문 스크롤러(<main>) 위에 떠 있는
    반투명+blur 헤더(absolute)로 만들고, 본문은 그만큼 위쪽 패딩을 줘 헤더 아래에서 시작한다.
    스크롤하면 본문이 헤더 뒤로 지나가며 글래스 질감이 드러난다(스크롤 할 때만). TopBar 는


### PR DESCRIPTION
## 증상
- 로그인 화면: 키보드와 폼 사이 큰 빈 공간 → '웹 느낌'
- 관리자 페이지: 텍스트 필드 포커스 시 하단 네비게이션 바가 키보드와 함께 따라 올라옴

## 원인
- iOS Keyboard plugin 의 `resize: native` 는 WebView 를 줄이긴 하지만 키보드 표시/숨김 자체의 신호를 CSS 로 전달하지 않음
- 로그인 폼 `<main>` 이 `pb-32` 만 가져 폼이 화면 가운데 정렬 → 키보드와 큰 간격
- 하단 네비바(.app-bottomnav)는 `position: fixed; bottom: 0` 이라 WebView 가 줄어들면 같이 위로 끌려옴

## 수정
- `nativeKeyboard.ts`: Capacitor Keyboard 의 keyboardWillShow/DidShow/WillHide/DidHide 리스너 추가. html 에 `hinest-keyboard-open` 클래스 + CSS 변수 `--hinest-keyboard-h` 설정
- `styles.css`: `.hinest-keyboard-open` 일 때 `.app-bottomnav`·`.console-bottomnav` 숨김
- `LoginPage.tsx`: `<main>` paddingBottom 을 `calc(8rem + var(--hinest-keyboard-h, 0px))` 로, 부드러운 transition 적용

## 검증
- `client` tsc 통과 + vite build ✓

Closes #859
