### PR TITLE
🔀 :: (#907) 다운로드 안됨·느림·파일명 깨짐 — IPC 직접 다운로드 + getURLChain

### DIFF
--- a/HiNest-MacOS/src/main.ts
+++ b/HiNest-MacOS/src/main.ts
@@ -83,11 +83,18 @@ function createWindow() {
   mainWindow.webContents.session.on("will-download", (_e, item) => {
     try {
       let name = "";
-      try {
-        const u = new URL(item.getURL());
-        const q = u.searchParams.get("name");
-        if (q) name = decodeURIComponent(q);
-      } catch {}
+      // ?name= 을 리다이렉트 체인 전체에서 찾는다 — /uploads 는 S3 presigned URL 로 302 되는데
+      // getURL() 은 리다이렉트 후 S3 URL(name 없음)을 줄 수 있어 원본 요청 URL(getURLChain)을 훑는다.
+      const chain: string[] =
+        typeof item.getURLChain === "function" && item.getURLChain().length
+          ? item.getURLChain()
+          : [item.getURL()];
+      for (const link of chain) {
+        try {
+          const q = new URL(link).searchParams.get("name");
+          if (q) { name = decodeURIComponent(q); break; }
+        } catch {}
+      }
       if (!name) {
         const cd = item.getContentDisposition?.() || "";
         const star = /filename\*=UTF-8''([^;]+)/i.exec(cd);
@@ -270,6 +277,21 @@ ipcMain.handle("hinest:flashFrame", () => {
   try {
     mainWindow?.flashFrame(true);
   } catch {}
+});
+
+// 파일 다운로드 — 메인 webContents 가 직접 받아 will-download 가 ?name= 으로 원본명 저장.
+ipcMain.handle("hinest:downloadFile", (_e, url: unknown) => {
+  try {
+    if (typeof url !== "string") return { ok: false, error: "invalid url" };
+    const lower = url.trim().toLowerCase();
+    if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
+      return { ok: false, error: "disallowed scheme" };
+    }
+    mainWindow?.webContents.downloadURL(url);
+    return { ok: true };
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
 });
 
 ipcMain.handle("hinest:showNotification", (_e, opts: { title: string; body?: string; silent?: boolean; icon?: string }) => {

--- a/HiNest-MacOS/src/preload.ts
+++ b/HiNest-MacOS/src/preload.ts
@@ -17,6 +17,9 @@ contextBridge.exposeInMainWorld("hinest", {
   setBadge: (count: number) => ipcRenderer.invoke("hinest:setBadge", count),
   flashFrame: () => ipcRenderer.invoke("hinest:flashFrame"),
   openExternal: (url: string) => ipcRenderer.invoke("hinest:openExternal", url),
+  // 파일 다운로드 — 메인이 webContents.downloadURL 로 직접 받게 한다(<a download> cross-origin
+  // 302·창 네비게이션 불안정 회피). will-download 가 ?name= 으로 원본 파일명 강제.
+  downloadFile: (url: string) => ipcRenderer.invoke("hinest:downloadFile", url),
   showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) =>
     ipcRenderer.invoke("hinest:showNotification", opts),
   relaunch: () => ipcRenderer.invoke("hinest:relaunch"),

--- a/client/src/lib/download.ts
+++ b/client/src/lib/download.ts
@@ -28,6 +28,19 @@ import { imgSrc } from "../api";
  *   이 경우 브라우저가 서버의 Content-Disposition 파일명으로 폴백한다.
  */
 export function downloadFromUrl(href: string, filename = ""): void {
+  // 데스크탑(Electron): 메인 프로세스가 webContents.downloadURL 로 직접 받게 한다.
+  //   <a download> 는 cross-origin 302(/uploads → S3 presigned) 에서 download 속성·파일명이
+  //   무시되고, 리다이렉트 추적 중 창 네비게이션 edge case 로 "안 받아지거나 느린" 현상이 있었다.
+  //   IPC 로 넘기면 will-download 가 단번에 떠 ?name= 으로 원본 파일명을 강제하고 즉시 저장된다.
+  //   (will-download 핸들러는 getURLChain 으로 리다이렉트 전 ?name= 까지 읽는다.)
+  const hinest = (window as any).hinest;
+  if (hinest?.downloadFile) {
+    try {
+      const abs = new URL(href, window.location.origin).toString();
+      hinest.downloadFile(abs);
+      return;
+    } catch { /* IPC 실패 시 아래 <a download> 폴백 */ }
+  }
   // 네이티브 앱(Capacitor WKWebView)은 <a download> 로 파일을 저장하지 못한다.
   // 인증된 절대 URL 을 인앱 브라우저(SFSafariViewController)로 열어 iOS 가 미리보기 +
   // 공유/저장 시트를 제공하게 한다. imgSrc 가 /uploads 상대경로를 절대화하고 ?token= 을 붙인다.

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -80,12 +80,20 @@ function createWindow() {
   mainWindow.webContents.session.on("will-download", (_e, item) => {
     try {
       let name = "";
-      // 1) ?name= 쿼리 (클라가 다운로드 URL 에 항상 붙임)
-      try {
-        const u = new URL(item.getURL());
-        const q = u.searchParams.get("name");
-        if (q) name = decodeURIComponent(q);
-      } catch {}
+      // 1) ?name= 쿼리 — 리다이렉트 체인 전체를 훑는다.
+      //    /uploads/<key>?download=1&name=<원본명> 은 서버에서 S3 presigned URL 로 302 되는데,
+      //    item.getURL() 은 리다이렉트 "후" 의 S3 URL(=name 없음)을 줄 수 있다. getURLChain() 은
+      //    원본 요청 URL 부터 담으므로 거기서 name= 을 찾아야 파일명이 키 해시로 깨지지 않는다.
+      const chain: string[] =
+        typeof item.getURLChain === "function" && item.getURLChain().length
+          ? item.getURLChain()
+          : [item.getURL()];
+      for (const link of chain) {
+        try {
+          const q = new URL(link).searchParams.get("name");
+          if (q) { name = decodeURIComponent(q); break; }
+        } catch {}
+      }
       // 2) Content-Disposition (RFC5987 filename*=UTF-8'' 우선, 그다음 filename=)
       if (!name) {
         const cd = item.getContentDisposition?.() || "";
@@ -328,6 +336,23 @@ ipcMain.handle("hinest:flashFrame", () => {
   try {
     mainWindow?.flashFrame(true);
   } catch {}
+});
+
+// 파일 다운로드 — 렌더러가 넘긴 (절대) URL 을 메인 webContents 가 직접 받는다.
+// <a download> 의 cross-origin 302·창 네비게이션 불안정을 피해 will-download 가 단번에 떠
+// 원본 파일명(?name=)으로 저장된다. http/https 만 허용(스킴 화이트리스트).
+ipcMain.handle("hinest:downloadFile", (_e, url: unknown) => {
+  try {
+    if (typeof url !== "string") return { ok: false, error: "invalid url" };
+    const lower = url.trim().toLowerCase();
+    if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
+      return { ok: false, error: "disallowed scheme" };
+    }
+    mainWindow?.webContents.downloadURL(url);
+    return { ok: true };
+  } catch (e: any) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
 });
 
 ipcMain.handle("hinest:showNotification", (_e, opts: { title: string; body?: string; silent?: boolean; icon?: string }) => {

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -12,6 +12,9 @@ contextBridge.exposeInMainWorld("hinest", {
   setBadge: (count: number) => ipcRenderer.invoke("hinest:setBadge", count),
   flashFrame: () => ipcRenderer.invoke("hinest:flashFrame"),
   openExternal: (url: string) => ipcRenderer.invoke("hinest:openExternal", url),
+  // 파일 다운로드 — 메인이 webContents.downloadURL 로 직접 받게 한다(<a download> 의 cross-origin
+  // 302·창 네비게이션 불안정 회피). will-download 가 ?name= 으로 원본 파일명을 강제한다.
+  downloadFile: (url: string) => ipcRenderer.invoke("hinest:downloadFile", url),
   showNotification: (opts: { title: string; body?: string; silent?: boolean; icon?: string }) =>
     ipcRenderer.invoke("hinest:showNotification", opts),
   relaunch: () => ipcRenderer.invoke("hinest:relaunch"),


### PR DESCRIPTION
## 증상
데스크탑 웹앱(Electron)에서 문서·폴더 다운로드가 ① 안 되거나 ② 너무 느리거나 ③ 파일명이 이상하게(스토리지 키 해시) 저장됨.

## 원인
1. **파일명 깨짐**: 클라가 `/uploads/<key>?download=1&name=<원본명>` 으로 요청 → 서버가 S3 presigned URL 로 302 리다이렉트. Electron `will-download` 핸들러가 `item.getURL()` 로 `?name=` 을 읽는데, **리다이렉트 후의 S3 URL(name 없음)** 을 반환할 수 있어 원본명을 못 찾음
2. **안 됨/느림**: 클라가 `<a download href>` 클릭으로 다운로드를 트리거하는데, cross-origin 302(/uploads→S3)에서 `download` 속성이 무시되고 리다이렉트 추적 중 창 네비게이션 edge case 로 다운로드가 시작 안 되거나 지연되는 경우가 있음

## 작업 내용
**수정 — `desktop/src/main.ts` · `HiNest-MacOS/src/main.ts`** (will-download 핸들러)
- `item.getURL()` 단일 URL → `item.getURLChain()`(리다이렉트 체인, 원본 요청 URL 부터 포함)을 순회하며 `?name=` 탐색 → 302 후에도 원본 파일명 확보

**추가 — IPC 직접 다운로드** (가장 확실한 경로)
- preload(`desktop`·`HiNest-MacOS`)에 `downloadFile(url)` 노출 → ipcMain `hinest:downloadFile` 핸들러가 `mainWindow.webContents.downloadURL(url)` 로 메인 프로세스가 직접 받음. http/https 스킴만 허용
- `client/src/lib/download.ts`: `window.hinest.downloadFile` 가 있으면(데스크탑) 절대 URL 로 IPC 호출 후 반환. `<a download>` 의 cross-origin 302·창 네비게이션 불안정을 회피해 will-download 가 단번에 떠 즉시 저장
- **graceful fallback**: `window.hinest.downloadFile` 가 없으면(웹·구버전 데스크탑·네이티브) 기존 경로(`<a download>` / Browser.open) 그대로 → 무회귀

**호환성·외부 영향**
- 웹·iOS 동작 무변경(IPC 브리지 없으면 기존 경로)
- 데스크탑 앱은 **재빌드·재배포 시** IPC 다운로드 활성화. 그 전까지는 client 가 자동으로 `<a download>` 폴백(에러 없음)
- 모든 다운로드(문서·채팅 파일·결재)가 동일 경로로 일원화

## 검증
- [x] `client` tsc + `vite build` 통과
- [x] desktop·macOS main/preload 은 기존 ipcMain/ipcRenderer 패턴 그대로(추가 핸들러) — CI 빌드로 검증
- [ ] 데스크탑 재빌드 후 문서/폴더 다운로드 즉시 + 원본명 저장 확인

Closes #907