### PR TITLE
🔀 :: (#917) 다운로드 진행 토스트 — 모바일·네이티브 일관 표시

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import { isDesktopApp } from "./lib/platform";
 import UpdateBanner from "./components/UpdateBanner";
 import DesktopUpdateBanner from "./components/DesktopUpdateBanner";
 import AppStoreUpdatePrompt from "./components/AppStoreUpdatePrompt";
+import DownloadToastHost from "./components/DownloadToast";
 import ConfirmHost from "./components/ConfirmHost";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import LoginPage from "./pages/LoginPage";
@@ -127,6 +128,7 @@ export default function App() {
     <UpdateBanner />
     <DesktopUpdateBanner />
     <AppStoreUpdatePrompt />
+    <DownloadToastHost />
     <ConfirmHost />
     <ErrorBoundary resetKey={pathname}>
     <Suspense fallback={<RouteFallback />}>

--- a/client/src/components/DownloadToast.tsx
+++ b/client/src/components/DownloadToast.tsx
@@ -1,0 +1,85 @@
+/**
+ * 글로벌 다운로드 토스트 — 하단 중앙 알약(pill) 형태로 "다운로드 준비/진행" 을 알린다.
+ *
+ * 왜 버튼 스피너가 아니라 토스트인가:
+ *   버튼별 스피너는 데스크탑(테이블/호버 액션)에선 보이지만, 모바일은 문서 카드 탭으로 바로
+ *   다운로드돼 스피너를 띄울 버튼이 없고, 네이티브(iOS)는 인앱 브라우저로 빠져 앱 내 표시가
+ *   없다 → 모바일에서 "눌러도 아무 반응 없는" 느낌. 토스트는 웹·모바일·네이티브 어디서나
+ *   동일하게 화면 하단에 뜬다(플랫폼 무관). safe-area·탭바 위로 올라오게 배치.
+ *
+ * 사용:
+ *   const id = showDownloadToast("📦 압축 파일 준비 중…", { spinner: true });
+ *   ...완료...
+ *   hideDownloadToast(id);                       // 특정 토스트 닫기
+ *   showDownloadToast("다운로드를 시작했어요", { autoHideMs: 2000 }); // 자동 닫힘
+ */
+import { useEffect, useState } from "react";
+import Portal from "./Portal";
+
+type ToastState = { id: number; text: string; spinner: boolean } | null;
+
+let _seq = 1;
+let _current: ToastState = null;
+const _listeners = new Set<(s: ToastState) => void>();
+function _emit() { _listeners.forEach((fn) => fn(_current)); }
+
+/** 토스트 표시(또는 교체). 반환된 id 로 나중에 hide. autoHideMs 주면 그 시간 뒤 자동 닫힘. */
+export function showDownloadToast(
+  text: string,
+  opts: { spinner?: boolean; autoHideMs?: number } = {},
+): number {
+  const id = _seq++;
+  _current = { id, text, spinner: opts.spinner ?? false };
+  _emit();
+  if (opts.autoHideMs && opts.autoHideMs > 0) {
+    setTimeout(() => hideDownloadToast(id), opts.autoHideMs);
+  }
+  return id;
+}
+
+/** 토스트 닫기 — id 가 지금 떠 있는 토스트와 같을 때만(다른 토스트로 교체됐으면 무시). */
+export function hideDownloadToast(id?: number): void {
+  if (id != null && _current?.id !== id) return;
+  _current = null;
+  _emit();
+}
+
+export default function DownloadToastHost() {
+  const [state, setState] = useState<ToastState>(_current);
+  useEffect(() => {
+    const fn = (s: ToastState) => setState(s);
+    _listeners.add(fn);
+    return () => { _listeners.delete(fn); };
+  }, []);
+
+  return (
+    <Portal>
+      <div
+        aria-live="polite"
+        className="fixed inset-x-0 z-[1200] flex justify-center pointer-events-none px-4"
+        style={{
+          // 모바일 하단 탭바·홈 인디케이터 위로 — safe-area + 여유. 데스크탑은 env=0 이라 하단에서 24px.
+          bottom: "calc(env(safe-area-inset-bottom, 0px) + 88px)",
+        }}
+      >
+        <div
+          className="flex items-center gap-2.5 rounded-full bg-ink-900/92 text-white text-[13px] font-semibold px-4 py-2.5 shadow-2xl backdrop-blur-sm"
+          style={{
+            transform: state ? "translateY(0)" : "translateY(16px)",
+            opacity: state ? 1 : 0,
+            transition: "transform 240ms cubic-bezier(.32,.72,0,1), opacity 200ms ease",
+            pointerEvents: state ? "auto" : "none",
+            maxWidth: "90vw",
+          }}
+        >
+          {state?.spinner && (
+            <svg className="hinest-spin flex-shrink-0" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" aria-hidden>
+              <path d="M21 12a9 9 0 1 1-6.2-8.5" />
+            </svg>
+          )}
+          <span className="truncate">{state?.text ?? ""}</span>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import Portal from "../components/Portal";
 import { confirmAsync, alertAsync, promptAsync } from "../components/ConfirmHost";
+import { showDownloadToast, hideDownloadToast } from "../components/DownloadToast";
 import ShareSheet, { type SharePayload } from "../components/ShareSheet";
 import { presentShareNative } from "../lib/share";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
@@ -740,9 +741,11 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     if (hint) url.searchParams.set("name", hint);
     downloadFromUrl(url.toString(), hint);
     // 개별 파일은 브라우저·OS 다운로드 매니저가 진행을 표시하므로(앱이 blob 을 들고 있지 않음)
-    // 짧게 "다운로드 시작" 피드백만 준다 — 누르고 반응 없는 느낌 제거. 1.2초 후 자동 해제.
+    // 짧게 "다운로드 시작" 피드백만 준다 — 누르고 반응 없는 느낌 제거.
+    // 데스크탑 버튼 스피너(1.2초) + 모바일·네이티브에선 토스트(문서 카드엔 버튼이 없어 토스트가 유일한 신호).
     setDownloadingDocId(d.id);
     window.setTimeout(() => setDownloadingDocId((cur) => (cur === d.id ? null : cur)), 1200);
+    showDownloadToast("⬇ 다운로드를 시작했어요", { autoHideMs: 1800 });
   }
 
   // 미리보기 가능한 타입(이미지·PDF·영상)인가. 그 외(.docx·.pptx·.zip 등)는 미리보기 의미가 없어 다운로드.
@@ -774,11 +777,15 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     // (서버 /folders/:id/download 는 이 GET 한정으로 ?token= 인증을 허용하도록 했다.)
     if (downloadingFolderId) return; // 중복 클릭 가드
     if (isCapacitorNative()) {
+      // 네이티브: 인앱 브라우저로 빠지므로 앱 내 버튼 스피너가 안 보인다 → 토스트로 시작 알림.
+      showDownloadToast("📦 폴더 다운로드를 시작했어요", { autoHideMs: 2500 });
       const u = imgSrc(`/api/document/folders/${f.id}/download`);
       if (u) void Browser.open({ url: u }).catch(() => {});
       return;
     }
     setDownloadingFolderId(f.id);
+    // 폴더 ZIP 은 서버 압축·스트리밍에 시간이 걸려 모바일·데스크탑 모두 진행 표시가 필요.
+    const toastId = showDownloadToast("📦 압축 파일 준비 중…", { spinner: true });
     try {
       const res = await apiFetch(`/api/document/folders/${f.id}/download`);
       if (!res.ok) {
@@ -799,10 +806,12 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       const mName = /filename\*=UTF-8''([^;]+)/i.exec(cd) || /filename="?([^";]+)"?/i.exec(cd);
       const fname = mName ? decodeURIComponent(mName[1]) : `${f.name}.zip`;
       downloadBlob(blob, fname);
+      showDownloadToast("✓ 다운로드를 시작했어요", { autoHideMs: 1800 });
     } catch (err: any) {
       await alertAsync({ title: "폴더 다운로드 실패", description: err?.message ?? String(err) });
     } finally {
       setDownloadingFolderId(null);
+      hideDownloadToast(toastId);
     }
   }
 


### PR DESCRIPTION
## 증상
직전 PR(#916)의 다운로드 진행 스피너가 **모바일에서 거의 안 보임**(사용자 지적):
- 모바일 문서 카드는 탭하면 바로 다운로드 → 스피너를 띄울 버튼이 없어 **아무 표시 없음**
- 네이티브(iOS)는 폴더 다운로드 시 인앱 브라우저로 빠지며 `downloadFolder` 가 일찍 return → **스피너 안 뜸**
- 모바일 웹 폴더 버튼은 우상단 작은 버튼 4개 몰린 곳이라 스피너가 어색

## 원인
진행 표시를 **버튼별 스피너**로만 구현 → 버튼이 보이는 데스크탑 전용. 모바일 카드 탭·네이티브 인앱브라우저 경로엔 표시 자리가 없음.

## 작업 내용
**추가 — 플랫폼 무관 글로벌 토스트**
- `components/DownloadToast.tsx`: 하단 중앙 알약 토스트 + `showDownloadToast`/`hideDownloadToast` 컨트롤러. safe-area·탭바 위 배치, 스프링 슬라이드업, 스피너 옵션, autoHide 옵션
- `App.tsx`: `<DownloadToastHost />` 전역 마운트
- `DocumentsPage`: 폴더(웹)=진행 스피너 토스트→완료 토스트, 폴더(네이티브)=시작 토스트, 개별 파일=시작 토스트. 기존 데스크탑 버튼 스피너는 유지(보조)

## 호환성·외부 영향
- 웹·모바일·네이티브 **모두 동일하게** 화면 하단에 다운로드 피드백 표시
- 데스크탑 버튼 스피너는 그대로(중복 아닌 보조 — 어느 항목인지 표시)
- 다른 페이지 영향 없음(토스트는 호출 시에만 표시)

## 검증
- [x] `client` tsc + vite build 통과
- [ ] 모바일·데스크탑·네이티브에서 폴더/파일 다운로드 시 토스트 표시 확인

Closes (이어지는 개선)