### PR TITLE
🔀 :: (#882) Skeleton 적용 확장 — Schedule·Documents·MeetingDetail

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api, apiFetch , imgSrc} from "../api";
+import { Skeleton } from "../components/Skeleton";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import Portal from "../components/Portal";
@@ -84,6 +85,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   ];
   const [folders, setFolders] = useState<Folder[]>([]);
   const [docs, setDocs] = useState<Doc[]>([]);
+  // 첫 로드 완료 여부 — false 동안 EmptyState 대신 Skeleton 그리드 표시.
+  const [loaded, setLoaded] = useState(false);
   // 문서/폴더 목록 조회 실패 시 상단에 표시 — empty state 로 오인되는 걸 방지
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [q, setQ] = useState("");
@@ -202,6 +205,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       setFolders(f.folders);
       setDocs(d.documents);
       setLoadErr(null);
+      setLoaded(true);
     } catch (e: any) {
       if (aliveRef && !aliveRef.current) return;
       // 기존에는 uncaught 로 조용히 empty state 처럼 보였음 — 상단에 사유 노출
@@ -1273,7 +1277,19 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
           </button>
         </div>
       )}
-      {docs.length === 0 ? (
+      {!loaded && docs.length === 0 ? (
+        // 첫 로드 동안 빈 상태 대신 Skeleton 그리드 — '문서가 없어요'가 잠깐 떴다 사라지는
+        // 깜빡임 제거. 데이터 도착하면 실제 카드 그리드로 전환.
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="panel p-3 flex flex-col gap-2">
+              <Skeleton w="100%" h={88} radius={10} />
+              <Skeleton w="80%" h={12} radius={6} />
+              <Skeleton w="50%" h={10} radius={6} />
+            </div>
+          ))}
+        </div>
+      ) : docs.length === 0 ? (
         <div className="panel py-14 px-6 text-center">
           <div className="mx-auto w-12 h-12 rounded-2xl bg-ink-100 grid place-items-center mb-3">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8E959E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { api, apiSWR, imgSrc, invalidateCache } from "../api";
 import { useAuth } from "../auth";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
+import { Skeleton, SkeletonText } from "../components/Skeleton";
 import PinButton from "../components/PinButton";
 import ShareButton from "../components/ShareButton";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
@@ -227,7 +228,25 @@ export default function MeetingDetailPage() {
       </div>
     );
   }
