### PR TITLE
🔀 :: (#925) 햅틱 — iOS와 동일 지점 전부 적용

### DIFF
--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -43,4 +43,7 @@
     <!-- Android 13+(API 33) 푸시 알림 표시 권한 — @capacitor/push-notifications 가 런타임에 요청.
          없으면 알림이 조용히 무시된다. iOS 의 알림 권한 요청과 동일 흐름. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- 햅틱(@capacitor/haptics)이 Vibrator 로 진동을 주려면 필요. iOS 와 동일 지점의 탭/토글/
+         버튼 햅틱을 안드로이드에서도 동작시킨다. -->
+    <uses-permission android:name="android.permission.VIBRATE" />
 </manifest>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/app": "^8.1.0",
         "@capacitor/browser": "^8.0.3",
         "@capacitor/core": "^8.3.4",
+        "@capacitor/haptics": "^8.0.2",
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/push-notifications": "^8.1.1",
@@ -879,6 +880,15 @@
       "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-8.0.2.tgz",
+      "integrity": "sha512-c2hZzRR5Fk1tbTvhG1jhh2XBAf3EhnIerMIb2sl7Mt41Gxx1fhBJFDa0/BI1IbY4loVepyyuqNC9820/GZuoWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/ios": {

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "@capacitor/app": "^8.1.0",
     "@capacitor/browser": "^8.0.3",
     "@capacitor/core": "^8.3.4",
+    "@capacitor/haptics": "^8.0.2",
     "@capacitor/keyboard": "^8.0.3",
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/push-notifications": "^8.1.1",

--- a/client/src/lib/haptics.ts
+++ b/client/src/lib/haptics.ts
@@ -1,22 +1,51 @@
 /**
- * 햅틱 피드백 헬퍼 — iOS/iPadOS 네이티브에서만 동작, 그 외(웹/데스크톱/안드로이드)는 no-op.
+ * 햅틱 피드백 헬퍼 — iOS/iPadOS·안드로이드 네이티브에서 동작, 웹/데스크톱은 no-op.
  *
- * 네이티브 LiquidGlassTabBar.haptic 을 호출(추가 Capacitor 플러그인 의존성 없음).
- * 탭바 전환은 Swift 쪽 UITabBarDelegate 가 직접 selection 햅틱을 주고, 웹 DOM 의 버튼·토글
- * 탭은 AppLayout 의 전역 pointerdown 리스너가 light 햅틱을 준다(아래 attachGlobalHaptics).
+ * iOS: 네이티브 LiquidGlassTabBar.haptic(기존 경로 — 느낌 그대로 유지). 탭바 전환은 Swift
+ *      UITabBarDelegate 가 직접 selection 햅틱.
+ * 안드로이드: @capacitor/haptics(Vibrator) — iOS 와 동일 지점(attachGlobalHaptics 의 버튼·토글·탭,
+ *      data-haptic, AdminPage 드래그 등)에서 같은 강도로 진동. 하단 탭은 CSS 바라 [role=tab]
+ *      분기가 selection 햅틱을 준다.
  */
-import { nativePlatform } from "./platform";
+import { isCapacitorNative, nativePlatform } from "./platform";
 
 type HapticStyle = "light" | "medium" | "heavy" | "selection" | "success" | "warning" | "error";
 
 let _plugin: typeof import("./liquidGlassTabBar").LiquidGlassTabBar | null = null;
 
 function isNative(): boolean {
-  return nativePlatform() === "ios"; // iPad 도 Capacitor 에선 "ios"
+  return isCapacitorNative(); // iOS + Android (웹/데스크톱 제외)
+}
+
+/** 안드로이드 햅틱 — @capacitor/haptics 로 매핑(impact/notification). */
+function androidHaptic(style: HapticStyle): void {
+  void import("@capacitor/haptics")
+    .then(({ Haptics, ImpactStyle, NotificationType }) => {
+      try {
+        if (style === "success" || style === "warning" || style === "error") {
+          const type =
+            style === "success" ? NotificationType.Success : style === "warning" ? NotificationType.Warning : NotificationType.Error;
+          void Haptics.notification({ type }).catch(() => {});
+        } else {
+          // selection/light → Light, medium → Medium, heavy → Heavy (iOS 강도 차등과 동일 결).
+          const impact =
+            style === "heavy" ? ImpactStyle.Heavy : style === "medium" ? ImpactStyle.Medium : ImpactStyle.Light;
+          void Haptics.impact({ style: impact }).catch(() => {});
+        }
+      } catch {
+        /* no-op */
+      }
+    })
+    .catch(() => {});
 }
 
 export function haptic(style: HapticStyle = "light"): void {
   if (!isNative()) return;
+  if (nativePlatform() === "android") {
+    androidHaptic(style);
+    return;
+  }
+  // iOS — 기존 네이티브 경로(느낌 유지).
   try {
     if (!_plugin) {
       // 동기 import 캐시 — 첫 호출 시 모듈 로드.


### PR DESCRIPTION
## 증상
iOS는 탭바 전환·토글·버튼에 햅틱 피드백이 있는데 **안드로이드는 같은 지점이 전부 무진동**이라 촉감 일관성이 없었다.

## 원인
햅틱 호출 경로가 iOS 전용(`LiquidGlassTabBar.haptic`)으로만 구현돼 있어 안드로이드 분기가 아예 없었다. 안드로이드는 `Vibrator` 권한·플러그인도 미연결.

## 작업 내용
- **추가** `@capacitor/haptics@^8.0.2` 의존성(`client/package.json`/`lock`).
- **수정** `client/src/lib/haptics.ts`: `isNative()`→`isCapacitorNative()`, 안드로이드면 `Haptics.impact`(Light/Medium/Heavy)·`notification`(Success/Warning/Error) 호출. iOS는 기존 `LiquidGlassTabBar` 경로 유지.
- **추가** `AndroidManifest.xml`: `android.permission.VIBRATE`.
- 외부 영향: iOS·웹 무변경(분기 분리).

## 검증
- [x] `client` tsc 통과
- [x] 에뮬레이터/실기기에서 탭·토글 진동 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #925

## 분류
- **type:** feat
- **area:** android
- **priority:** P2

## 비고
- iOS와 "동일 지점" 전수 적용(탭바·토글·주요 버튼).
