### PR TITLE
🔀 :: (#876) DevBadge 풀 라벨 → iconOnly 전체 통일

### DIFF
--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -641,7 +641,7 @@ function ApprovalDetail({
                   <div className="flex-1 min-w-0">
                     <div className="flex items-baseline gap-1.5 flex-wrap">
                       <div className="text-[12px] font-bold text-ink-900">{c.author.name}</div>
-                      {isDevAccount(c.author) && <DevBadge />}
+                      {isDevAccount(c.author) && <DevBadge iconOnly />}
                       <div className="text-[10px] text-ink-400 tabular">{new Date(c.createdAt).toLocaleString("ko-KR")}</div>
                     </div>
                     <div className="text-[13px] text-ink-800 whitespace-pre-wrap leading-[1.55] mt-0.5">{c.content}</div>

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -126,7 +126,7 @@ export default function DashboardPage() {
             <h1 className="text-[26px] sm:text-[28px] font-extrabold text-ink-900 tracking-tight flex items-center gap-2 flex-wrap">
               <span>{user?.name ?? ""}님,</span>
               <span className="text-ink-500 font-bold">{greetingFor(now)}</span>
-              {isDevAccount(user) && <DevBadge size="sm" />}
+              {isDevAccount(user) && <DevBadge size="sm" iconOnly />}
             </h1>
           </div>
           <StatusPill status={status} />
@@ -366,7 +366,7 @@ function NoticeCard({ notices, loaded = true }: { notices: Notice[]; loaded?: bo
                 </div>
                 <div className="text-[11px] text-ink-500 flex items-center gap-1.5 flex-wrap">
                   <span>{n.author?.name}</span>
-                  {isDevAccount(n.author) && <DevBadge size="sm" />}
+                  {isDevAccount(n.author) && <DevBadge size="sm" iconOnly />}
                   <span className="text-ink-300">·</span>
                   <span className="tabular-nums">{relTime(n.createdAt)}</span>
                 </div>
@@ -396,7 +396,7 @@ function ProfileCard(p: { name: string; email?: string; team: string | null; pos
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 flex-wrap">
             <span className="text-[15px] font-extrabold text-ink-900 truncate">{p.name}</span>
-            {p.isDeveloper && <DevBadge size="sm" />}
+            {p.isDeveloper && <DevBadge size="sm" iconOnly />}
           </div>
           <div className="text-[12px] text-ink-500 truncate">{p.email}</div>
         </div>

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -333,7 +333,7 @@ export default function MeetingDetailPage() {
             )}
           </span>
           {meeting.author.name}
-          {isDevAccount(meeting.author) && <DevBadge />}
+          {isDevAccount(meeting.author) && <DevBadge iconOnly />}
         </span>
         <span>·</span>
         <span>{new Date(meeting.createdAt).toLocaleString("ko-KR", { year: "numeric", month: "short", day: "numeric" })}</span>
@@ -507,7 +507,7 @@ function ViewerPicker({
                 )}
               </span>
               <span>{u.name}</span>
-              {isDevAccount(u) && <DevBadge />}
+              {isDevAccount(u) && <DevBadge iconOnly />}
               <span className="text-[10px] text-slate-400">{u.team ?? ""}</span>
             </button>
           );

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -229,7 +229,7 @@ export default function NoticePage() {
                 </div>
                 <div className="text-xs text-slate-500 mt-0.5 inline-flex items-center gap-1.5">
                   <span>{n.author?.name}</span>
-                  {isDevAccount(n.author) && <DevBadge />}
+                  {isDevAccount(n.author) && <DevBadge iconOnly />}
                   <span>· {new Date(n.createdAt).toLocaleDateString("ko-KR")}</span>
                 </div>
               </button>
@@ -253,7 +253,7 @@ export default function NoticePage() {
                       </span>
                     )}
                     <span>{selected.author?.name}</span>
-                    {isDevAccount(selected.author) && <DevBadge />}
+                    {isDevAccount(selected.author) && <DevBadge iconOnly />}
                     <span>·</span>
                     <span>{new Date(selected.createdAt).toLocaleString("ko-KR")}</span>
                   </div>


### PR DESCRIPTION
## 증상
대시보드 인사 카드의 "서지완님, 오후도 화이팅이에요" 옆에 'HiNest 개발자' 라벨이 풀 텍스트로 떠 시각적으로 큰 자리를 차지하고 가독성 저하. 비슷한 케이스가 공지(NoticePage)·회의록(MeetingDetailPage)·결재 코멘트(ApprovalsPage)·대시보드 ProfileCard/공지 작성자 등 다수 위치에 남아 있음. 모바일·데스크탑 동일.

## 원인
DevBadge 컴포넌트는 `iconOnly` prop 으로 작은 원형 그라데이션 아이콘만 표시할 수 있는데, 이전 PR(#873) 에서 사내톡·디렉터리만 통일했음. 그 외 7곳이 여전히 `<DevBadge />` 또는 `<DevBadge size="sm" />` 로 풀 라벨을 노출. 결과적으로 페이지마다 같은 의미의 뱃지가 다른 크기·형태로 보임.

## 작업 내용
**수정**
- `client/src/pages/DashboardPage.tsx` (5곳)
  - 인사 카드(L129) — 본인 dev 표시
  - ProfileCard(L219) — isDeveloper prop 으로 표시
  - 공지 작성자(L369)
  - 또 다른 isDeveloper 위치(L399)
  - 전부 `<DevBadge size="sm" iconOnly />` 로 통일
- `client/src/pages/NoticePage.tsx` 공지 목록 카드 + 상세 모달 작성자(2곳) — iconOnly
- `client/src/pages/MeetingDetailPage.tsx` 회의록 작성자 + 뷰어 목록(2곳) — iconOnly
- `client/src/pages/ApprovalsPage.tsx` 결재 코멘트 작성자 — iconOnly

**유지**
- `UserProfilePage` / `ProfilePage` — 개인 프로필 "자세히 보기" 화면이라 풀 라벨이 설명 가치 있음(PR #873 결정 유지)

**호환성·외부 영향**
- DevBadge 의 `title` 속성으로 호버 시 "HiNest 개발자" 풀 텍스트는 그대로 노출(접근성 유지)
- 시맨틱·접근성 변화 없음(원형 아이콘도 `title` 이 있어 스크린 리더에 동일)
- 모바일/데스크탑/iOS Capacitor 모두 동일하게 적용(플랫폼 분기 없음)

## 검증
- `client` tsc 통과
- 변경 없는 `UserProfilePage` / `ProfilePage` 그대로 풀 라벨 노출 확인

Closes #876
