### PR TITLE
🔀 :: (#909) 폴더 다운로드 500(서버 오류) — 핸들러 전체 try/catch + folderPath 사이클 가드

### DIFF
--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -769,6 +769,7 @@ async function fetchFileBuffer(key: string): Promise<Buffer | null> {
 
 router.get("/folders/:id/download", async (req, res) => {
   const u = (req as any).user;
+  try {
   const folder = await prisma.folder.findUnique({ where: { id: req.params.id } });
   if (!folder) return res.status(404).json({ error: "not found" });
 
@@ -805,12 +806,14 @@ router.get("/folders/:id/download", async (req, res) => {
 
   // 폴더 경로(prefix) 를 메모리에서 계산 — 루트는 빈 문자열.
   const folderMap = new Map(subtree.map((f) => [f.id, f]));
-  function folderPath(id: string | null): string {
+  function folderPath(id: string | null, seen: Set<string> = new Set()): string {
     if (!id || id === rootId) return "";
+    if (seen.has(id)) return ""; // 데이터 손상으로 parentId 사이클이 생겨도 무한 재귀(스택오버플로) 방지
+    seen.add(id);
     const f = folderMap.get(id);
     if (!f) return "";
     const safe = f.name.replace(/[\\/:*?"<>|]/g, "_");
-    const parent = folderPath(f.parentId);
+    const parent = folderPath(f.parentId, seen);
     return parent ? `${parent}/${safe}` : safe;
   }
 
@@ -883,8 +886,34 @@ router.get("/folders/:id/download", async (req, res) => {
     console.warn("[doc:zip] no readable files", folder.id);
   }
 
-  await archive.finalize();
-  await writeLog(u.id, "FOLDER_DOWNLOAD", folder.id, `${folder.name} (${added} files)`);
+  // ★ 감사 로그는 다운로드 "전에" + 비차단으로 — 예전엔 finalize 뒤 await writeLog 였는데,
+  //   writeLog 가 던지면(compression 버퍼링으로 헤더가 아직 안 나간 사이) 글로벌 에러 핸들러가
+  //   500 JSON("서버 오류가 발생했습니다")을 내보내 다운로드가 통째로 실패했다(사용자 신고).
+  //   로깅 실패가 다운로드를 깨뜨리면 안 되므로 fire-and-forget + catch.
+  void writeLog(u.id, "FOLDER_DOWNLOAD", folder.id, `${folder.name} (${added} files)`).catch((e) =>
+    console.error("[doc:zip] writeLog failed (non-fatal)", e),
+  );
+
+  // finalize 실패도 다운로드 스트림 한정 처리 — 글로벌 핸들러로 새어 500 JSON 이 되지 않게.
+  // (헤더가 이미 나갔으면 어차피 JSON 으로 못 바꾸고, 안 나갔으면 stream 을 깔끔히 끝낸다.)
+  try {
+    await archive.finalize();
+  } catch (err) {
+    console.error("[doc:zip] finalize failed", folder.id, err);
+    if (!res.headersSent) res.status(500).json({ error: "압축 파일을 만들지 못했어요. 잠시 후 다시 시도해주세요." });
+    else { try { res.end(); } catch {} }
+  }
+  } catch (err) {
+    // 핸들러 전체 안전망 — 권한·BFS·쿼리·folderPath 등 헤더 전송 전 어떤 예외든 여기서 잡아
+    // 깔끔한 500 으로 응답한다(express-async-errors 로 새어 글로벌 "서버 오류가 발생했습니다"가
+    // 되던 것을 방지). 실제 원인은 폴더 id 와 함께 로깅 → CloudWatch 에서 추적 가능.
+    console.error("[doc:zip] folder download failed", req.params.id, err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: "폴더 다운로드 중 오류가 발생했어요. 잠시 후 다시 시도하거나 개별 파일로 받아주세요." });
+    } else {
+      try { res.end(); } catch {}
+    }
+  }
 });
 
 export default router;


### PR DESCRIPTION
## 증상
데스크탑(및 웹)에서 폴더 전체 다운로드 시 **"폴더 다운로드 실패 / 서버 오류가 발생했습니다"** 모달이 뜨고 ZIP 이 안 받아짐(스크린샷).

## 원인
- "서버 오류가 발생했습니다" 는 글로벌 에러 핸들러(`index.ts:472`)의 500 메시지 → 폴더 다운로드 핸들러가 **헤더 전송 전 uncaught 예외**를 던지고 있고, 직전 PR(#897 express-async-errors)로 이제 hang 대신 500 으로 드러남(예전엔 30초 행)
- 폴더 ZIP 라우트(`/folders/:id/download`)는 헤더 설정 전 구간(권한 검사·BFS 폴더 수집·`folderPath` 재귀·문서 쿼리)에서 예외가 나면 그대로 글로벌 핸들러로 새어 일반 500 이 됐다. 특히 `folderPath` 는 폴더 트리 `parentId` 사이클(데이터 손상) 시 무한 재귀 → 스택 오버플로 가능
- finalize 실패도 글로벌 핸들러로 새어 같은 일반 500 이 됐다

## 작업 내용
**수정 — `server/src/routes/document.ts` 폴더 다운로드 라우트**
- **핸들러 전체를 try/catch 로 감쌈**: 헤더 전송 전 어떤 예외(권한·쿼리·folderPath 등)든 잡아 **명확한 안내 메시지**의 500 으로 응답(`"폴더 다운로드 중 오류… 개별 파일로 받아주세요"`). 실제 원인은 `[doc:zip] folder download failed <folderId>` 로 로깅 → CloudWatch 에서 정확 추적
- **`folderPath` 사이클 가드**: `seen` Set 으로 parentId 순환 시 무한 재귀(스택 오버플로) 차단
- **`archive.finalize()` try/catch**: 압축 실패를 스트림 한정 처리(헤더 미전송 시 깔끔한 500, 전송 후 res.end) — 글로벌 핸들러로 안 샘
- **`writeLog` 비차단화**: finalize 뒤 `await writeLog` → fire-and-forget + `.catch`. 감사 로깅 실패가 다운로드를 깨뜨리지 않게(애초에 writeLog 자체 try/catch 있으나 순서·안전성 강화)

**호환성·외부 영향**
- 정상 폴더(파일 있음)는 기존대로 ZIP 스트리밍 — 무변경
- 빈 폴더/권한 없음은 기존 404/403 그대로
- 클라이언트(`downloadFolder`)는 이미 500 JSON 의 `error` 를 모달로 표시 → 이제 더 명확한 안내가 뜸

## 검증
- [x] `server` tsc 통과(try/catch brace 균형 확인)
- [ ] 배포 후 폴더 다운로드 재시도 — 정상 폴더는 ZIP 받아지고, 실패 시 CloudWatch 에 실제 원인(`[doc:zip] folder download failed`) 기록 확인

Closes #909