### PR TITLE
🔀 :: (#953) 채팅 알림 중복 + 잠금화면 가림 해결 (JS 로컬 배너가 FCM 과 겹침)

### DIFF
--- a/client/src/lib/appActive.ts
+++ b/client/src/lib/appActive.ts
@@ -1,0 +1,38 @@
+/**
+ * 네이티브 앱 포그라운드(active) 상태 추적 — @capacitor/app 의 appStateChange.
+ *
+ * 왜 document.visibilityState 가 아니라 이걸 쓰나:
+ *   안드로이드 Capacitor WebView 는 앱을 백그라운드로 내리거나 화면을 잠가도 document.visibilityState
+ *   가 "visible"(hidden=false, hasFocus=true)로 남는다 — 실기기(SM-S901N, Android 16)에서 확인됨.
+ *   그래서 "포그라운드일 때만" 류의 가드가 안드로이드에선 항상 통과한다. @capacitor/app 의
+ *   appStateChange(isActive) 는 Activity onResume/onPause(OS 레벨)에 정확히 대응해 iOS·안드로이드
+ *   양쪽에서 신뢰할 수 있다.
+ *
+ * 비네이티브(웹/데스크톱)에선 항상 true 를 반환한다(호출 측이 네이티브 분기 안에서만 쓰는 전제).
+ */
+import { isCapacitorNative } from "./platform";
+
+let active = true;
+let wired = false;
+
+function ensureWired(): void {
+  if (wired || !isCapacitorNative()) return;
+  wired = true;
+  import("@capacitor/app")
+    .then(({ App }) => {
+      // 초기 상태 시드(앱은 보통 포그라운드로 시작하지만 정확히 맞춘다).
+      App.getState()
+        .then((s) => { active = s.isActive; })
+        .catch(() => {});
+      App.addListener("appStateChange", ({ isActive }) => { active = isActive; });
+    })
+    .catch(() => {
+      /* 플러그인 미가용 — 기본값 active=true 유지 */
+    });
+}
+
+/** 네이티브 앱이 현재 포그라운드(active)인지. 비네이티브거나 미확정이면 true. */
+export function isNativeAppActive(): boolean {
+  ensureWired();
+  return active;
+}

--- a/client/src/lib/desktopNotify.ts
+++ b/client/src/lib/desktopNotify.ts
@@ -13,8 +13,9 @@
  *  - https 또는 localhost 에서만 동작 (HiNest dev: localhost:1000 ✅)
  */
 
-import { isCapacitorNative } from "./platform";
+import { isCapacitorNative, nativePlatform } from "./platform";
 import { showNativeNotifications } from "./nativeNotify";
+import { isNativeAppActive } from "./appActive";
 
 export type DesktopNotifPermission = "default" | "granted" | "denied" | "unsupported";
 
@@ -224,15 +225,25 @@ export function deliverPendingNotifications(
 ) {
   // 네이티브(Capacitor): WKWebView 는 Web Notification 미지원 → local-notifications 로 배너 표시.
   if (isCapacitorNative()) {
-    const fresh = items.filter((it) => !alreadySeen(it.id));
+    // Android: 채팅 알림은 FCM(HiNestMessagingService)이 전경·후경 모두에서 발신자 아바타로 직접
+    // 그린다 → JS 로컬 배너는 항상 중복이고, 로컬 배너(vis=PRIVATE)가 여러 개 쌓이면 시스템 자동그룹
+    // 요약(PRIVATE)이 잠금화면 내용까지 가린다. 그래서 Android 에선 채팅 항목을 JS 배너 후보에서
+    // 제외(FCM 가 소유). iOS 는 전경에서 APNs 가 억제되므로 JS 배너로 보완해야 해 유지한다.
+    const isAndroid = nativePlatform() === "android";
+    const candidates = isAndroid
+      ? items.filter((it) => !((it.linkUrl ?? "").includes("room=") || (it.linkUrl ?? "").startsWith("/chat")))
+      : items;
+    const fresh = candidates.filter((it) => !alreadySeen(it.id));
     if (fresh.length) {
       // 항상 seen 처리 — 포그라운드 복귀 시 같은 알림이 로컬배너로 재등장하지 않게.
       markSeen(fresh.map((f) => f.id));
-      // ★ 포그라운드(visible)일 때만 로컬 배너를 띄운다. 백그라운드면 원격 APNs 푸시(+NSE 발신자
-      //   아바타)가 알림을 처리하므로, 여기서 로컬 알림을 스케줄하면 "앱로고 = 아바타 X" 배너가
-      //   먼저 떠버린다(앱이 백그라운드라도 잠깐 살아있으면 SSE 로 이 경로가 실행됐던 버그).
-      //   iOS 는 포그라운드에선 원격푸시 배너를 억제하므로, 포그라운드만 로컬 배너로 보완.
-      const foreground = typeof document !== "undefined" && document.visibilityState === "visible";
+      // ★ 포그라운드(active)일 때만 로컬 배너를 띄운다. 백그라운드면 원격 푸시(iOS=APNs+NSE,
+      //   Android=FCM+HiNestMessagingService)가 발신자 아바타 알림을 처리하므로, 여기서 로컬
+      //   알림을 스케줄하면 중복 + "앱로고=아바타 X" 배너가 같이 떠버린다(특히 Android: 로컬 배너는
+      //   vis=PRIVATE 라 잠금화면 내용까지 가려지고, 여러 개가 시스템 자동그룹으로 묶임).
+      //   ⚠️ document.visibilityState 는 Android WebView 에서 백그라운드/잠금에도 "visible" 로
+      //   남아(실기기 확인) 가드가 무력화됐다 → @capacitor/app 의 실제 앱 상태(appStateChange)로 가드.
+      const foreground = isNativeAppActive();
       if (foreground) void showNativeNotifications(fresh);
     }
     return;


### PR DESCRIPTION
## 증상
안드로이드에서 채팅 푸시를 백그라운드/잠금으로 받으면 (1) 알림이 메시지마다 **중복**(FCM 아바타 알림 + 밋밋한 JS 로컬 배너), (2) **잠금화면에서 내용이 안 보임**(여러 `vis=PRIVATE` 로컬 알림이 시스템 자동그룹 PRIVATE 요약으로 묶임).

## 원인
채팅은 FCM(`HiNestMessagingService`)이 전경·후경 모두 발신자 아바타 MessagingStyle(`vis=PUBLIC`)로 직접 그리는데, JS(SSE poll)의 `showNativeNotifications` 도 같은 메시지에 로컬 배너를 띄운다. "포그라운드만" 가드가 `document.visibilityState` 인데 **안드로이드 WebView 는 백그라운드/잠금에서도 `"visible"` 로 남아**(실기기 확인: 잠금화면 표시 중 `App.getState().isActive` 로는 백그라운드 판별 가능하나 `visibilityState="visible"`) 가드가 무력화 → 중복 + 잠금화면 가림.

## 작업 내용
- **추가** `lib/appActive.ts`: `@capacitor/app` 의 `appStateChange`/`getState` 로 실제 앱 active 상태를 추적하는 `isNativeAppActive()`(웹/데스크톱은 항상 true).
- **수정** `lib/desktopNotify.ts`:
  1. 로컬 배너 포그라운드 가드를 `document.visibilityState` → `isNativeAppActive()` 로 교체(백그라운드/잠금에서 JS 배너 미발사).
  2. **안드로이드에선 채팅 항목(linkUrl `room=`/`/chat`)을 JS 배너 후보에서 제외** — 채팅은 FCM 이 소유(전경·후경 모두 아바타로 그림)하므로 JS 배너는 항상 중복. iOS 는 전경에서 APNs 가 억제되므로 JS 배너 유지.
- **외부 영향**: iOS/웹/데스크톱 동작 동일(비채팅·전경 배너 유지). 안드로이드만 채팅 중복 제거 + 백그라운드 JS 배너 차단. **JS 레이어라 OTA 배포**(새 APK 불필요).

## 검증
- [x] `client` tsc(`tsc --noEmit`) 통과
- [x] 실기기(SM-S901N) CDP 로 근본원인 확정: 잠금화면 표시 중 `document.visibilityState="visible"`, HOME/화면꺼짐에선 `App.getState().isActive=false`(가드 신호로 적합)
- [x] dumpsys 로 중복 확인: FCM MessagingStyle(category=msg, vis=PUBLIC) + 메시지별 로컬(vis=PRIVATE) 동시 존재 → 자동그룹 PRIVATE 요약이 잠금화면 가림
- [ ] 배포 후 OTA 적용본에서 잠금화면 내용 표시 + 단일 알림 재확인(기기)
- [x] 본인(@Xixn2) Assignee 지정

Closes #953

## 분류
- **type:** fix
- **area:** android · client
- **priority:** P1
