### PR TITLE
🔀 :: (#923) 고중요도 '기본 알림' 채널 — 헤드업 배너 + Instagram급 속도

### DIFF
--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,13 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <!-- FCM 백그라운드 notification 메시지가 채널을 명시하지 않은 첫 실행 전 엣지케이스에서도
+             고중요도 'default' 채널(MainActivity 가 생성)로 라우팅되게 하는 폴백. 서버 fcm.ts 는
+             channelId="default" 를 항상 명시하므로 평시엔 이 메타데이터 없이도 동작. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="default" />
     </application>
 
     <!-- Permissions -->

--- a/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
@@ -1,5 +1,40 @@
 package com.hivits.hinest;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.os.Build;
+import android.os.Bundle;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // 고중요도 알림 채널을 앱 시작 시 미리 만든다.
+        //
+        // 왜: 서버(fcm.ts)는 channelId="default" 로 푸시를 보내는데, 앱이 그 채널을 만든 적이
+        //   없으면 안드로이드가 IMPORTANCE_DEFAULT 폴백 채널을 자동 생성한다 → 헤드업 배너도
+        //   사운드도 없이 트레이에만 조용히 떠서 "알림이 느리다/안 온다" 처럼 보였다.
+        //   (android.priority="HIGH" 는 전송(기기 깨우기)용일 뿐, 배너 노출은 채널 importance 가
+        //   결정한다.) IMPORTANCE_HIGH 채널을 직접 만들어 iOS 의 항상-배너(apns-priority 10) 와
+        //   동등한 즉시 헤드업 + 사운드를 보장한다 → Instagram 급 체감 속도.
+        //
+        // 채널은 한 번 만들면 앱 삭제 전까지 영속한다(앱이 닫혀 있어도 시스템이 기억). Activity
+        // 가 한 번이라도 떴으면 백그라운드 푸시도 이 채널로 헤드업으로 뜬다. AndroidManifest 의
+        // default_notification_channel_id 메타데이터가 첫 실행 전 엣지케이스를 보강한다.
+        createDefaultNotificationChannel();
+    }
+
+    private void createDefaultNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return; // 채널 개념은 O(API 26)+
+        NotificationManager nm = getSystemService(NotificationManager.class);
+        if (nm == null) return;
+        NotificationChannel channel = new NotificationChannel(
+            "default", "기본 알림", NotificationManager.IMPORTANCE_HIGH);
+        channel.setDescription("새 메시지·결재·공지 등 실시간 알림");
+        channel.enableVibration(true);
+        channel.enableLights(true);
+        nm.createNotificationChannel(channel);
+    }
+}

--- a/client/src/lib/nativeNotify.ts
+++ b/client/src/lib/nativeNotify.ts
@@ -47,6 +47,9 @@ export async function showNativeNotifications(items: NotifItem[]): Promise<void>
         id: (Date.now() + _seq++) % 2_147_483_000,
         title: it.title,
         body: it.body ?? "",
+        // 안드로이드: MainActivity 가 만든 고중요도 'default' 채널을 써서 포그라운드 로컬
+        // 배너도 헤드업으로 뜨게 한다(미지정 시 IMPORTANCE_DEFAULT 폴백 → 조용함). iOS 는 무시.
+        channelId: "default",
         extra: { linkUrl: it.linkUrl ?? null },
       })),
     });


### PR DESCRIPTION
## 증상
안드로이드에서 채팅·공지 푸시가 상태바 트레이에만 조용히 뜨고 **헤드업 배너·사운드가 없어** "알림이 느리다/안 온다"처럼 보였다. iOS는 동일 알림이 즉시 배너로 뜸.

## 원인
서버 `fcm.ts`는 `channelId="default"`로 푸시를 보내는데, 앱이 그 채널을 만든 적이 없으면 안드로이드가 `IMPORTANCE_DEFAULT` 폴백 채널을 자동 생성한다 → 배너·사운드 없이 트레이에만 표시. `android.priority="HIGH"`는 전송(기기 깨우기)용일 뿐, 배너 노출은 **채널 importance**가 결정한다.

## 작업 내용
- **추가** `client/android/.../MainActivity.java` `onCreate`: `IMPORTANCE_HIGH` "기본 알림" 채널 생성(진동·라이트 on). 채널은 앱 삭제 전까지 영속.
- **추가** `AndroidManifest.xml`: `com.google.firebase.messaging.default_notification_channel_id=default` 메타데이터(첫 실행 전 엣지케이스 폴백).
- **수정** `client/src/lib/nativeNotify.ts`: `LocalNotifications.schedule`에 `channelId:"default"`.
- 외부 영향: 안드로이드 전용. iOS·웹 무관.

## 검증
- [x] `client` tsc 통과
- [x] 에뮬레이터에서 채널 생성·헤드업 배너 동작 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #923

## 분류
- **type:** feat
- **area:** android
- **priority:** P1

## 비고
- iOS 항상-배너(apns-priority 10)와 동등한 즉시 헤드업 + 사운드 = Instagram급 체감 속도.
