### PR TITLE
🔀 :: (#880) Live Updates directUpdate=true — '앱 켜면 즉시 최신'

### DIFF
--- a/client/capacitor.config.ts
+++ b/client/capacitor.config.ts
@@ -74,8 +74,15 @@ const config: CapacitorConfig = {
     //                서버가 Vercel manifest.json 를 읽어 응답을 만든다(routes/updates.ts).
     //   appReadyTimeout: 새 번들 부팅 후 notifyAppReady() 가 이 시간(ms) 안에 안 불리면 직전
     //                정상 번들로 자동 롤백 → 빌드가 깨져도 사용자가 벽돌 앱을 만나지 않음.
+    //   directUpdate (★ 2026-06-09 추가): true 면 SDK 가 새 번들을 다운로드한 직후 곧바로
+    //                set+reload 한다. 기본값(false) 은 "다음 콜드 스타트에야 새 번들 적용"
+    //                이라 사용자가 새로고침으로는 옛 번들을 못 벗어났음 — directUpdate 로
+    //                "앱 켜면 즉시 최신" 에 가까운 UX 제공. 첫 진입 시 1초 내외의 가벼운
+    //                리로드 깜빡임은 SplashScreen(launchShowDuration:1500) 안에서 대부분
+    //                흡수된다. App Store 정책 4.7 OTA 허용 범위에 그대로 머물러 안전.
     CapacitorUpdater: {
       autoUpdate: true,
+      directUpdate: true,
       updateUrl: "https://nest.hi-vits.com/api/updates/check",
       appReadyTimeout: 10000,
       responseTimeout: 20,


### PR DESCRIPTION
## 증상
iOS Capacitor 앱에서 새로운 OTA 번들이 서버(`updates.ts` manifest)에 올라가도, **사용자가 한 번 앱을 완전히 종료(콜드 스타트)** 해야 새 번들이 활성화. 즉:
- 데스크탑 Electron / 웹은 새로고침으로 즉시 최신
- 그러나 iOS 는 새로고침해도 박힌 옛 번들만 다시 읽어 변화 없음 → 사용자가 "새 코드 안 보임" 으로 느낌
- 사용자 요구: "새로고침하면 웹 다시 불러오게는 못 하나?" — 데스크탑처럼 빠른 반영을 원함

"원격 URL 로드" (server.url) 방식은 App Store 4.2("Minimum Functionality") reject 위험·오프라인 불가·네이티브 기능 충돌 가능성으로 채택 불가.

## 원인
`client/capacitor.config.ts` 의 `CapacitorUpdater` 설정에 `directUpdate` 키가 없어 SDK 가 기본(false) 으로 동작:
- 백그라운드에서 새 번들 다운로드까지는 OK
- 하지만 다운로드 완료 후 "다음 콜드 스타트" 까지 set+reload 가 지연
- iOS 의 `window.location.reload()` 는 박힌 번들을 다시 읽는 거라 새 번들 활성화 효과 X

즉 "새 번들이 디스크에 있지만 SDK 가 아직 안 바꿈" 상태가 사용자 입장의 "새로고침해도 그대로" 의 정체.

## 작업 내용
**수정**
- `client/capacitor.config.ts` 의 `plugins.CapacitorUpdater` 에 한 줄 추가:
  ```ts
  directUpdate: true,
  ```
- 같은 블록의 주석에 동작 차이·트레이드오프·App Store 정책 안전성(4.7 OTA 명시적 허용 범위)·SplashScreen 흡수 시간(`launchShowDuration: 1500`) 설명 추가
- 다른 옵션은 그대로 — `autoUpdate`, `appReadyTimeout: 10000` (안전망 — 다운로드+적용이 10초 안에 안 끝나면 자동 폴백·롤백)

**동작 변화 (사용자 입장)**
- 이전: 앱 켬 → 옛 번들 표시 → 백그라운드 다운로드 → **닫고 다시 열어야** 새 코드 활성화
- 이후: 앱 켬 → SDK 가 새 번들 발견 → 백그라운드 다운로드 직후 **즉시 set+reload** → 새 코드 즉시 표시 (스플래시·짧은 리로드 깜빡임 안에서 대부분 흡수)
- 새 번들이 없으면 변화 없음(즉, 매번 리로드되는 게 아님 — 신규 번들 있을 때만)

**호환성·롤백 안전성**
- `appReadyTimeout: 10000` 안전망 유지: 새 번들이 깨져 부팅 후 10초 안에 `notifyAppReady()` 호출 못 하면 직전 정상 번들로 자동 롤백 → 사용자가 벽돌 앱 안 만남
- `autoDeleteFailed: true` + `autoDeletePrevious: true` 도 유지 — 실패 번들·옛 번들 디스크 정리
- 첫 심사 통과 빌드(빌드 2)엔 이 변경이 들어가지 않음 → 첫 심사는 영향 0
- Live Update 가 빌드 2 사용자에게 도달하면, 그 시점부터 directUpdate=true 코드가 활성화 (다음 빌드부터 즉시 적용 UX)

**외부 영향**
- iOS 만 영향: Android 도 같은 SDK 가 도는 환경이라면 동일 동작(현재 우리 채널은 iOS 위주)
- 웹(`UpdateBanner`)/데스크탑(`DesktopUpdateBanner`)/App Store 모달(`AppStoreUpdatePrompt`) — 별도 채널이라 이번 변경 무영향
- 서버 `/api/updates/check` 엔드포인트 변경 없음 — 클라이언트만 즉시 적용 모드로 전환

## 검증
- [x] `client` tsc 통과 (capacitor.config 타입 `@capacitor/cli` 의 `CapacitorConfig` 와 호환 — `@capgo/capacitor-updater ^8.47.9` 에서 `directUpdate` 옵션 정식 지원)
- [ ] 첫 번들 콜드 스타트 → 두 번째 콜드 스타트 시 새 번들 즉시 활성화 확인 (다음 OTA 배포 시점)
- [ ] 깨진 번들이 우연히 배포돼도 10초 후 자동 롤백 확인

Closes #880
