### PR TITLE
🔀 :: (#900) SSE 살아있으면 안전망 폴링 스킵 — Fargate egress 절감

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -78,7 +78,7 @@ export default function ChatMiniApp({
   openRoomRequest?: { id: number; roomId: string } | null;
 }) {
   const { user } = useAuth();
-  const { items: notifItems, markRoomRead } = useNotifications();
+  const { items: notifItems, markRoomRead, isSseAlive } = useNotifications();
 
   const [rooms, setRooms] = useState<Room[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -286,7 +286,9 @@ export default function ChatMiniApp({
     if (!isPanelOpen) return;
     // SSE (chat:sse-message / chat:sse-room) 가 primary path — 방 목록은
     // 상태 확인용 안전망으로 60초만 돈다 (기존 5~10s 는 SSE 와 충돌해 느림의 원인).
-    const t = setInterval(loadRooms, 60_000);
+    // ★ SSE 가 살아있으면(주로 네이티브) onRoom 이벤트가 이미 loadRooms 를 트리거하므로
+    //   이 60초 폴링(모든 방×멤버 아바타 재전송)은 순수 중복 → 스킵. 끊겼을 때만 안전망 가동.
+    const t = setInterval(() => { if (!isSseAlive()) loadRooms(); }, 60_000);
     return () => clearInterval(t);
   }, [isPanelOpen, activeId]);
   useEffect(() => {
@@ -305,7 +307,10 @@ export default function ChatMiniApp({
     let tick = 0;
     const t = setInterval(() => {
       tick++;
-      const full = tick % 3 === 0; // 90초마다 full
+      // 90초마다 full 동기화(수정/삭제/리액션 반영). 단 SSE 가 살아있으면 chat:sse-update 가
+      // 그것들을 이미 실시간 푸시하므로 300건 full 재전송은 불필요 → 증분(after=)만.
+      // SSE 끊김 시에만 full 로 떨어져 정합성 안전망 유지. (서버 egress 절감, 성능 무영향)
+      const full = tick % 3 === 0 && !isSseAlive();
       loadMessages(activeId, { full });
       if (isChatVisible()) {
         markRead(activeId);

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -34,6 +34,9 @@ type Ctx = {
   markRead: (ids?: string[], all?: boolean) => Promise<void>;
   /** 특정 채팅방에 들어갔을 때 해당 방의 DM/MENTION 알림 일괄 읽음 처리 */
   markRoomRead: (roomId: string) => Promise<void>;
+  /** SSE 스트림이 살아있는지(연결됨/연결중) — 폴링 소비자가 안전망 폴링을 건너뛰는 데 쓴다.
+   *  ref 기반 안정 콜백이라 호출해도 리렌더를 유발하지 않음. */
+  isSseAlive: () => boolean;
 };
 
 const NotificationCtx = createContext<Ctx>({
@@ -45,6 +48,7 @@ const NotificationCtx = createContext<Ctx>({
   reload: async () => {},
   markRead: async () => {},
   markRoomRead: async () => {},
+  isSseAlive: () => false,
 });
 
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
@@ -278,9 +282,16 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   // (AppLayout·ChatFab·NotificationBell) 가 값이 안 바뀌어도 전부 리렌더된다.
   // reload/markRead/markRoomRead 는 useCallback 으로 고정이고 bellItems/unread/chatUnread
   // 는 items 파생이라, 실제로 items·ready 가 바뀔 때만 새 객체가 만들어진다.
+  // SSE 생존 여부 — esRef readyState 로 판정(CONNECTING/OPEN 이면 살아있음). ref 읽기라
+  // deps 불필요한 안정 콜백 → value 가 이것 때문에 재생성되지 않음.
+  const isSseAlive = useCallback(
+    () => !!esRef.current && esRef.current.readyState !== EventSource.CLOSED,
+    [],
+  );
+
   const value = useMemo<Ctx>(
-    () => ({ items, bellItems, unread, chatUnread, ready, reload, markRead, markRoomRead }),
-    [items, bellItems, unread, chatUnread, ready, reload, markRead, markRoomRead]
+    () => ({ items, bellItems, unread, chatUnread, ready, reload, markRead, markRoomRead, isSseAlive }),
+    [items, bellItems, unread, chatUnread, ready, reload, markRead, markRoomRead, isSseAlive]
   );
 
   return (


### PR DESCRIPTION
## 증상
서버비 감사에서 발견: 채팅 패널을 열어둔 동안 SSE 가 살아있어도(주로 네이티브) 두 개의 안전망 폴링이 계속 돌아 Fargate egress 를 낭비:
- **방 목록 60초 폴링**: 모든 방 × 모든 멤버(아바타 포함) + 마지막 메시지 전체 재전송
- **활성 방 90초 full 재동기화**: 최대 300건 메시지(sender+reactions+avatarUrl 포함) 전체 재전송

## 원인
두 폴링 모두 SSE 끊김·누락 대비 "안전망"으로 설계됐으나 SSE 생존 여부와 무관하게 항상 돌았음:
- 방 생성/삭제/메시지는 `chat:sse-room`/`chat:sse-message` SSE 이벤트가 이미 실시간 푸시(`ChatMiniApp.tsx:421` onRoom → loadRooms, onMessage → 로컬 갱신)
- 수정/삭제/리액션은 `chat:sse-update` 가 푸시
- 즉 SSE 가 살아있으면 두 full 재전송은 순수 중복. 그런데 ChatMiniApp 이 SSE 생존 신호에 접근할 방법이 없었음(SSE 는 NotificationProvider 의 EventSource 가 window 이벤트로 재방송)

## 작업 내용
**추가 — `notifications.tsx`**
- 컨텍스트에 `isSseAlive(): boolean` 노출 — `esRef.current.readyState !== CLOSED` 로 판정. `useCallback([])` 안정 콜백이라 호출해도 리렌더 없음(가장 뜨거운 Provider 의 value 재생성도 안 일으킴)

**수정 — `ChatMiniApp.tsx`** (notifications.tsx 가 fallback 폴링에 쓰는 검증된 "SSE 살아있으면 스킵" 패턴 이식)
- 방 목록 60초 폴링: `if (!isSseAlive()) loadRooms()` — SSE 살아있으면 스킵
- 활성 방 90초 full: `full = tick % 3 === 0 && !isSseAlive()` — SSE 살아있으면 full 대신 증분(after=)만. 30초 증분 폴링은 cheap 안전망으로 유지

**호환성·성능 영향**
- **성능 유지**: SSE 가 edit/delete/reaction/new-message/room 을 모두 실시간 푸시하므로 full 재전송을 생략해도 정합성·실시간성 동일. 오히려 중복 왕복이 줄어 체감 개선
- SSE 끊김 시(웹 등 SSE 미가동 환경)엔 기존대로 full 폴링이 안전망으로 동작 → 무회귀
- 30초 증분 폴링(after=, 보통 빈 응답)은 그대로 둬 메시지 누락 방지

## 검증
- [x] `client` tsc + `vite build` 통과
- [ ] 네이티브(SSE 살아있음)에서 full 재전송 빈도 감소 + 웹(SSE 끊김)에서 안전망 유지 확인

Closes #900