### PR TITLE
🔀 :: (#866) 로그아웃 제거 + 모바일 '서비스로 돌아가기' 통합

### DIFF
--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 import AdminLockup from "./AdminLockup";
-import { confirmLogout } from "../lib/confirmLogout";
 import { LiquidGlassTabBar } from "../lib/liquidGlassTabBar";
 import { nativePlatform } from "../lib/platform";
 
@@ -72,7 +71,7 @@ function ShieldIcon() {
 }
 
 export default function ConsoleLayout() {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const nav = useNavigate();
   const loc = useLocation();
 
@@ -148,11 +147,8 @@ export default function ConsoleLayout() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loc.pathname]);
 
-  async function doLogout() {
-    if (!(await confirmLogout())) return;
-    await logout();
-    nav("/login");
-  }
+  // doLogout 제거 — 콘솔에선 로그아웃 버튼을 노출하지 않는다(사용자 요구).
+  // 로그아웃은 회사 페이지에서 처리.
 
   function itemClass(isActive: boolean) {
     return [
@@ -229,11 +225,9 @@ export default function ConsoleLayout() {
               <div className="text-[12.5px] font-semibold truncate">{user?.name}</div>
               <div className="text-[10.5px] text-white/45 truncate">{user?.email}</div>
             </div>
-            <button onClick={doLogout} className="text-white/50 hover:text-white transition" title="로그아웃" aria-label="로그아웃">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4" /><path d="m16 17 5-5-5-5" /><path d="M21 12H9" />
-              </svg>
-            </button>
+            {/* 데스크탑 사이드바 user profile — 로그아웃 버튼 제거(사용자 요구).
+                콘솔은 회사 앱 안의 운영 도구라 로그아웃은 회사 페이지에서 처리.
+                "서비스로 돌아가기"는 사이드바 상단의 큰 버튼이 이미 담당. */}
           </div>
         </div>
       </aside>
@@ -258,16 +252,22 @@ export default function ConsoleLayout() {
             {/* onDark 를 넘기지 않으면 AdminLockup 이 앱 테마(resolved)를 따라간다. */}
             <AdminLockup variant="compact" />
             <div className="ml-auto flex items-center gap-1">
+              {/* 모바일 콘솔 상단 우측 — '서비스로 돌아가기' 단일 버튼.
+                  기존엔 "서비스" 텍스트 + 별도 로그아웃 아이콘 두 개가 있었으나, 콘솔은
+                  회사 앱 안의 운영 도구라 로그아웃이 별도로 필요 없음(회사 페이지에서 처리).
+                  하나로 통합해 깔끔하게(아이콘은 '왼쪽 화살표' = 돌아가기). */}
               {hasCompany && (
-                <button onClick={() => nav("/")} className="text-[12px] font-semibold text-ink-500 hover:text-ink-900 dark:text-white/70 dark:hover:text-white px-2 py-1">
+                <button
+                  onClick={() => nav("/")}
+                  className="inline-flex items-center gap-1.5 text-[12.5px] font-semibold text-ink-600 hover:text-ink-900 dark:text-white/75 dark:hover:text-white px-2.5 py-1.5 rounded-md hover:bg-ink-50 dark:hover:bg-white/5 transition"
+                  aria-label="서비스로 돌아가기"
+                >
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                    <path d="m15 18-6-6 6-6" />
+                  </svg>
                   서비스
                 </button>
               )}
-              <button onClick={doLogout} className="text-ink-400 hover:text-ink-700 dark:text-white/60 dark:hover:text-white px-2 py-1" aria-label="로그아웃">
-                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4" /><path d="m16 17 5-5-5-5" /><path d="M21 12H9" />
-                </svg>
-              </button>
             </div>
           </div>
         </header>


### PR DESCRIPTION
## 증상
- 모바일 콘솔 상단 우측에 **로그아웃 아이콘만** 있고 '서비스로 돌아가기' 버튼이 없음(텍스트 '서비스' 가 있긴 했지만 별개 + 로그아웃과 나란히 두 개라 산만)
- 데스크탑 사이드바 user 박스에도 작은 로그아웃 아이콘이 있어 콘솔 안에서 로그아웃이 노출됨

## 원인
콘솔은 회사 앱 안의 운영 도구라 로그아웃이 별도로 필요 없음(회사 페이지에서 처리하면 됨). 그런데도 모바일·데스크탑 양쪽 콘솔 셸에 로그아웃 버튼이 노출돼 있었음.

## 수정
- ConsoleLayout 모바일 상단 우측 = 로그아웃 아이콘 + '서비스' 텍스트 버튼 두 개를 → **'← 서비스' 단일 버튼**(아이콘+텍스트)으로 통합
- 데스크탑 사이드바 user 박스의 로그아웃 아이콘 제거
- 미사용된 `logout` / `doLogout` / `confirmLogout` import·함수 정리
- consoleOnly 계정(회사 앱 진입 X)은 hasCompany=false 라 이 버튼이 자연스럽게 숨겨짐

## 검증
- `client` tsc 통과

Closes #866
