### PR TITLE
🔀 :: (#862) 강도 차등화 — 자주 누르는 작은 버튼은 selection

### DIFF
--- a/client/src/lib/haptics.ts
+++ b/client/src/lib/haptics.ts
@@ -52,14 +52,32 @@ export function attachGlobalHaptics(): () => void {
     // 비활성 요소·data-no-haptic 은 제외.
     if (el.hasAttribute("disabled") || el.getAttribute("aria-disabled") === "true") return;
     if (el.closest("[data-no-haptic]")) return;
-    // 스위치/체크박스/탭은 selection, 나머지는 light.
+
+    // 강도 차등화(사용자 요구):
+    //  - selection : 가장 약함. 토글·자주 누르는 작은 버튼(btn-ghost / btn-icon / btn-xs).
+    //                네비바 탭 전환도 selection — "딱 적당함" 보존.
+    //  - light     : 일반 액션 버튼·링크·CTA(btn-primary 등). 기존 기본값 그대로.
+    //  - medium    : 명시적 [data-haptic="medium"] 만 사용(파괴적 액션·중요 확정).
+    // 명시 [data-haptic="<style>"] 가 있으면 그걸 우선.
+    const explicit = el.getAttribute("data-haptic") as
+      | "light" | "medium" | "heavy" | "selection" | "success" | "warning" | "error" | null;
+    if (explicit) { haptic(explicit); return; }
+
     const role = el.getAttribute("role");
     const isToggle =
       role === "switch" ||
       role === "tab" ||
       (el as HTMLInputElement).type === "checkbox" ||
       (el as HTMLInputElement).type === "radio";
-    haptic(isToggle ? "selection" : "light");
+    if (isToggle) { haptic("selection"); return; }
+
+    // 작고 자주 누르는 보조 버튼(btn-ghost / btn-icon / btn-xs) — 강도 한 단계 낮춤.
+    const cls = el.className || "";
+    if (typeof cls === "string" && /\b(btn-ghost|btn-icon|btn-xs)\b/.test(cls)) {
+      haptic("selection");
+      return;
+    }
+    haptic("light");
   };
   // passive — 스크롤 성능 영향 없음. capture 로 자식이 stopPropagation 해도 잡음.
   document.addEventListener("pointerdown", handler, { passive: true, capture: true });


### PR DESCRIPTION
## 증상
앱 전반 햅틱이 거의 동일한 강도(light)로 동작. 자주 누르는 작은 버튼(아이콘 버튼·서브 버튼)
까지 모두 같은 강도라 손목이 피곤하고 미세한 위계가 안 보임.

## 원인
`attachGlobalHaptics` 의 SELECTOR 가 모든 button/a/role=button 에 대해 일률적으로 `light` 햅틱.
토글(switch/checkbox/radio/tab)만 `selection` 으로 약하게 처리. 자주 누르는 보조 버튼 구분 없음.

## 수정
3단계 위계:
- selection (가장 약함): 토글, 자주 누르는 작은 버튼(btn-ghost / btn-icon / btn-xs), 네비바 탭
- light (기존 기본): 일반 액션 버튼·링크·CTA(btn-primary 등)
- medium (수동 명시): `[data-haptic="medium"]` — 파괴적/중요 확정용

또한 `[data-haptic]` 명시 우선 — 임의 위치에서 강도 override 가능.

## 검증
- `client` tsc 통과 + vite build ✓

Closes #862
