### PR TITLE
🔀 :: (#920) 사이드바 프로필을 회사 앱과 동일하게 — 사진·개발자뱃지·개발자모드·로그아웃

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -16,7 +16,8 @@ import { NotificationProvider, useNotifications } from "../notifications";
 import { PinsProvider, usePins, pinLinkUrl } from "../pins";
 import { ROUTE_PREFETCH, loadProject } from "../routes";
 import { isDevAccount, DevBadge } from "../lib/devBadge";
-import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
+import { getDevPagesEnabled } from "../lib/devPagesPref";
+import DevQuickToggle from "./DevQuickToggle";
 import { isPreviewMode, disablePreview } from "../lib/previewFlag";
 import { isInstalledApp, isDesktopApp, nativePlatform, isCapacitorNative } from "../lib/platform";
 import { LiquidGlassTabBar, setNativeTabBarHidden, syncNativeTabBarVisibility } from "../lib/liquidGlassTabBar";
@@ -1443,55 +1444,7 @@ type ProjectLite = {
   status: "ACTIVE" | "ARCHIVED";
 };
 
-/** 사이드바 본인 정보 옆 \"개발 중 페이지 보기\" 빠른 토글 — 개발자 전용. */
-function DevQuickToggle() {
-  const [on, setOn] = useState<boolean>(() => getDevPagesEnabled());
-  useEffect(() => {
-    function refresh() { setOn(getDevPagesEnabled()); }
-    window.addEventListener("hinest:devPagesChange", refresh);
-    window.addEventListener("storage", refresh);
-    return () => {
-      window.removeEventListener("hinest:devPagesChange", refresh);
-      window.removeEventListener("storage", refresh);
-    };
-  }, []);
-  function toggle() {
-    const next = !on;
-    setOn(next);
-    setDevPagesEnabled(next);
-  }
-  return (
-    <button
-      type="button"
-      onClick={toggle}
-      className="btn-icon"
-      title={on ? "“개발 중” 페이지 진입 켜짐 — 클릭해서 끄기" : "“개발 중” 페이지 진입 꺼짐 — 클릭해서 켜기"}
-      aria-label={on ? "개발 페이지 보기 끄기" : "개발 페이지 보기 켜기"}
-      style={{
-        position: "relative",
-        color: on ? "var(--c-warning)" : "var(--c-text-3)",
-      }}
-    >
-      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <polyline points="16 18 22 12 16 6" />
-        <polyline points="8 6 2 12 8 18" />
-      </svg>
-      <span
-        aria-hidden
-        style={{
-          position: "absolute",
-          right: 2,
-          bottom: 2,
-          width: 7,
-          height: 7,
-          borderRadius: "50%",
-          background: on ? "var(--c-warning)" : "var(--c-border-strong)",
-          border: "1.5px solid var(--c-surface)",
-        }}
-      />
-    </button>
-  );
-}
+// DevQuickToggle 은 공용 컴포넌트(components/DevQuickToggle.tsx)로 추출 — ConsoleLayout 과 공유.
 
 /**
  * 사이드바 "팀" 섹션 — 내가 참여중인 프로젝트 목록.

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
+import { imgSrc } from "../api";
 import AdminLockup from "./AdminLockup";
 import { LiquidGlassTabBar } from "../lib/liquidGlassTabBar";
 import { nativePlatform } from "../lib/platform";
@@ -215,12 +216,24 @@ export default function ConsoleLayout() {
           style={{ paddingBottom: "max(8px, env(safe-area-inset-bottom))" }}
         >
           <div className="flex items-center gap-2 px-3 py-2">
-            <div
-              className="avatar avatar-sm flex-shrink-0"
-              style={{ background: user?.avatarColor ?? "#3B5CF0" }}
-            >
-              {user?.name?.[0] ?? "?"}
-            </div>
+            {/* 회사 앱 상단바와 동일하게 — 프로필 사진(avatarUrl)이 있으면 사진을, 없으면 색+이니셜 폴백.
+                예전엔 색+이니셜만 렌더해 같은 계정인데도 콘솔 아바타가 회사 앱과 달라 보였다. */}
+            {user?.avatarUrl ? (
+              <img
+                src={imgSrc(user.avatarUrl)}
+                alt={user.name ?? "프로필"}
+                className="avatar avatar-sm flex-shrink-0 object-cover"
+                loading="lazy"
+                decoding="async"
+              />
+            ) : (
+              <div
+                className="avatar avatar-sm flex-shrink-0"
+                style={{ background: user?.avatarColor ?? "#3B5CF0" }}
+              >
+                {user?.name?.[0] ?? "?"}
+              </div>
+            )}
             <div className="min-w-0 flex-1">
               <div className="text-[12.5px] font-semibold truncate">{user?.name}</div>
               <div className="text-[10.5px] text-white/45 truncate">{user?.email}</div>

--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -5,6 +5,9 @@ import { imgSrc } from "../api";
 import AdminLockup from "./AdminLockup";
 import { LiquidGlassTabBar } from "../lib/liquidGlassTabBar";
 import { nativePlatform } from "../lib/platform";
