### PR TITLE
🔀 :: (#915) 다운로드 진행 표시 + 폴더 ZIP 병렬 fetch 속도 개선

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -96,6 +96,10 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   const [modalErr, setModalErr] = useState<string | null>(null);
   const [busyFolderId, setBusyFolderId] = useState<string | null>(null);
   const [busyDocId, setBusyDocId] = useState<string | null>(null);
+  // 다운로드 진행 표시 — 폴더 ZIP 은 서버가 압축해 스트리밍하느라 시간이 걸려서, 누른 뒤
+  // 아무 표시 없이 기다리면 멈춘 줄 안다(사용자 신고). 진행 중인 폴더/문서 id 를 표시.
+  const [downloadingFolderId, setDownloadingFolderId] = useState<string | null>(null);
+  const [downloadingDocId, setDownloadingDocId] = useState<string | null>(null);
   // 새로고침/링크 공유 대비해 탭·프로젝트·현재 폴더를 URL 쿼리로 동기화.
   // embed 모드에선 상위 페이지(예: 프로젝트 상세)의 쿼리와 충돌할 수 있어 scope/project 는 비활성화.
   const [sp, setSp] = useSearchParams();
@@ -735,6 +739,10 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     const hint = d.fileName || d.title || "";
     if (hint) url.searchParams.set("name", hint);
     downloadFromUrl(url.toString(), hint);
+    // 개별 파일은 브라우저·OS 다운로드 매니저가 진행을 표시하므로(앱이 blob 을 들고 있지 않음)
+    // 짧게 "다운로드 시작" 피드백만 준다 — 누르고 반응 없는 느낌 제거. 1.2초 후 자동 해제.
+    setDownloadingDocId(d.id);
+    window.setTimeout(() => setDownloadingDocId((cur) => (cur === d.id ? null : cur)), 1200);
   }
 
   // 미리보기 가능한 타입(이미지·PDF·영상)인가. 그 외(.docx·.pptx·.zip 등)는 미리보기 의미가 없어 다운로드.
@@ -764,11 +772,13 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     // 예전엔 fetch→blob→Browser.open(blob:) 라 폴더 ZIP 다운로드가 조용히 실패했다.
     // 인증된 절대 URL(imgSrc 가 ?token= 부여)을 직접 열어 iOS 가 ZIP 다운로드/공유 시트를 띄우게 한다.
     // (서버 /folders/:id/download 는 이 GET 한정으로 ?token= 인증을 허용하도록 했다.)
+    if (downloadingFolderId) return; // 중복 클릭 가드
     if (isCapacitorNative()) {
       const u = imgSrc(`/api/document/folders/${f.id}/download`);
       if (u) void Browser.open({ url: u }).catch(() => {});
       return;
     }
+    setDownloadingFolderId(f.id);
     try {
       const res = await apiFetch(`/api/document/folders/${f.id}/download`);
       if (!res.ok) {
@@ -791,6 +801,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       downloadBlob(blob, fname);
     } catch (err: any) {
       await alertAsync({ title: "폴더 다운로드 실패", description: err?.message ?? String(err) });
+    } finally {
+      setDownloadingFolderId(null);
     }
   }
 
@@ -1256,8 +1268,12 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                 <svg className="md:hidden text-ink-300 flex-shrink-0" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
                 {/* 호버 액션은 absolute 오버레이 — 평소엔 레이아웃을 먹지 않아 이름·날짜 영역이 잘리지 않음. */}
                 <div className="touch-reveal-flex absolute top-2 right-2 hidden group-hover:flex items-center gap-0.5 bg-[color:var(--c-surface)]/95 backdrop-blur-sm rounded-lg px-1 py-0.5 shadow-sm border border-ink-100">
