### PR TITLE
🔀 :: (#929) Play Store 정비 — allowBackup=false + network security config

### DIFF
--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -2,9 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">

--- a/client/android/app/src/main/res/xml/network_security_config.xml
+++ b/client/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  네트워크 보안 정책.
+  - 기본: 모든 도메인의 cleartext(HTTP) 트래픽 차단 → 운영 API(nest.hi-vits.com 등)는 HTTPS 강제.
+    Capacitor WebView 는 https://localhost 로 로드(HTTPS)라 무관.
+  - 예외: 에뮬레이터 호스트(10.0.2.2)·localhost 의 개발 hot-reload(http://...:1000)만 허용.
+    릴리스 빌드는 이 주소를 사용하지 않으므로 운영 보안에 영향 없음(개발 편의만 유지).
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## 증상
Play Store 제출 기준에서 기본 설정이 느슨했다 — 앱 데이터가 자동 백업 대상이고, 평문(cleartext) HTTP 트래픽이 기본 허용 상태라 보안 검토에서 지적될 수 있었다.

## 원인
Capacitor 스캐폴드 기본값(`allowBackup="true"`, network security config 없음)이 그대로 남아 있어, 민감한 세션·토큰이 백업/평문 노출 표면에 들어갔다.

## 작업 내용
- **추가** `client/android/app/src/main/res/xml/network_security_config.xml`: base `cleartextTrafficPermitted=false` + dev용 예외(localhost/127.0.0.1/10.0.2.2).
- **수정** `AndroidManifest.xml`: `allowBackup="false"` + `networkSecurityConfig=@xml/network_security_config`.
- 외부 영향: 운영 HTTPS(`nest.hi-vits.com`)만 쓰므로 평시 동작 무영향. dev 에뮬레이터 cleartext는 예외로 허용.

## 검증
- [x] gradle 머지 매니페스트에 설정 반영 확인
- [x] `client` tsc 통과(클라 코드 무변경)
- [x] 본인(@Xixn2) Assignee 지정

Closes #929

## 분류
- **type:** chore
- **area:** android
- **priority:** P2

## 비고
- Play 제출 정비의 일부(서명 keystore/AAB는 별도).
