### PR TITLE
🔀 :: (#886) OrgChart·Notifications Skeleton + 데스크탑 새로고침

### DIFF
--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useNotifications, type Notif } from "../notifications";
 import { NotifRow, navigateToNotif } from "../components/notifShared";
 import NotificationPrefsModal from "../components/NotificationPrefsModal";
+import { Skeleton } from "../components/Skeleton";
 
 /**
  * 전용 알림 페이지 — 주로 모바일에서 진입한다(벨을 누르면 드롭다운 대신 이 페이지로 이동).
@@ -14,11 +15,23 @@ export default function NotificationsPage() {
   const { bellItems, unread, reload, markRead } = useNotifications();
   const [tab, setTab] = useState<"all" | "unread">("all");
   const [prefsOpen, setPrefsOpen] = useState(false);
+  // 첫 reload 완료 여부 — useNotifications 훅이 loading 을 노출하지 않으므로 로컬로 추적.
+  // false 동안엔 빈 영역 대신 Skeleton 행을 띄워 깜빡임 제거.
+  const [loaded, setLoaded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   // 페이지 진입 시 최신 알림으로 한 번 갱신(프로바이더의 주기 폴링과 별개로 즉시 동기화).
   useEffect(() => {
-    reload();
+    let alive = true;
+    Promise.resolve(reload()).finally(() => { if (alive) setLoaded(true); });
+    return () => { alive = false; };
   }, [reload]);
+
+  // 데스크탑 새로고침 버튼 — 알림 목록만 다시 불러온다(전체 reload 아님). 모바일은 PTR 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await reload(); } finally { setRefreshing(false); }
+  }
 
   const visible = tab === "unread" ? bellItems.filter((n) => !n.readAt) : bellItems;
 
@@ -46,6 +59,20 @@ export default function NotificationsPage() {
               모두 읽음
             </button>
           )}
+          {/* 데스크탑 전용 새로고침 — 모바일은 PTR 이 담당하므로 hidden md:inline-flex. */}
+          <button
+            className="btn-icon !w-8 !h-8 hidden md:inline-flex disabled:opacity-50"
+            title="새로고침"
+            aria-label="새로고침"
+            onClick={refresh}
+            disabled={refreshing}
+            data-haptic="selection"
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" className={refreshing ? "hinest-spin" : ""} aria-hidden>
+              <path d="M3 12a9 9 0 0 1 9-9c2.39 0 4.68.94 6.4 2.6L21 8" /><path d="M21 3v5h-5" />
+              <path d="M21 12a9 9 0 0 1-9 9c-2.39 0-4.68-.94-6.4-2.6L3 16" /><path d="M3 21v-5h5" />
+            </svg>
+          </button>
           <button
             className="btn-icon !w-8 !h-8"
             title="알림 설정"