+import { isDevAccount, DevBadge } from "../lib/devBadge";
+import { confirmLogout } from "../lib/confirmLogout";
+import DevQuickToggle from "./DevQuickToggle";
 
 // 콘솔 탭 라우트 → 네이티브 탭바용 아이콘 에셋(Assets.xcassets) 이름.
 const CONSOLE_TAB_ICON: Record<string, string> = {
@@ -72,7 +75,7 @@ function ShieldIcon() {
 }
 
 export default function ConsoleLayout() {
-  const { user } = useAuth();
+  const { user, logout } = useAuth();
   const nav = useNavigate();
   const loc = useLocation();
 
@@ -235,12 +238,30 @@ export default function ConsoleLayout() {
               </div>
             )}
             <div className="min-w-0 flex-1">
-              <div className="text-[12.5px] font-semibold truncate">{user?.name}</div>
+              {/* 회사 앱 사이드바 프로필과 동일하게 — 이름 옆 개발자 뱃지(<>). */}
+              <div className="text-[12.5px] font-semibold truncate flex items-center gap-1.5 min-w-0">
+                <span className="truncate min-w-0">{user?.name}</span>
+                {isDevAccount(user) && <DevBadge iconOnly />}
+              </div>
               <div className="text-[10.5px] text-white/45 truncate">{user?.email}</div>
             </div>
-            {/* 데스크탑 사이드바 user profile — 로그아웃 버튼 제거(사용자 요구).
-                콘솔은 회사 앱 안의 운영 도구라 로그아웃은 회사 페이지에서 처리.
-                "서비스로 돌아가기"는 사이드바 상단의 큰 버튼이 이미 담당. */}
+            {/* 회사 앱과 동일한 프로필 액션 — 개발자모드 토글(<> 주황점) + 로그아웃.
+                (이전엔 콘솔에서 로그아웃을 뺐으나, 회사 앱 프로필과 통일해 달라는 요청으로 복원.) */}
+            {isDevAccount(user) && <DevQuickToggle />}
+            <button
+              onClick={async () => {
+                if (!(await confirmLogout())) return;
+                await logout();
+                nav("/login");
+              }}
+              className="btn-icon text-white/60 hover:text-white"
+              title="로그아웃"
+              aria-label="로그아웃"
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h4" /><path d="m16 17 5-5-5-5" /><path d="M21 12H9" />
+              </svg>
+            </button>
           </div>
         </div>
       </aside>

--- a/client/src/components/DevQuickToggle.tsx
+++ b/client/src/components/DevQuickToggle.tsx
@@ -1,0 +1,56 @@
+/**
+ * 개발자 빠른 토글 — "개발 중" 페이지 진입 ON/OFF (사이드바 프로필 옆 작은 `<>` 버튼).
+ * 마이페이지의 "개발자 옵션" 패널과 같은 localStorage 키(devPagesPref)를 공유한다.
+ * ON 이면 주황(warning) 색 + 우하단 점. AppLayout(회사 앱)·ConsoleLayout(운영 콘솔) 공용.
+ */
+import { useEffect, useState } from "react";
+import { getDevPagesEnabled, setDevPagesEnabled } from "../lib/devPagesPref";
+
+export default function DevQuickToggle() {
+  const [on, setOn] = useState<boolean>(() => getDevPagesEnabled());
+  useEffect(() => {
+    function refresh() { setOn(getDevPagesEnabled()); }
+    window.addEventListener("hinest:devPagesChange", refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener("hinest:devPagesChange", refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+  function toggle() {
+    const next = !on;
+    setOn(next);
+    setDevPagesEnabled(next);
+  }
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="btn-icon"
+      title={on ? "“개발 중” 페이지 진입 켜짐 — 클릭해서 끄기" : "“개발 중” 페이지 진입 꺼짐 — 클릭해서 켜기"}
+      aria-label={on ? "개발 페이지 보기 끄기" : "개발 페이지 보기 켜기"}
+      style={{
+        position: "relative",
+        color: on ? "var(--c-warning)" : "var(--c-text-3)",
+      }}
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polyline points="16 18 22 12 16 6" />
+        <polyline points="8 6 2 12 8 18" />
+      </svg>
+      <span
+        aria-hidden
+        style={{
+          position: "absolute",
+          right: 2,
+          bottom: 2,
+          width: 7,
+          height: 7,
+          borderRadius: "50%",
+          background: on ? "var(--c-warning)" : "var(--c-border-strong)",
+          border: "1.5px solid var(--c-surface)",
+        }}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## 증상
운영 콘솔 사이드바 프로필이 회사 앱과 달랐음(스크린샷): (1) 프로필 사진 대신 색+이니셜만 (2) 개발자 뱃지(<>) 없음 (3) 개발자모드 토글 없음 (4) 로그아웃 버튼 없음.

## 원인
- ConsoleLayout 이 `avatarUrl` 미사용(색+name[0] 만)
- PR #867 에서 콘솔 로그아웃을 제거했고, 개발자 뱃지·개발자모드 토글은 애초에 콘솔에 없었음
- DevQuickToggle 은 AppLayout 내부 함수라 콘솔에서 재사용 불가

## 작업 내용 (커밋 3개)
1. `fix(console)`: 사이드바 아바타에 사진(avatarUrl) 표시 — 회사 앱과 동일(사진 우선, 없으면 색+이니셜)
2. `refactor(client)`: DevQuickToggle 을 공용 컴포넌트(components/DevQuickToggle.tsx)로 추출 — AppLayout/ConsoleLayout 공유
3. `fix(console)`: 사이드바 프로필에 DevBadge(<>) + DevQuickToggle(개발자모드) + 로그아웃 버튼 추가 → 회사 앱 사이드바 풋터와 동일 구성

## 호환성
- 회사 앱 동작 무변경(DevQuickToggle 추출은 동작 동일)
- 사진 없는 계정·비개발자는 각 요소 폴백/숨김
- 콘솔 로그아웃은 회사 앱과 동일하게 confirmLogout 확인 후 처리

## 검증
- [x] client tsc + vite build 통과