### PR TITLE
🔀 :: (#913) 한글 폴더 다운로드 ERR_INVALID_CHAR — Content-Disposition ASCII 폴백

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -358,9 +358,13 @@ function applyUploadSecurityHeaders(
     const fn = downloadName || name;
     // RFC 5987 로 UTF-8 파일명 인코딩 — 한글/공백 파일명도 깨지지 않게.
     const encoded = encodeURIComponent(fn).replace(/['()]/g, escape).replace(/\*/g, "%2A");
+    // plain filename="..." 은 ASCII 만 — Node res.setHeader 가 비-ASCII(한글) 헤더 값에
+    // ERR_INVALID_CHAR 를 던지므로 ASCII 폴백으로 둔다(유니코드 원본명은 filename*= 가 담당).
+    // presigned 302 경로(getSignedDownloadUrl)는 이 함수를 안 타지만, 버퍼-폴백 시 안전하게.
+    const asciiFn = fn.replace(/[^\x20-\x7E]/g, "_").replace(/"/g, "");
     res.setHeader(
       "Content-Disposition",
-      `attachment; filename="${fn.replace(/"/g, "")}"; filename*=UTF-8''${encoded}`,
+      `attachment; filename="${asciiFn}"; filename*=UTF-8''${encoded}`,
     );
   }
 }

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -841,9 +841,14 @@ router.get("/folders/:id/download", async (req, res) => {
   const zipName = `${folder.name.replace(/[\\/:*?"<>|]/g, "_")}.zip`;
   res.setHeader("Content-Type", "application/zip");
   const encodedZip = encodeURIComponent(zipName);
+  // ★ plain filename="..." 은 ASCII 만 허용 — Node res.setHeader 는 헤더 값에 비-ASCII(한글 등)가
+  //   있으면 ERR_INVALID_CHAR 를 던진다. 한글 폴더명("회사 정보")이 그대로 들어가 모든 한글 폴더
+  //   다운로드가 500 으로 실패했음. 유니코드 원본명은 filename*=UTF-8'' 가 담당하고, plain 은
+  //   ASCII 폴백(비-ASCII → "_")으로 둔다(구형 클라 호환).
+  const asciiZip = zipName.replace(/[^\x20-\x7E]/g, "_").replace(/"/g, "");
   res.setHeader(
     "Content-Disposition",
-    `attachment; filename="${zipName.replace(/"/g, "")}"; filename*=UTF-8''${encodedZip}`,
+    `attachment; filename="${asciiZip}"; filename*=UTF-8''${encodedZip}`,
   );
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Cache-Control", "no-store");
@@ -909,13 +914,7 @@ router.get("/folders/:id/download", async (req, res) => {
     // 되던 것을 방지). 실제 원인은 폴더 id 와 함께 로깅 → CloudWatch 에서 추적 가능.
     console.error("[doc:zip] folder download failed", req.params.id, err);
     if (!res.headersSent) {
-      // 진단용 힌트 — Prisma 코드(P20xx) 또는 에러명만 노출(스택·시크릿 아님). 원인 파악 후 제거 예정.
-      const e: any = err;
-      const hint = e?.code || e?.name || "unknown";
-      res.status(500).json({
-        error: `폴더 다운로드 중 오류가 발생했어요. (${hint}) 개별 파일로 받아주세요.`,
-        _debug: { code: e?.code ?? null, name: e?.name ?? null, message: typeof e?.message === "string" ? e.message.slice(0, 200) : null },
-      });
+      res.status(500).json({ error: "폴더 다운로드 중 오류가 발생했어요. 잠시 후 다시 시도하거나 개별 파일로 받아주세요." });
     } else {
       try { res.end(); } catch {}
     }

--- a/server/src/routes/folderShareLink.ts
+++ b/server/src/routes/folderShareLink.ts
@@ -169,9 +169,12 @@ export async function streamFolderZip(
 
   const zipName = `${folderName.replace(/[\\/:*?"<>|]/g, "_")}.zip`;
   res.setHeader("Content-Type", "application/zip");
+  // plain filename 은 ASCII 만 — 한글 폴더명이 그대로 들어가면 Node setHeader 가 ERR_INVALID_CHAR
+  // 를 던져 공유 링크 폴더 다운로드가 실패한다. 유니코드 원본명은 filename*=UTF-8'' 가 담당.
+  const asciiZip = zipName.replace(/[^\x20-\x7E]/g, "_").replace(/"/g, "");
   res.setHeader(
     "Content-Disposition",
-    `attachment; filename="${zipName.replace(/"/g, "")}"; filename*=UTF-8''${encodeURIComponent(zipName)}`,
+    `attachment; filename="${asciiZip}"; filename*=UTF-8''${encodeURIComponent(zipName)}`,
   );
 
   const archive = archiver("zip", { zlib: { level: 5 } });


### PR DESCRIPTION
## 증상
한글 이름 폴더("회사 정보", "조직문화교육" 등) 전체 다운로드가 **항상 "폴더 다운로드 실패 / 서버 오류"** 로 실패. 진단 결과 에러 코드 **`ERR_INVALID_CHAR`** 확인.

## 원인 (확정)
**근본 원인**: Node `res.setHeader()` 는 헤더 값에 **비-ASCII(한글) 문자**가 있으면 `ERR_INVALID_CHAR` 를 던진다. 폴더 ZIP 다운로드가 Content-Disposition 을
```
attachment; filename="회사 정보.zip"; filename*=UTF-8...
```
로 설정하는데, **plain `filename="회사 정보.zip"` 의 한글이 그대로** 헤더 값에 들어가 throw → 헤더 전송 전이라 글로벌 핸들러가 500 으로 응답.

- HTTP 헤더 값은 ASCII(latin1)만 허용. 유니코드 파일명은 RFC 5987 의 `filename*=UTF-8<percent-encoded>` 가 담당하고, plain `filename="..."` 는 **ASCII 폴백**이어야 한다(구형 클라용).
- 개별 파일 다운로드가 멀쩡했던 이유: presigned 302(S3 ResponseContentDisposition) 경로라 Node `res.setHeader` 를 안 탔음. 폴더 ZIP·버퍼-폴백·공유링크만 직접 setHeader → 한글에서 터졌음.

## 작업 내용
**수정 — 비-ASCII → "_" 폴백을 plain filename 에 적용**(유니코드 원본명은 `filename*=` 가 유지)
- `server/src/routes/document.ts` 폴더 ZIP 다운로드: `asciiZip = zipName.replace(/[^\x20-\x7E]/g, "_")`
- `server/src/index.ts` `applyUploadSecurityHeaders`(개별 파일 버퍼-폴백 경로): `asciiFn` 동일 적용
- `server/src/routes/folderShareLink.ts` 공유 링크 폴더 ZIP: 동일 적용
- 진단용 `_debug`/에러 코드 노출 제거(원인 확정됨)

**안전 확인 — 같은 패턴 전수 점검**
- `shareLink.ts`(개별 파일 공유): `filename*=` 만 사용 → ASCII 이슈 없음(안전)
- `storage.ts` presigned: 이미 `asciiFallback` 적용됨
- `desktopDownload.ts`: 빌드 산출물명(항상 ASCII)

**호환성·외부 영향**
- 다운로드 파일명은 모던 브라우저·OS 에서 **여전히 한글 원본명**으로 저장됨(`filename*=UTF-8` 우선). plain 폴백은 아주 구형 클라에서만 사용
- 한글뿐 아니라 모든 비-ASCII(이모지·일본어 등) 폴더명도 이제 안전

## 검증
- [x] `server` tsc 통과
- [ ] 배포 후 한글 폴더 다운로드 → ZIP 정상 + 파일명 한글 유지 확인

Closes #913