@@ -70,7 +97,20 @@ export default function NotificationsPage() {
 
       {/* 리스트 */}
       <div className="panel overflow-hidden">
-        {visible.length === 0 ? (
+        {!loaded && visible.length === 0 ? (
+          // 첫 로드 동안 — 알림 행 형태의 Skeleton(아바타 + 제목·시간 두 줄).
+          <div className="divide-y divide-[color:var(--c-border)]">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 px-4 py-3">
+                <Skeleton circle w={36} h={36} />
+                <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+                  <Skeleton w="70%" h={12} />
+                  <Skeleton w="40%" h={10} />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : visible.length === 0 ? (
           <div className="py-16 text-center">
             <div className="mx-auto w-11 h-11 rounded-xl bg-ink-100 grid place-items-center mb-2.5">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#8E959E" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
+import { Skeleton } from "../components/Skeleton";
 import { alertAsync } from "../components/ConfirmHost";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 
@@ -29,6 +30,8 @@ export default function OrgChartPage() {
   const navigate = useNavigate();
   const [users, setUsers] = useState<DirUser[]>([]);
   const [positions, setPositions] = useState<Position[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [dmBusyId, setDmBusyId] = useState<string | null>(null);
   const [view, setView] = useState<ViewMode>(() => {
     try {
@@ -55,6 +58,13 @@ export default function OrgChartPage() {
     const u = await api<{ users: DirUser[] }>("/api/users");
     if (!aliveRef.current) return;
     setUsers(u.users);
+    setLoaded(true);
+  }
+
+  // 데스크탑 새로고침 — 구성원 + 직급을 다시 불러온다(전체 reload 아님). 모바일은 PTR 담당.
+  async function refresh() {
+    setRefreshing(true);
+    try { await Promise.all([load(), loadPositions()]); } finally { setRefreshing(false); }
   }
 
   async function loadPositions() {
@@ -169,6 +179,8 @@ export default function OrgChartPage() {
         eyebrow="조직"
         title="조직도"
         description={totalDesc}
+        onRefresh={refresh}
+        refreshing={refreshing}
       />
 
       {/* 뷰 전환 탭 */}
@@ -178,14 +190,32 @@ export default function OrgChartPage() {
         <ViewTab active={view === "list"} onClick={() => setView("list")} label="팀 카드" hint="팀별 카드 리스트" />
       </div>
 
-      {view === "list" && (
-        <ListView grouped={grouped} meId={user?.id ?? null} dmBusyId={dmBusyId} onDM={startDM} onSchedule={scheduleWith} />
-      )}
-      {view === "tree" && (
-        <TeamTreeView grouped={grouped} rank={rank} meId={user?.id ?? null} dmBusyId={dmBusyId} onDM={startDM} onSchedule={scheduleWith} totalCount={orgUsers.length} />
-      )}
-      {view === "rank" && (
-        <RankTreeView byRank={byRank} meId={user?.id ?? null} dmBusyId={dmBusyId} onDM={startDM} onSchedule={scheduleWith} />
+      {!loaded && users.length === 0 ? (
+        // 첫 로드 동안 — 뷰 모드와 무관하게 구성원 카드 형태의 Skeleton 그리드.
+        // 데이터 도착하면 선택된 뷰(list/tree/rank)로 전환.
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="panel p-4 flex items-center gap-3">
+              <Skeleton circle w={40} h={40} />
+              <div className="flex-1 min-w-0 flex flex-col gap-2">
+                <Skeleton w="55%" h={13} />
+                <Skeleton w="35%" h={10} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <>
+          {view === "list" && (
+            <ListView grouped={grouped} meId={user?.id ?? null} dmBusyId={dmBusyId} onDM={startDM} onSchedule={scheduleWith} />
+          )}
+          {view === "tree" && (
+            <TeamTreeView grouped={grouped} rank={rank} meId={user?.id ?? null} dmBusyId={dmBusyId} onDM={startDM} onSchedule={scheduleWith} totalCount={orgUsers.length} />
+          )}
+          {view === "rank" && (
+            <RankTreeView byRank={byRank} meId={user?.id ?? null} dmBusyId={dmBusyId} onDM={startDM} onSchedule={scheduleWith} />
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## 증상
지난 PR(#885)에서 구조가 복잡해 제외했던 두 페이지에 로딩 깜빡임 + 데스크탑 새로고침 부재가 남아 있음:
- **OrgChartPage**(조직도): 첫 진입 시 3개 뷰 모드(직급 트리/팀 트리/팀 카드) 어디서든 데이터 오기 전 빈 화면. 데스크탑 새로고침 수단 없음
- **NotificationsPage**(알림): 첫 진입 시 알림 목록 오기 전 빈 영역. `useNotifications` 훅이 loading 을 노출하지 않아 로딩 상태 구분 불가. PageHeader 미사용이라 새로고침 버튼 자리도 없었음

## 원인
- OrgChartPage 는 users·positions 두 데이터 소스를 각각 load()/loadPositions() 로 받고, loaded 플래그가 없어 "로딩 중" vs "팀 0개" 구분 불가 → 첫 로드에 "팀이 없어요" 가 잠깐 노출될 수 있음
- NotificationsPage 는 useNotifications 훅의 bellItems 만 받고 훅 내부 로딩 상태를 밖으로 안 줌 → 페이지 레벨에서 첫 로드 완료 시점을 알 수 없었음
- 둘 다 PageHeader 의 onRefresh 슬롯(#885 도입)을 안 쓰거나(OrgChart) PageHeader 자체를 안 씀(Notifications)

## 작업 내용
**OrgChartPage (추가/수정)**
- `loaded`·`refreshing` state 추가. load() 성공 시 setLoaded(true)
- `refresh()` 함수: users·positions 를 Promise.all 로 동시 재요청(전체 reload 아님)
- PageHeader 에 `onRefresh`·`refreshing` 연결 → 데스크탑 새로고침 버튼
- 첫 로드 동안(`!loaded && users.length === 0`) 3개 뷰 공통으로 구성원 카드 Skeleton 그리드(아바타 circle + 이름·부서 2줄, 6개) 표시 → 데이터 도착 시 선택된 뷰로 전환. 기존 "팀이 없어요" EmptyState 는 진짜 0건일 때만

**NotificationsPage (추가/수정)**
- `loaded`·`refreshing` state 추가. 마운트 시 reload() Promise 완료되면 setLoaded(true)
- `refresh()` 함수: reload() 만 재호출(soft)
- 헤더 우측(설정 버튼 앞)에 데스크탑 전용 새로고침 버튼(`hidden md:inline-flex` + hinest-spin 회전 + selection 햅틱)
- 첫 로드 동안(`!loaded && visible.length === 0`) 알림 행 Skeleton(아바타 + 제목·시간 2줄, 6개) 표시. 기존 "알림이 없어요" EmptyState 는 로드 후 0건일 때만

**호환성·외부 영향**
- 모두 React 컴포넌트·CSS → 웹·iOS·macOS 동일. prefers-reduced-motion 대응(공용 Skeleton·hinest-spin)
- OrgChart 의 뷰 전환·DM·일정 잡기, Notifications 의 모두읽음·설정·markRead·navigateToNotif 등 기존 동작 무회귀
- 캐시/초기 데이터 있으면 Skeleton 안 보임(첫 로드·수동 새로고침 시에만)

## 검증
- [x] `client` tsc 통과
- [ ] 실기기/실웹/Electron 에서 두 페이지 Skeleton + 데스크탑 새로고침 동작 확인(다음 배포 후)

Closes #886