### PR TITLE
🔀 :: (#896) async hang + 경비 수정 잠금 + 토큰 로그 스크럽 + dead 라우트 제거

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hinest-server",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hinest-server",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1033.0",
@@ -21,6 +21,7 @@
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "express": "^4.21.1",
+        "express-async-errors": "^3.1.1",
         "express-rate-limit": "^8.3.2",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -3560,6 +3561,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "license": "ISC",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-rate-limit": {

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "express": "^4.21.1",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^8.3.2",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,3 +1,8 @@
+// ★ 반드시 다른 import 보다 먼저 — Express 4 는 async 라우트 핸들러가 reject 하면 에러
+//   미들웨어로 흘려보내지 못해(동기 throw·next(err)만 처리) 응답이 안 가고 요청이 행(hang)한다.
+//   이 패키지가 Router 를 패치해 async 핸들러의 reject 를 자동으로 next(err) 로 전달 → 아래
+//   글로벌 에러 미들웨어가 500 JSON 을 응답하게 한다. (DB 순단·예외 시 30초 타임아웃 대신 즉시 에러)
+import "express-async-errors";
 import express from "express";
 import cors from "cors";
 import cookieParser from "cookie-parser";
@@ -247,7 +252,9 @@ app.use((req, res, next) => {
     if (res.statusCode >= 400 || originalUrl.startsWith("/api/auth/")) {
       const u = (req as any).user;
       const who = u ? `user=${u.email}(super=${u.superAdmin})` : "user=-";
-      console.log(`[${new Date().toISOString().slice(11, 19)}] ${req.method} ${originalUrl} → ${res.statusCode} ${who} (${Date.now() - started}ms)`);
+      // scrubUrl — ?token=/?password= 등 민감 쿼리값을 ●●● 로 마스킹(이 로그는 stdout→CloudWatch 로
+      // 흘러가므로 위 access 로거와 동일하게 스크럽해 토큰 평문 노출을 막는다).
+      console.log(`[${new Date().toISOString().slice(11, 19)}] ${req.method} ${scrubUrl(originalUrl)} → ${res.statusCode} ${who} (${Date.now() - started}ms)`);
     }
   });
   next();

--- a/server/src/routes/expense.ts
+++ b/server/src/routes/expense.ts
@@ -125,6 +125,12 @@ router.patch("/:id", async (req, res) => {
   }
 
   if (exist.userId !== u.id) return res.status(403).json({ error: "forbidden" });
+  // 승인·반려가 끝난 경비는 작성자라도 내용 수정 불가 — 승인 이력과 실제 값이 어긋나는
+  // 워크플로 무결성 훼손을 막는다(금액·상호·날짜 등을 사후 변경하는 행위 차단).
+  // 수정이 필요하면 관리자가 PENDING 으로 되돌린 뒤(위 status 분기) 다시 편집.
+  if (exist.status !== "PENDING") {
+    return res.status(409).json({ error: "이미 처리된 경비는 수정할 수 없어요. 관리자에게 상태 변경을 요청하세요." });
+  }
   const parsed = schema.partial().safeParse(body);
   if (!parsed.success) return res.status(400).json({ error: "invalid input" });
   const d = parsed.data;

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -186,27 +186,9 @@ function maskEmail(email: string): string {
   return `${head}***@${domain}`;
 }
 
-// 팀 목록 — 60초 in-process 캐시. 팀 목록은 관리자가 유저를 편집할 때만 바뀜.
-let _teamsCache: { teams: string[]; exp: number } | null = null;
-
-router.get("/teams", async (_req, res) => {
-  if (_teamsCache && _teamsCache.exp > Date.now()) {
-    res.setHeader("Cache-Control", "private, max-age=60");
-    return res.json({ teams: _teamsCache.teams });
-  }
-  const rows = await prisma.user.findMany({
-    where: { team: { not: null }, active: true },
-    select: { team: true },
-    distinct: ["team"],
-  });
-  const teams = rows.map((r) => r.team).filter(Boolean) as string[];
-  _teamsCache = { teams, exp: Date.now() + 60_000 };
-  res.setHeader("Cache-Control", "private, max-age=60");
-  res.json({ teams });
-});
-
-export function invalidateTeamsCache() {
-  _teamsCache = null;
-}
+// (GET /users/teams 제거 — router.get("/:id") 가 먼저 등록돼 "/teams" 가 id="teams" 로
+//  매칭되는 도달 불가(dead) 라우트였고, 모듈 전역 _teamsCache 는 companyId 키가 없어
+//  살아날 경우 회사 간 팀명 누수 위험이 있었다. 클라이언트는 팀 목록을 users 배열에서
+//  파생하므로 이 엔드포인트를 호출하지 않는다(OrgChartPage 주석 참고). 캐시·무효화 함수 함께 제거.)
 
 export default router;


### PR DESCRIPTION
## 증상
보안·기능 감사에서 발견된 서버측 안전성/무결성 이슈 4건:
1. **요청이 30초 행(hang)**: 라우트 핸들러에서 잡히지 않은 예외가 나면 응답이 안 가고 클라가 30초 타임아웃까지 매달림 — DB 순단·예외 시 적절한 에러 메시지 대신 무한 로딩
2. **승인된 경비를 작성자가 사후 수정 가능**: APPROVED/REJECTED 경비도 작성자가 금액·상호·날짜를 바꿀 수 있어 승인 이력과 실제 값이 어긋남
3. **CloudWatch 로그에 ?token= 평문**: 4xx/auth 요청 로거가 URL 을 raw 로 console.log → 세션 토큰이 평문으로 남을 수 있음
4. **dead 라우트 + 테넌트 누수 위험**: GET /users/teams 가 도달 불가(dead)인데 모듈 전역 캐시가 companyId 키 없이 회사 팀명을 캐시 — 라우트 순서가 바뀌면 회사 간 누수

## 원인
1. Express 4.21 은 async 핸들러의 reject 를 에러 미들웨어로 전달 못 함(동기 throw/next(err)만). `express-async-errors` 미설치 → unhandledRejection 이 로그만 찍고 응답 안 감
2. `expense.ts` 일반 수정 경로가 `exist.userId === u.id` 만 보고 `status` 미검사
3. `index.ts:255` 요청 로거가 `scrubUrl` 없이 `originalUrl` 사용(같은 파일 access 로거는 스크럽함)
4. `users.ts` `router.get("/:id")`(139) 가 `router.get("/teams")`(192) 보다 먼저 등록 → "/teams" 가 id="teams" 로 매칭. `_teamsCache` 는 companyId 키 없음. 클라는 이 엔드포인트 미사용

## 작업 내용
**수정 — server**
- `index.ts`: 최상단에 `import "express-async-errors"` 추가(다른 import 보다 먼저). async 핸들러 reject → 글로벌 에러 미들웨어 → 500 JSON 즉시 응답
- `index.ts`: 요청 로거의 `originalUrl` → `scrubUrl(originalUrl)` 로 토큰/비번 마스킹
- `expense.ts`: 일반 수정 경로에 `if (exist.status !== "PENDING") return 409` 추가 — 처리 완료 경비 잠금. 수정하려면 관리자가 PENDING 으로 되돌린 뒤
- `users.ts`: dead `GET /teams` 라우트 + `_teamsCache` + `invalidateTeamsCache` 제거(호출처 없음 확인)
- `package.json`: `express-async-errors` 의존성 추가

**호환성·외부 영향**
- express-async-errors 는 Router 를 패치해 async reject 만 next(err) 로 전달 — 정상 응답 경로 무변경. 매우 표준적인 패키지
- 경비 잠금: PENDING 경비 수정은 그대로. 이미 처리된 것만 409 — 정상 워크플로 무영향
- /teams 제거: 클라 미사용이라 무영향(previewMock 핸들러는 mock 이라 무관)

## 검증
- [x] `server` tsc 통과
- [ ] 운영 배포 후 예외 발생 라우트가 30초 행 대신 500 즉시 응답 확인

Closes #896