### PR TITLE
🔀 :: (#878) iOS App Store 자동 감지 + 업데이트 권장 모달

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,40 @@
 <!--
   PR 제목: `type(scope): 한국어 설명`  (예: fix(console): 하단 네비바 숨김)
   머지 시 연결 이슈가 자동 종료되도록 아래 "Closes #" 를 꼭 채워주세요.
+  본문은 아래 4섹션(증상·원인·수정·검증) 표준을 갖춰주세요.
 -->
 
-## 작업 요약
-<!-- 무엇을, 왜 바꿨는지 1~3줄 -->
+## 증상
+<!--
+  사용자 입장에서 보이는 결과 + 재현 단계 + 스크린샷(있으면).
+  단순 "안 됨" 금지 — 어떤 화면, 어떤 동작, 어떤 결과인지 구체적으로.
+-->
 
-Closes #
+## 원인
+<!--
+  근본 원인을 짧게라도 인과관계로. 파일·라인·코드 인용 환영.
+  '근본 원인' vs '표면 증상' 구분해서 적기.
+-->
 
-## 변경 사항
--
-
-## 유형 · 영역 (라벨)
-- **type:** <!-- feat / fix / refactor / perf / security / chore / docs -->
-- **area:** <!-- client / server / ios / desktop / console / ci -->
-- **priority:** <!-- P0 / P1 / P2 (선택) -->
+## 작업 내용
+<!--
+  무엇을 어떻게 바꿨는지 — 파일별/기능별 글머리표.
+  추가/수정/제거를 명확히 구분.
+  부작용·호환성·idempotent·롤백 가능성 + 외부 영향(다른 페이지·다른 플랫폼) 명시.
+-->
 
 ## 검증
 - [ ] `server` tsc / `client` tsc 통과
 - [ ] 로컬 빌드 또는 실기기 · 프리뷰로 동작 확인
 - [ ] 연결 이슈에 `Closes #N` 기입
 - [ ] 본인(@Xixn2)을 Assignee 로 지정
+
+Closes #
+
+## 분류
+- **type:** <!-- feat / fix / refactor / perf / security / chore / docs -->
+- **area:** <!-- client / server / ios / desktop / console / ci -->
+- **priority:** <!-- P0 / P1 / P2 (선택) -->
 
 ## 비고 · 스크린샷
 <!-- 회귀 위험, 후속 작업, before/after 등 -->

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "./auth";
 import { isDesktopApp } from "./lib/platform";
 import UpdateBanner from "./components/UpdateBanner";
 import DesktopUpdateBanner from "./components/DesktopUpdateBanner";
+import AppStoreUpdatePrompt from "./components/AppStoreUpdatePrompt";
 import ConfirmHost from "./components/ConfirmHost";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import LoginPage from "./pages/LoginPage";
@@ -125,6 +126,7 @@ export default function App() {
     <>
     <UpdateBanner />
     <DesktopUpdateBanner />
+    <AppStoreUpdatePrompt />
     <ConfirmHost />
     <ErrorBoundary resetKey={pathname}>
     <Suspense fallback={<RouteFallback />}>

--- a/client/src/components/AppStoreUpdatePrompt.tsx
+++ b/client/src/components/AppStoreUpdatePrompt.tsx
@@ -1,0 +1,125 @@
+/**
+ * iOS App Store 업데이트 권장 모달.
+ *
+ * 동작:
+ *  - AppLayout 마운트 시 + 앱이 백그라운드→포그라운드로 돌아올 때 checkAppStoreUpdate() 호출.
+ *  - needsUpdate=true 이면 모달 표시. "지금 업데이트" → App Store 트랙 URL 외부 열림.
+ *    "나중에" → 24시간 dismiss(localStorage 에 기록 — 같은 버전 다시 안 뜸).
+ *  - 결과는 1시간 캐시 — 같은 세션 내 같은 모달이 반복적으로 뜨지 않게.
+ *
+ * 비 iOS(웹·데스크탑·안드)는 컴포넌트가 일찍 null 을 반환해 무영향.
+ * 데스크탑 / 웹 업데이트는 기존 DesktopUpdateBanner / UpdateBanner 가 담당(별도 채널).
+ */
+
+import { useEffect, useState } from "react";
+import Portal from "./Portal";
+import { Browser } from "@capacitor/browser";
+import { isCapacitorNative } from "../lib/platform";
+import {
+  checkAppStoreUpdate,
+  dismissAppStoreUpdate,
+  type AppStoreCheckResult,
+} from "../lib/checkAppStoreUpdate";
+
+export default function AppStoreUpdatePrompt() {
+  const [result, setResult] = useState<AppStoreCheckResult | null>(null);
+  const [open, setOpen] = useState(false);
+  const [opening, setOpening] = useState(false);
+
+  useEffect(() => {
+    if (!isCapacitorNative()) return; // iOS Capacitor 만 활성
+    let alive = true;
+    const run = async () => {
+      try {
+        const r = await checkAppStoreUpdate();
+        if (!alive) return;
+        setResult(r);
+        if (r.needsUpdate) setOpen(true);
+      } catch { /* silent */ }
+    };
+    // 초기 마운트 시 1회.
+    void run();
+    // 포그라운드 복귀 시 재체크 — 백그라운드 동안 새 버전이 배포됐을 수 있음.
+    const onVis = () => { if (document.visibilityState === "visible") void run(); };
+    document.addEventListener("visibilitychange", onVis);
+    return () => { alive = false; document.removeEventListener("visibilitychange", onVis); };
+  }, []);
+
+  if (!open || !result?.needsUpdate) return null;
+
+  const onUpdate = async () => {
+    if (opening) return;
+    setOpening(true);
+    try {
+      if (result.trackUrl) {
+        // 외부 Safari 가 아닌 in-app Browser 로 App Store 페이지로 이동(앱 알림 X, 빠름).
+        await Browser.open({ url: result.trackUrl, presentationStyle: "fullscreen" });
+      }
+    } catch { /* 사용자 취소·실패는 silent */ }
+    finally { setOpening(false); }
+  };
+  const onLater = () => {
+    if (result.latest) dismissAppStoreUpdate(result.latest);
+    setOpen(false);
+  };
+
+  return (
+    <Portal>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="앱 업데이트 권장"
+        className="modal-safe fixed inset-0 z-[1100] grid place-items-center"
+        style={{ background: "rgba(15,18,28,0.55)" }}
+      >
+        <div className="panel p-5 w-full max-w-[400px] flex flex-col gap-3">
+          <div className="flex items-start gap-3">
+            <div
+              aria-hidden
+              className="grid place-items-center rounded-2xl flex-shrink-0"
+              style={{ width: 44, height: 44, background: "linear-gradient(135deg, #3B5CF0 0%, #7C3AED 100%)", color: "#fff" }}
+            >
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12a9 9 0 0 1-9 9c-2.39 0-4.68-.94-6.4-2.6L3 21" />
+                <path d="M3 12a9 9 0 0 1 9-9c2.39 0 4.68.94 6.4 2.6L21 3" />
+                <path d="M21 3v6h-6" /><path d="M3 21v-6h6" />
+              </svg>
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-[15.5px] font-extrabold text-ink-900 leading-tight">
+                새 버전이 있어요
+              </div>
+              <div className="text-[12.5px] text-ink-500 mt-1 leading-relaxed">
+                App Store 에 최신 버전 <b className="text-ink-800">{result.latest}</b> 가
+                올라왔어요. 더 나아진 기능과 안정성을 위해 업데이트를 권장해요.
+              </div>
+              {result.current && (
+                <div className="text-[11px] text-ink-400 mt-1.5 tabular-nums">
+                  현재 {result.current} → 최신 {result.latest}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="flex gap-2 mt-2">
+            <button
+              type="button"
+              onClick={onLater}
+              className="flex-1 h-11 rounded-[12px] font-bold text-[13.5px] text-ink-700 bg-[var(--c-surface-3)] active:scale-[0.98] transition"
+            >
+              나중에
+            </button>
+            <button
+              type="button"
+              onClick={onUpdate}
+              disabled={opening || !result.trackUrl}
+              className="flex-[1.4] h-11 rounded-[12px] font-extrabold text-[13.5px] text-white bg-brand-500 disabled:opacity-50 active:scale-[0.98] transition"
+            >
+              {opening ? "여는 중…" : "지금 업데이트"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/client/src/lib/checkAppStoreUpdate.ts
+++ b/client/src/lib/checkAppStoreUpdate.ts
@@ -1,0 +1,113 @@
+/**
+ * iOS App Store 업데이트 자동 감지.
+ *
+ * 동작:
+ *  1) iOS Capacitor 앱에서만 활성(웹/데스크탑/안드는 no-op).
+ *  2) iTunes Lookup API(공개 무인증) 로 App Store 의 최신 `version` 을 조회.
+ *  3) `@capacitor/app` 의 `App.getInfo().version` 과 비교 — 최신이 더 크면 업데이트 권장.
+ *  4) 결과(필요/생략)는 캐시(1시간) — 매 진입 시 itunes 를 때리지 않음.
+ *  5) 사용자가 "나중에" 누르면 24시간 dismiss(localStorage 기록) — 같은 버전 계속 안 띄움.
+ *
+ * 호출부(AppLayout)는 이 결과를 받아 모달을 띄울지 결정한다.
+ *
+ * 안전장치:
+ *  - itunes lookup 실패(네트워크/심사 전이라 결과 없음)는 silent. 절대 throw 안 함.
+ *  - 버전 비교는 semver 순서 비교(1.2 < 1.10). x.y.z 만 가정(App Store 정책상 그대로).
+ *  - Bundle ID 는 capacitor.config.ts 와 동일(com.hivits.hinest). 변경 시 같이 갱신.
+ */
+
+import { nativePlatform } from "./platform";
+
+const BUNDLE_ID = "com.hivits.hinest";
+const COUNTRY = "kr";
+const CACHE_KEY = "hinest.appstore-check";
+const DISMISS_KEY = "hinest.appstore-dismiss";
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1시간
+const DISMISS_TTL_MS = 24 * 60 * 60 * 1000; // 24시간
+
+export type AppStoreCheckResult = {
+  /** 최신 버전이 더 크면 true. */
+  needsUpdate: boolean;
+  /** 현재 설치된 앱 버전(예: "1.0.2"). */
+  current?: string;
+  /** App Store 최신 버전(예: "1.0.3"). */
+  latest?: string;
+  /** App Store 의 앱 페이지(트랙 URL) — "지금 업데이트" 버튼에서 외부 열림. */
+  trackUrl?: string;
+};
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map((x) => parseInt(x, 10) || 0);
+  const pb = b.split(".").map((x) => parseInt(x, 10) || 0);
+  const n = Math.max(pa.length, pb.length);
+  for (let i = 0; i < n; i++) {
+    const av = pa[i] ?? 0;
+    const bv = pb[i] ?? 0;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+function readCache(): AppStoreCheckResult | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const j = JSON.parse(raw) as { at: number; r: AppStoreCheckResult };
+    if (Date.now() - j.at < CACHE_TTL_MS) return j.r;
+  } catch { /* corrupt → 무시 */ }
+  return null;
+}
+function writeCache(r: AppStoreCheckResult) {
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ at: Date.now(), r })); } catch {}
+}
+
+/** "나중에" 로 닫은 버전. 같은 latest 가 다시 떠도 24시간 안엔 안 띄운다. */
+function isDismissed(latest: string): boolean {
+  try {
+    const raw = localStorage.getItem(DISMISS_KEY);
+    if (!raw) return false;
+    const j = JSON.parse(raw) as { at: number; v: string };
+    return j.v === latest && Date.now() - j.at < DISMISS_TTL_MS;
+  } catch { return false; }
+}
+export function dismissAppStoreUpdate(latest: string): void {
+  try { localStorage.setItem(DISMISS_KEY, JSON.stringify({ at: Date.now(), v: latest })); } catch {}
+}
+
+/**
+ * 현재 환경에서 App Store 업데이트가 필요한지 결과를 돌려준다.
+ *  - iOS 가 아니거나 itunes 호출 실패 → needsUpdate:false
+ *  - 같은 버전이거나 더 새 버전 설치 → needsUpdate:false
+ *  - 더 큰 버전이 App Store 에 있으면 needsUpdate:true + 비교용 메타
+ */
+export async function checkAppStoreUpdate(): Promise<AppStoreCheckResult> {
+  if (nativePlatform() !== "ios") return { needsUpdate: false };
+  const cached = readCache();
+  if (cached) return cached;
+
+  try {
+    // 현재 설치된 앱 버전.
+    const { App } = await import("@capacitor/app");
+    const info = await App.getInfo();
+    const current = (info.version || "").trim();
+
+    // App Store 최신 버전.
+    const url = `https://itunes.apple.com/lookup?bundleId=${encodeURIComponent(BUNDLE_ID)}&country=${COUNTRY}&t=${Date.now()}`;
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) { const r = { needsUpdate: false, current }; writeCache(r); return r; }
+    const data = (await res.json()) as { resultCount: number; results: Array<{ version?: string; trackViewUrl?: string }> };
+    if (!data.resultCount || !data.results?.[0]?.version) {
+      // 심사 전·국가 미출시 등 — 결과 없음. silent.
+      const r = { needsUpdate: false, current }; writeCache(r); return r;
+    }
+    const latest = data.results[0].version.trim();
+    const trackUrl = data.results[0].trackViewUrl;
+
+    const needsUpdate = !!current && compareSemver(current, latest) < 0 && !isDismissed(latest);
+    const r: AppStoreCheckResult = { needsUpdate, current, latest, trackUrl };
+    writeCache(r);
+    return r;
+  } catch {
+    const r = { needsUpdate: false }; writeCache(r); return r;
+  }
+}


### PR DESCRIPTION
## 증상
앱이 출시되면 사용자가 App Store 에 새 버전이 올라온 사실을 모를 가능성이 큼. 현재 데스크탑(electron-updater)·웹(서비스워커) 은 업데이트 배너가 있지만, **iOS 앱은 App Store 외부에서 새 버전을 감지·안내할 수단이 전혀 없어** 사용자가 옛 번들로 계속 사용할 수 있음. 보안 패치·중요 수정이 적용 안 됨.

또 사용자가 "앱스토어 아니더라도 업데이트 필요할 때 팝업" 도 원함 — 데스크탑·웹은 이미 배너가 있으나 모달이 아니라 눈에 덜 띌 수 있음(이번 PR 에선 기존 배너 유지, iOS 모달만 신규 추가).

## 원인
`UpdateBanner.tsx` (웹 SW) / `DesktopUpdateBanner.tsx` (electron-updater) 는 각각 자기 채널에서 새 번들 감지 후 hinest:update-ready 이벤트 → 배너 표시. **iOS App Store 채널은 채널 자체가 없음**. itunes lookup API 로 외부에서 조회는 가능하지만 호출하는 코드가 없었음.

## 작업 내용
**추가**
- `client/src/lib/checkAppStoreUpdate.ts` — 핵심 로직
  - `checkAppStoreUpdate(): Promise<AppStoreCheckResult>`
  - iOS Capacitor 만 활성(`nativePlatform() === 'ios'` 가드), 그 외 즉시 `{needsUpdate:false}`
  - 무인증 itunes lookup API 호출(`https://itunes.apple.com/lookup?bundleId=com.hivits.hinest&country=kr`)
  - `@capacitor/app` 의 `App.getInfo().version` 으로 현재 버전 조회 → semver 비교(1.10 > 1.2 정상)
  - 1시간 캐시(localStorage `hinest.appstore-check`)
  - "나중에" 누른 버전은 24시간 dismiss(`hinest.appstore-dismiss`)
  - itunes 결과 0건(심사 전·국가 미출시)·네트워크 실패는 silent → `{needsUpdate:false}`
- `client/src/components/AppStoreUpdatePrompt.tsx` — 모달 UI
  - 마운트 시 + visibilitychange 'visible' 시 자동 체크
  - 표시: 그라데이션 아이콘 + 현재→최신 버전 + "나중에" / "지금 업데이트" 버튼
  - 업데이트 버튼 → `@capacitor/browser` `Browser.open(trackUrl)` 으로 App Store 페이지(in-app Safari) 열기

**연결**
- `App.tsx` 의 글로벌 마운트 영역에 `<AppStoreUpdatePrompt />` 1줄 추가(UpdateBanner / DesktopUpdateBanner 옆)

**호환성·외부 영향**
- 비 iOS(웹/데스크탑/안드) 환경: 컴포넌트가 일찍 null 반환 → 영향 0
- iOS Capacitor: 마운트 직후 itunes 1회 + 포그라운드 복귀마다 1회 호출(둘 다 1시간 캐시 안에선 네트워크 X)
- 사용자가 "나중에" 한 버전은 24시간 동안 다시 안 뜸(같은 버전 한정)
- App Store ID 가 아니라 Bundle ID 로 조회 — 심사 통과 전엔 결과 0건이라 silent(잘못된 동작 X)
- 기존 `UpdateBanner` / `DesktopUpdateBanner` 는 그대로 — 채널 분리(웹 SW / Electron / App Store)

## 검증
- `client` tsc 통과
- `@capacitor/app` ^8.1.0 이미 설치돼 있어 추가 의존성 0
- 첫 심사 통과 전엔 itunes 결과 0건이라 무동작(정상). 통과 후 다음 패치 배포부터 자동 동작
- 캐시 키(`hinest.appstore-check`/`hinest.appstore-dismiss`)는 `hinest.` 네임스페이스로 다른 항목과 충돌 X

Closes #878
