### PR TITLE
🔀 :: (#921) 운영 콘솔 하단바 높이 키움 (회사 앱과 동일 49px)

### DIFF
--- a/client/src/components/ConsoleLayout.tsx
+++ b/client/src/components/ConsoleLayout.tsx
@@ -368,13 +368,16 @@ export default function ConsoleLayout() {
               key={l.to}
               to={l.to}
               className="flex-1 min-w-0 flex flex-col items-center justify-center gap-1 select-none text-[10px] font-bold tracking-tight leading-none"
-              style={({ isActive }) => ({ color: isActive ? "var(--c-brand)" : "var(--c-text-3)" })}
+              // 안드로이드 평면 바는 회사 앱(AppLayout BottomNavTab)과 동일하게 탭 높이 49px 로
+              // 키운다(부착형이라 콘텐츠에 딱 붙어 너무 낮아 보이던 것 보정). iOS 플로팅 알약은
+              // nav 자체 padding(6px) 으로 높이를 확보하므로 그대로 둔다.
+              style={({ isActive }) => ({ color: isActive ? "var(--c-brand)" : "var(--c-text-3)", ...(ios ? {} : { height: 49 }) })}
             >
               {({ isActive }) => (
                 <>
                   <span
                     className="inline-flex items-center justify-center"
-                    style={{ width: 44, height: 26, borderRadius: 999, background: isActive ? "var(--c-brand-soft)" : "transparent" }}
+                    style={{ width: 44, height: 28, borderRadius: 999, background: isActive ? "var(--c-brand-soft)" : "transparent" }}
                   >
                     <l.icon active={isActive} />
                   </span>


### PR DESCRIPTION
## 증상
안드로이드 운영 콘솔 하단 네비바(회사/로그/시스템/보안/개발자)가 너무 낮아 보임.

## 원인
평면 부착형 바로 전환하면서 탭에 명시 높이가 없어 아이콘+라벨 높이만큼만 차지(아이콘 pill 26px). 회사 앱 BottomNavTab 은 49px.

## 작업 내용
- 안드로이드(비-iOS) 탭 높이를 회사 앱과 동일한 **49px** 로 지정.
- 아이콘 pill 26→28px.
- iOS 플로팅 알약은 nav 자체 padding 으로 높이 확보 → 그대로 둠.
- 에뮬레이터에서 더 높아진 바 확인.