### PR TITLE
🔀 :: (#904) 근태 탭 화면 전체 덮는 파란 애니메이션 제거

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -2288,7 +2288,7 @@ function StatusDot({ status }: { status: AttStatus }) {
   return (
     <span className="inline-flex items-center gap-1.5 text-[11.5px] font-bold whitespace-nowrap" style={{ color: m.fg }}>
       <span
-        className={`inline-block rounded-full ${status === "working" ? "siri-pulse" : ""}`}
+        className={`inline-block rounded-full ${status === "working" ? "live-dot" : ""}`}
         style={{ width: 6, height: 6, background: m.fg }}
         aria-hidden
       />

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1305,6 +1305,29 @@ html.dark .nav-active {
 }
 html.dark .nav-active svg { stroke: var(--c-brand-soft-fg); }
 
+/* 근무중 라이브 점 — 점 크기에 정확히 스코프된 잔잔한 파동.
+   ⚠️ .siri-pulse 를 작은 점에 쓰면 안 됨: .siri-pulse 는 position 을 안 주는데(FAB 는 fixed 라 OK)
+      inline 점은 static 이라 ::after(inset:-14px 방사형 글로우)가 "가장 가까운 positioned 조상"
+      (큰 컨테이너/페이지) 기준으로 퍼져 화면 전체가 파랗게 덮이는 버그가 났음(근태탭 신고).
+   → 여기서는 position:relative 로 점에 스코프 + currentColor(점 색) 기반의 작은 ring 만 반복. */
+.live-dot { position: relative; }
+.live-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: currentColor;     /* 부모 span 의 color(상태색)를 그대로 사용 */
+  opacity: 0.55;
+  z-index: -1;
+  animation: live-dot-ring 2s ease-out infinite;
+}
+@keyframes live-dot-ring {
+  0%   { transform: scale(1);   opacity: .55; }
+  70%  { transform: scale(2.6); opacity: 0; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) { .live-dot::after { animation: none; opacity: 0; } }
+
 /* ===== Notification pulse — 파란 계열, 강한 강조 ===== */
 /* 새 알림이 올 때 2.8초 동안 파랑 글로우로 강하게 반짝이고 부드럽게 사라짐.
    .siri-pulse — 원형/사각 버튼 테두리 + 외부 halo (FAB 용)


### PR DESCRIPTION
## 증상
관리자 → 근태 탭에서 화면 전체가 **파랗게 덮이는 정체불명의 애니메이션**(방사형 글로우 + 코너 대각선)이 떠 내용이 안 보임(데스크탑 웹앱 스크린샷).

## 원인
근태 현황의 상태 점(`StatusDot`)이 "근무 중"일 때 `.siri-pulse` 클래스를 붙임(AdminPage.tsx:2291). 그런데 `.siri-pulse` 는 **자기 자신에 `position` 을 주지 않는다**(원래 FAB·사이드바 NavLink 용 — 그쪽은 `fixed`/`relative` 라 OK). StatusDot 의 점은 `inline-block`(static position) → `.siri-pulse::after`(방사형 글로우, `inset: -14px`)가 자기 6px 점이 아니라 **가장 가까운 positioned 조상**(큰 컨테이너/페이지) 기준으로 퍼짐 → 화면 전체가 파란 글로우로 덮임. 게다가 알림용 강조 애니메이션이라 작은 리스트 점에는 과함.

## 작업 내용
**추가 — `styles.css`**: 점 크기에 정확히 스코프된 `.live-dot` 클래스 신설. `position: relative` + `::after`(`inset: 0`, `currentColor` 기반 ring)가 점 크기에서만 잔잔히 퍼졌다 사라지는 2초 무한 루프. `prefers-reduced-motion` 대응

**수정 — `AdminPage.tsx`**: StatusDot 의 working 상태 클래스를 `siri-pulse` → `live-dot` 로 교체. 6px 점 주위에만 작은 "라이브" 파동이 돌아 화면 덮임 버그 제거

**호환성·외부 영향**
- `.siri-pulse`(FAB·NavLink 알림 강조)는 그대로 — 그쪽은 positioned 라 정상 동작. 근태 점만 교체
- 다크/라이트 무관(currentColor=상태색 상속). reduced-motion 시 애니메이션 끔

## 검증
- [x] `client` tsc + `vite build` 통과

Closes #904