### PR TITLE
🔀 :: (#951) FCM 푸시 등록을 빌드 플래그 없이 항상 켜기 (백그라운드 푸시 루트 원인)

### DIFF
--- a/client/src/lib/pushNotifications.ts
+++ b/client/src/lib/pushNotifications.ts
@@ -21,16 +21,19 @@ let lastToken: string | null = null;
 // iOS(APNs)·Android(FCM) 모두 동일한 @capacitor/push-notifications 플로우를 쓴다.
 // 토큰 종류만 OS 가 다르게 발급(iOS=APNs hex, Android=FCM) → 서버는 platform 으로 라우팅.
 //
-// ⚠️ Android 주의: register() 는 FirebaseMessaging.getInstance() 를 호출하는데, google-services.json
-//    이 없어 FirebaseApp 이 초기화 안 됐으면 IllegalStateException 으로 **네이티브 크래시**가 난다
-//    (JS try/catch 로 못 잡음). 그래서 Android 는 Firebase 가 실제로 번들된 빌드에서만 켠다 —
-//    VITE_ANDROID_FCM=1 로 빌드할 때만(=google-services.json 추가 + 서버 FCM 설정 완료 시).
-//    그 전까지 Android 는 푸시 미등록(앱은 정상, 알림만 없음). iOS 는 APNs 라 추가 설정 없이 동작.
+// Android FCM 등록을 항상 켠다 — google-services.json 이 안드로이드 프로젝트에 상시 포함되고(빌드 시
+// google-services 플러그인이 FirebaseApp 을 초기화) 서버 FCM 도 설정 완료라, register() 가 안전하다.
+//
+// ⚠️ 과거엔 VITE_ANDROID_FCM=1 빌드 플래그로 게이트했는데(google-services.json 없을 때 register() 가
+//    FirebaseApp 미초기화로 네이티브 크래시 나는 걸 막으려고), Vercel 이 만드는 OTA 번들은 그 플래그를
+//    안 박아 안드로이드 FCM 이 영영 비활성 → 백그라운드 푸시 0 이 됐다(VITE_API_BASE 폴백과 동일 유형
+//    의 함정). FCM 셋업이 끝난 지금은 플래그 없이 항상 켠다. (google-services.json 을 제거하는 빌드를
+//    한다면 그때 다시 가드를 둘 것.)
 function isNativePush(): boolean {
   const p = nativePlatform();
   if (!isCapacitorNative()) return false;
   if (p === "ios") return true;
-  if (p === "android") return (import.meta as any).env?.VITE_ANDROID_FCM === "1";
+  if (p === "android") return true;
   return false;
 }
 


### PR DESCRIPTION
## 증상
안드로이드 앱에서 **백그라운드·잠금 상태 푸시 알림이 전혀 오지 않는다**(포그라운드 SSE 알림만 동작). 아바타 알림·고중요도 채널까지 갖춰도 백그라운드 푸시 0건.

## 원인
`isNativePush()` 의 안드로이드 분기가 `VITE_ANDROID_FCM=1` 빌드 플래그로 게이트돼 있었다(과거 `google-services.json` 부재 시 `register()` 네이티브 크래시 방어용). 그런데 **Vercel 이 빌드하는 OTA 번들은 네이티브 빌드 플래그를 박지 않아** 안드로이드에서 `isNativePush()` 가 항상 `false` → `PushNotifications.register()` 미호출 → FCM 토큰 미발급 → 서버 발송 대상 토큰이 없음 → 백그라운드 푸시 0건. (이전 `VITE_API_BASE` 가 OTA 번들에서 비어 localhost 로 새던 것과 **동일 유형의 함정**.)

## 작업 내용
- **수정** `client/src/lib/pushNotifications.ts`: `isNativePush()` 의 android 분기를 `VITE_ANDROID_FCM === "1"` → `true` 로 변경(항상 등록).
- **근거**: `google-services.json` 이 안드로이드 프로젝트에 상시 포함돼 빌드 시 google-services 플러그인이 `FirebaseApp` 을 초기화하고 서버 FCM 도 설정 완료라, `register()` 가 더는 크래시하지 않는다. 플래그 게이트는 불필요.
- **주석 갱신**: 왜 플래그를 없애도 안전한지 + OTA 번들 함정 경위를 코드 주석에 남김(`google-services.json` 을 제거하는 빌드를 한다면 그때 다시 가드).
- **외부 영향**: iOS(APNs)·웹·데스크톱은 분기 무변경으로 동작 동일. 안드로이드만 FCM 등록이 켜진다. **JS 레이어 변경이라 OTA 로 배포**(새 APK 불필요).

## 검증
- [x] `client` tsc(`tsc --noEmit`) 통과
- [x] iOS/웹/데스크톱 분기 무변경 — 회귀 영향 없음 확인(코드 인스펙션)
- [ ] 실기기(SM-S901N) 로그인 → `/api/push/register` 호출·FCM 토큰 서버 등록 확인(배포 후 OTA 적용본으로)
- [ ] 백그라운드/잠금 상태에서 테스트 메시지 수신 확인(사용자 협조 — 종단 테스트)
- [x] 본인(@Xixn2) Assignee 지정

Closes #951

## 분류
- **type:** fix
- **area:** android · client
- **priority:** P1

## 비고
- 이 한 줄이 안드로이드 백그라운드 푸시의 루트 원인이었다. 배포 후 기기가 OTA 로 새 번들을 받아 로그인하면 토큰이 등록되고, 그때부터 서버 발송 푸시가 도착한다.
