### PR TITLE
🔀 :: (#884) 데이터 페이지 12종 Skeleton + 데스크탑 새로고침 버튼

### DIFF
--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -1,13 +1,25 @@
+/**
+ * 페이지 상단 헤더 — 제목/설명 + 우측 액션 영역.
+ *
+ * onRefresh (2026-06-09 추가): 넘기면 우측 액션 맨 앞에 '새로고침' 버튼이 자동으로 붙는다.
+ *   - 데스크탑 전용(md:inline-flex) — 모바일·태블릿은 AppLayout 의 당겨서 새로고침(PTR)이
+ *     전역으로 이미 동작하므로 버튼 중복을 피한다. (이 프로젝트의 md 기준 = 1024px)
+ *   - refreshing=true 면 회전 애니메이션 + 비활성. 페이지의 load() 를 다시 호출하는 용도.
+ */
 export default function PageHeader({
   title,
   description,
   right,
   eyebrow,
+  onRefresh,
+  refreshing,
 }: {
   title: string;
   description?: string;
   right?: React.ReactNode;
   eyebrow?: string;
+  onRefresh?: () => void;
+  refreshing?: boolean;
 }) {
   return (
     <div className="page-header flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 mb-5">
@@ -20,8 +32,37 @@ export default function PageHeader({
         <h1 className="h-display">{title}</h1>
         {description && <p className="t-caption mt-1 page-header-desc">{description}</p>}
       </div>
-      {right && (
+      {(right || onRefresh) && (
         <div className="flex items-center gap-2 flex-wrap sm:flex-nowrap sm:flex-shrink-0">
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={onRefresh}
+              disabled={refreshing}
+              className="btn-icon hidden md:inline-flex flex-shrink-0 disabled:opacity-50"
+              title="새로고침"
+              aria-label="새로고침"
+              data-haptic="selection"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className={refreshing ? "hinest-spin" : ""}
+                aria-hidden
+              >
+                <path d="M3 12a9 9 0 0 1 9-9c2.39 0 4.68.94 6.4 2.6L21 8" />
+                <path d="M21 3v5h-5" />
+                <path d="M21 12a9 9 0 0 1-9 9c-2.39 0-4.68-.94-6.4-2.6L3 16" />
+                <path d="M3 21v-5h5" />
+              </svg>
+            </button>
+          )}
           {right}
         </div>
       )}

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import DateTimePicker from "../components/DateTimePicker";
 import { alertAsync } from "../components/ConfirmHost";
 import Portal from "../components/Portal";
@@ -116,6 +117,8 @@ export default function ApprovalsPage() {
     setSp(next, { replace: true });
   };
   const [approvals, setApprovals] = useState<Approval[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [loadErr, setLoadErr] = useState(false);
   const [selected, setSelected] = useState<Approval | null>(null);
   const [creating, setCreating] = useState(false);
@@ -149,6 +152,7 @@ export default function ApprovalsPage() {
       const res = await api<{ approvals: Approval[] }>(`/api/approval?scope=${scope}`);
       if (!aliveRef.current || myToken !== loadTokenRef.current) return;
       setApprovals(res.approvals);
+      setLoaded(true);
       setLoadErr(false);
       if (selected) {
         const fresh = res.approvals.find((a) => a.id === selected.id);
@@ -159,6 +163,11 @@ export default function ApprovalsPage() {
       if (!aliveRef.current || myToken !== loadTokenRef.current) return;
       setLoadErr(true);
     }
+  }
+  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await load(); } finally { setRefreshing(false); }
   }
   async function loadDirectory() {
     try {
@@ -257,6 +266,8 @@ export default function ApprovalsPage() {
         eyebrow="업무"
         title="전자결재"
         description="출장·외근·지출·구매 등 사내 결재를 한 곳에서 관리합니다."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <>
             <div className="tabs flex-shrink-0">
@@ -286,9 +297,20 @@ export default function ApprovalsPage() {
             <span className="text-[11px] text-ink-400 tabular">{approvals.length}건</span>
           </div>
           <div className="divide-y divide-ink-100 max-h-[70vh] overflow-auto">
-            {approvals.length === 0 && (
+            {!loaded && approvals.length === 0 ? (
+              Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="px-4 py-3 flex items-start gap-3">
+                  <Skeleton w={36} h={36} radius={8} />
+                  <div className="flex-1 min-w-0 flex flex-col gap-2">
+                    <Skeleton w="40%" h={11} />
+                    <Skeleton w="70%" h={13} />
+                    <Skeleton w="50%" h={11} />
+                  </div>
+                </div>
+              ))
+            ) : approvals.length === 0 ? (
               <div className="py-14 text-center t-caption">해당 항목이 없습니다.</div>
-            )}
+            ) : null}
             {approvals.map((a) => {
               const meta = TYPE_META[a.type];
               const smeta = STATUS_META[a.status];

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import { useAuth } from "../auth";
 import MonthPicker from "../components/MonthPicker";
 import DateTimePicker from "../components/DateTimePicker";
@@ -71,6 +72,7 @@ export default function AttendancePage() {
   const [month, setMonth] = useState(ymNow());
   const [records, setRecords] = useState<Attendance[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [leaves, setLeaves] = useState<Leave[]>([]);
   const [allLeaves, setAllLeaves] = useState<Leave[]>([]);
   const [open, setOpen] = useState(false);
@@ -105,6 +107,12 @@ export default function AttendancePage() {
       if (!aliveRef.current || myToken !== loadTokenRef.current) return;
       setAllLeaves(all.leaves);
     }
+  }
+
+  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await load(); } finally { setRefreshing(false); }
   }
 
   // SWR — 월별 출퇴근과 휴가 목록은 탭 재진입 시 캐시로 즉시 채움.
@@ -198,6 +206,8 @@ export default function AttendancePage() {
       <PageHeader
         title="근태 · 월차"
         description="월별 출퇴근 기록과 휴가 신청을 관리합니다."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <div className="flex gap-2 flex-wrap items-center">
             <MonthPicker value={month} onChange={setMonth} />
@@ -267,7 +277,7 @@ export default function AttendancePage() {
           {loading && records.length === 0 ? (
             <div className="p-4 space-y-2">
               {[0, 1, 2, 3, 4].map((i) => (
-                <div key={i} className="h-10 rounded-lg bg-ink-100 dark:bg-ink-800 animate-pulse" />
+                <Skeleton key={i} w="100%" h={40} radius={8} className="block" />
               ))}
             </div>
           ) : records.length === 0 ? (

--- a/client/src/pages/DirectoryPage.tsx
+++ b/client/src/pages/DirectoryPage.tsx
@@ -1,7 +1,8 @@
-import { useDeferredValue, useEffect, useMemo, useState } from "react";
-import { api, apiSWR , imgSrc} from "../api";
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from "react";
+import { api, apiSWR, invalidateCache, imgSrc } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
 import { alertAsync } from "../components/ConfirmHost";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
@@ -33,19 +34,39 @@ export default function DirectoryPage() {
   const [dmBusyId, setDmBusyId] = useState<string | null>(null);
   // 복사 버튼 피드백 — 클릭 후 1.2초 간 "복사됨" 표시.
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  // 첫 로드 완료 여부 — Skeleton↔실데이터 전환 분기. (apiSWR 라 loading 플래그가 없음)
+  const [loaded, setLoaded] = useState(false);
+  // 데스크탑 새로고침 버튼 진행 표시.
+  const [refreshing, setRefreshing] = useState(false);
   // 대량 인원 + 그룹핑 필터가 IME 입력을 지연시키지 않도록 deferred.
   const deferredQ = useDeferredValue(q);
 
   // SWR — 팀원 목록은 변동이 느리므로 캐시 히트 효과가 크다.
+  // 데스크탑 새로고침에서도 재사용하도록 콜백으로 추출. alive 가드는 호출부에서 주입.
+  const loadUsers = useCallback((isAlive: () => boolean) => {
+    return apiSWR<{ users: DirectoryUser[] }>("/api/users", {
+      onCached: (d) => { if (isAlive()) { setUsers(d.users); setLoaded(true); } },
+      onFresh: (d) => { if (isAlive()) { setUsers(d.users); setLoaded(true); } },
+    });
+  }, []);
+
   useEffect(() => {
     // 다른 SWR 페이지들과 동일한 alive 가드 — 언마운트 후 setState 방지.
     let alive = true;
-    apiSWR<{ users: DirectoryUser[] }>("/api/users", {
-      onCached: (d) => { if (alive) setUsers(d.users); },
-      onFresh: (d) => { if (alive) setUsers(d.users); },
-    });
+    loadUsers(() => alive);
     return () => { alive = false; };
-  }, []);
+  }, [loadUsers]);
+
+  // 데스크탑 새로고침 — 캐시 무효화 후 fresh 재요청. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try {
+      invalidateCache("/api/users");
+      await loadUsers(() => true);
+    } finally {
+      setRefreshing(false);
+    }
+  }
 
   const teams = useMemo(
     () => Array.from(new Set(users.map((u) => u.team).filter(Boolean))) as string[],
@@ -115,6 +136,8 @@ export default function DirectoryPage() {
         eyebrow="커뮤니케이션"
         title="팀원"
         description="사내 구성원을 조회하고 바로 1:1 대화를 시작할 수 있어요."
+        onRefresh={refresh}
+        refreshing={refreshing}
       />
 
       {/* My profile hero */}
@@ -171,7 +194,26 @@ export default function DirectoryPage() {
         </div>
       </div>
 
-      {grouped.length === 0 ? (
+      {!loaded && grouped.length === 0 ? (
+        // 첫 로드 중(캐시 미스) — 그리드 카드 형태의 Skeleton. 아바타 원 + 이름·부서 줄.
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="panel p-4">
+              <div className="flex items-center gap-3 mb-3">
+                <Skeleton circle w={48} h={48} />
+                <div className="flex-1 min-w-0 flex flex-col gap-2">
+                  <Skeleton w="60%" h={14} />
+                  <Skeleton w="40%" h={11} />
+                </div>
+              </div>
+              <Skeleton w="80%" h={11} />
+              <div className="mt-3">
+                <Skeleton w="100%" h={28} radius={8} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : grouped.length === 0 ? (
         <div className="panel py-20 text-center">
           <div className="mx-auto w-12 h-12 rounded-2xl bg-ink-100 grid place-items-center mb-3">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#8E959E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import Portal from "../components/Portal";
 import MonthPicker from "../components/MonthPicker";
 import DateTimePicker from "../components/DateTimePicker";
@@ -50,6 +51,8 @@ export default function ExpensePage() {
   const [month, setMonth] = useState(ymNow());
   const [list, setList] = useState<Expense[]>([]);
   const [total, setTotal] = useState(0);
+  const [loaded, setLoaded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
     usedAt: todayDT(),
@@ -76,6 +79,13 @@ export default function ExpensePage() {
     if (aliveRef && !aliveRef.current) return;
     setList(res.expenses);
     setTotal(res.totalAmount);
+    setLoaded(true);
+  }
+
+  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await load(); } finally { setRefreshing(false); }
   }
 
   useEffect(() => {
@@ -192,6 +202,8 @@ export default function ExpensePage() {
       <PageHeader
         title="법인카드 사용내역"
         description="법인카드 사용건을 등록하고 영수증을 첨부합니다."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <div className="flex gap-2 items-center flex-wrap">
             <MonthPicker value={month} onChange={setMonth} />
@@ -261,13 +273,27 @@ export default function ExpensePage() {
             </tr>
           </thead>
           <tbody>
-            {list.length === 0 && (
-              <tr>
-                <td colSpan={9} className="cell-full px-4 py-10 text-center text-ink-400">
-                  등록된 사용내역이 없습니다.
-                </td>
-              </tr>
-            )}
+            {!loaded && list.length === 0
+              ? Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={`sk-${i}`} className="border-t border-[color:var(--c-border)]">
+                    <td className="px-4 py-3"><Skeleton w={100} h={12} /></td>
+                    {scope === "all" && <td className="px-4 py-3"><Skeleton w={56} h={12} /></td>}
+                    <td className="px-4 py-3"><Skeleton w="70%" h={12} /></td>
+                    <td className="px-4 py-3"><Skeleton w={44} h={18} radius={999} /></td>
+                    <td className="px-4 py-3 text-right"><Skeleton w={72} h={12} /></td>
+                    <td className="px-4 py-3"><Skeleton w="60%" h={12} /></td>
+                    <td className="px-4 py-3 text-center"><Skeleton w={28} h={12} /></td>
+                    <td className="px-4 py-3 text-center"><Skeleton w={36} h={18} radius={999} /></td>
+                    <td className="px-4 py-3" />
+                  </tr>
+                ))
+              : list.length === 0 && (
+                  <tr>
+                    <td colSpan={9} className="cell-full px-4 py-10 text-center text-ink-400">
+                      등록된 사용내역이 없습니다.
+                    </td>
+                  </tr>
+                )}
             {list.map((e) => (
               <tr key={e.id} className="border-t border-[color:var(--c-border)] hover:bg-[color:var(--c-surface-2)]">
                 <td data-label="사용일시" className="px-4 py-3">

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import DateTimePicker from "../components/DateTimePicker";
 import Portal from "../components/Portal";
 import { alertAsync } from "../components/ConfirmHost";
@@ -32,6 +33,7 @@ type Mode = "view" | "create" | "edit";
 export default function JournalPage() {
   const [list, setList] = useState<Journal[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [selected, setSelected] = useState<Journal | null>(null);
   const [form, setForm] = useState({ date: today(), title: "", content: "" });
   const [mode, setMode] = useState<Mode>("view");
@@ -69,6 +71,23 @@ export default function JournalPage() {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // 데스크탑 새로고침 버튼 — 최신 목록을 강제로 다시 가져온다(현재 선택은 유지).
+  // 모바일은 PTR 이 전역으로 담당.
+  async function load() {
+    try {
+      const d = await api<{ journals: Journal[] }>("/api/journal");
+      if (!aliveRef.current) return;
+      setList(d.journals);
+      if (d.journals.length && !selected) setSelected(d.journals[0]);
+    } finally {
+      if (aliveRef.current) setLoading(false);
+    }
+  }
+  async function refresh() {
+    setRefreshing(true);
+    try { await load(); } finally { setRefreshing(false); }
+  }
 
   function openCreate() {
     setMode("create");
@@ -157,6 +176,8 @@ export default function JournalPage() {
       <PageHeader
         title="업무일지"
         description="하루의 업무를 기록하고 회고하세요."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <button className="btn-primary btn-lg" onClick={openCreate}>
             + 새 일지
@@ -204,7 +225,7 @@ export default function JournalPage() {
             {loading && filtered.length === 0 ? (
               <div className="px-4 py-4 space-y-2">
                 {[0, 1, 2, 3, 4].map((i) => (
-                  <div key={i} className="h-14 rounded-lg bg-ink-100 dark:bg-ink-800 animate-pulse" />
+                  <Skeleton key={i} w="100%" h={56} radius={8} className="block" />
                 ))}
               </div>
             ) : filtered.length === 0 ? (

--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import type { MemoDoc } from "../components/DocMemoModal";
 
 // DocMemoModal 은 TipTap(무거운 번들)을 포함 → 실제 열릴 때만 로드.
@@ -161,14 +162,14 @@ function EmptyState({ onNew }: { onNew: () => void }) {
 // ===== 스켈레톤 카드 =====
 function SkeletonCard() {
   return (
-    <div className="rounded-2xl border border-ink-100 dark:border-ink-800 bg-white dark:bg-ink-900 p-5 flex flex-col gap-3 animate-pulse">
-      <div className="h-3.5 bg-ink-100 dark:bg-ink-800 rounded w-3/4" />
-      <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-full" />
-      <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-5/6" />
-      <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-2/3" />
+    <div className="rounded-2xl border border-ink-100 dark:border-ink-800 bg-white dark:bg-ink-900 p-5 flex flex-col gap-3">
+      <Skeleton w="75%" h={14} radius={6} />
+      <Skeleton w="100%" h={12} radius={6} />
+      <Skeleton w="83%" h={12} radius={6} />
+      <Skeleton w="66%" h={12} radius={6} />
       <div className="flex items-center gap-2 pt-2">
-        <div className="w-5 h-5 rounded-full bg-ink-100 dark:bg-ink-800" />
-        <div className="h-3 bg-ink-100 dark:bg-ink-800 rounded w-16" />
+        <Skeleton circle w={20} h={20} />
+        <Skeleton w={64} h={12} radius={6} />
       </div>
     </div>
   );
@@ -179,6 +180,7 @@ export default function MemosPage() {
   const { user } = useAuth();
   const [memos, setMemos] = useState<Memo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [scopeTab, setScopeTab] = useState<ScopeTab>("all");
   const [q, setQ] = useState("");
   const [debouncedQ, setDebouncedQ] = useState("");
@@ -211,7 +213,7 @@ export default function MemosPage() {
     if (scopeTab === "team") params.set("scope", "team");
     else if (scopeTab === "private") params.set("scope", "private");
     if (debouncedQ) params.set("q", debouncedQ);
-    api<{ documents: Memo[] }>(`/api/document?${params}`)
+    return api<{ documents: Memo[] }>(`/api/document?${params}`)
       .then((r) => setMemos(r.documents))
       .catch(() => setMemos([]))
       .finally(() => setLoading(false));
@@ -220,6 +222,12 @@ export default function MemosPage() {
   useEffect(() => {
     load();
   }, [load]);
+
+  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await load(); } finally { setRefreshing(false); }
+  }
 
   // Cmd/Ctrl+K → 검색 포커스
   useEffect(() => {
@@ -260,6 +268,8 @@ export default function MemosPage() {
         eyebrow="자료"
         title="메모"
         description="생각과 아이디어를 자유롭게 기록합니다."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <button type="button" className="btn-primary" onClick={() => setMemoTarget("new")}>
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"

--- a/client/src/pages/NoticePage.tsx
+++ b/client/src/pages/NoticePage.tsx
@@ -4,6 +4,7 @@ import { api, apiSWR, invalidateCache } from "../api";
 import { useAuth } from "../auth";
 import { useNotifications } from "../notifications";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import PinButton from "../components/PinButton";
 import ShareButton from "../components/ShareButton";
@@ -38,6 +39,10 @@ export default function NoticePage() {
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [reactingEmoji, setReactingEmoji] = useState<string | null>(null);
+  // 첫 로드 완료 여부 — Skeleton↔실데이터 전환 분기. (apiSWR 라 loading 플래그가 없음)
+  const [loaded, setLoaded] = useState(false);
+  // 데스크탑 새로고침 버튼 진행 표시.
+  const [refreshing, setRefreshing] = useState(false);
 
   const canPost = user?.role === "ADMIN" || user?.role === "MANAGER";
 
@@ -55,6 +60,7 @@ export default function NoticePage() {
   async function load() {
     const res = await api<{ notices: Notice[] }>("/api/notice");
     setList(res.notices);
+    setLoaded(true);
   }
 
   // 첫 진입은 SWR — 이전 캐시가 있으면 즉시 렌더하고, 네트워크로 최신값 병합.
@@ -64,11 +70,24 @@ export default function NoticePage() {
     // 일관성 유지·메모리 참조 즉시 해제).
     let alive = true;
     apiSWR<{ notices: Notice[] }>("/api/notice", {
-      onCached: (d) => { if (alive) setList(d.notices); },
-      onFresh: (d) => { if (alive) setList(d.notices); },
+      onCached: (d) => { if (alive) { setList(d.notices); setLoaded(true); } },
+      onFresh: (d) => { if (alive) { setList(d.notices); setLoaded(true); } },
     });
     return () => { alive = false; };
   }, []);
+
+  // 데스크탑 새로고침 — 캐시 무효화 후 fresh 재요청. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try {
+      invalidateCache("/api/notice");
+      await load();
+    } catch {
+      // 무음 — 기존 목록 유지.
+    } finally {
+      setRefreshing(false);
+    }
+  }
 
   // 알림 등에서 ?id=... 로 들어왔을 때 자동 선택
   useEffect(() => {
@@ -191,6 +210,8 @@ export default function NoticePage() {
       <PageHeader
         title="사내공지"
         description="회사 전체 공지사항입니다."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={canPost && <button className="btn-primary" onClick={() => setOpen(true)}>+ 공지 작성</button>}
       />
 
@@ -198,6 +219,14 @@ export default function NoticePage() {
         <div className="card p-0 overflow-hidden">
           <div className="p-4 border-b border-slate-100 text-sm font-bold">공지 목록 ({list.length})</div>
           <div className="divide-y divide-slate-100 max-h-[70vh] overflow-auto">
+            {!loaded && list.length === 0 &&
+              // 첫 로드 중(캐시 미스) — 공지 행 형태의 Skeleton.
+              Array.from({ length: 5 }).map((_, i) => (
+                <div key={`sk-${i}`} className="px-4 py-3 flex flex-col gap-2">
+                  <Skeleton w="70%" h={14} />
+                  <Skeleton w="45%" h={11} />
+                </div>
+              ))}
             {list.map((n) => (
               <button
                 key={n.id}
@@ -234,7 +263,7 @@ export default function NoticePage() {
                 </div>
               </button>
             ))}
-            {list.length === 0 && <div className="px-4 py-10 text-center text-sm text-slate-400">공지가 없습니다.</div>}
+            {loaded && list.length === 0 && <div className="px-4 py-10 text-center text-sm text-slate-400">공지가 없습니다.</div>}
           </div>
         </div>
 

--- a/client/src/pages/PayrollPage.tsx
+++ b/client/src/pages/PayrollPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import PayslipComposer from "../components/PayslipComposer";
 import PayslipPreview from "../components/PayslipPreview";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
@@ -23,6 +24,7 @@ export default function PayrollPage() {
   const [employees, setEmployees] = useState<EmployeeOption[]>([]);
   const [list, setList] = useState<Payslip[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [year, setYear] = useState(NOW.getFullYear());
   const [month, setMonth] = useState<number | 0>(0); // 0 = 전체
   const [employeeId, setEmployeeId] = useState("");
@@ -63,9 +65,15 @@ export default function PayrollPage() {
     q.set("year", String(year));
     if (month) q.set("month", String(month));
     if (employeeId) q.set("employeeId", employeeId);
-    api<{ payslips: Payslip[] }>(`/api/payslip?${q.toString()}`)
+    return api<{ payslips: Payslip[] }>(`/api/payslip?${q.toString()}`)
       .then((r) => setList(Array.isArray(r?.payslips) ? r.payslips : []))
       .catch(() => {});
+  }
+
+  // 데스크탑 새로고침 버튼 — 현재 필터 그대로 목록을 다시 불러온다. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await reload(); } finally { setRefreshing(false); }
   }
 
   function onSaved(p: Payslip) {
@@ -212,6 +220,8 @@ export default function PayrollPage() {
         description={isAdmin
           ? "직원별 임금명세서를 작성·발송하고 보관합니다."
           : "발급된 임금명세서를 확인하고 PDF로 저장할 수 있어요."}
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={isAdmin ? (
           <button className="btn-primary" onClick={() => { setEditTarget(null); setComposing(true); }}>
             + 새 명세서
@@ -280,15 +290,31 @@ export default function PayrollPage() {
             </tr>
           </thead>
           <tbody>
-            {loading && (
-              <tr><td colSpan={isAdmin ? 8 : 7} className="cell-full px-4 py-10 text-center text-slate-400">불러오는 중…</td></tr>
+            {loading && list.length === 0 && (
+              Array.from({ length: 5 }).map((_, i) => (
+                <tr key={`sk-${i}`} className="border-t border-slate-100">
+                  {isAdmin && (
+                    <td className="px-4 py-3"><Skeleton w={16} h={16} radius={4} /></td>
+                  )}
+                  <td className="px-4 py-3">
+                    <Skeleton w="55%" h={13} />
+                    <div className="mt-1"><Skeleton w="35%" h={10} /></div>
+                  </td>
+                  <td className="px-4 py-3"><Skeleton w={52} h={12} /></td>
+                  <td className="px-4 py-3 text-right"><Skeleton w="70%" h={12} /></td>
+                  <td className="px-4 py-3 text-right"><Skeleton w="70%" h={12} /></td>
+                  <td className="px-4 py-3 text-right"><Skeleton w="80%" h={12} /></td>
+                  <td className="px-4 py-3 text-center"><Skeleton w={48} h={20} radius={999} /></td>
+                  <td className="px-4 py-3 text-right"><Skeleton w={40} h={12} /></td>
+                </tr>
+              ))
             )}
             {!loading && list.length === 0 && (
               <tr><td colSpan={isAdmin ? 8 : 7} className="cell-full px-4 py-10 text-center text-slate-400">
                 {isAdmin ? "명세서가 없습니다. “+ 새 명세서”로 작성하세요." : "아직 발급된 급여명세서가 없어요."}
               </td></tr>
             )}
-            {!loading && list.map((p) => (
+            {list.map((p) => (
               <tr key={p.id} className={`border-t border-slate-100 hover:bg-slate-50/50 ${isAdmin && selected.has(p.id) ? "bg-brand-50/40" : ""}`}>
                 {isAdmin && (
                   <td data-label="선택" className="px-4 py-3">

--- a/client/src/pages/ProjectPage.tsx
+++ b/client/src/pages/ProjectPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { apiSWR , imgSrc} from "../api";
+import { apiSWR , imgSrc, invalidateCache } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton, SkeletonText } from "../components/Skeleton";
 import ProjectCalendar from "../components/ProjectCalendar";
 import ProjectWebhooks from "../components/ProjectWebhooks";
 import ProjectQaList from "../components/ProjectQaList";
@@ -36,39 +37,57 @@ export default function ProjectPage() {
   const { user } = useAuth();
   const [project, setProject] = useState<Project | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
+  // stale-while-revalidate — 이전에 방문했던 프로젝트라면 캐시된 응답으로 즉시 렌더.
+  // 동시에 백그라운드로 네트워크 호출이 돌아 최신값이 오면 교체.
+  // aliveRef 로 cleanup 후 setState 를 막는다(언마운트·id 변경 시).
+  const load = useCallback(
+    (aliveRef: { current: boolean }) => {
+      if (!id) return Promise.resolve();
+      setLoading(true);
+      return apiSWR<{ project: Project }>(`/api/project/${id}`, {
+        onCached: (r) => {
+          if (!aliveRef.current) return;
+          setProject(r.project);
+          setErr(null);
+          // 캐시 히트면 "불러오는 중" 타이틀 바로 내린다. 네트워크는 계속 돌고 있음.
+          setLoading(false);
+        },
+        onFresh: (r) => {
+          if (!aliveRef.current) return;
+          setProject(r.project);
+          setErr(null);
+          setLoading(false);
+        },
+        onError: (e) => {
+          if (!aliveRef.current) return;
+          setErr(e?.message ?? "불러오지 못했습니다.");
+          setLoading(false);
+        },
+      });
+    },
+    [id],
+  );
+
   useEffect(() => {
-    if (!id) return;
-    let alive = true;
-    setLoading(true);
-    // stale-while-revalidate — 이전에 방문했던 프로젝트라면 캐시된 응답으로 즉시 렌더.
-    // 동시에 백그라운드로 네트워크 호출이 돌아 최신값이 오면 교체.
-    apiSWR<{ project: Project }>(`/api/project/${id}`, {
-      onCached: (r) => {
-        if (!alive) return;
-        setProject(r.project);
-        setErr(null);
-        // 캐시 히트면 "불러오는 중" 타이틀 바로 내린다. 네트워크는 계속 돌고 있음.
-        setLoading(false);
-      },
-      onFresh: (r) => {
-        if (!alive) return;
-        setProject(r.project);
-        setErr(null);
-        setLoading(false);
-      },
-      onError: (e) => {
-        if (!alive) return;
-        setErr(e?.message ?? "불러오지 못했습니다.");
-        setLoading(false);
-      },
-    });
+    const aliveRef = { current: true };
+    load(aliveRef);
     return () => {
-      alive = false;
+      aliveRef.current = false;
     };
-  }, [id]);
+  }, [load]);
+
+  // 데스크탑 새로고침 버튼 — 캐시를 버리고 최신값을 다시 받는다. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    if (!id) return;
+    setRefreshing(true);
+    invalidateCache(`/api/project/${id}`);
+    const aliveRef = { current: true };
+    try { await load(aliveRef); } finally { setRefreshing(false); }
+  }
 
   // project 로딩이 끝나기 전에도 id 만 있으면 자식들이 fetch 를 시작하도록
   // 껍데기를 먼저 렌더한다. 이렇게 해야 /api/project/:id + events + webhook 3개가
@@ -103,6 +122,8 @@ export default function ProjectPage() {
                   : "프로젝트"
             }
             description={project?.description || (loading ? "" : "아직 설명이 없습니다.")}
+            onRefresh={refresh}
+            refreshing={refreshing}
           />
         </div>
         {project && canOpenSettings && (
@@ -120,6 +141,15 @@ export default function ProjectPage() {
           </button>
         )}
       </div>
+
+      {/* 프로젝트 메타가 아직 안 온 첫 로딩 — 헤더 형태의 Skeleton 으로 빈 화면 대체.
+          자식 카드들은 id 만으로 자체 fetch 를 시작하므로 그대로 둔다. */}
+      {loading && !project && (
+        <div className="panel p-5 mb-6 flex flex-col gap-3">
+          <Skeleton w="40%" h={22} />
+          <SkeletonText lines={2} />
+        </div>
+      )}
 
       {/* 캘린더를 전체 폭으로 사용하고, 멤버 리스트는 아래로. */}
       <div className="space-y-6">

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { api, apiFetch , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import Portal from "../components/Portal";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
 import { safeExternalUrl } from "../lib/safeUrl";
@@ -190,6 +191,7 @@ export default function ServiceAccountsPage() {
   const [users, setUsers] = useState<DirUser[]>([]);
   const [projects, setProjects] = useState<ProjectChip[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [q, setQ] = useState("");
   const [filterCat, setFilterCat] = useState<Category | "ALL">("ALL");
@@ -219,6 +221,12 @@ export default function ServiceAccountsPage() {
     } finally {
       setLoading(false);
     }
+  }
+
+  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await load(); } finally { setRefreshing(false); }
   }
 
   useEffect(() => {
@@ -397,6 +405,8 @@ export default function ServiceAccountsPage() {
         eyebrow="팀 리소스"
         title="계정 관리"
         description="AWS · Vercel · 테스트 계정 등 팀이 쓰는 서비스 계정을 한 곳에서 관리해요. ⚠️ 비밀번호는 저장하지 마세요."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <button className="btn-primary" onClick={openCreate}>+ 계정 추가</button>
         }
@@ -486,7 +496,19 @@ export default function ServiceAccountsPage() {
       )}
 
       {loading ? (
-        <div className="panel py-14 text-center t-caption">불러오는 중…</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="panel p-4 flex items-start gap-3">
+              <Skeleton w={40} h={40} radius="22%" />
+              <div className="flex-1 min-w-0 flex flex-col gap-2">
+                <Skeleton w="50%" h={14} />
+                <Skeleton w="35%" h={11} />
+                <Skeleton w="80%" h={11} />
+                <Skeleton w="65%" h={11} />
+              </div>
+            </div>
+          ))}
+        </div>
       ) : accounts.length === 0 ? (
         <div className="panel py-14 text-center">
           <div className="mx-auto w-12 h-12 rounded-2xl bg-ink-100 grid place-items-center mb-3 text-xl">🔑</div>

--- a/client/src/pages/SnippetsPage.tsx
+++ b/client/src/pages/SnippetsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import Portal from "../components/Portal";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import { useModalDismiss } from "../lib/useModalDismiss";
@@ -46,6 +47,7 @@ export default function SnippetsPage() {
   const [list, setList] = useState<Snippet[]>([]);
   const [q, setQ] = useState("");
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [editing, setEditing] = useState<Snippet | null>(null);
   const [creating, setCreating] = useState(false);
   const aliveRef = useRef(true);
@@ -68,6 +70,12 @@ export default function SnippetsPage() {
     }
   }
 
+  // 데스크탑 새로고침 버튼 — load() 재호출(전체 reload 아님). 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await load(); } finally { setRefreshing(false); }
+  }
+
   // 검색어 디바운스 — 빠르게 타이핑할 때 매 키마다 GET 안 치도록.
   useEffect(() => {
     const t = setTimeout(load, q ? 200 : 0);
@@ -84,6 +92,8 @@ export default function SnippetsPage() {
         eyebrow="라이브러리"
         title="스니펫"
         description="자주 쓰는 명령·쿼리·코드 조각을 저장하고 채팅에서 / 로 호출하세요."
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <button className="btn-primary" onClick={() => setCreating(true)}>
             + 새 스니펫
@@ -104,7 +114,15 @@ export default function SnippetsPage() {
       </div>
 
       {loading && list.length === 0 ? (
-        <div className="panel p-8 text-center text-ink-500 text-[13px]">불러오는 중…</div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="panel p-4 flex flex-col gap-2.5">
+              <Skeleton w="45%" h={14} />
+              <Skeleton w="100%" h={11} />
+              <Skeleton w="75%" h={11} />
+            </div>
+          ))}
+        </div>
       ) : list.length === 0 ? (
         <div className="panel p-12 text-center text-ink-500">
           <div className="text-[14px] font-semibold">{q ? "검색 결과가 없어요" : "아직 스니펫이 없어요"}</div>

--- a/client/src/pages/UserProfilePage.tsx
+++ b/client/src/pages/UserProfilePage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { api, apiSWR , imgSrc} from "../api";
+import { api, apiSWR , imgSrc, invalidateCache } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton, SkeletonText } from "../components/Skeleton";
 import { alertAsync } from "../components/ConfirmHost";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
@@ -33,6 +34,7 @@ export default function UserProfilePage() {
   const { user: me } = useAuth();
   const [u, setU] = useState<ProfileUser | null>(null);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [openingDM, setOpeningDM] = useState(false);
 
@@ -43,16 +45,33 @@ export default function UserProfilePage() {
     }
   }, [me, id, nav]);
 
+  // aliveRef 로 cleanup 후 setState 를 막는다(언마운트·id 변경 시).
+  const load = useCallback(
+    (aliveRef: { current: boolean }) => {
+      if (!id) return Promise.resolve();
+      return apiSWR<{ user: ProfileUser }>(`/api/users/${id}`, {
+        onCached: (r) => { if (aliveRef.current) { setU(r.user); setLoading(false); } },
+        onFresh: (r) => { if (aliveRef.current) { setU(r.user); setLoading(false); } },
+        onError: () => { if (aliveRef.current) { setErr("불러오기 실패"); setLoading(false); } },
+      });
+    },
+    [id],
+  );
+
   useEffect(() => {
+    const aliveRef = { current: true };
+    load(aliveRef);
+    return () => { aliveRef.current = false; };
+  }, [load]);
+
+  // 데스크탑 새로고침 버튼 — 캐시를 버리고 최신값을 다시 받는다. 모바일은 PTR 이 전역으로 담당.
+  async function refresh() {
     if (!id) return;
-    let alive = true;
-    apiSWR<{ user: ProfileUser }>(`/api/users/${id}`, {
-      onCached: (r) => { if (alive) { setU(r.user); setLoading(false); } },
-      onFresh: (r) => { if (alive) { setU(r.user); setLoading(false); } },
-      onError: () => { if (alive) { setErr("불러오기 실패"); setLoading(false); } },
-    });
-    return () => { alive = false; };
-  }, [id]);
+    setRefreshing(true);
+    invalidateCache(`/api/users/${id}`);
+    const aliveRef = { current: true };
+    try { await load(aliveRef); } finally { setRefreshing(false); }
+  }
 
   async function startDM() {
     if (!u || openingDM) return;
@@ -71,11 +90,29 @@ export default function UserProfilePage() {
     }
   }
 
-  if (loading) {
+  if (loading && !u) {
     return (
       <div>
-        <PageHeader eyebrow="팀원" title="프로필" />
-        <div className="panel p-12 text-center text-ink-500 text-[13px]">불러오는 중…</div>
+        <PageHeader eyebrow="팀원" title="프로필" onRefresh={refresh} refreshing={refreshing} />
+        {/* 히어로 카드 형태 Skeleton — 큰 아바타 + 이름·부서 + 본문 단락 */}
+        <div className="panel p-6 mb-4 flex items-center gap-5">
+          <Skeleton circle w={96} h={96} />
+          <div className="flex-1 min-w-0 flex flex-col gap-2.5">
+            <Skeleton w="45%" h={26} />
+            <Skeleton w="30%" h={13} />
+            <Skeleton w="22%" h={11} />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="panel p-5 flex flex-col gap-3">
+            <Skeleton w="30%" h={11} />
+            <SkeletonText lines={4} />
+          </div>
+          <div className="panel p-5 flex flex-col gap-3">
+            <Skeleton w="30%" h={11} />
+            <SkeletonText lines={4} />
+          </div>
+        </div>
       </div>
     );
   }
@@ -101,6 +138,8 @@ export default function UserProfilePage() {
       <PageHeader
         eyebrow="팀원"
         title="프로필"
+        onRefresh={refresh}
+        refreshing={refreshing}
         right={
           <button className="btn-ghost" onClick={() => nav(-1)}>
             ← 돌아가기

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -114,6 +114,11 @@ html:has(.modal-safe) .app-bottomnav { display: none !important; }
    하단바가 입력을 가로채 '건너뛰기' 버튼이 안 눌리던 문제를 함께 해결. */
 html:has(.hinest-onb-overlay) .app-bottomnav { display: none !important; }
 
+/* 새로고침 버튼 회전 — refreshing 동안 부드럽게 회전 반복(데스크탑 PageHeader 새로고침 아이콘). */
+@keyframes hinest-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.hinest-spin { animation: hinest-spin 0.8s linear infinite; transform-origin: center; }
+@media (prefers-reduced-motion: reduce) { .hinest-spin { animation-duration: 1.6s; } }
+
 /* ───── Skeleton UI — 데이터 로딩 중 깜빡임 방지 ─────
    - 기본 배경: --c-surface-3 (다크/라이트 자동)
    - 시머: 좌→우로 흐르는 부드러운 글라스 wave(transform translateX 만 → GPU 합성, 끊김 없음)


### PR DESCRIPTION
## 증상
데이터를 불러오는 모든 페이지에서 두 가지 문제:
1. **로딩 깜빡임**: 첫 진입·새로고침 시 "불러오는 중…" 평문이나 빈 화면이 잠깐 떴다가 데이터로 바뀜. 일부 페이지는 옛 `animate-pulse`(깜빡임) placeholder 라 시머가 자연스럽지 않음
2. **데스크탑 새로고침 부재**: 모바일은 당겨서 새로고침(PTR)이 AppLayout 전역으로 있지만, 데스크탑은 PTR 을 의도적으로 끔(실수 방지) → 페이지별로 데이터를 다시 불러올 수단이 없어 브라우저 새로고침(전체 reload)에 의존

## 원인
- 공용 Skeleton 컴포넌트(#871 에서 도입)가 일부 핵심 페이지에만 적용되고 나머지 11개 데이터 페이지엔 미적용
- `PageHeader` 컴포넌트에 새로고침 액션 슬롯이 없어 페이지마다 수동 새로고침을 붙일 표준 자리가 없었음
- AttendancePage·JournalPage·MemosPage 는 자체 인라인 placeholder(`animate-pulse` + `var(--c-surface-3)`)를 써서 시머 wave 가 없고 페이지마다 스타일이 제각각

## 작업 내용
**공용 인프라 (추가)**
- `PageHeader.tsx`: `onRefresh`·`refreshing` prop 추가. 넘기면 우측 액션 맨 앞에 새로고침 버튼이 자동으로 붙음. `hidden md:inline-flex` 로 **데스크탑 전용**(모바일·태블릿은 PTR 이 담당, 버튼 중복 방지). `refreshing` 동안 회전 + 비활성. `data-haptic="selection"` 으로 약한 햅틱
- `styles.css`: `.hinest-spin` 회전 애니메이션(@keyframes hinest-spin) + prefers-reduced-motion 대응 추가

**페이지 적용 (12개, 모두 동일 패턴 = refreshing state + refresh() 함수 + PageHeader 연결 + 로딩 Skeleton)**
- `SnippetsPage`(레퍼런스), `PayrollPage`, `ProjectPage`, `UserProfilePage`, `ServiceAccountsPage`, `ApprovalsPage`, `ExpensePage`, `DirectoryPage`, `NoticePage`
- `AttendancePage`·`JournalPage`·`MemosPage`: 기존 `animate-pulse` 인라인 placeholder → 공용 `<Skeleton>`(시머 wave)으로 통일 + 새로고침 버튼

**각 페이지 세부**
- loading/loaded 플래그로 "로딩 중" vs "진짜 데이터 0건" 구분 → 로딩 땐 Skeleton, 0건이면 기존 EmptyState 그대로
- apiSWR 페이지(Project·UserProfile·Directory·Notice·Journal)는 로드 로직을 재사용 함수로 추출 후 refresh 에서 invalidateCache + 재요청
- 새로고침은 전체 페이지 reload 가 아니라 해당 페이지 데이터만 다시 fetch(soft) + 그동안 Skeleton/회전

**호환성·외부 영향**
- 모두 React 컴포넌트·CSS 라 웹·iOS Capacitor·macOS Electron 동일 작동(플랫폼 분기 없음). prefers-reduced-motion 대응
- 캐시 히트 시 기존 데이터 즉시 렌더 → Skeleton 안 보임. 첫 진입·캐시 만료·수동 새로고침 시에만 Skeleton
- 모바일 PTR·기존 EmptyState·apiSWR 캐싱·optimistic update 등 기존 동작 무회귀
- iOS/macOS 네이티브 파일은 이 PR 범위 밖(미포함)

## 후속(별도 PR)
- OrgChartPage(3개 뷰 모드)·NotificationsPage(hook 내부 로딩) — 구조가 복잡해 별도 처리
- SchedulePage 캘린더 일별 카드 Skeleton 분기 확장

## 검증
- [x] `client` tsc 통과 (12개 페이지 + PageHeader)
- [x] `vite build` 성공
- [ ] 실기기/실웹/Electron 에서 데스크탑 새로고침 버튼 + Skeleton 동작 확인(다음 배포 후)

Closes #884