### PR TITLE
🔀 :: (#947) 배터리 최적화 제외 안내(카톡 방식) — 백그라운드/잠금 알림 신뢰도

### DIFF
--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -70,4 +70,7 @@
     <!-- 햅틱(@capacitor/haptics)이 Vibrator 로 진동을 주려면 필요. iOS 와 동일 지점의 탭/토글/
          버튼 햅틱을 안드로이드에서도 동작시킨다. -->
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- 배터리 최적화 제외 요청(카톡 방식) — 백그라운드/잠금 상태에서도 알림이 즉시 오게.
+         메시징 앱의 핵심 기능(실시간 알림)에 필요. Play Console 에 해당 사용처 선언 필요. -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 </manifest>

--- a/client/android/app/src/main/java/com/hivits/hinest/HiNestNativePlugin.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/HiNestNativePlugin.java
@@ -1,8 +1,13 @@
 package com.hivits.hinest;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.PowerManager;
+import android.provider.Settings;
 
+import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -35,5 +40,44 @@ public class HiNestNativePlugin extends Plugin {
             sp.edit().putString(KEY_TOKEN, token).apply();
         }
         call.resolve();
+    }
+
+    /**
+     * JS: HiNestNative.isIgnoringBatteryOptimizations() → { ignoring: boolean }.
+     * 앱이 OEM 배터리 최적화에서 제외돼 있는지 — 백그라운드/잠금 상태 알림 신뢰도의 핵심 지표.
+     */
+    @PluginMethod
+    public void isIgnoringBatteryOptimizations(PluginCall call) {
+        PowerManager pm = (PowerManager) getContext().getSystemService(Context.POWER_SERVICE);
+        boolean ignoring = pm != null && pm.isIgnoringBatteryOptimizations(getContext().getPackageName());
+        JSObject ret = new JSObject();
+        ret.put("ignoring", ignoring);
+        call.resolve(ret);
+    }
+
+    /**
+     * JS: HiNestNative.requestIgnoreBatteryOptimizations().
+     * 배터리 최적화 제외 시스템 다이얼로그를 띄운다(카톡 방식). 일부 기기에서 이 인텐트가 없으면
+     * 배터리 최적화 설정 목록 화면으로 폴백. 실제 허용은 사용자가 시스템 UI 에서 결정한다.
+     */
+    @PluginMethod
+    public void requestIgnoreBatteryOptimizations(PluginCall call) {
+        Context ctx = getContext();
+        try {
+            Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+            intent.setData(Uri.parse("package:" + ctx.getPackageName()));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            ctx.startActivity(intent);
+            call.resolve();
+        } catch (Throwable t) {
+            try {
+                Intent fallback = new Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
+                fallback.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                ctx.startActivity(fallback);
+                call.resolve();
+            } catch (Throwable t2) {
+                call.reject("배터리 최적화 설정을 열 수 없어요");
+            }
+        }
     }
 }

--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import { api, clearApiCache } from "./api";
 import { setAuthToken, clearAuthToken } from "./lib/authToken";
 import { requestNotifPermissionOnLogin } from "./lib/notifPermission";
+import { ensureAndroidBatteryExemption } from "./lib/batteryOptimization";
 import { setupIosPush, unregisterIosPush } from "./lib/pushNotifications";
 
 export type User = {
@@ -101,6 +102,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUser(res.user);
     // 로그인 직후 알림 권한 요청(iOS/macOS 등 설치형 앱). 라우팅을 막지 않도록 fire-and-forget.
     void requestNotifPermissionOnLogin();
+    // 안드로이드: 백그라운드/잠금 상태 알림 신뢰도 위해 배터리 최적화 제외 1회 안내(카톡 방식).
+    void ensureAndroidBatteryExemption();
     // 호출부(LoginPage)가 superAdmin 여부로 진입 경로를 정할 수 있도록 사용자 객체를 반환.
     return res.user;
   }, []);
@@ -113,8 +116,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setAuthToken(res.token);
     clearApiCache();
     setUser(res.user);
-    // 가입(=최초 로그인) 직후에도 동일하게 알림 권한 요청.
+    // 가입(=최초 로그인) 직후에도 동일하게 알림 권한 요청 + 배터리 최적화 제외 안내(안드로이드).
     void requestNotifPermissionOnLogin();
