### PR TITLE
🔀 :: (#955) 배터리 최적화 안내 — OS 팝업 바로(커스텀 다이얼로그 제거)

### DIFF
--- a/client/src/lib/batteryOptimization.ts
+++ b/client/src/lib/batteryOptimization.ts
@@ -14,7 +14,6 @@
  */
 import { nativePlatform } from "./platform";
 import { HiNestNative } from "./hinestNative";
-import { confirmAsync } from "../components/ConfirmHost";
 
 const ASKED_KEY = "hinest.battery.askedV1";
 
@@ -37,26 +36,19 @@ export async function ensureAndroidBatteryExemption(): Promise<void> {
   } catch {
     return;
   }
-  // 알림 권한 시스템 다이얼로그가 먼저 처리되도록 잠깐 양보(두 다이얼로그가 겹치지 않게).
+  // 알림 권한 시스템 다이얼로그가 먼저 처리되도록 잠깐 양보(두 시스템 다이얼로그가 겹치지 않게).
   await sleep(2500);
-  const ok = await confirmAsync({
-    title: "알림을 놓치지 않으려면",
-    description:
-      "백그라운드·잠금 상태에서도 채팅·알림이 바로 오게 하려면 ‘배터리 최적화’에서 HiNest를 제외해 주세요.\n\n설정 화면을 열어드릴까요?",
-    confirmLabel: "설정 열기",
-    cancelLabel: "나중에",
-  });
-  // 허용/거부 무관 1회만 안내(다시 안 나오게). 거부해도 사용자가 설정에서 직접 바꿀 수 있음.
+  // 허용/거부 무관 1회만(다시 안 뜨게). 거부해도 사용자가 설정에서 직접 바꿀 수 있음.
   try {
     localStorage.setItem(ASKED_KEY, "1");
   } catch {
     /* 무시 */
   }
-  if (ok === true) {
-    try {
-      await HiNestNative.requestIgnoreBatteryOptimizations();
-    } catch {
-      /* 인텐트 미지원 등 — 무시 */
-    }
+  // 커스텀 안내 다이얼로그 없이 OS '배터리 최적화 제외' 요청 팝업을 바로 띄운다.
+  // (예전엔 confirmAsync 안내 → 설정 화면 2단계였는데, 사용자 요청으로 OS 승인 팝업 1번으로 단순화.)
+  try {
+    await HiNestNative.requestIgnoreBatteryOptimizations();
+  } catch {
+    /* 인텐트 미지원 등 — 무시 */
   }
 }


### PR DESCRIPTION
## 증상
안드로이드 로그인 직후 배터리 최적화 안내가 **2단계**로 떴다 — (1) 커스텀 안내 다이얼로그("…배터리 최적화에서 제외해 주세요. 설정 화면을 열어드릴까요?"), (2) "설정 열기" 누르면 그제서야 OS 배터리 최적화 제외 요청 팝업.

## 원인
`ensureAndroidBatteryExemption()`(`lib/batteryOptimization.ts`)가 `confirmAsync` 커스텀 다이얼로그를 먼저 띄우고, 동의 시에만 `requestIgnoreBatteryOptimizations()`(OS 팝업)를 호출했다.

## 작업 내용
- **수정** `lib/batteryOptimization.ts`: 커스텀 `confirmAsync` 안내 다이얼로그 제거 → 바로 `HiNestNative.requestIgnoreBatteryOptimizations()`(OS 승인 요청 팝업) 호출. 사용 안 하는 `confirmAsync` import 제거.
- **유지**: 안드로이드 전용 가드, 이미 제외/플러그인 미가용 시 no-op, `localStorage` 1회 가드(재요청 X), 알림 권한 다이얼로그와 안 겹치게 2.5s 양보.
- **외부 영향**: 안드로이드만. iOS/웹/데스크톱 no-op 유지. **JS 라 OTA 배포**.

## 검증
- [x] `client` tsc 통과
- [ ] 실기기 로그인 시 OS 팝업 1번만 뜨는지(배포 후 OTA 적용본)
- [x] 본인(@Xixn2) Assignee 지정

Closes #955

## 분류
- **type:** fix
- **area:** android · client
- **priority:** P2
