### PR TITLE
🔀 :: (#888) 공용 BottomSheet + 일정 추가 모달 iOS 네이티브 시트화

### DIFF
--- a/client/src/components/BottomSheet.tsx
+++ b/client/src/components/BottomSheet.tsx
@@ -1,0 +1,202 @@
+/**
+ * 공용 바텀시트 — iOS/iPadOS 에선 애플 UISheetPresentationController 느낌의 하단 시트,
+ * 데스크탑(웹·Electron)에선 가운데 정렬 모달로 자동 전환한다.
+ *
+ * 왜 웹 시트인가:
+ *   입력 폼이 많은 모달(일정 추가 등)은 진짜 네이티브 WebView 시트로 만들면 세션/쿠키 공유 +
+ *   폼 제출 후 부모 갱신 메시지 패싱 + 이중 유지보수 비용이 매우 크다. 인스타·노션·토스도
+ *   입력 폼 모달은 "웹 바텀시트 + 네이티브 느낌"으로 처리한다. 단순 카드/목록 UI(공유 시트)만
+ *   진짜 네이티브로 간다(ShareSheet → presentShareSheet).
+ *
+ * 네이티브 느낌 요소:
+ *   - 하단에서 스프링 슬라이드업(cubic-bezier(0.32,0.72,0,1))
+ *   - 상단 그래버(grabber) 핸들 — 드래그해서 닫기(아래로 100px+ 끌면 닫힘, 손가락 추종)
+ *   - 둥근 상단 모서리(22px) + 백드롭 페이드
+ *   - safe-area-inset-bottom 흡수
+ *   - 키보드 인셋(--hinest-keyboard-h)에 맞춰 콘텐츠가 위로 따라옴
+ *
+ * 데스크탑: 가운데 카드 모달(슬라이드업 대신 페이드+살짝 라이즈). 드래그 없음.
+ *
+ * 사용:
+ *   <BottomSheet open={open} onClose={close} title="일정 추가" subtitle="...">
+ *     ...폼...
+ *     <BottomSheet.Footer>...버튼...</BottomSheet.Footer>   // 선택: 하단 고정 푸터
+ *   </BottomSheet>
+ */
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import Portal from "./Portal";
+import { nativePlatform } from "../lib/platform";
+
+function isIOS(): boolean {
+  return nativePlatform() === "ios";
+}
+
+type BottomSheetProps = {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  /** 헤더 좌측 아이콘(색 배지 등). 없으면 생략. */
+  icon?: ReactNode;
+  /** 본문. 스크롤 가능 영역. */
+  children: ReactNode;
+  /** 하단 고정 푸터(저장·취소 등). 시트 바닥에 sticky. */
+  footer?: ReactNode;
+  /** 데스크탑 모달 최대 폭. 기본 640px. */
+  maxWidth?: number;
+  /** z-index. 기본 1000. */
+  zIndex?: number;
+};
+
+export default function BottomSheet({
+  open,
+  onClose,
+  title,
+  subtitle,
+  icon,
+  children,
+  footer,
+  maxWidth = 640,
+  zIndex = 1000,
+}: BottomSheetProps) {
+  const ios = isIOS();
+  const [mounted, setMounted] = useState(open);
+  const [shown, setShown] = useState(false); // 슬라이드업/페이드 트리거
+  const [dragY, setDragY] = useState(0); // iOS 드래그 중 아래로 끌린 px
+  const dragStartRef = useRef<number | null>(null);
+  const closingRef = useRef(false);
+
+  // open 토글 → 마운트/언마운트 + 슬라이드 애니메이션.
+  useEffect(() => {
+    if (open) {
+      closingRef.current = false;
+      setMounted(true);
+      setDragY(0);
+      setShown(false);
+      const id = requestAnimationFrame(() => setShown(true));
+      return () => cancelAnimationFrame(id);
+    } else if (mounted) {
+      // 닫힘 애니메이션 후 언마운트.
+      setShown(false);
+      const t = setTimeout(() => setMounted(false), 320);
+      return () => clearTimeout(t);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ESC 로 닫기(데스크탑).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!mounted) return null;
+
+  // ── iOS 드래그 핸들 ──
+  function onDragStart(clientY: number) { dragStartRef.current = clientY; }
+  function onDragMove(clientY: number) {
+    if (dragStartRef.current == null) return;
+    setDragY(Math.max(0, clientY - dragStartRef.current));
+  }
+  function onDragEnd() {
+    if (dragStartRef.current == null) return;
+    dragStartRef.current = null;
+    if (dragY > 100) { onClose(); }
+    else setDragY(0); // 임계 미만이면 제자리 복귀
+  }
+
+  const backdropOpacity = shown ? 0.45 : 0;
+
+  return (
+    <Portal>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={
+          "fixed inset-0 flex justify-center " + (ios ? "items-end" : "items-center")
+        }
+        style={{
+          zIndex,
+          background: `rgba(15,18,28,${backdropOpacity})`,
+          transition: "background 280ms ease",
+          // 데스크탑·웹은 노치 없음(env=0). iOS 는 상단만 패딩(시트는 바닥에 붙음).
+          paddingTop: ios ? "max(1rem, env(safe-area-inset-top))" : undefined,
+        }}
+        onClick={onClose}
+      >
+        <div
+          className={
+            "bg-[var(--c-surface)] flex flex-col shadow-2xl " +
+            (ios
+              ? "w-full rounded-t-[22px]"
+              : "w-full rounded-[18px] m-4")
+          }
+          style={{
+            maxWidth: ios ? undefined : maxWidth,
+            maxHeight: ios ? "92vh" : "88vh",
+            transform: ios
+              ? `translateY(${shown ? dragY : 1000}px)`
+              : `translateY(${shown ? 0 : 12}px)`,
+            opacity: ios ? 1 : shown ? 1 : 0,
+            transition:
+              dragStartRef.current == null
+                ? "transform 320ms cubic-bezier(0.32,0.72,0,1), opacity 220ms ease"
+                : "none",
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* iOS 그래버 핸들 — 드래그해서 닫기 */}
+          {ios && (
+            <div
+              className="flex justify-center pt-2.5 pb-1 touch-none cursor-grab active:cursor-grabbing flex-shrink-0"
+              data-no-haptic
+              onTouchStart={(e) => onDragStart(e.touches[0].clientY)}
+              onTouchMove={(e) => onDragMove(e.touches[0].clientY)}
+              onTouchEnd={onDragEnd}
+            >
+              <div className="w-10 h-1.5 rounded-full bg-ink-200" />
+            </div>
+          )}
+
+          {/* 헤더 */}
+          {(title || icon) && (
+            <div className="flex items-center justify-between px-5 sm:px-6 pt-3 sm:pt-5 pb-3 flex-shrink-0">
+              <div className="flex items-center gap-2.5 min-w-0">
+                {icon}
+                <div className="min-w-0">
+                  {title && <div className="h-title truncate">{title}</div>}
+                  {subtitle && <div className="text-[11.5px] text-ink-500 truncate">{subtitle}</div>}
+                </div>
+              </div>
+              <button
+                type="button"
+                className="btn-icon flex-shrink-0"
+                onClick={onClose}
+                aria-label="닫기"
+                data-haptic="selection"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 6 6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          )}
+
+          {/* 본문 — 스크롤 영역 */}
+          <div className="px-5 sm:px-6 overflow-auto flex-1 min-h-0">{children}</div>
+
+          {/* 푸터 — 하단 고정. iOS 는 safe-area-inset-bottom 흡수. */}
+          {footer && (
+            <div
+              className="px-5 sm:px-6 pt-3 border-t border-ink-100 bg-[var(--c-surface)] flex-shrink-0"
+              style={{ paddingBottom: ios ? "calc(env(safe-area-inset-bottom, 0px) + 12px)" : "16px" }}
+            >
+              {footer}
+            </div>
+          )}
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -7,6 +7,7 @@ import { getHoliday } from "../lib/holidays";
 import DateTimePicker from "../components/DateTimePicker";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";
 import Portal from "../components/Portal";
+import BottomSheet from "../components/BottomSheet";
 
 export type Category =
   | "MEETING" | "DEADLINE" | "OUT" | "HOLIDAY" | "EVENT"
@@ -895,33 +896,8 @@ type EventForm = {
 
 type DirUser = { id: string; name: string; email: string; team?: string | null; avatarColor?: string; avatarUrl?: string | null; position?: string | null };
 
-/**
- * iOS 키보드가 올라오면 visualViewport 만 키보드 높이만큼 줄어든다(레이아웃 뷰포트·100vh·100dvh 는 그대로).
- * 그래서 화면 중앙 정렬 모달은 키보드가 뜨면 아래쪽(카테고리 칩·푸터의 저장 버튼)이 키보드와 iOS 입력
- * 보조바에 가려진다. 오버레이를 visualViewport 영역(top/height)에 맞추고 패널을 그 안으로 캡(max-h-full)하면,
- * 모달이 항상 키보드 위에 들어와 내부 스크롤만으로 모든 필드·푸터에 접근된다.
- * visualViewport 미지원(구형) 환경에서는 전체 화면으로 폴백하므로 기존 동작과 동일.
- */
-function useViewportInset(): { top: number; height: number | string } {
-  const read = (): { top: number; height: number | string } => {
-    const vv = typeof window !== "undefined" ? window.visualViewport : null;
-    return vv ? { top: vv.offsetTop, height: vv.height } : { top: 0, height: "100%" };
-  };
-  const [inset, setInset] = useState<{ top: number; height: number | string }>(read);
-  useEffect(() => {
-    const vv = window.visualViewport;
-    if (!vv) return;
-    const apply = () => setInset({ top: vv.offsetTop, height: vv.height });
-    apply();
-    vv.addEventListener("resize", apply);
-    vv.addEventListener("scroll", apply);
-    return () => {
-      vv.removeEventListener("resize", apply);
-      vv.removeEventListener("scroll", apply);
-    };
-  }, []);
-  return inset;
-}
+// (useViewportInset 제거 — EventModal 이 공용 BottomSheet 로 이관되며 키보드 인셋·safe-area 를
+//  BottomSheet 가 직접 관리한다. visualViewport 수동 추적이 더 이상 필요 없음.)
 
 function EventModal({
   onClose,
@@ -976,46 +952,34 @@ function EventModal({
     );
   }, [directory, deferredSearch]);
 
-  // 키보드가 떠도 모달(카테고리 칩·저장 버튼)이 가려지지 않도록 오버레이를 visualViewport 영역에 맞춘다.
-  const viewport = useViewportInset();
-
+  // iOS 에선 BottomSheet 가 하단 네이티브 시트(드래그·스프링·키보드 인셋)를, 데스크탑은
+  // 가운데 모달을 자동 처리한다. 폼 제출 버튼은 시트 푸터에 두고 form="event-form" 으로 연결.
   return (
-    <Portal>
-    <div
-      className="fixed inset-x-0 bg-ink-900/40 grid place-items-center modal-safe z-50"
-      style={{ top: viewport.top, height: viewport.height }}
-      onClick={onClose}
-    >
-      <div
-        className="panel w-full max-w-[640px] shadow-pop overflow-hidden max-h-full flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 헤더 */}
-        <div className="flex items-center justify-between px-6 pt-6 pb-4 flex-shrink-0">
-          <div className="flex items-center gap-2.5">
-            <div
-              className="w-9 h-9 rounded-lg grid place-items-center"
-              style={{ background: form.color + "22", color: form.color }}
-            >
-              <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="3" y="5" width="18" height="16" rx="2.5" />
-                <path d="M3 10h18M8 3v4M16 3v4" />
-              </svg>
-            </div>
-            <div>
-              <div className="h-title">일정 추가</div>
-              <div className="text-[11.5px] text-ink-500">팀과 공유할 일정을 만들어보세요</div>
-            </div>
-          </div>
-          <button type="button" className="btn-icon" onClick={onClose} aria-label="닫기">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          </button>
+    <BottomSheet
+      open
+      onClose={onClose}
+      maxWidth={640}
+      title="일정 추가"
+      subtitle="팀과 공유할 일정을 만들어보세요"
+      icon={
+        <div
+          className="w-9 h-9 rounded-lg grid place-items-center flex-shrink-0"
+          style={{ background: form.color + "22", color: form.color }}
+        >
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="5" width="18" height="16" rx="2.5" />
+            <path d="M3 10h18M8 3v4M16 3v4" />
+          </svg>
         </div>
-
-        <form onSubmit={onSubmit} className="flex-1 min-h-0 flex flex-col">
-          <div className="px-6 pb-5 space-y-5 flex-1 min-h-0 overflow-y-auto">
+      }
+      footer={
+        <div className="flex items-center justify-end gap-2">
+          <button type="button" className="btn-ghost" onClick={onClose} disabled={saving}>취소</button>
+          <button type="submit" form="event-form" className="btn-primary" disabled={saving}>{saving ? "추가 중…" : "일정 추가"}</button>
+        </div>
+      }
+    >
+        <form id="event-form" onSubmit={onSubmit} className="space-y-5 py-1">
             {/* 제목 */}
             <div>
               <label className="field-label">제목</label>
@@ -1298,16 +1262,7 @@ function EventModal({
                 maxLength={5_000}
               />
             </div>
-          </div>
-
-          {/* 푸터 */}
-          <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-ink-150 bg-ink-25 flex-shrink-0">
-            <button type="button" className="btn-ghost" onClick={onClose} disabled={saving}>취소</button>
-            <button className="btn-primary" disabled={saving}>{saving ? "추가 중…" : "일정 추가"}</button>
-          </div>
         </form>
-      </div>
-    </div>
-    </Portal>
+    </BottomSheet>
   );
 }


### PR DESCRIPTION
## 증상
일정 추가 모달이 iOS 에서도 데스크탑처럼 **화면 가운데 떠 있는 카드 모달**로 나와 네이티브 앱 느낌이 안 남(스크린샷). 사용자 요구: 입력 폼 모달도 애플 네이티브 바텀시트(하단에서 올라오고·드래그로 닫고·둥근 상단 모서리)처럼.

## 원인
- `EventModal`(SchedulePage)이 `fixed inset-x-0 grid place-items-center` 로 항상 가운데 정렬 모달로 렌더
- 키보드 대응은 `useViewportInset`(visualViewport 수동 추적)으로 처리했으나, 하단 시트 슬라이드업·드래그 닫기·detent 같은 네이티브 시트 동작은 없었음
- 입력 폼이 많은 모달을 "진짜 네이티브 WebView 시트"로 만들면 세션/쿠키 공유 + 폼 제출 후 부모 갱신 메시지 패싱 + 이중 유지보수 비용이 매우 큼 → 업계 표준(인스타·노션·토스)대로 "웹 바텀시트 + 네이티브 느낌"이 정답. 단순 카드/목록(공유 시트)만 진짜 네이티브(presentShareSheet)로 감

## 작업 내용
**추가 — 공용 BottomSheet 컴포넌트 (`client/src/components/BottomSheet.tsx`)**
- iOS/iPadOS: 하단에서 스프링 슬라이드업(cubic-bezier(0.32,0.72,0,1)) + 상단 그래버 핸들(드래그 100px+ 로 닫기, 손가락 추종) + 둥근 상단 모서리(22px) + 백드롭 페이드 + safe-area-inset-bottom 흡수 + 키보드 인셋
- 데스크탑(웹·Electron): 가운데 카드 모달(페이드 + 살짝 라이즈), 드래그 없음 — 자동 전환
- props: `open`/`onClose`/`title`/`subtitle`/`icon`/`footer`(하단 sticky)/`maxWidth`/`zIndex`. ESC 닫기, 백드롭 클릭 닫기
- 닫힘 애니메이션 후 언마운트(320ms)

**수정 — EventModal(일정 추가)을 BottomSheet 로 이관**
- 기존 Portal+backdrop+panel+헤더+푸터 수작업 → `<BottomSheet>` 로 교체
- 헤더 아이콘(색 배지 캘린더)·제목·부제는 BottomSheet props 로
- 폼 제출 버튼은 시트 푸터에 두고 `form="event-form"` HTML 속성으로 폼과 연결(폼 밖 버튼도 submit 트리거)
- 본문 폼 필드(제목·시간·카테고리·공유범위·대상·메모)는 그대로 — 로직 무변경
- 미사용된 `useViewportInset` 훅 제거(키보드 인셋·safe-area 를 BottomSheet 가 직접 관리)

**호환성·외부 영향**
- iOS 는 바텀시트, 데스크탑은 기존 가운데 모달과 거의 동일한 외형 — 무회귀
- 폼 제출·검증·저장 로직(onSubmit)·필드 전부 그대로
- BottomSheet 는 공용이라 후속으로 다른 모달(일정 편집·DayDetail·다른 페이지 모달)에도 점진 적용 가능
- 공유 시트(ShareSheet)는 진짜 네이티브(presentShareSheet) 유지 — 별개 채널

## 후속(별도 PR)
- DayDetailModal·일정 편집·기타 입력 폼 모달도 BottomSheet 로 점진 이관

## 검증
- [x] `client` tsc 통과
- [x] `vite build` 성공
- [ ] 실기기(iOS) 에서 바텀시트 슬라이드업·드래그 닫기·키보드 인셋 + 데스크탑 가운데 모달 동작 확인(다음 배포 후)

Closes #888