+    void ensureAndroidBatteryExemption();
   }, []);
 
   const logout = useCallback(async () => {

--- a/client/src/lib/batteryOptimization.ts
+++ b/client/src/lib/batteryOptimization.ts
@@ -1,0 +1,62 @@
+/**
+ * 안드로이드 배터리 최적화 제외 안내(카카오톡 방식).
+ *
+ * 백그라운드·잠금 상태에서도 채팅·알림이 즉시 오게 하려면 OEM 배터리 최적화에서 앱이 제외돼야
+ * 한다(삼성 절전, 샤오미/화웨이 등 공격적 백그라운드 킬러가 앱을 재워 알림을 늦춤). FCM
+ * `priority:high` + 고중요도 채널까지 갖춰도 이 OEM 변수만은 코드로 못 이겨 사용자 설정이 필요하다.
+ * 카톡·디스코드도 같은 이유로 사용자에게 "배터리 최적화 제외" 안내를 띄운다.
+ *
+ * 동작:
+ *  - 안드로이드 네이티브에서만(다른 플랫폼·구 APK·플러그인 미가용이면 조용히 no-op).
+ *  - 이미 제외돼 있으면 아무것도 안 함.
+ *  - 안 돼 있으면 1회 친절 안내(앱 확인 다이얼로그) → "설정 열기" 시 시스템 제외 화면으로 유도.
+ *  - 한 번 물어보면(허용/거부 무관) 다시 안 묻는다(localStorage 가드).
+ */
+import { nativePlatform } from "./platform";
+import { HiNestNative } from "./hinestNative";
+import { confirmAsync } from "../components/ConfirmHost";
+
+const ASKED_KEY = "hinest.battery.askedV1";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export async function ensureAndroidBatteryExemption(): Promise<void> {
+  if (typeof window === "undefined") return;
+  if (nativePlatform() !== "android") return;
+  try {
+    if (localStorage.getItem(ASKED_KEY) === "1") return;
+  } catch {
+    /* localStorage 불가 — 계속 진행 */
+  }
+  // 이미 제외돼 있으면 안내 불필요. 플러그인 미가용(구 APK 등)이면 조용히 종료.
+  try {
+    const { ignoring } = await HiNestNative.isIgnoringBatteryOptimizations();
+    if (ignoring) return;
+  } catch {
+    return;
+  }
+  // 알림 권한 시스템 다이얼로그가 먼저 처리되도록 잠깐 양보(두 다이얼로그가 겹치지 않게).
+  await sleep(2500);
+  const ok = await confirmAsync({
+    title: "알림을 놓치지 않으려면",
+    description:
+      "백그라운드·잠금 상태에서도 채팅·알림이 바로 오게 하려면 ‘배터리 최적화’에서 HiNest를 제외해 주세요.\n\n설정 화면을 열어드릴까요?",
+    confirmLabel: "설정 열기",
+    cancelLabel: "나중에",
+  });
+  // 허용/거부 무관 1회만 안내(다시 안 나오게). 거부해도 사용자가 설정에서 직접 바꿀 수 있음.
+  try {
+    localStorage.setItem(ASKED_KEY, "1");
+  } catch {
+    /* 무시 */
+  }
+  if (ok === true) {
+    try {
+      await HiNestNative.requestIgnoreBatteryOptimizations();
+    } catch {
+      /* 인텐트 미지원 등 — 무시 */
+    }
+  }
+}

--- a/client/src/lib/hinestNative.ts
+++ b/client/src/lib/hinestNative.ts
@@ -13,6 +13,10 @@ import { registerPlugin } from "@capacitor/core";
 export interface HiNestNativePlugin {
   /** 세션 토큰을 네이티브에 보관(아바타 /uploads 인증용). token="" 이면 제거(로그아웃). */
   setSessionToken(options: { token: string }): Promise<void>;
+  /** 앱이 OEM 배터리 최적화에서 제외돼 있는지(백그라운드 알림 신뢰도 지표). 안드로이드 전용. */
+  isIgnoringBatteryOptimizations(): Promise<{ ignoring: boolean }>;
+  /** 배터리 최적화 제외 시스템 다이얼로그 띄우기(카톡 방식). 안드로이드 전용. */
+  requestIgnoreBatteryOptimizations(): Promise<void>;
 }
 
 export const HiNestNative = registerPlugin<HiNestNativePlugin>("HiNestNative");


### PR DESCRIPTION
## 증상
안드로이드에서 FCM `priority:high` + 고중요도 채널(`hinest_alerts`)까지 갖춰도, **삼성 절전·샤오미/화웨이 등 OEM 배터리 최적화가 백그라운드 앱을 재워** 잠금/백그라운드 상태 알림이 늦거나 누락될 수 있다. 카톡·디스코드급 즉시성에 남은 마지막 격차.

## 원인
OEM 배터리 최적화는 **앱이 코드로 끌 수 없는 사용자 설정 영역**이라, FCM 전송 priority·채널 importance 와 별개로 백그라운드 데몬을 죽인다. 사용자가 직접 "최적화 제외"해야 한다. 카톡·디스코드도 같은 이유로 사용자에게 제외 안내를 띄운다(코드로 못 이김).

## 작업 내용
- **추가** `AndroidManifest.xml`: `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` 권한.
- **추가** `HiNestNativePlugin.java`: `isIgnoringBatteryOptimizations()`(제외 여부) + `requestIgnoreBatteryOptimizations()`(시스템 제외 다이얼로그, 미지원 기기는 배터리 최적화 설정목록으로 폴백).
- **추가** `hinestNative.ts`: 두 메서드 브리지 타입.
- **추가** `batteryOptimization.ts`(신규): `ensureAndroidBatteryExemption()` — 미제외 시 1회 친절 안내(앱 확인 다이얼로그) → "설정 열기"면 시스템 제외 화면 유도. 이미 제외/구 APK/타 플랫폼이면 no-op, `localStorage` 가드로 재안내 안 함, 알림 권한 다이얼로그 후 2.5s 양보.
- **연결** `auth.tsx`: login·signup 성공 직후 호출(알림 권한 요청과 나란히 fire-and-forget).
- **외부 영향**: 안드로이드 전용. iOS/웹/데스크톱은 플러그인 웹 폴백으로 no-op. 네이티브 권한·메서드라 **새 APK 필요**. 1회만 안내(거부해도 재안내 X — 사용자가 설정에서 직접 변경 가능).

## 검증
- [x] `client` tsc 통과
- [x] `./gradlew :app:compileDebugJavaWithJavac` BUILD SUCCESSFUL
- [x] 실기기(SM-S901N) 설치·실행 크래시 없음(플러그인 등록 정상)
- [x] 앱이 deviceidle 화이트리스트 미포함(안내 조건 충족) 확인
- [ ] 로그인 후 안내 다이얼로그 → "설정 열기" → 시스템 제외 화면 육안 확인(사용자)
- [x] 본인(@Xixn2) Assignee 지정

Closes #947

## 분류
- **type:** feat
- **area:** android · client
- **priority:** P2

## 비고
- Play Console 에 `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` 사용처(실시간 메시징 알림)를 선언해야 함(정책상 제한 권한 — 메시징 앱은 허용 사례).
