### PR TITLE
🔀 :: (#898) 반차 0.5일 집계 + 출퇴근 버튼 더블탭 가드

### DIFF
--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -182,7 +182,9 @@ export default function AttendancePage() {
     const avgMs = completed.length ? totalMs / completed.length : 0;
     const usedDays = leaves
       .filter((l) => l.status === "APPROVED")
-      .reduce((acc, l) => acc + dayDiff(l.startDate, l.endDate), 0);
+      // 반차(HALF)는 0.5일로 집계 — dayDiff 는 같은 날이면 1을 반환하므로 type 으로 보정.
+      // (이전엔 모든 휴가를 종일로 세어 반차가 쌓일수록 '사용한 휴가'가 부풀려졌음)
+      .reduce((acc, l) => acc + (l.type === "HALF" ? 0.5 : dayDiff(l.startDate, l.endDate)), 0);
     const pending = leaves.filter((l) => l.status === "PENDING").length;
     return {
       workDays: completed.length,

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -58,7 +58,13 @@ export default function DashboardPage() {
   }
   useEffect(() => { load(); }, []);
 
+  // 출퇴근 버튼 더블탭 가드 — 빠르게 두 번 누르면 POST 가 2번 나가던 문제 방지(서버는 멱등이라
+  // 데이터 손상은 없지만 불필요한 요청·깜빡임 제거). 처리 중엔 버튼 비활성.
+  const [attBusy, setAttBusy] = useState(false);
+
   async function checkIn() {
+    if (attBusy) return;
+    setAttBusy(true);
     // 다중 세션 — "다시 출근" 은 이전 기록을 보존하고 새 세션을 추가하므로 강제확인 불필요.
     try {
       await api("/api/attendance/check-in", { method: "POST" });
@@ -66,10 +72,14 @@ export default function DashboardPage() {
       const title = err?.code === "IP_NOT_ALLOWED" ? "출근 불가" : "출근 실패";
       alertAsync({ title, description: err?.message ?? "출근 처리에 실패했어요" });
       return;
+    } finally {
+      setAttBusy(false);
     }
     load();
   }
   async function checkOut() {
+    if (attBusy) return;
+    setAttBusy(true);
     try {
       await api("/api/attendance/check-out", { method: "POST" });
     } catch (err: any) {
@@ -149,7 +159,7 @@ export default function DashboardPage() {
             <button
               type="button"
               onClick={checkIn}
-              disabled={working}
+              disabled={working || attBusy}
               className="px-5 py-2.5 rounded-xl text-[13.5px] font-extrabold transition disabled:opacity-40"
               style={{ background: "var(--c-brand)", color: "#fff" }}
             >
@@ -158,7 +168,7 @@ export default function DashboardPage() {
             <button
               type="button"
               onClick={checkOut}
-              disabled={!working}
+              disabled={!working || attBusy}
               className="px-5 py-2.5 rounded-xl text-[13.5px] font-extrabold transition disabled:opacity-40"
               style={{ background: "var(--c-surface-3)", color: "var(--c-text-1)" }}
             >


### PR DESCRIPTION
## 증상
기능 감사에서 발견된 클라이언트 버그 2건:
1. **반차 휴가가 1일로 집계**: 반차(0.5일)를 신청·승인받아도 근태 페이지 상단 "사용한 휴가" 카드가 1일로 셈. 반차가 여러 번 쌓이면 실제보다 최대 2배 부풀려 보임
2. **출퇴근 버튼 더블탭 시 중복 요청**: 출근/퇴근 버튼을 빠르게 두 번 누르면 POST 가 2번 나감

## 원인
1. `AttendancePage.tsx` usedDays 계산이 `dayDiff(l.startDate, l.endDate)` 만 사용 — 휴가 type 무관하게 "양 끝 포함 일수"를 더함. 반차(start=end 같은 날)도 1일. `Leave.type` 에 HALF 값이 있지만 가중치 미적용
2. `DashboardPage.tsx` checkIn/checkOut 에 재진입 가드 없음(같은 파일 AttendancePage 의 다른 액션은 saving 가드가 있는 것과 대조). 서버 check-in/out 은 멱등이라 데이터 손상은 없지만 불필요한 요청·깜빡임 발생

## 작업 내용
**수정 — client**
- `AttendancePage.tsx`: usedDays reduce 에서 `l.type === "HALF" ? 0.5 : dayDiff(...)` 로 보정 → 반차는 0.5일로 집계
- `DashboardPage.tsx`: `attBusy` state 추가. checkIn/checkOut 진입 시 `if (attBusy) return` + `setAttBusy(true)`, finally 에서 해제. 두 버튼 disabled 에 `|| attBusy` 추가

**호환성·외부 영향**
- 종일 휴가(ANNUAL/SICK/OTHER) 계산 무변경 — HALF 만 0.5 로 보정
- 출퇴근 동작·멱등성 무변경 — 처리 중 짧은 시간만 버튼 비활성(중복 클릭 방지)
- 서버 변경 없음

## 검증
- [x] `client` tsc + `vite build` 통과
- [ ] 반차 신청 후 "사용한 휴가" 0.5 표시 + 출퇴근 버튼 연타 시 1회만 요청 확인(배포 후)

Closes #898