### PR TITLE
🔀 :: (#868) 좌우·하단 갭 제거

### DIFF
--- a/client/src/components/ShareSheet.tsx
+++ b/client/src/components/ShareSheet.tsx
@@ -212,8 +212,16 @@ export default function ShareSheet({
       role="dialog"
       aria-modal="true"
       aria-label={`${label} 공유`}
-      className="modal-safe fixed inset-0 z-[1000] flex items-end justify-center"
-      style={{ background: `rgba(15,18,28,${shown ? 0.45 : 0})`, transition: "background 280ms ease" }}
+      className="fixed inset-0 z-[1000] flex items-end justify-center"
+      style={{
+        background: `rgba(15,18,28,${shown ? 0.45 : 0})`,
+        transition: "background 280ms ease",
+        // 시트는 화면 바닥에 딱 붙어야 자연스럽다(.modal-safe 의 좌우·하단 패딩이 적용되면
+        // 좌우/아래로 떠 보여 분리감이 생기는 문제). 상단만 노치 회피로 패딩 두고, 시트
+        // 자체는 가장자리까지 차게 한다. 키보드 인셋은 ShareSheet 내부가 자체 관리(보내기
+        // 버튼이 safe-area-inset-bottom 흡수).
+        paddingTop: "max(1rem, env(safe-area-inset-top))",
+      }}
       onClick={onClose}
     >
       <div
@@ -405,7 +413,7 @@ export default function ShareSheet({
 
         {/* 보내기 버튼 — safe-area inset bottom 흡수 */}
         <div
-          className="px-5 pt-2 pb-3 border-t border-ink-100 bg-white rounded-b-[20px] md:rounded-b-[18px]"
+          className="px-5 pt-2 pb-3 border-t border-ink-100 bg-white"
           style={{ paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 12px)" }}
         >
           <button


### PR DESCRIPTION
## 증상
공유 시트가 좌우와 아래로 살짝 떠 있어 분리감이 강함(스크린샷). 모달 같은 카드 느낌.

## 원인
ShareSheet 컨테이너에 `.modal-safe` 클래스가 붙어 있어 `padding: max(1rem, env(safe-area-inset-*))` 좌우·하단 패딩이 시트에도 적용됨. `.modal-safe` 는 화면 가운데 모달용 패딩이라 하단 시트엔 부적절.

## 수정
- ShareSheet 오버레이 className 에서 `modal-safe` 제거
- 노치 회피용 `paddingTop` 만 inline style 로 보존(상단만 노치 안 가리게)
- 좌우/하단 = 0 → 시트가 화면 가장자리에 딱 붙는다
- 하단 보내기 버튼 영역의 `rounded-b-[20px]` 도 제거(바닥에 붙으니 둥근 모서리 불필요)

키보드 인셋은 ShareSheet 내부의 보내기 버튼이 `env(safe-area-inset-bottom)` 으로 자체 흡수.

## 검증
- `client` tsc 통과 + vite build ✓

Closes #868
