### PR TITLE
🔀 :: (#870) Skeleton 컴포넌트 인프라 + MeetingsPage 통일

### DIFF
--- a/client/src/components/Skeleton.tsx
+++ b/client/src/components/Skeleton.tsx
@@ -1,0 +1,104 @@
+/**
+ * Skeleton UI — 데이터 로딩 중 깜빡임을 막고 다가올 콘텐츠의 형태를 미리 보여준다.
+ *
+ * 사용 예:
+ *   const { data, loading } = useFetch(...);
+ *   if (loading) return <SkeletonList rows={5} />;
+ *   return <Real data={data} />;
+ *
+ * 또는 부분적으로:
+ *   <Skeleton w={120} h={20} />
+ *   <SkeletonText lines={3} />
+ *
+ * 디자인 토큰:
+ *   - 배경: var(--c-surface-3) (다크/라이트 자동)
+ *   - 시머 그라데이션: 상위에 글라스 같은 부드러운 wave (styles.css 의 @keyframes hinest-skeleton)
+ *   - 모서리: 8px 기본(둥근 사각형). 아바타·원형 placeholder 는 borderRadius="999px".
+ *
+ * 성능: pure CSS animation(transform/opacity 만). 백그라운드 탭에서도 GPU 합성 그대로.
+ */
+import { CSSProperties } from "react";
+
+type SkeletonProps = {
+  /** 너비. number → px, string → 그대로. 미지정 시 100% */
+  w?: number | string;
+  /** 높이. 미지정 시 1em(글자 한 줄 높이) */
+  h?: number | string;
+  /** 모서리 둥글기. number → px, string → 그대로. 기본 8 */
+  radius?: number | string;
+  /** 원형(아바타 등). true 면 radius=999. */
+  circle?: boolean;
+  /** 추가 className(margin 등). 색·애니메이션은 건드리지 말 것. */
+  className?: string;
+  /** 인라인 style override. */
+  style?: CSSProperties;
+};
+
+export function Skeleton({ w, h = "1em", radius = 8, circle, className = "", style }: SkeletonProps) {
+  const toCss = (v: number | string | undefined): string | undefined =>
+    v === undefined ? undefined : typeof v === "number" ? `${v}px` : v;
+  return (
+    <span
+      className={`hinest-skeleton inline-block align-middle ${className}`}
+      aria-hidden
+      style={{
+        width: toCss(w) ?? "100%",
+        height: toCss(h),
+        borderRadius: circle ? 999 : toCss(radius),
+        ...style,
+      }}
+    />
+  );
+}
+
+/** 여러 줄 문장 placeholder. 마지막 줄은 80% 폭으로 자연스러운 종결. */
+export function SkeletonText({ lines = 3, gap = 8 }: { lines?: number; gap?: number }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap }}>
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton key={i} w={i === lines - 1 ? "80%" : "100%"} h={12} radius={6} />
+      ))}
+    </div>
+  );
+}
+
+/** 카드 한 장. 큰 영역 + 제목 + 부제 + 메타라인. 대시보드·리스트 항목 공통. */
+export function SkeletonCard({ height = 96 }: { height?: number }) {
+  return (
+    <div className="panel p-4 flex items-center gap-3">
+      <Skeleton circle w={40} h={40} />
+      <div className="flex-1 min-w-0 flex flex-col gap-2">
+        <Skeleton w="55%" h={14} />
+        <Skeleton w="40%" h={11} />
+      </div>
+      <Skeleton w={56} h={28} radius={8} />
+      {void height /* 호출부 일관성 위해 prop 유지(향후 가변 카드용) */}
+    </div>
+  );
+}
+
+/** 리스트 형태. rows 만큼 SkeletonCard 반복. */
+export function SkeletonList({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="space-y-2.5">
+      {Array.from({ length: rows }).map((_, i) => (
+        <SkeletonCard key={i} />
+      ))}
+    </div>
+  );
+}
+
+/** 통계 그리드(StatCard 4개) placeholder. */
+export function SkeletonStatGrid({ count = 4 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="panel p-4 flex flex-col gap-2">
+          <Skeleton w="55%" h={11} />
+          <Skeleton w="40%" h={22} />
+          <Skeleton w="70%" h={10} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/MeetingsPage.tsx
+++ b/client/src/pages/MeetingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { api, apiSWR, invalidateCache , imgSrc} from "../api";
+import { Skeleton } from "../components/Skeleton";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { alertAsync } from "../components/ConfirmHost";
@@ -422,10 +423,11 @@ function StatCard({
 }
 
 function SkeletonRow() {
+  // 공용 Skeleton 컴포넌트로 통일 — 시머 wave 가 깜빡임 대신 부드러운 진행감을 준다.
   return (
-    <div className="panel p-4 animate-pulse">
-      <div className="h-4 rounded w-2/3 mb-3" style={{ background: "var(--c-surface-3)" }} />
-      <div className="h-3 rounded w-1/3" style={{ background: "var(--c-surface-3)" }} />
+    <div className="panel p-4">
+      <div className="mb-3"><Skeleton w="65%" h={16} radius={6} /></div>
+      <Skeleton w="35%" h={12} radius={6} />
     </div>
   );
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -114,6 +114,46 @@ html:has(.modal-safe) .app-bottomnav { display: none !important; }
    하단바가 입력을 가로채 '건너뛰기' 버튼이 안 눌리던 문제를 함께 해결. */
 html:has(.hinest-onb-overlay) .app-bottomnav { display: none !important; }
 
+/* ───── Skeleton UI — 데이터 로딩 중 깜빡임 방지 ─────
+   - 기본 배경: --c-surface-3 (다크/라이트 자동)
+   - 시머: 좌→우로 흐르는 부드러운 글라스 wave(transform translateX 만 → GPU 합성, 끊김 없음)
+   - prefers-reduced-motion 사용자에겐 wave 없이 정적 표시
+*/
+.hinest-skeleton {
+  position: relative;
+  background: var(--c-surface-3);
+  overflow: hidden;
+  isolation: isolate;
+}
+.hinest-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.15) 50%,
+    transparent 100%
+  );
+  animation: hinest-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+.dark .hinest-skeleton::after {
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.06) 50%,
+    transparent 100%
+  );
+}
+@keyframes hinest-skeleton-shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hinest-skeleton::after { animation: none; }
+}
+
 /* 키보드가 열려 있는 동안 하단 네비게이션 바를 숨긴다. 이전엔 iOS Keyboard resize='native'
    가 WebView 만 줄여 하단 바가 키보드와 같이 위로 끌려 올라오는 현상이 있었다(사용자 신고).
    keyboardWillShow 이벤트에서 html 에 .hinest-keyboard-open 이 붙으면, 같은 :has 패턴으로


### PR DESCRIPTION
## 증상
새로고침 / 페이지 진입 시 데이터 로딩 동안 빈 화면이 잠깐 뜨거나 깜빡거림이 보임.
'불러오는 중…' 텍스트는 정보 가치 낮음. 토스/리니어처럼 콘텐츠 형태를 미리 보여주는 Skeleton 이 필요.

## 원인
공용 Skeleton 컴포넌트 없음. 페이지별로 인라인 placeholder 가 각자 다른 스타일/색·애니메이션을 가짐(MeetingsPage 의 SkeletonRow 는 animate-pulse, 다른 곳은 무애니메이션).

## 수정 (이번 PR — 인프라 + 1페이지 적용)
- `client/src/components/Skeleton.tsx` — `<Skeleton>`, `<SkeletonText>`, `<SkeletonCard>`, `<SkeletonList>`, `<SkeletonStatGrid>` 공용 컴포넌트
- `styles.css` — `.hinest-skeleton` 클래스 + 좌→우 시머 wave(@keyframes hinest-skeleton-shimmer, transform translateX 만 → GPU 합성 끊김 없음). 다크 톤 별도, prefers-reduced-motion 대응
- MeetingsPage 의 인라인 SkeletonRow 를 공용 `<Skeleton>` 로 통일

## 후속(별도 PR — 사용자에게 안내)
- Dashboard / Schedule / Documents / Admin Attendance 등 핵심 페이지의 loading 상태에 SkeletonList·SkeletonStatGrid 적용
- 새로고침 시 기존 데이터 유지하면서 Skeleton overlay(pull-to-refresh UX)

## 검증
- `client` tsc 통과 + vite build ✓

Closes #870