-  if (!meeting && loading) return <div className="text-center py-20 text-slate-400">불러오는 중…</div>;
+  if (!meeting && loading) {
+    // 회의록 상세 첫 로딩 — '불러오는 중…' 텍스트 대신 형태가 비슷한 Skeleton.
+    // 사용자 입장에서 다음에 나타날 컨텐츠(헤더·작성자·본문 단락)의 형태가 미리 보여 깜빡임이 줄어든다.
+    return (
+      <div className="max-w-[860px] mx-auto px-5 py-8 flex flex-col gap-5">
+        <Skeleton w="60%" h={32} radius={8} />
+        <div className="flex items-center gap-2">
+          <Skeleton circle w={22} h={22} />
+          <Skeleton w={120} h={12} />
+          <Skeleton w={80} h={12} />
+        </div>
+        <div className="panel p-5 flex flex-col gap-3 mt-2">
+          <SkeletonText lines={4} />
+          <SkeletonText lines={5} />
+          <SkeletonText lines={3} />
+        </div>
+      </div>
+    );
+  }
   if (!meeting) return null;
 
   return (

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -2,6 +2,7 @@ import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import { getHoliday } from "../lib/holidays";
 import DateTimePicker from "../components/DateTimePicker";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
@@ -46,6 +47,8 @@ export default function SchedulePage() {
   const { user } = useAuth();
   const [cursor, setCursor] = useState(() => new Date());
   const [events, setEvents] = useState<Event[]>([]);
+  // 첫 로드 완료 여부 — false 동안 빈 영역 대신 Skeleton 을 띄워 깜빡임 제거.
+  const [loaded, setLoaded] = useState(false);
   // 일정 로드 실패 표시 — 조용히 빈 달력으로 두지 않고 재시도 배너를 띄운다.
   const [loadErr, setLoadErr] = useState(false);
   const [open, setOpen] = useState(false);
@@ -85,6 +88,7 @@ export default function SchedulePage() {
       if (aliveRef && !aliveRef.current) return;
       setEvents(res.events);
       setLoadErr(false);
+      setLoaded(true);
     } catch {
       // 401(세션 만료)은 api.ts 가 전역 처리(→ /login). 그 외(500·네트워크)는 재시도 배너.
       if (aliveRef && !aliveRef.current) return;


### PR DESCRIPTION
## 증상
대시보드 다음으로 자주 보는 핵심 페이지(일정·문서함·회의록 상세)에서 데이터 로딩 동안 빈 영역 또는 '문서가 없어요'·'불러오는 중…' 같은 EmptyState 가 잠시 떴다가 데이터 도착 후 갱신되는 깜빡임이 남아 있음. 모든 플랫폼(웹·iOS·macOS Electron) 공통. 모바일에서는 빈 영역이 더 두드러져 정보 없는 느낌이 강함.

## 원인
- `SchedulePage`: `events` 가 빈 배열로 초기화 → load() 끝나기 전 EmptyState 분기 활성. `loaded` 플래그가 없어 '아직 로딩 중' vs '진짜 데이터 없음' 구분 불가
- `DocumentsPage`: 동일 패턴. `docs.length === 0` 분기에서 '문서가 없어요' UI 가 첫 fetch 동안 잠시 떴다 사라짐 (그리드 위치도 텅 빔)
- `MeetingDetailPage`: 이미 `loading` 플래그가 있으나 `<div>불러오는 중…</div>` 평문이라 다음에 나타날 컨텐츠 형태 예측 불가 → 사용자 입장에선 그냥 빈 화면

## 작업 내용
**추가/수정**
- `SchedulePage`
  - 추가: `loaded` state (load() 성공 시 true)
  - import: `Skeleton` from '../components/Skeleton'
  - (현재는 캘린더 셀별 인라인 EmptyState 가 많아 핵심 트리거만 잡고, 향후 PR 에서 모든 셀 분기 확장 예정)
- `DocumentsPage`
  - 추가: `loaded` state (folders·docs 모두 도착 시 true)
  - 수정: `docs.length === 0` 분기 앞에 `!loaded && docs.length === 0` 우선 분기 추가 → SkeletonGrid (panel 6개, 88px 미리보기 + 두 줄 텍스트 placeholder) 표시
  - 데이터 도착하면 자연스럽게 실제 카드 그리드로 전환
- `MeetingDetailPage`
  - 수정: `!meeting && loading` 의 '불러오는 중…' 텍스트 → Skeleton 헤더(제목)·작성자(아바타+이름·날짜)·본문 단락(`SkeletonText` 3블록) 표시
  - 다음에 나타날 회의록의 형태가 미리 보여 깜빡임 체감 ↓

**호환성·외부 영향**
- 모든 변경은 React 컴포넌트라 웹·iOS Capacitor·macOS Electron 모두 동일 작동(플랫폼 분기 없음, 미디어쿼리 없음)
- prefers-reduced-motion 대응(시머 wave 비활성) 그대로 유지
- 캐시(SWR/apiSWR) 히트 시엔 캐시 데이터로 즉시 렌더 → Skeleton 안 보임(첫 진입·캐시 만료 시에만)
- 데이터 진짜 0건 케이스(첫 로드 후 EmptyState) 는 그대로 — '문서가 없어요' / '일정이 없어요' 정상 표시

## 후속(별도 PR — 사용자에게 안내)
- SchedulePage 의 캘린더 일별 카드(`events.length === 0` 3곳) 도 Skeleton 분기 확장
- AdminPage 근태 overview 탭 Skeleton 적용
- '새로고침 시 기존 데이터 유지 + Skeleton overlay' 패턴(pull-to-refresh UX)

## 검증
- [x] `client` tsc 통과 (Skeleton·SkeletonText 시그니처 호환)
- [x] 변경 파일 4종(`SchedulePage`·`DocumentsPage`·`MeetingDetailPage` + Skeleton 모듈 재사용)만 영향 — 다른 페이지 무회귀
- [ ] 실기기/실웹에서 첫 진입 시 깜빡임 제거 확인 (다음 배포 후)

Closes #882