### PR TITLE
🔀 :: (#933) 클라 에러 콘솔 리포팅 + 로그아웃 활동로그

### DIFF
--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { reportClientError } from "../lib/errorReporter";
 
 /**
  * Route-level Error Boundary — 한 페이지의 렌더 에러가 앱 전체를 흰 화면으로
@@ -35,13 +36,15 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    // 운영 환경에서 외부 리포터(Sentry/Datadog 등) 가 있다면 여기서 호출.
-    // 사내툴 규모에선 console.error 로도 superadmin 콘솔의 인메모리 버퍼에 잡힘.
-    console.error("[ErrorBoundary] render failure", {
-      message: error.message,
-      stack: error.stack?.split("\n").slice(0, 6).join("\n"),
-      component: info.componentStack?.split("\n").slice(0, 5).join("\n"),
-    });
+    // 운영 콘솔 "에러" 탭으로 보고. (예전 주석은 "console.error 가 콘솔 인메모리 버퍼에
+    // 잡힌다" 였지만 그건 서버 프로세스의 console 훅 — 브라우저 console.error 는 서버로
+    // 안 간다. 그래서 reportClientError 로 명시 전송한다.)
+    const componentStack = info.componentStack?.split("\n").slice(0, 5).join("\n") ?? "";
+    reportClientError(
+      "[render] " + error.message,
+      (error.stack ?? "") + (componentStack ? "\n--- component ---\n" + componentStack : ""),
+    );
+    console.error("[ErrorBoundary] render failure", error);
   }
 
   componentDidUpdate(prev: Props) {

--- a/client/src/lib/errorReporter.ts
+++ b/client/src/lib/errorReporter.ts
@@ -1,0 +1,39 @@
+import { apiUrl } from "../api";
+
+/**
+ * 클라이언트 런타임 에러를 서버(/api/client-error)로 보고 → 운영 콘솔 "에러" 탭에 노출.
+ *
+ * 지금까지 클라 JS 에러는 서버로 전혀 전달되지 않아 콘솔 에러 탭엔 서버 5xx 만 떴다.
+ * main.tsx 의 window error/unhandledrejection 핸들러와 ErrorBoundary 가 이 함수를 호출한다.
+ *
+ * 폭주 방지: 10초 창에서 최대 5건만 전송(에러 핸들러가 또 에러를 유발하는 루프 차단).
+ */
+let _windowStart = 0;
+let _count = 0;
+
+export function reportClientError(message: string, stack?: string): void {
+  try {
+    const now = Date.now();
+    if (now - _windowStart > 10_000) {
+      _windowStart = now;
+      _count = 0;
+    }
+    if (_count >= 5) return;
+    _count++;
+    const body = JSON.stringify({
+      message: String(message ?? "").slice(0, 1000),
+      stack: String(stack ?? "").slice(0, 4000),
+      path: typeof location !== "undefined" ? location.pathname + location.search : "",
+    });
+    // keepalive: 언로드 직전 에러도 전송 보장. 공개 엔드포인트라 인증 불요.
+    void fetch(apiUrl("/api/client-error"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      credentials: "include",
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* 리포팅 실패는 조용히 무시(절대 throw 금지 — 또 에러 유발 방지) */
+  }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from "./auth";
 import { FeatureFlagsProvider } from "./lib/featureFlags";
 import { isPreviewMode, ensurePreviewPatched } from "./lib/previewFlag";
 import { notifyLiveUpdateReady } from "./lib/liveUpdates";
+import { reportClientError } from "./lib/errorReporter";
 import { ThemeProvider } from "./theme";
 import "./styles.css";
 
@@ -84,6 +85,17 @@ if (typeof window !== "undefined") {
       // 10초 내 재발이면 reload 생략 → 기본 동작으로 ErrorBoundary 표시.
     });
   }
+
+  // 전역 클라이언트 에러 → 운영 콘솔 "에러" 탭으로 보고(지금까진 클라 에러가 서버로 안 갔음).
+  // 폭주 방지(10초/5건)는 reportClientError 내부. chunk reload(vite:preloadError)와는 별개.
+  window.addEventListener("error", (e) => {
+    const err = (e as ErrorEvent).error;
+    reportClientError(err?.message || (e as ErrorEvent).message || "window error", err?.stack);
+  });
+  window.addEventListener("unhandledrejection", (e) => {
+    const r = (e as PromiseRejectionEvent).reason as { message?: string; stack?: string } | undefined;
+    reportClientError(r?.message || String(r ?? "unhandledrejection"), r?.stack);
+  });
 
   // 핀치 줌 (iOS)
   document.addEventListener("gesturestart", (e) => e.preventDefault());

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -51,6 +51,7 @@ import serviceAccountRouter from "./routes/serviceAccount.js";
 import payslipRouter from "./routes/payslip.js";
 import desktopDownloadRouter from "./routes/desktopDownload.js";
 import platformRouter from "./routes/platform.js";
+import clientErrorRouter from "./routes/clientError.js";
 import path from "node:path";
 import mime from "mime-types";
 import { installConsoleHook, pushHttpLog, pushErrorEvent } from "./lib/logBuffer.js";
@@ -312,6 +313,8 @@ app.use("/api/push", pushRouter);
 // Capacitor Live Updates (Capgo self-hosted) — 네이티브 셸이 OTA 새 번들 여부 확인.
 // Phase 1: 항상 'no_new_version_available' 응답(placeholder). Phase 2 에서 진짜 OTA 활성화.
 app.use("/api/updates", updatesRouter);
+// 클라이언트 런타임 에러 수집(운영 콘솔 에러 탭) — 인증 불요(로그인 전 에러도 수집).
+app.use("/api/client-error", clientErrorRouter);
 app.use("/api/search", searchRouter);
 app.use("/api/document", documentRouter);
 // extras(templates/lines) 를 approval 보다 먼저 마운트 — approval 의 /:id 와 경로가 겹치는

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -375,6 +375,9 @@ router.post("/logout", requireAuth, async (req, res) => {
   // 컨텍스트가 의도치 않게 되살아나는 걸 막는다. 이전엔 clearImpCookie 호출이 빠져서
   // 1시간 동안 잔류하다 같은 super-admin 로그인 시 자동 재활성화됐었다.
   clearImpCookie(res, req);
+  // 활동 로그 — LOGIN 은 기록되는데 LOGOUT 이 빠져 세션 종료가 감사에 안 남았음(비대칭 해소).
+  const lu = (req as any).user;
+  if (lu?.id) await writeLog(lu.id, "LOGOUT", lu.email, sid ? `sid=${sid}` : "", req.ip).catch(() => {});
   res.json({ ok: true });
 });
 

--- a/server/src/routes/clientError.ts
+++ b/server/src/routes/clientError.ts
@@ -1,0 +1,44 @@
+import { Router } from "express";
+import { pushErrorEvent } from "../lib/logBuffer.js";
+
+/**
+ * 클라이언트(브라우저·iOS/Android WebView·데스크톱) 런타임 에러 수집 → 운영 콘솔 "에러" 탭.
+ *
+ * 배경: 지금까지 클라 JS 에러는 서버로 전혀 보고되지 않아(window.onerror/unhandledrejection
+ *   없음, ErrorBoundary 는 console.error 만) 콘솔 에러 탭엔 서버 5xx 만 떴다. 이 엔드포인트로
+ *   클라 에러도 같은 인메모리 에러 버퍼(pushErrorEvent)에 들어가 콘솔에 노출된다.
+ *
+ * - 인증 불요(public): 로그인 화면 등 인증 이전 에러도 받아야 하므로. (req.user 가 있으면 첨부)
+ * - 남용 방지: 전역 apiLimiter + 페이로드 크기 클램프 + 에러 버퍼 자체가 4000개 ring buffer.
+ * - 메시지에 "[클라]" prefix 를 붙여 서버 5xx 와 구분.
+ */
+const router = Router();
+
+router.post("/", (req, res) => {
+  try {
+    const b = (req.body ?? {}) as { message?: unknown; stack?: unknown; path?: unknown; userId?: unknown };
+    const message = String(b.message ?? "").trim().slice(0, 1000);
+    if (!message) return res.status(204).end();
+    const stack = String(b.stack ?? "").slice(0, 4000);
+    const path = String(b.path ?? "").slice(0, 300);
+    // userId: 서버 세션(있으면) 우선, 없으면 클라가 보낸 값(진단용 best-effort).
+    const userId = (req as any).user?.id ?? (b.userId ? String(b.userId).slice(0, 64) : null);
+    pushErrorEvent({
+      ts: Date.now(),
+      status: 0, // HTTP 상태 아님(클라 런타임 에러) — 0 으로 구분.
+      method: "CLIENT",
+      path: path || (req.get("referer") ?? ""),
+      message: "[클라] " + message,
+      stack: stack || "(no stack)",
+      userId,
+      ua: req.get("user-agent") ?? null,
+      ip: req.ip ?? null,
+    });
+  } catch {
+    /* 진단 수집 실패는 조용히 무시 */
+  }
+  // 항상 204 — 클라 에러 리포팅이 실패 응답으로 또 에러를 유발하지 않도록.
+  res.status(204).end();
+});
+
+export default router;


### PR DESCRIPTION
## 증상
관리자 콘솔에 유저 활동/오류가 떠야 하는데, **클라이언트에서 터진 런타임 에러가 서버로 보고되지 않아** 콘솔에서 안 보였다. 또 로그아웃이 활동 로그에 안 남았다.

## 원인
- 클라 전역 에러(`window.error`/`unhandledrejection`)·ErrorBoundary가 잡은 예외를 서버로 전송하는 경로가 아예 없었음.
- `server/src/routes/auth.ts`의 `/logout`에 `writeLog` 호출 누락.

## 작업 내용
- **추가** `server/src/routes/clientError.ts`: `POST /` → `pushErrorEvent`(로그 버퍼). 공개·클램프. `server/src/index.ts`에 마운트.
- **추가** `client/src/lib/errorReporter.ts`: `reportClientError`(10s/5건 스로틀 fetch).
- **수정** `client/src/main.tsx`: `error`·`unhandledrejection` 리스너 + import.
- **수정** `client/src/components/ErrorBoundary.tsx`: `componentDidCatch`에서 reportClientError 호출.
- **추가** `server/src/routes/auth.ts` `/logout`: `writeLog(... "LOGOUT" ...)`.
- 외부 영향: 보고 실패해도 앱 동작 무영향(throttle·catch).

## 검증
- [x] `server`·`client` tsc 통과
- [x] 클라 에러 강제 발생 시 서버 로그 버퍼 적재 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #933

## 분류
- **type:** fix
- **area:** client · server
- **priority:** P2

## 비고
- 서버 에러 DB 영속화·warm FCM 토큰 등은 후속.
