### PR TITLE
🔀 :: (#902) previewMock 목 데이터 메인 번들에서 분리 — ~23KB gzip 절감

### DIFF
--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -120,7 +120,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(async () => {
     // 미리보기 모드는 서버 호출 없이 플래그만 끄고 빠져나옴.
     if (typeof window !== "undefined" && (window as any).__HINEST_PREVIEW__) {
-      const m = await import("./lib/previewMock");
+      const m = await import("./lib/previewFlag");
       m.disablePreview();
       clearAuthToken();
       setUser(null);

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -17,7 +17,7 @@ import { PinsProvider, usePins, pinLinkUrl } from "../pins";
 import { ROUTE_PREFETCH, loadProject } from "../routes";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
 import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
-import { isPreviewMode, disablePreview } from "../lib/previewMock";
+import { isPreviewMode, disablePreview } from "../lib/previewFlag";
 import { isInstalledApp, isDesktopApp, nativePlatform, isCapacitorNative } from "../lib/platform";
 import { LiquidGlassTabBar, setNativeTabBarHidden, syncNativeTabBarVisibility } from "../lib/liquidGlassTabBar";
 import { attachGlobalHaptics } from "../lib/haptics";

--- a/client/src/components/PreviewBanner.tsx
+++ b/client/src/components/PreviewBanner.tsx
@@ -1,4 +1,4 @@
-import { isPreviewMode, disablePreview } from "../lib/previewMock";
+import { isPreviewMode, disablePreview } from "../lib/previewFlag";
 import { isCapacitorNative } from "../lib/platform";
 
 /**

--- a/client/src/components/PreviewOnboarding.tsx
+++ b/client/src/components/PreviewOnboarding.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { isPreviewMode } from "../lib/previewMock";
+import { isPreviewMode } from "../lib/previewFlag";
 import { setNativeTabBarHidden } from "../lib/liquidGlassTabBar";
 
 /**

--- a/client/src/lib/previewFlag.ts
+++ b/client/src/lib/previewFlag.ts
@@ -1,0 +1,98 @@
+/**
+ * 미리보기(둘러보기) 모드 — 경량 플래그 모듈.
+ *
+ * 왜 분리했나(2026-06-09 성능):
+ *   isPreviewMode/enablePreview/disablePreview 는 main.tsx·AppLayout·DashboardPage 등이
+ *   "정적" import 한다. 이게 같은 모듈(previewMock.ts)의 ~95KB 목 데이터(DEMO_USERS,
+ *   MEETING_BODIES 등)를 프로덕션 메인 번들로 끌어와 모든 사용자 첫 로드에 ~25KB(gzip)를
+ *   다운로드시켰다. 플래그·정리 로직만 이 경량 모듈로 떼고, 무거운 네트워크 패치(목 데이터
+ *   참조)는 미리보기가 실제 활성일 때만 `import("./previewMock")` 로 지연 로드한다.
+ *   → 일반 사용자 번들에서 목 데이터 완전 제거. api.ts/auth.tsx 는 이미 동적 import 라 무관.
+ */
+
+export const PREVIEW_KEY = "hinest:preview";
+
+function active(): boolean {
+  if (typeof window === "undefined") return false;
+  if ((window as any).__HINEST_PREVIEW__ === true) return true;
+  try {
+    return sessionStorage.getItem(PREVIEW_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+let _patchRequested = false;
+/** 무거운 네트워크 패치(목 데이터 포함)를 지연 로드해 적용. 미리보기 활성 시에만 호출됨. */
+function lazyInstall(): Promise<void> {
+  _patchRequested = true;
+  return import("./previewMock")
+    .then((m) => m.installNetworkPatches())
+    .catch(() => {});
+}
+
+/**
+ * 미리보기 활성 여부(동기). api.ts/여러 hook 이 검사용으로 호출.
+ * 활성인데 아직 네트워크 패치가 안 깔렸으면 무거운 모듈을 지연 로드해 깐다(fire-and-forget).
+ * api() 호출은 어차피 동기 window.__HINEST_PREVIEW__ 플래그로 단락되므로 패치 지연과 무관하게 안전.
+ */
+export function isPreviewMode(): boolean {
+  const on = active();
+  if (on) {
+    (window as any).__HINEST_PREVIEW__ = true;
+    if (!_patchRequested) void lazyInstall();
+  }
+  return on;
+}
+
+/**
+ * 미리보기 네트워크 패치가 적용 완료될 때까지 기다린다(렌더 전 보장용 — main.tsx 부트스트랩).
+ * 비활성이면 즉시 resolve(무거운 모듈 로드 안 함 → 일반 사용자 비용 0).
+ */
+export function ensurePreviewPatched(): Promise<void> {
+  if (!active()) return Promise.resolve();
+  (window as any).__HINEST_PREVIEW__ = true;
+  return lazyInstall();
+}
+
+export function enablePreview(): void {
+  if (typeof window === "undefined") return;
+  (window as any).__HINEST_PREVIEW__ = true;
+  try {
+    sessionStorage.setItem(PREVIEW_KEY, "1");
+  } catch {}
+  void lazyInstall();
+}
+
+export function disablePreview(): void {
+  if (typeof window === "undefined") return;
+  (window as any).__HINEST_PREVIEW__ = false;
+  try {
+    sessionStorage.removeItem(PREVIEW_KEY);
+  } catch {}
+  // 네트워크 패치 해제 — 무거운 모듈이 이미 로드된 경우에만 실제 효과(아니면 패치도 안 깔림).
+  void import("./previewMock")
+    .then((m) => m.uninstallNetworkPatches())
+    .catch(() => {});
+  // 데모 동안 누적된 SWR 캐시 정리 — 실 서버 호출 시 stale 가짜 데이터 방지. (목 데이터 불필요·경량)
+  try {
+    const PREFIX = "hinest.swr:";
+    const keys: string[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const k = sessionStorage.key(i);
+      if (k && k.startsWith(PREFIX)) keys.push(k);
+    }
+    for (const k of keys) sessionStorage.removeItem(k);
+  } catch {}
+  // 미리보기 동안 localStorage 에 누적될 수 있는 데모-결정 키들 정리 — 실 가입 후 데모 ID 잔존으로 색/상태가 어긋나는 일 방지.
+  try {
+    const PREFIXES = ["chat:theme:", "chat:lastSeen:", "hinest:lastSeenNoticeUnread", "emoji-recent", "desktop-notify-seen", "hinest:notif-prefs"];
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (!k) continue;
+      if (PREFIXES.some((p) => k === p || k.startsWith(p))) toRemove.push(k);
+    }
+    for (const k of toRemove) localStorage.removeItem(k);
+  } catch {}
+}

--- a/client/src/lib/previewMock.ts
+++ b/client/src/lib/previewMock.ts
@@ -1322,66 +1322,19 @@ function jsonResponse(status: number, body: any): Response {
   });
 }
 
-/** 미리보기 활성 여부 — api.ts / 여러 hook 에서 동일하게 검사. */
-export function isPreviewMode(): boolean {
-  if (typeof window === "undefined") return false;
-  if ((window as any).__HINEST_PREVIEW__ === true) return true;
-  try {
-    if (sessionStorage.getItem(PREVIEW_KEY) === "1") {
-      (window as any).__HINEST_PREVIEW__ = true; // 다음 호출 빠르게.
-      installNetworkPatches();                    // 새로고침 직후에도 fetch/SSE 패치 재적용.
-      return true;
-    }
-  } catch {}
-  return false;
-}
-
-const PREVIEW_KEY = "hinest:preview";
+// 미리보기 플래그·활성화/비활성화 API 는 경량 모듈 previewFlag.ts 로 이동했다(번들 분리).
+// 이 모듈(목 데이터 ~95KB)은 미리보기가 실제 활성일 때만 동적 로드된다.
+// 아래 installNetworkPatches/uninstallNetworkPatches 는 previewFlag 가 지연 호출한다.
 
 let _origFetch: typeof fetch | null = null;
 let _origEventSource: typeof EventSource | null = null;
-
-export function enablePreview() {
-  if (typeof window === "undefined") return;
-  (window as any).__HINEST_PREVIEW__ = true;
-  try { sessionStorage.setItem(PREVIEW_KEY, "1"); } catch {}
-  installNetworkPatches();
-}
-
-export function disablePreview() {
-  if (typeof window === "undefined") return;
-  (window as any).__HINEST_PREVIEW__ = false;
-  try { sessionStorage.removeItem(PREVIEW_KEY); } catch {}
-  uninstallNetworkPatches();
-  // 이전 가짜 응답이 sessionStorage 에 캐시돼있을 수 있어 비움 — 진짜 서버 호출 시 stale 데이터 방지.
-  try {
-    const PREFIX = "hinest.swr:";
-    const keys: string[] = [];
-    for (let i = 0; i < sessionStorage.length; i++) {
-      const k = sessionStorage.key(i);
-      if (k && k.startsWith(PREFIX)) keys.push(k);
-    }
-    for (const k of keys) sessionStorage.removeItem(k);
-  } catch {}
-  // 미리보기 동안 localStorage 에 누적될 수 있는 데모-결정 키들도 정리 — 실 가입 후 데모 ID 가 잔존해 색/상태가 어긋나는 일 방지.
-  try {
-    const PREFIXES = ["chat:theme:", "chat:lastSeen:", "hinest:lastSeenNoticeUnread", "emoji-recent", "desktop-notify-seen", "hinest:notif-prefs"];
-    const toRemove: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const k = localStorage.key(i);
-      if (!k) continue;
-      if (PREFIXES.some((p) => k === p || k.startsWith(p))) toRemove.push(k);
-    }
-    for (const k of toRemove) localStorage.removeItem(k);
-  } catch {}
-}
 
 /* ---- 보안 ----
  *  api() 만 미리보기로 단락하면 직접 fetch / EventSource 를 쓰는 코드(파일 업로드, SSE 등) 가
  *  실제 서버로 노출된다. enablePreview() 시점에 window 레벨에서 monkey-patch 해 /api/* 진출을 막는다.
  *  - fetch: /api/* 면 mock 응답, 외부 URL(이미지 등) 은 그대로 통과
  *  - EventSource: /api/* 라면 즉시 close 되는 더미 객체, 외부는 통과 */
-function installNetworkPatches() {
+export function installNetworkPatches() {
   if (typeof window === "undefined") return;
   if (!_origFetch) {
     _origFetch = window.fetch.bind(window);
@@ -1421,7 +1374,7 @@ function installNetworkPatches() {
   }
 }
 
-function uninstallNetworkPatches() {
+export function uninstallNetworkPatches() {
   if (typeof window === "undefined") return;
   if (_origFetch) { window.fetch = _origFetch; _origFetch = null; }
   if (_origEventSource) { (window as any).EventSource = _origEventSource; _origEventSource = null; }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,13 +4,10 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { AuthProvider } from "./auth";
 import { FeatureFlagsProvider } from "./lib/featureFlags";
-import { isPreviewMode } from "./lib/previewMock";
+import { isPreviewMode, ensurePreviewPatched } from "./lib/previewFlag";
 import { notifyLiveUpdateReady } from "./lib/liveUpdates";
 import { ThemeProvider } from "./theme";
 import "./styles.css";
-
-// 미리보기 모드 부트스트랩 — 새로고침 후 fetch/EventSource 가 실제 서버로 새지 않게 가장 먼저 패치.
-isPreviewMode();
 
 // Capacitor Live Updates — 새 OTA 번들이 로드된 직후 10초 안에 호출돼야 '정상 시작' 으로 간주.
 // 안 호출되면 직전 정상 번들로 자동 롤백(벽돌 앱 방지). 네이티브가 아니면 no-op.
@@ -164,16 +161,24 @@ if (typeof window !== "undefined") {
   }
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <ThemeProvider>
-      <BrowserRouter>
-        <AuthProvider>
-          <FeatureFlagsProvider>
-            <App />
-          </FeatureFlagsProvider>
-        </AuthProvider>
-      </BrowserRouter>
-    </ThemeProvider>
-  </React.StrictMode>
-);
+function renderApp() {
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <ThemeProvider>
+        <BrowserRouter>
+          <AuthProvider>
+            <FeatureFlagsProvider>
+              <App />
+            </FeatureFlagsProvider>
+          </AuthProvider>
+        </BrowserRouter>
+      </ThemeProvider>
+    </React.StrictMode>
+  );
+}
+
+// 미리보기 모드 부트스트랩 — 새로고침 후 fetch/EventSource 가 실제 서버로 새지 않게, 무거운
+// 목 데이터 모듈(previewMock)을 지연 로드해 네트워크 패치를 적용한 "뒤에" 렌더한다.
+// 일반 사용자(미리보기 아님)는 ensurePreviewPatched 가 즉시 resolve → previewMock 을 아예
+// 로드하지 않아 메인 번들에서 목 데이터(~25KB gzip)가 빠진다. preview 일 때만 짧게 await.
+ensurePreviewPatched().finally(renderApp);

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../auth";
 import InstallAppBanner from "../components/InstallAppBanner";
 import { alertAsync } from "../components/ConfirmHost";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
-import { isPreviewMode } from "../lib/previewMock";
+import { isPreviewMode } from "../lib/previewFlag";
 import { Skeleton } from "../components/Skeleton";
 
 type Notice = { id: string; title: string; content: string; createdAt: string; author: { name: string; isDeveloper?: boolean }; pinned: boolean };

--- a/client/src/pages/PreviewEntry.tsx
+++ b/client/src/pages/PreviewEntry.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useAuth } from "../auth";
 import { clearApiCache } from "../api";
-import { enablePreview } from "../lib/previewMock";
+import { enablePreview } from "../lib/previewFlag";
 import AppLayout from "../components/AppLayout";
 import DashboardPage from "./DashboardPage";
 


### PR DESCRIPTION
## 증상
성능 감사 실측: 프로덕션 메인 번들에 **미리보기(둘러보기) 전용 목 데이터 ~25KB(gzip)** 가 동봉돼 모든 사용자가 첫 로드에 다운로드. 메인 청크의 약 28%가 미리보기 전용 죽은 코드였음.

## 원인
`previewMock.ts`(약 95KB minify)는 데모용 목 데이터(DEMO_USERS, 300줄+ TipTap 회의록 본문, DEMO_PROJECTS, QA 픽스처, fetch 핸들러)가 95%를 차지. 작은 플래그 헬퍼 `isPreviewMode`/`enablePreview`/`disablePreview` 가 같은 모듈에 있고, eager 진입 경로(`main.tsx`·`AppLayout`·`DashboardPage`·`PreviewBanner`·`PreviewOnboarding`·`PreviewEntry`)가 이 헬퍼를 **정적** import. `isPreviewMode` → `installNetworkPatches` → HANDLERS(목 데이터) 참조 체인이라 Vite tree-shaking 불가 → 모듈 전체가 메인 청크에 포함. (정작 무거운 `previewMockFetch` 는 api.ts/auth.tsx 에서 이미 동적 import 중이었으나 헬퍼의 정적 import 가 데이터를 끌어왔음)

## 작업 내용
**추가 — `client/src/lib/previewFlag.ts`** (경량, 목 데이터 미참조)
- `isPreviewMode`·`enablePreview`·`disablePreview`·`ensurePreviewPatched` 를 여기로 분리. sessionStorage/localStorage 정리 로직(목 데이터 불필요)도 이관
- 무거운 네트워크 패치(`installNetworkPatches`)는 **미리보기가 실제 활성일 때만** `import("./previewMock")` 로 지연 로드

**수정 — `previewMock.ts`**
- 이동된 `isPreviewMode`/`enablePreview`/`disablePreview`/`PREVIEW_KEY` 제거
- `installNetworkPatches`/`uninstallNetworkPatches` 를 `export` 로 노출(previewFlag 가 지연 호출)

**수정 — eager importer 6곳 + auth.tsx**
- `main.tsx`·`AppLayout`·`DashboardPage`·`PreviewBanner`·`PreviewOnboarding`·`PreviewEntry` → `previewFlag` 에서 import
- `main.tsx`: 렌더를 `ensurePreviewPatched().finally(renderApp)` 로 — **일반 사용자는 즉시 resolve(목 데이터 로드 0)**, 미리보기일 때만 패치 적용 후 렌더(SSE/이미지 레이스 없음)
- `auth.tsx` 로그아웃의 동적 import 도 `previewFlag` 로

## 측정 (vite build 산출물)
- 메인 청크: **315KB raw / 91KB gzip → 230KB / 68KB** (약 **23KB gzip 절감**)
- `previewMock` 이 별도 lazy 청크(gzip 24KB)로 분리 — 일반 사용자는 다운로드 안 함

## 호환성·외부 영향
- 미리보기 동작 동일: api 호출은 동기 `__HINEST_PREVIEW__` 플래그로 단락(패치 지연 무관), main.tsx 가 패치 적용 후 렌더해 SSE/이미지도 안전
- 일반 사용자: previewMock 청크를 아예 안 받음 → 첫 로드 빨라짐
- 기능·라우팅 무변경

## 검증
- [x] `client` tsc + `vite build` 통과 + 청크 분리 산출물로 절감 확인
- [ ] 둘러보기(미리보기) 진입·새로고침·로그아웃 정상 동작 확인(배포 후)

Closes #902