### PR TITLE
🔀 :: (#922) 테스트 알림 진단 Android(FCM) 지원 — iOS 전용 버그

### DIFF
--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { api, invalidateCache, clearApiCache, apiFetch , imgSrc} from "../api";
-import { isCapacitorNative } from "../lib/platform";
+import { isCapacitorNative, nativePlatform } from "../lib/platform";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import Portal from "../components/Portal";
@@ -525,20 +525,21 @@ function NativePushPanel() {
     setBusy(true);
     setResult(null);
     try {
-      const d = await api<{
-        enabled: boolean;
-        tokens: number;
-        results: { status: number; reason?: string }[];
-      }>("/api/push/diag");
+      type Diag = { enabled: boolean; tokens: number; results: { status: number; reason?: string }[]; note?: string };
+      // 서버는 iOS(APNs)·Android(FCM) 진단을 { ios, android } 로 함께 준다. 내 플랫폼 결과만 본다.
+      const d = await api<{ ios: Diag; android: Diag }>("/api/push/diag");
+      const android = nativePlatform() === "android";
+      const r: Diag = (android ? d.android : d.ios) ?? d.ios;
+      const svc = android ? "FCM" : "APNs";
       let msg: string;
-      if (!d.enabled) {
-        msg = "❌ 서버에 APNs 키가 설정되지 않았어요 (관리자: APNS_KEY/KEY_ID/TEAM_ID 환경변수 확인).";
-      } else if (!d.tokens) {
-        msg = "⚠️ 이 기기의 푸시 토큰이 등록되지 않았어요. 아래 안내대로 알림 권한을 켠 뒤 앱을 다시 실행해 주세요.";
-      } else if (d.results.some((r) => r.status === 200)) {
+      if (!r.enabled) {
+        msg = `❌ 서버에 ${svc} 설정이 안 돼 있어요 (관리자: ${android ? "FCM_SERVICE_ACCOUNT_JSON" : "APNS_KEY/KEY_ID/TEAM_ID"} 환경변수 확인).`;
+      } else if (!r.tokens) {
+        msg = "⚠️ 이 기기의 푸시 토큰이 등록되지 않았어요. 아래 안내대로 알림 권한을 켠 뒤 앱을 다시 실행해 주세요." + (r.note ? `\n(${r.note})` : "");
+      } else if (r.results.some((x) => x.status === 200)) {
         msg = "✅ 발송 성공! 잠시 후 이 기기에 테스트 알림이 도착합니다.";
       } else {
-        msg = "❌ 발송 실패: " + d.results.map((r) => `${r.status} ${r.reason ?? ""}`).join(", ");
+        msg = "❌ 발송 실패: " + r.results.map((x) => `${x.status} ${x.reason ?? ""}`).join(", ");
       }
       setResult(msg);
     } catch (e: any) {
@@ -552,7 +553,7 @@ function NativePushPanel() {
     <div className="panel p-6">
       <div className="h-sub">푸시 알림</div>
       <div className="t-caption mt-0.5">
-        앱이 백그라운드이거나 꺼져 있을 때도 새 메시지·결재·공지 등을 iOS 푸시로 받아요.
+        앱이 백그라운드이거나 꺼져 있을 때도 새 메시지·결재·공지 등을 푸시 알림으로 받아요.
       </div>
       <button type="button" className="btn-primary mt-4" onClick={test} disabled={busy}>
         {busy ? "테스트 중…" : "테스트 알림 보내기"}
@@ -563,7 +564,7 @@ function NativePushPanel() {
         </div>
       )}
       <div className="t-caption mt-3 text-ink-500">
-        알림이 안 오면 — iOS 설정 → HiNest → 알림에서 "알림 허용"이 켜져 있는지 확인하세요.
+        알림이 안 오면 — 기기 설정 → HiNest → 알림에서 "알림 허용"이 켜져 있는지 확인하세요.
       </div>
     </div>
   );

--- a/server/src/lib/fcm.ts
+++ b/server/src/lib/fcm.ts
@@ -173,3 +173,38 @@ export async function sendFcmToUsers(items: { userId: string; payload: FcmPayloa
   if (dead.length) await prisma.pushToken.deleteMany({ where: { token: { in: dead } } });
   if (ok.length) await prisma.pushToken.updateMany({ where: { token: { in: ok } }, data: { lastUsedAt: new Date() } });
 }
+
+/**
+ * 진단 — 본인 안드로이드 토큰으로 테스트 FCM 을 실제 발송하고 결과를 돌려준다.
+ * apns.ts 의 apnsDiag 와 동일 계약(enabled/tokens/results)으로, /api/push/diag 가
+ * iOS(APNs)·Android(FCM) 양쪽을 한 번에 진단할 수 있게 한다. 본인 토큰만 대상이라 안전.
+ */
+export async function fcmDiag(userId: string): Promise<{
+  enabled: boolean;
+  projectId: string | null;
+  tokens: number;
+  results: { token: string; status: number; reason?: string }[];
+  note?: string;
+}> {
+  const base = { enabled: SA != null, projectId: SA?.projectId ?? null };
+  if (!SA) {
+    return { ...base, tokens: 0, results: [], note: "FCM 미설정 — 서버 env FCM_SERVICE_ACCOUNT_JSON(또는 FCM_PROJECT_ID/CLIENT_EMAIL/PRIVATE_KEY) 확인" };
+  }
+  const access = await accessToken();
+  if (!access) {
+    return { ...base, tokens: 0, results: [], note: "FCM OAuth 액세스 토큰 발급 실패 — 서비스 계정 키 값 확인" };
+  }
+  const tokens = await prisma.pushToken.findMany({ where: { userId, platform: "android" }, select: { token: true } });
+  if (!tokens.length) {
+    return { ...base, tokens: 0, results: [], note: "등록된 Android 토큰 없음 — 알림 권한 허용 + 앱 재실행(또는 google-services.json/VITE_ANDROID_FCM 미포함 빌드)" };
+  }
+  const payload: FcmPayload = { title: "테스트 알림", body: "푸시 진단 테스트입니다.", linkUrl: "/" };
+  const results = await Promise.all(
+    tokens.map(async (t) => {
+      const r = await sendOne(t.token, payload, access);
+      const status = r === "ok" ? 200 : r === "dead" ? 410 : 500;
+      return { token: t.token.slice(0, 10) + "…", status, reason: r };
+    }),
+  );
+  return { ...base, tokens: tokens.length, results };
+}

--- a/server/src/routes/push.ts
+++ b/server/src/routes/push.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth } from "../lib/auth.js";
 import { apnsDiag } from "../lib/apns.js";
+import { fcmDiag } from "../lib/fcm.js";
 
 /**
  * 원격 푸시(APNs/FCM) 기기 토큰 등록·해제.
@@ -56,13 +57,15 @@ router.post("/unregister", async (req, res) => {
 });
 
 /**
- * 진단 — 본인 iOS 토큰으로 테스트 푸시를 실제 발송하고 APNs 응답을 그대로 돌려준다.
- * 브라우저에서 로그인된 채로 /api/push/diag 를 열면 결과 JSON 을 볼 수 있고,
- * 정상이면 등록된 기기에 "테스트 알림" 푸시가 도착한다. 본인 토큰만 대상이라 안전.
+ * 진단 — 본인 기기 토큰으로 테스트 푸시를 실제 발송하고 결과를 돌려준다.
+ * iOS(APNs)·Android(FCM) 양쪽을 한 번에 진단해 `{ ios, android }` 로 반환 →
+ * 클라가 자기 플랫폼 결과만 골라 보여준다. 본인 토큰만 대상이라 안전.
+ * 하위호환: 기존 클라가 기대하던 top-level enabled/tokens/results 는 iOS 값을 그대로 펼쳐 둔다.
  */
 router.get("/diag", async (req, res) => {
   const u = (req as any).user;
-  res.json(await apnsDiag(u.id));
+  const [ios, android] = await Promise.all([apnsDiag(u.id), fcmDiag(u.id)]);
+  res.json({ ...ios, ios, android });
 });
 
 export default router;


### PR DESCRIPTION
## 증상
프로필 "테스트 알림 보내기"를 안드로이드에서 눌러도 알림이 안 옴.

## 원인
`/api/push/diag` 가 `apnsDiag`(iOS 전용)만 호출 → 안드로이드 기기(FCM 토큰)는 iOS 토큰 조회가 비어 아무것도 발송 안 됨.

## 작업 내용
- `fcm.ts` 에 `fcmDiag(userId)` 추가(본인 android 토큰으로 테스트 FCM 발송, apnsDiag 동일 계약).
- `/api/push/diag` → APNs+FCM 동시 진단, `{ ios, android }` 반환(top-level 하위호환 유지).
- ProfilePage 테스트 패널이 자기 플랫폼 결과만 표시 + 미설정 시 플랫폼별 안내. iOS 고정 문구 중립화.

## 주의
실제 안드 발송은 서버 env `FCM_SERVICE_ACCOUNT_JSON` 설정 후 동작. 미설정이면 진단이 "FCM 미설정"으로 정확히 안내.