### PR TITLE
🔀 :: (#941) 채팅 감사 잠금해제 성공 로그 제거

### DIFF
--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1353,7 +1353,8 @@ ops.post("/chat-audit/unlock", requireSuperAdminStepUp, async (req, res) => {
     // '세션 만료' 로 오인해 전역 로그아웃시킨다(버그). 암호 오류는 forbidden 으로 분리.
     return res.status(403).json({ code: "BAD_STEPUP_PW", error: "암호 불일치" });
   }
-  await writeLog(u.id, "CHAT_AUDIT_UNLOCK_OK", undefined, undefined, req.ip).catch(() => {});
+  // 성공(UNLOCK_OK)은 감사 로그에 남기지 않는다 — 슈퍼관리자의 정상 운영 동작이라 활동 피드 노이즈.
+  // 실패(UNLOCK_FAIL)만 보안상 기록한다(위 두 분기). 재추가 금지.
   // 채팅 감사 API(/api/chat/rooms?scope=audit, .../messages)는 super step-up 쿠키(hinest_super)를
   // verifySuperToken 으로 요구한다. CHAT_AUDIT_PW 가 맞았으니 여기서 그 쿠키를 함께 발급해야
   // 패널 진입 시 401 이 나지 않는다. (예전엔 쿠키를 안 줘서 패널이 401 → api() 가 세션 만료로


### PR DESCRIPTION
## 증상
슈퍼관리자가 채팅 감사 잠금을 해제할 때마다 활동 피드에 **`CHAT_AUDIT_UNLOCK_OK`가 계속 떴다**(스크린샷). 정상 운영 동작이라 매번 기록될 필요가 없는데 노이즈로 쌓였다.

## 원인
`server/src/routes/admin.ts`의 `/chat-audit/unlock` 성공 분기(line 1356)에서 매 성공마다 `writeLog(u.id, "CHAT_AUDIT_UNLOCK_OK", ...)`를 호출하고 있었다.

## 작업 내용
- **제거** `server/src/routes/admin.ts`: 성공 `writeLog("CHAT_AUDIT_UNLOCK_OK")` 호출 삭제 + 재추가 금지 주석.
- **유지** 실패 분기 `CHAT_AUDIT_UNLOCK_FAIL`(틀린 step-up 암호 시도)은 보안상 그대로 — 정상 동작만 안 남기고 의심 행위는 기록.
- 외부 영향: 잠금 해제 기능 동작 동일, 활동 로그에 성공만 안 남음.

## 검증
- [x] `server` tsc 통과
- [x] 본인(@Xixn2) Assignee 지정

Closes #941

## 분류
- **type:** security
- **area:** server
- **priority:** P2

## 비고
- 활동 피드 노이즈 제거 + 운영자 정상 행위 비기록(프라이버시).
