### PR TITLE
🔀 :: (#891) iOS 폴더 ZIP 다운로드 실패 + 레거시 파일명 폴백

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -730,8 +730,11 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     if (!d.fileUrl) return;
     const url = new URL(d.fileUrl, window.location.origin);
     url.searchParams.set("download", "1");
-    if (d.fileName) url.searchParams.set("name", d.fileName);
-    downloadFromUrl(url.toString(), d.fileName ?? "");
+    // 파일명 힌트 — fileName 우선, 없으면 title 로 폴백(레거시 문서엔 fileName 이 비어 키 해시가
+    // 파일명이 되던 문제 방지). 둘 다 없으면 서버 Content-Disposition 으로 폴백.
+    const hint = d.fileName || d.title || "";
+    if (hint) url.searchParams.set("name", hint);
+    downloadFromUrl(url.toString(), hint);
   }
 
   // 미리보기 가능한 타입(이미지·PDF·영상)인가. 그 외(.docx·.pptx·.zip 등)는 미리보기 의미가 없어 다운로드.
@@ -757,6 +760,15 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   // 서버가 404/500 을 내면 새 탭에 JSON/빈페이지가 뜨고 사용자는 왜 안되는지 알 수 없었음.
   // fetch 로 받아 Blob 으로 내려받으면: 에러 시 JSON 본문을 파싱해 alertAsync 로 안내 가능.
   async function downloadFolder(f: Folder) {
+    // 네이티브(iOS/iPadOS): blob URL 은 인앱 브라우저(SFSafariViewController)가 못 연다 —
+    // 예전엔 fetch→blob→Browser.open(blob:) 라 폴더 ZIP 다운로드가 조용히 실패했다.
+    // 인증된 절대 URL(imgSrc 가 ?token= 부여)을 직접 열어 iOS 가 ZIP 다운로드/공유 시트를 띄우게 한다.
+    // (서버 /folders/:id/download 는 이 GET 한정으로 ?token= 인증을 허용하도록 했다.)
+    if (isCapacitorNative()) {
+      const u = imgSrc(`/api/document/folders/${f.id}/download`);
+      if (u) void Browser.open({ url: u }).catch(() => {});
+      return;
+    }
     try {
       const res = await apiFetch(`/api/document/folders/${f.id}/download`);
       if (!res.ok) {

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import archiver from "archiver";
 import { Prisma } from "@prisma/client";
 import { prisma } from "../lib/db.js";
-import { requireAuth, writeLog } from "../lib/auth.js";
+import { requireAuth, writeLog, queryTokenAuth } from "../lib/auth.js";
 import { downloadFile, isStorageEnabled } from "../lib/storage.js";
 import { UPLOAD_DIR } from "./upload.js";
 import { safeUniqueZipEntry } from "../lib/zipSafe.js";
@@ -11,6 +11,16 @@ import path from "node:path";
 import fs from "node:fs";
 
 const router = Router();
+// 폴더 ZIP 다운로드(GET)만 ?token= 쿼리 인증을 허용한다 — 네이티브 앱(Capacitor WKWebView)은
+// 인앱 브라우저로 URL 을 직접 열어 받는데, 그땐 Authorization 헤더·쿠키를 못 싣기 때문.
+// requireAuth 보다 먼저 ?token= → Bearer 로 승격해야 인증이 통과한다. 다른 라우트(특히 변경
+// 요청)엔 적용하지 않아 토큰이 URL/로그에 남는 노출 면을 다운로드 GET 하나로 한정한다.
+router.use((req, res, next) => {
+  if (req.method === "GET" && /\/folders\/[^/]+\/download\/?$/.test(req.path)) {
+    return queryTokenAuth(req, res, next);
+  }
+  next();
+});
 router.use(requireAuth);
 
 /* ===== 프로젝트 멤버십 검사 =====


### PR DESCRIPTION
## 증상
- **폴더 ZIP 다운로드가 iOS/iPadOS 앱에서 조용히 실패**: 버튼을 눌러도 아무 일도 안 일어남
- 일부 레거시 문서(파일명 메타 없음)는 다운로드 시 파일명이 스토리지 키 해시로 떨어짐

## 원인
- `downloadFolder` 는 `fetch → res.blob() → downloadBlob()` 흐름. `downloadBlob` 은 `URL.createObjectURL` 로 만든 `blob:` URL 을 `downloadFromUrl` 에 넘기는데, 네이티브(Capacitor WKWebView)에선 `Browser.open(blob:...)` 로 인앱 브라우저(SFSafariViewController)를 여는 경로를 탄다. **인앱 브라우저는 앱 메모리의 blob: URL 에 접근할 수 없어** 빈 화면/무반응이 됨. (웹·Electron 은 `<a download>` 라 정상)
- `downloadDoc` 의 파일명 힌트가 `d.fileName` 만 사용 → fileName 이 비어있는 레거시 문서는 `?name=` 이 안 붙어 서버 키(해시)가 파일명이 됨

## 작업 내용
**수정 — client `DocumentsPage.tsx`**
- `downloadFolder`: 네이티브면 `imgSrc("/api/document/folders/<id>/download")`(= `?token=` 부여된 절대 URL)를 `Browser.open` 으로 직접 열어 iOS 가 ZIP 다운로드/공유 시트를 띄우게 함. 웹·Electron 은 기존 fetch→blob 경로 유지(에러 시 JSON 파싱해 사유 안내)
- `downloadDoc`: 파일명 힌트를 `fileName || title` 로 폴백 → 레거시 문서도 사람이 읽을 이름으로 저장

**수정 — server `document.ts`**
- 폴더 ZIP 다운로드 라우트(GET `/folders/:id/download`)에 한해 `queryTokenAuth`(`?token=` → Bearer 승격)를 `requireAuth` **앞에** 적용. 네이티브가 헤더·쿠키 없이 URL 만으로 인증되게 함
- 변경 라우트는 이 GET 하나로 한정 — 토큰이 URL/로그에 남는 노출 면을 다운로드에만 국한(변경 요청엔 미적용)

**호환성·외부 영향**
- 웹·Electron 다운로드 동작 무변경(기존 경로 유지)
- 개별 파일 다운로드(`/uploads/<key>?download=1&name=`)는 기존대로 — 서버가 presigned URL + Content-Disposition 으로 원본명 보장
- 폴더 zip 파일명 보존(`fileName || title || key`)·ZIP slip 방어(safeUniqueZipEntry) 기존 유지

## 검증
- [x] `client` tsc + `vite build` 통과
- [x] `server` tsc 통과
- [ ] 실기기(iOS) 폴더 ZIP 다운로드 + 레거시 문서 파일명 확인(다음 배포 후)

Closes #891