-                  <button className="btn-icon" onClick={(e) => { e.stopPropagation(); downloadFolder(f); }} title="폴더 전체 다운로드 (ZIP)">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></svg>
+                  <button className="btn-icon disabled:opacity-60" disabled={downloadingFolderId === f.id} onClick={(e) => { e.stopPropagation(); downloadFolder(f); }} title={downloadingFolderId === f.id ? "압축 중…" : "폴더 전체 다운로드 (ZIP)"}>
+                    {downloadingFolderId === f.id ? (
+                      <svg className="hinest-spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round"><path d="M21 12a9 9 0 1 1-6.2-8.5" /></svg>
+                    ) : (
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></svg>
+                    )}
                   </button>
                   <button className="btn-icon" onClick={async (e) => { e.stopPropagation(); const p = { kind: "DOCUMENT" as const, title: f.name, href: `/documents?folder=${f.id}` }; if (!(await presentShareNative(p))) setSharePayload(p); }} title="동료에게 공유">
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" /><path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4" /></svg>
@@ -1463,8 +1479,12 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                         /* 파일 문서 타입 */
                         <>
                           {d.fileUrl && (
-                            <button className="btn-icon" onClick={() => downloadDoc(d)} title="다운로드">
-                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></svg>
+                            <button className="btn-icon" onClick={() => downloadDoc(d)} title={downloadingDocId === d.id ? "다운로드 시작됨" : "다운로드"}>
+                              {downloadingDocId === d.id ? (
+                                <svg className="hinest-spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round"><path d="M21 12a9 9 0 1 1-6.2-8.5" /></svg>
+                              ) : (
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></svg>
+                              )}
                             </button>
                           )}
                           {d.fileUrl && (

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -862,25 +862,41 @@ router.get("/folders/:id/download", async (req, res) => {
   });
   archive.pipe(res);
 
+  // 엔트리명을 "먼저" 결정적으로 계산(문자열 연산이라 즉시) — 이후 fetch 를 병렬화해도
+  // safeUniqueZipEntry 의 "(2)" 중복 꼬리 번호가 순서에 흔들리지 않게.
+  const planned: { key: string; name: string }[] = [];
+  for (const d of collected) {
+    if (!d.fileUrl.startsWith("/uploads/")) continue;
+    const key = d.fileUrl.slice("/uploads/".length);
+    if (!key) continue;
+    const name = safeUniqueZipEntry(usedEntries, d.relPath || "", d.fileName || d.title || key);
+    planned.push({ key, name });
+  }
+
+  // ★ 속도 개선 — 예전엔 파일을 "순차" 로 S3 에서 받아(왕복 latency 가 직렬 합산) 폴더가 크면
+  //   매우 느렸다. 동시성 제한(워커 3개)으로 S3 fetch 를 겹쳐 체감 속도를 크게 줄인다.
+  //   cap=3 은 메모리 상한(최대 3개 파일 버퍼 동시 보유)과 속도의 절충 — 대용량 파일 다수에서도
+  //   Fargate 메모리를 과하게 먹지 않게. (완전한 무버퍼 스트리밍은 storage 스트림 API 후속 과제.)
+  const CONCURRENCY = 3;
   let added = 0;
-  try {
-    for (const d of collected) {
-      // 업로드 경로 파싱 — 기존 regex 가 너무 빡빡해 파일명에 허용되지 않는 글자가 하나라도
-      // 들어있으면 통째로 스킵됐음. key 추출은 마지막 슬래시 이후의 원시 문자열로.
-      if (!d.fileUrl.startsWith("/uploads/")) continue;
-      const key = d.fileUrl.slice("/uploads/".length);
-      if (!key) continue;
+  let idx = 0;
+  async function worker() {
+    while (idx < planned.length) {
+      const e = planned[idx++];
       let buf: Buffer | null = null;
       try {
-        buf = await fetchFileBuffer(key);
+        buf = await fetchFileBuffer(e.key);
       } catch (err) {
-        console.error("[doc:zip] fetch failed", key, err);
+        console.error("[doc:zip] fetch failed", e.key, err);
       }
-      if (!buf) continue;
-      const entryName = safeUniqueZipEntry(usedEntries, d.relPath || "", d.fileName || d.title || key);
-      archive.append(buf, { name: entryName });
-      added++;
+      if (buf) {
+        archive.append(buf, { name: e.name }); // archiver 가 내부 큐로 직렬화 — 동시 append 안전
+        added++;
+      }
     }
+  }
+  try {
+    await Promise.all(Array.from({ length: Math.min(CONCURRENCY, planned.length) }, () => worker()));
   } catch (err) {
     console.error("[doc:zip] collect loop failed", err);
   }


### PR DESCRIPTION
## 증상
1. **다운로드 진행 표시 없음**: 폴더/파일 다운로드 버튼을 눌러도 아무 표시 없이 기다려야 함 → 멈춘 줄 알게 됨(사용자 신고)
2. **폴더 ZIP 다운로드가 너무 느림**

## 원인
1. 다운로드 버튼에 로딩 상태가 없음. 특히 폴더 ZIP 은 서버가 압축·스트리밍하는 동안(수 초~수십 초) 클라가 아무 피드백을 안 줌
2. 서버 폴더 ZIP 라우트가 각 파일을 **순차적으로** S3 에서 메모리로 받음(`for...await fetchFileBuffer`) → S3 왕복 latency 가 파일 수만큼 직렬 합산되어 큰 폴더에서 매우 느림

## 작업 내용
**클라 — 진행 표시 (`DocumentsPage.tsx`)**
- `downloadingFolderId` / `downloadingDocId` state 추가
- 폴더 다운로드: 버튼이 **회전 스피너**(hinest-spin)로 바뀌고 비활성, title "압축 중…". 완료 시 해제. 중복 클릭 가드
- 개별 파일: 누르면 1.2초간 스피너 피드백(개별 파일은 브라우저/OS 다운로드 매니저가 실제 진행을 표시하므로 "시작됨" 신호만)

**서버 — 속도 개선 (`document.ts` 폴더 ZIP)**
- 엔트리명을 먼저 결정적으로 계산(중복 "(2)" 꼬리번호가 병렬화에 흔들리지 않게)
- 파일 fetch 를 **동시성 제한(워커 3개) 병렬**로 변경 → S3 왕복을 겹쳐 체감 속도 대폭 단축
- cap=3 으로 메모리 상한(최대 3개 파일 버퍼 동시) 유지 — 대용량 파일 다수에서도 Fargate 메모리 안전. archiver 는 내부 큐로 동시 append 직렬화하므로 안전

## 호환성·외부 영향
- ZIP 내용·파일명·권한·에러 처리 무변경. 순서만 병렬화(zip 엔트리 순서는 무의미)
- 완전 무버퍼 스트리밍(파일을 메모리에 안 올리고 S3→archiver 직결)은 storage 스트림 API 가 필요한 후속 과제 — 이번엔 병렬화로 안전하게 개선
- 네이티브(iOS)는 기존대로 인앱 브라우저 다운로드(진행은 OS 가 표시)

## 검증
- [x] `server` tsc + `client` tsc + vite build 통과
- [ ] 배포 후 폴더 다운로드 시 스피너 표시 + 다중 파일 폴더 속도 개선 확인

Closes #915