### PR TITLE
🔀 :: (#927) 중복 폴링 단일화 + 죽은 엔드포인트 제거 (성능 유지)

### DIFF
--- a/client/src/lib/useApprovalCounts.ts
+++ b/client/src/lib/useApprovalCounts.ts
@@ -1,52 +1,98 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { api } from "../api";
 
 /**
- * 결재 대기 / 내 미결 개수 — 사이드바 배지 + 탭 표시용.
+ * 결재 대기 / 내 미결 개수 — 사이드바 배지 + 하단탭 배지용.
  *
- * 비용 절감:
- *   - 폴링 주기 15초 → 60초. 사내 결재는 분 단위 SLA 가 충분.
- *   - 탭이 hidden 인 동안은 폴링 정지(setInterval clear). 다시 visible 이 되면 즉시 한 번 load 하고
- *     interval 재무장. 백그라운드 탭 수십 개에서 매분 4회씩 누적되던 요청을 0회로.
- *   - 결재 화면이 처리 직후 dispatch 하는 hinest:approvalCountsRefresh 이벤트는 그대로 사용.
+ * ⚠️ 모듈 싱글톤(공유 구독) 설계 — 비용 절감 핵심:
+ *   레이아웃은 데스크톱 사이드바(NavSection ×3)와 모바일 BottomNav 를 **항상 함께 마운트**하고
+ *   CSS(md:flex / md:hidden)로 한쪽만 보여준다. 예전엔 각 컴포넌트가 useApprovalCounts 를
+ *   호출해 **각자 60초 setInterval** 을 돌려 사용자당 ~4req/min 으로 /api/approval/counts(2쿼리)
+ *   를 때렸다. 이제 폴링 타이머·리스너·in-flight 를 모듈 레벨에 하나만 두고, 모든 컴포넌트는
+ *   useSyncExternalStore 로 같은 값을 구독한다 → 첫 구독자에서 1세트만 무장, 마지막 해제 시 정지.
+ *   동일한 신선도(60초 + 포커스 복귀 즉시 + hinest:approvalCountsRefresh 이벤트)·UX·지연을 그대로
+ *   유지하면서 요청 수만 ~75% 감소.
  */
-export function useApprovalCounts() {
-  const [counts, setCounts] = useState<{ pending: number; mine: number }>({ pending: 0, mine: 0 });
 
-  useEffect(() => {
-    let alive = true;
-    let timer: number | null = null;
-    async function load() {
-      try {
-        const r = await api<{ pending: number; mine: number }>("/api/approval/counts");
-        if (alive) setCounts(r);
-      } catch { /* 401 등은 무시 */ }
-    }
-    function startTimer() {
-      if (timer !== null) return;
-      timer = window.setInterval(load, 60_000);
-    }
-    function stopTimer() {
-      if (timer !== null) { window.clearInterval(timer); timer = null; }
-    }
-    load();
-    if (document.visibilityState === "visible") startTimer();
-    function onVis() {
-      if (document.visibilityState === "visible") { load(); startTimer(); }
-      else { stopTimer(); }
-    }
-    function onSignal() { load(); }
-    document.addEventListener("visibilitychange", onVis);
-    window.addEventListener("hinest:approvalCountsRefresh", onSignal);
-    return () => {
-      alive = false;
-      stopTimer();
-      document.removeEventListener("visibilitychange", onVis);
-      window.removeEventListener("hinest:approvalCountsRefresh", onSignal);
-    };
-  }, []);
+type Counts = { pending: number; mine: number };
 
-  return counts;
+let _counts: Counts = { pending: 0, mine: 0 };
+const _listeners = new Set<() => void>();
+let _refCount = 0;
+let _timer: number | null = null;
+let _inFlight = false;
+
+function emit() {
+  for (const l of _listeners) l();
+}
+
+async function load() {
+  if (_inFlight) return; // 동시 중복 요청 방지(여러 트리거가 겹쳐도 1회)
+  _inFlight = true;
+  try {
+    const r = await api<Counts>("/api/approval/counts");
+    // 값이 바뀐 경우에만 새 객체로 교체 → getSnapshot 참조 안정성(불필요한 리렌더 방지).
+    if (r && (r.pending !== _counts.pending || r.mine !== _counts.mine)) {
+      _counts = { pending: r.pending, mine: r.mine };
+      emit();
+    }
+  } catch {
+    /* 401 등은 무시 */
+  } finally {
+    _inFlight = false;
+  }
+}
+
+function startTimer() {
+  if (_timer === null) _timer = window.setInterval(() => void load(), 60_000);
+}
+function stopTimer() {
+  if (_timer !== null) {
+    window.clearInterval(_timer);
+    _timer = null;
+  }
+}
+function onVis() {
+  if (document.visibilityState === "visible") {
+    void load();
+    startTimer();
+  } else {
+    stopTimer(); // 탭 숨김 동안 폴링 정지
+  }
+}
+function onSignal() {
+  void load();
+}
+
+function activate() {
+  // 첫 구독자에서만 폴링/리스너 1세트 무장.
+  void load();
+  if (document.visibilityState === "visible") startTimer();
+  document.addEventListener("visibilitychange", onVis);
+  window.addEventListener("hinest:approvalCountsRefresh", onSignal);
+}
+function deactivate() {
+  stopTimer();
+  document.removeEventListener("visibilitychange", onVis);
+  window.removeEventListener("hinest:approvalCountsRefresh", onSignal);
+}
+
+function subscribe(cb: () => void): () => void {
+  _listeners.add(cb);
+  if (_refCount === 0) activate();
+  _refCount++;
+  return () => {
+    _listeners.delete(cb);
+    _refCount = Math.max(0, _refCount - 1);
+    if (_refCount === 0) deactivate();
+  };
+}
+function getSnapshot(): Counts {
+  return _counts;
+}
+
+export function useApprovalCounts(): Counts {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 /** 결재 화면이 처리 후 카운트 즉시 갱신을 트리거할 때 사용. */

--- a/server/src/routes/nav.ts
+++ b/server/src/routes/nav.ts
@@ -3,11 +3,13 @@ import { prisma } from "../lib/db.js";
 import { requireAuth } from "../lib/auth.js";
 
 /**
- * 사이드바 뱃지용 카운트 엔드포인트.
- * 클라이언트가 각 키 별 "마지막으로 본 시각(since)" 을 localStorage 에 보관 후
- * 쿼리스트링으로 넘기면, 해당 시각 이후 새로 생긴 항목 수를 반환.
+ * 사이드바 메뉴 노출 상태 엔드포인트.
  *
- *   GET /api/nav/counts?since_schedule=ISO&since_notice=ISO&...
+ *   GET /api/nav/visibility — { disabled: string[], dev: string[] }
+ *
+ * (예전의 GET /api/nav/counts 뱃지 카운트 엔드포인트는 클라이언트 호출처가 사라져
+ *  죽은 코드였으므로 제거했다 — 결재 카운트는 /api/approval/counts, 그 외 신규 알림은
+ *  알림 SSE 가 담당.)
  */
 const router = Router();
 router.use(requireAuth);
@@ -46,99 +48,6 @@ router.get("/visibility", async (_req, res) => {
   // 어드민이 변경 시 evictNavVisibilityCache() 로 즉시 무효화되므로 1분 이상 지연 없음.
   res.setHeader("Cache-Control", "private, max-age=60, stale-while-revalidate=30");
   res.json(data);
-});
-
-function parseSince(v: unknown): Date | null {
-  if (typeof v !== "string" || !v) return null;
-  const d = new Date(v);
-  if (isNaN(d.getTime())) return null;
-  return d;
-}
-
-router.get("/counts", async (req, res) => {
-  const u = (req as any).user;
-  const q = req.query as Record<string, string | undefined>;
-
-  const sinceSchedule  = parseSince(q.since_schedule);
-  const sinceNotice    = parseSince(q.since_notice);
-  const sinceDirectory = parseSince(q.since_directory);
-  const sinceDocuments = parseSince(q.since_documents);
-  const sinceExpense   = parseSince(q.since_expense);
-  const sinceAttendance = parseSince(q.since_attendance);
-
-  const isReviewer = u.role === "ADMIN" || u.role === "MANAGER";
-
-  const [
-    scheduleCount,
-    noticeCount,
-    directoryCount,
-    documentsCount,
-    approvalPendingCount,
-    expenseCount,
-    leaveCount,
-    inviteCount,
-  ] = await Promise.all([
-    sinceSchedule
-      ? prisma.event.count({ where: { createdAt: { gt: sinceSchedule } } })
-      : Promise.resolve(0),
-
-    sinceNotice
-      ? prisma.notice.count({ where: { createdAt: { gt: sinceNotice } } })
-      : Promise.resolve(0),
-
-    sinceDirectory
-      ? prisma.user.count({ where: { createdAt: { gt: sinceDirectory }, active: true } })
-      : Promise.resolve(0),
-
-    sinceDocuments
-      ? prisma.document.count({ where: { createdAt: { gt: sinceDocuments } } })
-      : Promise.resolve(0),
-
-    // 전자결재 — 내가 검토해야 하는 대기중 step 수
-    prisma.approvalStep.count({
-      where: {
-        reviewerId: u.id,
-        status: "PENDING",
-      },
-    }),
-
-    // 법인카드 — 리뷰어면 대기중 지출, 아니면 최근 등록 수
-    isReviewer
-      ? prisma.cardExpense.count({ where: { status: "PENDING" } })
-      : sinceExpense
-        ? prisma.cardExpense.count({ where: { userId: u.id, createdAt: { gt: sinceExpense } } })
-        : Promise.resolve(0),
-
-    // 근태·월차 — 리뷰어면 대기중 휴가 신청, 아니면 내 대기/변경
-    isReviewer
-      ? prisma.leave.count({ where: { status: "PENDING" } })
-      : sinceAttendance
-        ? prisma.leave.count({
-            where: { userId: u.id, status: { in: ["APPROVED", "REJECTED"] }, createdAt: { gt: sinceAttendance } },
-          })
-        : Promise.resolve(0),
-
-    // 관리자 — ADMIN 만, 사용 안 된 초대키 수
-    u.role === "ADMIN"
-      ? prisma.inviteKey.count({ where: { used: false } })
-      : Promise.resolve(0),
-  ]);
-
-  // 30초 캐시 — 뱃지 숫자가 30초 늦게 반영돼도 사용성 영향 없음.
-  // SSE 로 실시간 알림은 이미 처리됨.
-  res.setHeader("Cache-Control", "private, max-age=30, stale-while-revalidate=60");
-  res.json({
-    counts: {
-      schedule: scheduleCount,
-      attendance: leaveCount,
-      approvals: approvalPendingCount,
-      notice: noticeCount,
-      directory: directoryCount,
-      documents: documentsCount,
-      expense: expenseCount,
-      admin: inviteCount,
-    },
-  });
 });
 
 export default router;


### PR DESCRIPTION
## 증상
결재 카운트 배지를 쓰는 컴포넌트가 한 화면에 여러 개 마운트되면 **같은 엔드포인트를 각자 폴링**해 동일 요청이 중복으로 나갔다(서버 부하·서버비 낭비). 또한 호출자가 0인 죽은 라우트가 남아 있었다.

## 원인
- `useApprovalCounts` 훅이 인스턴스마다 독립 타이머로 폴링 → 마운트 수만큼 요청 배수.
- `server/src/routes/nav.ts`의 `/counts`(8개 count 쿼리)는 호출자가 0인 dead route, `parseSince`도 미사용.

## 작업 내용
- **수정** `client/src/lib/useApprovalCounts.ts`: 모듈 싱글톤 + `useSyncExternalStore`로 재작성 — 폴러 1개 + 리스너 + in-flight 가드로 모든 소비자가 한 요청 공유(약 75% 요청 감소).
- **제거** `server/src/routes/nav.ts`의 `/counts` 라우트 + 미사용 `parseSince`. (`/visibility`는 유지)
- 외부 영향: 동작 동일(성능만 개선), 죽은 엔드포인트 제거로 표면 축소.

## 검증
- [x] `server`·`client` tsc 통과
- [x] 단일 폴러로 카운트 정상 갱신 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #927

## 분류
- **type:** perf
- **area:** client · server
- **priority:** P2

## 비고
- 성능 유지/개선 전제하 서버비 감축 작업의 일부.
