### PR TITLE
🔀 :: (#872) DevBadge 사내톡·디렉터리에서도 iconOnly

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -2404,7 +2404,7 @@ function RoomView({
                         title="프로필 보기"
                       >
                         <span style={{ textDecoration: "none" }}>{m.sender.name}</span>
-                        {isDevAccount(m.sender) && <DevBadge />}
+                        {isDevAccount(m.sender) && <DevBadge iconOnly />}
                       </button>
                     )}
                     <div

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -325,7 +325,7 @@ function GridCard({
           <Link to={`/users/${u.id}`} className="min-w-0 flex-1 hover:opacity-80 transition">
             <div className="text-[15px] font-extrabold text-ink-900 tracking-tight flex items-center gap-1.5 min-w-0">
               <span className="truncate">{u.name}</span>
-              {isDevAccount(u) && <DevBadge />}
+              {isDevAccount(u) && <DevBadge iconOnly />}
             </div>
             <div className="text-[12px] text-ink-600 truncate mt-0.5">
               {u.position ?? "—"}
@@ -406,7 +406,7 @@ function ListRow({ u, onDM, divider, dmBusy }: { u: DirectoryUser; onDM: () => v
         <div className="flex items-center gap-1.5 min-w-0">
           <div className="text-[14px] font-extrabold text-ink-900 tracking-tight flex items-center gap-1.5 min-w-0">
             <span className="truncate">{u.name}</span>
-            {isDevAccount(u) && <DevBadge />}
+            {isDevAccount(u) && <DevBadge iconOnly />}
           </div>
           <PresenceBadge u={u} />
         </div>


### PR DESCRIPTION
## 증상
사내톡 메시지 발신자 이름 옆 / 구성원 목록 카드에 "HiNest 개발자" 뱃지가 풀 라벨로 떠 이름과 함께 줄이 길어지고 가독성 떨어짐.

## 원인
DevBadge 컴포넌트는 `iconOnly` prop 을 지원하고 회의록·조직도에서는 `<DevBadge iconOnly />` 로 작은 원형 아이콘만 표시. 그런데 사내톡(ChatMiniApp)·디렉터리(DirectoryPage) 는 `<DevBadge />` 로 풀 라벨이 그대로 노출.

## 수정
3곳을 모두 `iconOnly` 로 통일:
- ChatMiniApp 메시지 발신자
- DirectoryPage 그리드 카드 + 리스트 행

`UserProfilePage` 같이 개인 프로필 자세히 보는 곳은 풀 라벨 유지(설명 가치 있음).

## 검증
- `client` tsc 통과

Closes #872
