### PR TITLE
🔀 :: (#943) 🔴 fix(native): OTA 번들 API_BASE 빈 값 폴백 (로그인 실패 수정)

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -5,9 +5,20 @@
  * VITE_API_BASE 로 절대 오리진(예: https://nest.hi-vits.com)을 주입한다.
  */
 import { getAuthToken } from "./lib/authToken";
+import { isCapacitorNative } from "./lib/platform";
 
-export const API_BASE: string =
-  ((import.meta as any).env?.VITE_API_BASE as string | undefined)?.replace(/\/+$/, "") ?? "";
+const _envApiBase = ((import.meta as any).env?.VITE_API_BASE as string | undefined)?.replace(/\/+$/, "");
+
+/**
+ * API 오리진.
+ *  - 빌드시 VITE_API_BASE 가 박히면 그걸 쓴다(네이티브 빌드 cap:android/ios 스크립트가 주입).
+ *  - 비어 있고 **네이티브(Capacitor)** 면 운영 오리진으로 폴백한다.
+ *    왜: 라이브업데이트(OTA) 번들은 Vercel 이 `npm run build` 로 생성하는데, 웹은 동일 오리진이라
+ *    VITE_API_BASE 가 필요 없어 안 박힌다. 그 번들을 네이티브가 OTA 로 받으면 API_BASE 가 빈 값이 돼
+ *    모든 요청이 WebView 로컬(https://localhost)로 새서 로그인 등 전부 실패했다(데이터 타입 오류).
+ *    네이티브에서만 폴백하므로 웹/데스크톱은 기존처럼 상대경로(빈 base) 그대로 — 동작 변화 없음.
+ */
+export const API_BASE: string = _envApiBase || (isCapacitorNative() ? "https://nest.hi-vits.com" : "");
 
 /** 상대 API/자산 경로를 현재 빌드에 맞는 절대 URL 로. 절대 URL 은 그대로 통과. */
 export function apiUrl(path: string): string {


### PR DESCRIPTION
## 증상
실기기(갤럭시 S22, Android 16) HiNest 앱에서 이메일·비밀번호로 **로그인 시 실패**. 콘솔 오류 `Unexpected token '<', "<!doctype "... is not valid JSON`, 사용자에겐 "데이터 타입이 맞지 않다"로 보임. 로그인뿐 아니라 `/api/me` 등 **모든 API 호출이 동일하게 실패**.

## 원인
- logcat 확인 결과 요청이 `https://localhost/api/auth/login`(WebView 로컬 SPA)로 감 → 서버 JSON 대신 `index.html`(`<!doctype html>`)을 받아 `res.json()` 파싱이 깨짐.
- **근본 원인**: `client/src/api.ts`의 `API_BASE`는 빌드 시 `VITE_API_BASE`가 주입돼야 절대 오리진이 박힌다. 그런데 **라이브업데이트(OTA) 번들은 Vercel이 `npm run build`로 생성**하는데, 웹은 `vercel.json`의 rewrite(`/api/*` → `api.nest.hi-vits.com`)로 동일 오리진이라 `VITE_API_BASE`가 필요 없어 **안 박힌다** → OTA 번들의 `API_BASE=""`.
- 네이티브 앱(`autoUpdate`+`directUpdate`)이 이 OTA 번들을 받아 적용하면 APK 내장(정상) 번들을 덮어써, 상대경로 API가 WebView 로컬(`https://localhost`)로 누수된다. **iOS도 OTA 시 동일하게 터지는 잠복 버그.**

## 작업 내용
- **수정** `client/src/api.ts`: `API_BASE` 결정 로직에 네이티브 폴백 추가.
  - `const _envApiBase = import.meta.env.VITE_API_BASE?.replace(/\/+$/,"")`
  - `export const API_BASE = _envApiBase || (isCapacitorNative() ? "https://nest.hi-vits.com" : "")`
- **추가** import `isCapacitorNative` (`./lib/platform`) — platform.ts는 무의존 모듈이라 **순환참조 없음**.
- **호환성**: 웹/데스크톱은 env가 없으면 빈 base(상대경로) **그대로 → 동작 변화 없음**. 네이티브는 env가 있으면 그대로, 없으면(=OTA 번들) 운영 오리진으로 폴백.
- **외부 영향**: iOS도 동일 코드라 다음 OTA에서 자동 치유. 단일 상수 변경이라 롤백 용이.

## 검증
- [x] `client` tsc 통과
- [x] `VITE_API_BASE` 없이 빌드(Vercel 시뮬)해도 엔트리 번들에 `…||(W()?"https://nest.hi-vits.com":"")` 폴백 박힘 확인
- [x] 운영 OTA 번들(12371f7) 재배포 후 실기기(SM-S901N)에서 OTA 적용 → logcat `localhost/api` 누수 **0건**, `/api/me`가 진짜 서버 401 응답(HTML 파싱오류 사라짐) 확인
- [x] 본인(@Xixn2) Assignee 지정

Closes #943

## 분류
- **type:** fix
- **area:** client
- **priority:** P0

## 비고
- 회귀 위험 낮음(네이티브 전용 폴백, 웹/데스크톱 무변경). 폰은 재설치 없이 OTA로 자동 치유됨(cb6d65e 삭제 → 12371f7 적용).
