### PR TITLE
🔀 :: (#937) 채팅 푸시 발신자 아바타 알림 (iOS 통신알림 패리티)

### DIFF
--- a/client/android/app/build.gradle
+++ b/client/android/app/build.gradle
@@ -63,6 +63,11 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    // 채팅 아바타 알림(HiNestMessagingService) 컴파일에 필요한 타입.
+    //  · androidx.core: NotificationCompat.MessagingStyle / Person / IconCompat
+    //  · firebase-messaging: FirebaseMessagingService / RemoteMessage (push plugin 이 implementation 라 미노출)
+    implementation "androidx.core:core:$androidxCoreVersion"
+    implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"
@@ -35,6 +36,21 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <!-- 채팅 푸시 발신자 아바타(MessagingStyle) — iOS NSE 통신알림 미러.
+             @capacitor/push-notifications 의 MessagingService 를 제거하고, 그것을 확장한
+             HiNestMessagingService 하나만 등록한다(MESSAGING_EVENT 핸들러는 하나여야 함).
+             onNewToken/일반 알림은 super 위임으로 그대로 동작. -->
+        <service
+            android:name="com.capacitorjs.plugins.pushnotifications.MessagingService"
+            tools:node="remove" />
+        <service
+            android:name=".HiNestMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
     <!-- Permissions -->

--- a/client/android/app/src/main/java/com/hivits/hinest/HiNestMessagingService.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/HiNestMessagingService.java
@@ -1,0 +1,235 @@
+package com.hivits.hinest;
+
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.os.Build;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.Person;
+import androidx.core.graphics.drawable.IconCompat;
+
+import com.capacitorjs.plugins.pushnotifications.MessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Map;
+
+/**
+ * 채팅 푸시를 "발신자 아바타" 알림으로 표시한다 — iOS NSE(Communication Notification) 미러.
+ *
+ * 서버(fcm.ts)는 채팅(senderName 있음)을 <b>data-only</b> 고우선 메시지로 보낸다. 그래서 앱이
+ * 백그라운드여도 {@link #onMessageReceived} 가 깨어나 이 서비스가 직접 알림을 그린다.
+ * 채팅이 아니면(공지·결재 등) plugin 기본 동작에 위임한다.
+ *
+ * 견고성 원칙(iOS 와 동일):
+ *   · 아바타 다운로드가 실패해도 알림은 <b>무조건</b> 전달한다(절대 블록 X) — 기본 아바타(이니셜+색)로 폴백.
+ *   · /uploads 는 인증 필요 → SharedPreferences 에 저장된 세션 토큰(HiNestNativePlugin)을
+ *     ?token= 으로 붙여 받는다. 토큰이 없으면(로그인 전 등) 사진은 못 받지만 기본 아바타로 표시.
+ *
+ * @capacitor/push-notifications 의 MessagingService 를 확장하므로 토큰 등록(onNewToken)·일반
+ * 알림 경로는 그대로 유지된다(super 위임). 매니페스트에서 plugin 의 서비스를 제거하고 이 서비스만 등록한다.
+ */
+public class HiNestMessagingService extends MessagingService {
+
+    /** #924 에서 IMPORTANCE_HIGH 로 만든 "기본 알림" 채널. */
+    private static final String CHANNEL_ID = "default";
+    /** = VITE_API_BASE (운영). iOS NSE 와 동일하게 하드코딩. */
+    private static final String API_BASE = "https://nest.hi-vits.com";
+    private static final int AVATAR_PX = 128;
+
+    @Override
+    public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
+        Map<String, String> data = remoteMessage.getData();
+        String senderName = data != null ? data.get("senderName") : null;
+        boolean isChat = data != null && "chat".equals(data.get("kind")) && !TextUtils.isEmpty(senderName);
+        if (!isChat) {
+            // 채팅이 아니면 기존 동작 — plugin 이 JS 전달/표시.
+            super.onMessageReceived(remoteMessage);
+            return;
+        }
+        try {
+            showChatNotification(data);
+        } catch (Throwable t) {
+            // 무슨 일이 있어도 알림은 떠야 한다 → 최후의 폴백으로 plugin 기본 처리.
+            try {
+                super.onMessageReceived(remoteMessage);
+            } catch (Throwable ignored) {
+                // 폴백마저 실패 — 더는 할 수 있는 게 없다(알림 손실 < 크래시).
+            }
+        }
+    }
+
+    @Override
+    public void onNewToken(@NonNull String token) {
+        // 토큰 등록은 plugin 로직 그대로 유지(서버 /api/push/register 흐름).
+        super.onNewToken(token);
+    }
+
+    private void showChatNotification(Map<String, String> data) {
+        String senderName = data.get("senderName");
+        String title = nonEmpty(data.get("title"), senderName);
+        String body = nonEmpty(data.get("body"), "");
+        String linkUrl = data.get("linkUrl");
+        String groupId = data.get("groupId");
+        String avatarPath = data.get("senderAvatarPath");
+        String avatarColor = data.get("senderAvatarColor");
+
+        // 아바타 — 다운로드 성공 시 사진(원형), 아니면 기본(이니셜+색). 항상 non-null 보장.
+        Bitmap avatar = fetchAvatar(avatarPath);
+        if (avatar == null) avatar = defaultAvatar(senderName, avatarColor);
+        IconCompat icon = avatar != null ? IconCompat.createWithBitmap(avatar) : null;
+
+        Person sender = new Person.Builder()
+                .setName(senderName)
+                .setKey(groupId != null ? groupId : senderName)
+                .setIcon(icon)
+                .build();
+
+        // 1:1 이면 title == senderName, 그룹이면 title == 그룹명 → 대화 제목/그룹 표시.
+        boolean isGroup = title != null && !title.equals(senderName);
+
+        NotificationCompat.MessagingStyle style =
+                new NotificationCompat.MessagingStyle(new Person.Builder().setName("나").build());
+        style.addMessage(body, System.currentTimeMillis(), sender);
+        if (isGroup) {
+            style.setConversationTitle(title);
+            style.setGroupConversation(true);
+        }
+
+        Intent open = getPackageManager().getLaunchIntentForPackage(getPackageName());
+        if (open == null) open = new Intent(this, MainActivity.class);
+        open.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        if (linkUrl != null) open.putExtra("hinest.linkUrl", linkUrl);
+        // minSdk 24 → FLAG_IMMUTABLE(API 23+) 항상 사용 가능.
+        PendingIntent contentIntent = PendingIntent.getActivity(
+                this, notifId(groupId, senderName), open,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Builder b = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(smallIcon())
+                .setStyle(style)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setAutoCancel(true)
+                .setCategory(NotificationCompat.CATEGORY_MESSAGE)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setContentIntent(contentIntent);
+        if (groupId != null) b.setGroup(groupId);
+
+        NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if (nm != null) nm.notify(notifId(groupId, senderName), b.build());
+    }
+
+    /** 같은 방은 같은 id 로 묶여 갱신(=collapse). 없으면 발신자명 해시. */
+    private int notifId(String groupId, String senderName) {
+        String key = groupId != null ? groupId : (senderName != null ? senderName : "chat");
+        return key.hashCode();
+    }
+
+    /** 상태바 작은 아이콘 — 앱 아이콘(FCM 기본과 동일). 0 이면 시스템 기본. */
+    private int smallIcon() {
+        int icon = getApplicationInfo().icon;
+        return icon != 0 ? icon : android.R.drawable.sym_def_app_icon;
+    }
+
+    /** /uploads 아바타를 토큰 인증으로 받아 원형 크롭. 실패하면 null(→ 기본 아바타). 절대 throw 안 함. */
+    private Bitmap fetchAvatar(String path) {
+        if (path == null || !path.startsWith("/uploads/")) return null;
+        HttpURLConnection conn = null;
+        try {
+            SharedPreferences sp = getSharedPreferences(HiNestNativePlugin.PREFS, Context.MODE_PRIVATE);
+            String token = sp.getString(HiNestNativePlugin.KEY_TOKEN, null);
+            String urlStr = API_BASE + path;
+            if (token != null && !token.isEmpty()) {
+                String enc = URLEncoder.encode(token, "UTF-8");
+                urlStr += (urlStr.contains("?") ? "&" : "?") + "token=" + enc;
+            }
+            conn = (HttpURLConnection) new URL(urlStr).openConnection();
+            conn.setConnectTimeout(6000);
+            conn.setReadTimeout(7000);
+            conn.setInstanceFollowRedirects(true);
+            conn.connect();
+            if (conn.getResponseCode() != 200) return null;
+            InputStream is = conn.getInputStream();
+            try {
+                Bitmap raw = BitmapFactory.decodeStream(is);
+                return raw != null ? circleCrop(raw) : null;
+            } finally {
+                is.close();
+            }
+        } catch (Throwable t) {
+            return null;
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+
+    /** 정사각 중앙 크롭 → 원형 마스크(AVATAR_PX). */
+    private Bitmap circleCrop(Bitmap src) {
+        int size = Math.min(src.getWidth(), src.getHeight());
+        int x = (src.getWidth() - size) / 2;
+        int y = (src.getHeight() - size) / 2;
+        Bitmap sq = Bitmap.createBitmap(src, x, y, size, size);
+        Bitmap out = Bitmap.createBitmap(AVATAR_PX, AVATAR_PX, Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(out);
+        Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+        c.drawCircle(AVATAR_PX / 2f, AVATAR_PX / 2f, AVATAR_PX / 2f, p);
+        p.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
+        c.drawBitmap(sq, new Rect(0, 0, size, size), new RectF(0, 0, AVATAR_PX, AVATAR_PX), p);
+        if (sq != src) sq.recycle();
+        return out;
+    }
+
+    /** 사진 미등록/실패 시 앱 기본 아바타(색 원형 + 이름 첫 글자, 흰색)를 직접 그림 — iOS 와 동일. */
+    private Bitmap defaultAvatar(String name, String colorHex) {
+        String initial = (name != null && !name.isEmpty()) ? name.substring(0, 1) : "?";
+        int bg = parseColor(colorHex, 0xFF3D54C4); // 기본 인디고 (iOS 기본색과 동일)
+        Bitmap out = Bitmap.createBitmap(AVATAR_PX, AVATAR_PX, Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(out);
+        Paint circle = new Paint(Paint.ANTI_ALIAS_FLAG);
+        circle.setColor(bg);
+        c.drawCircle(AVATAR_PX / 2f, AVATAR_PX / 2f, AVATAR_PX / 2f, circle);
+        Paint text = new Paint(Paint.ANTI_ALIAS_FLAG);
+        text.setColor(Color.WHITE);
+        text.setTextSize(AVATAR_PX * 0.46f);
+        text.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
+        text.setTextAlign(Paint.Align.CENTER);
+        Paint.FontMetrics fm = text.getFontMetrics();
+        float baseline = AVATAR_PX / 2f - (fm.ascent + fm.descent) / 2f;
+        c.drawText(initial, AVATAR_PX / 2f, baseline, text);
+        return out;
+    }
+
+    private int parseColor(String hex, int fallback) {
+        if (hex == null) return fallback;
+        try {
+            String h = hex.trim();
+            if (!h.startsWith("#")) h = "#" + h;
+            return Color.parseColor(h);
+        } catch (Throwable t) {
+            return fallback;
+        }
+    }
+
+    private static String nonEmpty(String v, String fallback) {
+        return (v == null || v.isEmpty()) ? fallback : v;
+    }
+}

--- a/client/android/app/src/main/java/com/hivits/hinest/HiNestNativePlugin.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/HiNestNativePlugin.java
@@ -1,0 +1,39 @@
+package com.hivits.hinest;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+/**
+ * 네이티브 보조 플러그인.
+ *
+ * 현재 용도: 세션 토큰을 SharedPreferences 에 보관해 {@link HiNestMessagingService}(채팅 아바타
+ * 알림)가 /uploads 아바타를 인증 다운로드할 수 있게 한다. iOS 의 App Group
+ * (key "hinest.session.token") 공유와 동일한 목적의 안드로이드 미러.
+ *
+ * 토큰은 앱 전용 SharedPreferences 에만 저장되고 외부로 노출되지 않는다(MODE_PRIVATE).
+ */
+@CapacitorPlugin(name = "HiNestNative")
+public class HiNestNativePlugin extends Plugin {
+
+    /** SharedPreferences 파일명 / 키 — 메시징 서비스가 같은 값으로 읽는다. */
+    static final String PREFS = "hinest";
+    static final String KEY_TOKEN = "session.token";
+
+    /** JS: HiNestNative.setSessionToken({ token }). 빈/누락이면 제거(로그아웃). */
+    @PluginMethod
+    public void setSessionToken(PluginCall call) {
+        String token = call.getString("token", "");
+        SharedPreferences sp = getContext().getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+        if (token == null || token.isEmpty()) {
+            sp.edit().remove(KEY_TOKEN).apply();
+        } else {
+            sp.edit().putString(KEY_TOKEN, token).apply();
+        }
+        call.resolve();
+    }
+}

--- a/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
@@ -1,5 +1,15 @@
 package com.hivits.hinest;
 
+import android.os.Bundle;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        // 커스텀 플러그인은 반드시 super.onCreate(=Bridge 초기화) 이전에 등록.
+        // HiNestNative: 세션 토큰을 SharedPreferences 에 보관 → 채팅 아바타 알림이 /uploads 인증에 사용.
+        registerPlugin(HiNestNativePlugin.class);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/client/android/variables.gradle
+++ b/client/android/variables.gradle
@@ -13,4 +13,7 @@ ext {
     androidxJunitVersion = '1.3.0'
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
+    // @capacitor/push-notifications 의 기본값과 동일 — 여기 정의하면 plugin 과 app 이 같은 버전을 쓴다.
+    // (커스텀 HiNestMessagingService 가 RemoteMessage/FirebaseMessagingService 를 컴파일타임에 참조)
+    firebaseMessagingVersion = '25.0.1'
 }

--- a/client/src/lib/authToken.ts
+++ b/client/src/lib/authToken.ts
@@ -12,8 +12,9 @@
  * 않는다(JS 가 토큰을 읽을 수 없게 두어 XSS 토큰 탈취 표면을 만들지 않음). localStorage 는
  * WKWebView 에서 새로고침·앱 재실행 후에도 유지된다.
  */
-import { isCapacitorNative } from "./platform";
+import { isCapacitorNative, nativePlatform } from "./platform";
 import { LiquidGlassTabBar } from "./liquidGlassTabBar";
+import { HiNestNative } from "./hinestNative";
 
 const KEY = "hinest.authToken";
 
@@ -36,12 +37,20 @@ export function setAuthToken(token: string | null | undefined): void {
   } catch {
     /* storage 비활성/quota — 무시 */
   }
-  // NSE(채팅 발신자 아바타)가 /uploads 인증에 쓰도록 공유 App Group 에도 기록한다.
-  // App Group capability 미설정 / 구버전 네이티브면 내부 no-op·reject → 무시(무해). 토큰 없으면 빈 값=제거.
+  // 채팅 발신자 아바타 알림이 /uploads 인증에 쓰도록 네이티브에 토큰을 공유한다. 토큰 없으면 빈 값=제거.
+  //  · iOS: 공유 App Group(NSE 가 읽음). App Group 미설정/구버전이면 내부 no-op·reject → 무시(무해).
+  //  · Android: SharedPreferences(HiNestMessagingService 가 읽음). 플러그인 없으면 reject → 무시(무해).
   try {
     void LiquidGlassTabBar.setSharedToken({ token: token ?? "" }).catch(() => {});
   } catch {
     /* 플러그인 미가용 — 무시 */
+  }
+  if (nativePlatform() === "android") {
+    try {
+      void HiNestNative.setSessionToken({ token: token ?? "" }).catch(() => {});
+    } catch {
+      /* 플러그인 미가용 — 무시 */
+    }
   }
 }
 

--- a/client/src/lib/hinestNative.ts
+++ b/client/src/lib/hinestNative.ts
@@ -1,0 +1,18 @@
+/**
+ * 안드로이드 전용 네이티브 보조 플러그인 브리지.
+ *
+ * 현재 메서드는 setSessionToken 하나 — 세션 토큰을 네이티브 SharedPreferences 에 보관해
+ * HiNestMessagingService(채팅 아바타 알림)가 /uploads 아바타를 인증 다운로드할 수 있게 한다.
+ * iOS 의 App Group 공유(LiquidGlassTabBar.setSharedToken)에 대응하는 안드로이드 미러.
+ *
+ * iOS/웹/데스크톱에는 이 플러그인이 없으므로 registerPlugin 의 웹 폴백(no-op)으로 동작 →
+ * 호출해도 안전(reject 를 호출부에서 무시). 실제 동작은 안드로이드 네이티브에서만.
+ */
+import { registerPlugin } from "@capacitor/core";
+
+export interface HiNestNativePlugin {
+  /** 세션 토큰을 네이티브에 보관(아바타 /uploads 인증용). token="" 이면 제거(로그아웃). */
+  setSessionToken(options: { token: string }): Promise<void>;
+}
+
+export const HiNestNative = registerPlugin<HiNestNativePlugin>("HiNestNative");

--- a/server/src/lib/fcm.ts
+++ b/server/src/lib/fcm.ts
@@ -91,20 +91,53 @@ export interface FcmPayload {
   linkUrl?: string;
   /** 동일 스레드 묶음(예: 채팅방 id) — Android collapseKey 로 사용. */
   groupId?: string;
+  // ─ 통신알림(발신자 아바타) 용 — iOS APNs(NSE)와 동일 필드. 채팅(DM/MENTION)만 채워진다.
+  /** 발신자 표시명. 있으면 "채팅"으로 간주 → data-only 로 보내 커스텀 서비스가 아바타 알림을 그린다. */
+  senderName?: string;
+  /** 발신자 아바타 /uploads 상대경로. 안드로이드 서비스가 ?token= 로 받아 원형 비트맵으로 사용. */
+  senderAvatarPath?: string;
+  /** 발신자 아바타 색(#RRGGBB) — 사진 미등록/다운로드 실패 시 기본 아바타(이니셜+색) 폴백용. */
+  senderAvatarColor?: string;
 }
 
 /** 단일 FCM 토큰으로 1건 발송. 반환: "ok" | "dead"(토큰 무효 → 정리 대상) | "err". */
 async function sendOne(token: string, payload: FcmPayload, access: string): Promise<"ok" | "dead" | "err"> {
-  const message: any = {
-    token,
-    notification: { title: payload.title, ...(payload.body ? { body: payload.body } : {}) },
-    data: { ...(payload.linkUrl ? { linkUrl: payload.linkUrl } : {}) },
-    android: {
-      priority: "HIGH",
-      notification: { channelId: "default", ...(payload.groupId ? { tag: payload.groupId } : {}) },
-      ...(payload.groupId ? { collapseKey: payload.groupId } : {}),
-    },
-  };
+  // 채팅(senderName 있음)은 **data-only** 고우선 메시지로 보낸다.
+  //   · notification 블록이 있으면 백그라운드에서 시스템이 직접 표시 → 커스텀 서비스의 onMessageReceived 가
+  //     호출되지 않아 발신자 아바타(MessagingStyle)를 그릴 수 없다.
+  //   · data-only + priority HIGH 면 백그라운드에서도 HiNestMessagingService.onMessageReceived 가 깨어나
+  //     아바타 알림을 그린다(인스타/왓츠앱·카톡 방식 = iOS NSE 미러링).
+  // 채팅이 아니면(공지·결재 등) 기존처럼 notification 블록 — 앱 프로세스가 죽어 있어도 시스템이 표시.
+  const isChat = !!payload.senderName;
+  const message: any = isChat
+    ? {
+        token,
+        // 문자열만 허용(FCM data 제약) — 빈 값은 키 자체를 생략.
+        data: {
+          kind: "chat",
+          title: payload.title,
+          ...(payload.body ? { body: payload.body } : {}),
+          ...(payload.linkUrl ? { linkUrl: payload.linkUrl } : {}),
+          ...(payload.groupId ? { groupId: payload.groupId } : {}),
+          ...(payload.senderName ? { senderName: payload.senderName } : {}),
+          ...(payload.senderAvatarPath ? { senderAvatarPath: payload.senderAvatarPath } : {}),
+          ...(payload.senderAvatarColor ? { senderAvatarColor: payload.senderAvatarColor } : {}),
+        },
+        android: {
+          priority: "HIGH",
+          ...(payload.groupId ? { collapseKey: payload.groupId } : {}),
+        },
+      }
+    : {
+        token,
+        notification: { title: payload.title, ...(payload.body ? { body: payload.body } : {}) },
+        data: { ...(payload.linkUrl ? { linkUrl: payload.linkUrl } : {}) },
+        android: {
+          priority: "HIGH",
+          notification: { channelId: "default", ...(payload.groupId ? { tag: payload.groupId } : {}) },
+          ...(payload.groupId ? { collapseKey: payload.groupId } : {}),
+        },
+      };
   try {
     const res = await fetch(`https://fcm.googleapis.com/v1/projects/${SA!.projectId}/messages:send`, {
       method: "POST",

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -201,7 +201,8 @@ export async function notifyMany(inputs: NotifyInput[]) {
     }
     // 원격 푸시 — fire-and-forget. pushToken 조회를 1회로 묶어 일괄 발송. iOS=APNs, Android=FCM.
     // 각 함수가 자기 platform 토큰만 조회하므로 동일 타깃 목록을 둘 다 넘겨도 안전(미설정/토큰없음이면 no-op).
-    // FCM 은 senderName/avatar(통신알림) 미지원이라 공통 필드(title/body/linkUrl/groupId)만 사용.
+    // 채팅(DM/MENTION)은 senderName/avatar 가 실려 양쪽 모두 발신자 아바타 알림을 그린다
+    // (iOS=NSE 통신알림, Android=HiNestMessagingService MessagingStyle). 공통 필드는 그대로 사용.
     void sendApnsToUsers(apnsTargets);
     void sendFcmToUsers(apnsTargets);
   } catch (e) {


### PR DESCRIPTION
## 증상
iOS는 채팅 푸시를 발신자 프로필 사진(코너 앱 로고)으로 표시(Communication Notification)하는데, **안드로이드는 일반 텍스트 알림만** 떠서 발신자 아바타가 없었다.

## 원인
안드로이드엔 발신자 아바타 알림 경로가 미구현. 또한 채팅 푸시가 `notification` 블록으로 가면 백그라운드에서 시스템이 직접 표시해 커스텀 서비스의 `onMessageReceived`가 호출되지 않아, 아바타(MessagingStyle)를 그릴 수 없다.

## 작업 내용
- **수정** `server/src/lib/fcm.ts`: 채팅(senderName 있음)은 `notification` 블록 대신 **data-only 고우선** 전송 → 백그라운드에서도 깨어남. `FcmPayload`에 `senderName/senderAvatarPath/senderAvatarColor` 추가. 채팅 아닌 알림은 기존 `notification` 블록 유지.
- **추가** `client/android/.../HiNestMessagingService.java`: push 플러그인 `MessagingService` 확장 → `NotificationCompat.MessagingStyle`+`Person`(원형 아바타). 아바타는 `/uploads?token=` 다운로드·원형 크롭, 실패해도 **알림은 무조건 전달** + 기본 아바타(이니셜+색) 폴백. 채팅 아니면 `super` 위임.
- **추가** `HiNestNativePlugin.java`(세션 토큰 SharedPreferences 보관=iOS App Group 미러), `MainActivity` registerPlugin, `client/src/lib/hinestNative.ts`+`authToken.ts`(안드로이드 토큰 영속화).
- **수정** `AndroidManifest.xml`: plugin MessagingService 제거(`tools:node=remove`) + 우리 서비스 등록. `app/build.gradle`·`variables.gradle`: androidx.core·firebase-messaging 의존성.
- 외부 영향: iOS NSE와 동등. 안드로이드 채팅 FCM이 data-only로 바뀜(새 네이티브 빌드부터).

## 검증
- [x] `server`·`client` tsc 통과
- [x] `./gradlew :app:compileDebugJavaWithJavac` BUILD SUCCESSFUL
- [x] 머지 매니페스트에 우리 서비스 priority 0 / SDK 기본 -500 폴백 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #937

## 분류
- **type:** feat
- **area:** android · server · client
- **priority:** P1

## 비고
- 네이티브 코드라 OTA 불가 — 새 AAB/APK 필요. 런타임 배너는 스토어/사이드로드 빌드에서 확인.
