### PR TITLE
🔀 :: (#864) 직급 드래그·드롭에 햅틱 추가

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -6,6 +6,7 @@ import Portal from "../components/Portal";
 import { downloadCSV, downloadXLSX, openPrintable, parseSheet, type TableColumn } from "../lib/exportTable";
 import DatePicker from "../components/DatePicker";
 import TimePicker from "../components/TimePicker";
+import { haptic } from "../lib/haptics";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
 import { useAuth } from "../auth";
 
@@ -2130,6 +2131,8 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
                   e.dataTransfer.effectAllowed = "move";
                   // Firefox 는 setData 가 없으면 드래그가 아예 시작 안 됨.
                   e.dataTransfer.setData("text/plain", p.id);
+                  // 드래그 시작은 큰 액션 — medium 으로 "잡았다" 감 명확히.
+                  haptic("medium");
                 }}
                 onDragOver={(e) => {
                   if (!dragId || dragId === p.id) return;
@@ -2145,6 +2148,8 @@ function PositionsTab({ positions, reload }: { positions: Position[]; reload: ()
                   onDrop(p.id);
                   setDragId(null);
                   setOverId(null);
+                  // 드롭 성공 — light 로 부드러운 확정 감.
+                  haptic("light");
                 }}
                 onDragEnd={() => {
                   setDragId(null);


### PR DESCRIPTION
## 증상
관리자 페이지 직급 탭의 드래그&드롭 정렬에 햅틱 피드백 없음. '잡았다'·'놨다' 감이 안 옴.

## 원인
전역 `attachGlobalHaptics` 는 `pointerdown` 이벤트만 감시. HTML5 드래그&드롭의
`dragstart`/`drop` 이벤트는 별도 채널이라 자동 햅틱 안 들어감. (다른 관리자 페이지의
인터랙티브 요소는 모두 button/a/label/role=button 으로 만들어져 있어 전역 리스너가 정상 처리)

## 수정
직급 행의 `onDragStart` → `haptic("medium")`(잡았다 감), `onDrop` → `haptic("light")`
(부드러운 확정 감). `haptic` 헬퍼는 iOS/iPadOS 에서만 동작(웹/안드는 no-op).

## 검증
- `client` tsc 통과

Closes #864
