### PR TITLE
🔀 :: (#931) Electron openExternal 스킴 allowlist + apiToken 테넌트 경고

### DIFF
--- a/HiNest-MacOS/src/main.ts
+++ b/HiNest-MacOS/src/main.ts
@@ -150,7 +150,9 @@ function createWindow() {
       const u = new URL(url);
       const origin = new URL(DEFAULT_URL).origin;
       if (u.origin !== origin) {
-        shell.openExternal(url);
+        // 보안: http/https 만 외부 브라우저로 연다. file:/javascript:/커스텀 스킴은
+        // 사용자 렌더 콘텐츠(채팅 등)에 끼어들 수 있으므로 openExternal 에 넘기지 않음.
+        if (u.protocol === "http:" || u.protocol === "https:") shell.openExternal(url);
         return { action: "deny" };
       }
     } catch {}

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -193,7 +193,9 @@ function createWindow() {
       const u = new URL(url);
       const origin = new URL(DEFAULT_URL).origin;
       if (u.origin !== origin) {
-        shell.openExternal(url);
+        // 보안: http/https 만 외부 브라우저로 연다. file:/javascript:/커스텀 스킴은
+        // 사용자 렌더 콘텐츠(채팅 등)에 끼어들 수 있으므로 openExternal 에 넘기지 않음.
+        if (u.protocol === "http:" || u.protocol === "https:") shell.openExternal(url);
         return { action: "deny" };
       }
     } catch {}

--- a/server/src/lib/apiTokenAuth.ts
+++ b/server/src/lib/apiTokenAuth.ts
@@ -13,6 +13,15 @@ import { prisma } from "./db.js";
  * - 만료/취소 체크
  * - lastUsedAt 갱신 (블로킹 X — fire and forget)
  * - 스코프 체크
+ *
+ * ⚠️ 멀티테넌트 주의 (현재 미마운트 — 라우트 0개): requireAuth 와 달리 이 미들웨어는
+ *   runWithTenant 컨텍스트를 깔지 않는다. lib/db.ts 의 테넌트 확장은 "컨텍스트 없음"을
+ *   "스코프 없음"(fail-open) 으로 처리하므로, 이 미들웨어만으로 보호되는 라우트가
+ *   TENANT_MODELS(회사 소유 테이블)를 조회/수정하면 **전 회사 데이터가 새는** 크로스테넌트
+ *   취약점이 된다. ApiToken 모델엔 아직 companyId 가 없다.
+ *   → 테넌트 데이터 라우트에 마운트하기 전에 반드시: (1) ApiToken 에 companyId 추가,
+ *     (2) 핸들러를 runWithTenant({ companyId: tok.companyId, bypass:false }, ...) 로 감싸기.
+ *   그 전까지는 회사 비종속(전역) 데이터 라우트에만 쓸 것.
  */
 
 export function requireApiToken(scope?: string) {


### PR DESCRIPTION
## 증상
보안 점검 중 두 가지 표면 발견: (1) Electron 데스크톱이 새 창 열기 요청을 스킴 검증 없이 `shell.openExternal`로 넘겨 `file:`·커스텀 스킴 등이 외부로 열릴 여지, (2) `requireApiToken`이 테넌트 스코프 없이 fail-open이라 테넌트 라우트에 잘못 마운트되면 크로스테넌트 누출 위험(현재 미마운트).

## 원인
- `desktop/src/main.ts`·`HiNest-MacOS/src/main.ts`의 `setWindowOpenHandler`가 URL 스킴을 검사하지 않고 바로 openExternal 호출.
- `server/src/lib/apiTokenAuth.ts`의 `requireApiToken`은 `ApiToken` 모델에 `companyId`가 없어 `runWithTenant` 스코프가 안 걸림(설계상 fail-open).

## 작업 내용
- **수정** `desktop/src/main.ts`·`HiNest-MacOS/src/main.ts`: `if (u.protocol === "http:" || u.protocol === "https:") shell.openExternal(url)`로 스킴 allowlist 가드.
- **추가(주석)** `server/src/lib/apiTokenAuth.ts`: requireApiToken이 테넌트 데이터에 fail-open임을 ⚠️ 경고 — 테넌트 라우트에 마운트 금지(동작 변화 없음, 잠복 위험 문서화).
- 외부 영향: 데스크톱 외부링크 동작 동일(http/https만), 서버 동작 무변경.

## 검증
- [x] `server` tsc 통과
- [x] 데스크톱 외부 링크 http/https만 열림 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #931

## 분류
- **type:** security
- **area:** desktop · server
- **priority:** P1

## 비고
- apiToken 테넌트 스코프(runWithTenant)는 스키마 변경 필요 → 후속 과제.
