### PR TITLE
🔀 :: (#935) Skeleton 누락 모달(검색/리비전/공유링크) 로딩 표시

### DIFF
--- a/client/src/components/RevisionHistoryModal.tsx
+++ b/client/src/components/RevisionHistoryModal.tsx
@@ -3,6 +3,7 @@ import { api , imgSrc} from "../api";
 import { confirmAsync, alertAsync } from "./ConfirmHost";
 import { fmtSize } from "../lib/fmt";
 import Portal from "./Portal";
+import { SkeletonList } from "./Skeleton";
 
 /**
  * 문서/회의록 공용 히스토리 모달. API 경로만 prefix 로 갈아끼우면 됨.
@@ -82,7 +83,7 @@ export default function RevisionHistoryModal({
         </div>
         <div className="p-5 max-h-[70vh] overflow-auto">
           {loading ? (
-            <div className="text-[12px] text-ink-400 py-6 text-center">불러오는 중…</div>
+            <div className="py-2"><SkeletonList rows={4} /></div>
           ) : revs.length === 0 ? (
             <div className="text-[12px] text-ink-400 py-6 text-center">아직 기록이 없어요. 내용이 변경되면 자동으로 저장됩니다.</div>
           ) : (

--- a/client/src/components/SearchModal.tsx
+++ b/client/src/components/SearchModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { alertAsync } from "./ConfirmHost";
+import { SkeletonList } from "./Skeleton";
 
 type Results = {
   people?: any[];
@@ -198,7 +199,7 @@ export default function SearchModal({ open, onClose }: { open: boolean; onClose:
               <div className="text-[11px] text-ink-500 mt-1">다시 입력하면 자동으로 재시도돼요.</div>
             </div>
           ) : loading && totalCount === 0 ? (
-            <div className="py-12 text-center t-caption">검색 중…</div>
+            <div className="py-3 px-1"><SkeletonList rows={5} /></div>
           ) : totalCount === 0 ? (
             <div className="py-12 text-center">
               <div className="text-[13px] font-bold text-ink-800">결과가 없어요</div>

--- a/client/src/components/ShareLinkModal.tsx
+++ b/client/src/components/ShareLinkModal.tsx
@@ -3,6 +3,7 @@ import { api } from "../api";
 import { alertAsync, promptAsync } from "./ConfirmHost";
 import DateTimePicker from "./DateTimePicker";
 import Portal from "./Portal";
+import { SkeletonList } from "./Skeleton";
 
 /**
  * 외부 공유 링크 관리 모달.
@@ -144,7 +145,7 @@ export default function ShareLinkModal({ documentId, folderId, documentTitle, on
           <div>
             <div className="text-[12px] font-bold text-ink-700 mb-2">발급된 링크</div>
             {loading ? (
-              <div className="text-[12px] text-ink-400 py-6 text-center">불러오는 중…</div>
+              <div className="py-2"><SkeletonList rows={3} /></div>
             ) : links.length === 0 ? (
               <div className="text-[12px] text-ink-400 py-6 text-center">아직 없어요.</div>
             ) : (


### PR DESCRIPTION
## 증상
검색·리비전 히스토리·공유링크 모달이 로딩 중일 때 **평문 텍스트("불러오는 중…"/"검색 중…")**만 떠서, 앱 전반의 Skeleton 로딩 UI와 톤이 어긋났다(빈 화면처럼 보임).

## 원인
공통 `Skeleton` 컴포넌트가 이미 거의 모든 페이지에 적용됐는데, 이 3개 모달의 로딩 분기만 누락돼 평문 텍스트로 남아 있었다.

## 작업 내용
- **수정** `client/src/components/RevisionHistoryModal.tsx`·`ShareLinkModal.tsx`·`SearchModal.tsx`: `./Skeleton`의 `SkeletonList` import → 평문 로딩 텍스트를 `<SkeletonList rows={N}/>`로 교체.
- 외부 영향: 로딩 표시만 변경, 데이터/동작 동일. 플랫폼 무관(웹·iOS·Android·macOS 동일).

## 검증
- [x] `client` tsc 통과
- [x] 각 모달 로딩 상태에서 Skeleton 표시 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #935

## 분류
- **type:** fix
- **area:** client
- **priority:** P2

## 비고
- `loaded`/`loading` 플래그로 로딩 vs 진짜 0건(EmptyState) 구분 유지.
