### PR TITLE
🔀 :: (#957) 보던 방이 리스트에서 안읽음으로 남는 문제(읽음 동기화 레이스)

### DIFF
--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { api, apiUrl } from "./api";
 import { getAuthToken } from "./lib/authToken";
-import { deliverPendingNotifications, markSeen } from "./lib/desktopNotify";
+import { deliverPendingNotifications, markSeen, getActiveChatRoom } from "./lib/desktopNotify";
 import { isCapacitorNative } from "./lib/platform";
 import { initNativeNotificationTaps } from "./lib/nativeNotify";
 import { shouldDeliverNotif } from "./lib/notifPrefs";
@@ -187,6 +187,16 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         es.addEventListener("notification", (ev: MessageEvent) => {
           try {
             const n = JSON.parse(ev.data) as Notif;
+            // 지금 보고 있는 방의 채팅(DM/MENTION) 알림은 도착 즉시 읽음 처리한다. 안 그러면 방을
+            // 보다 나갔을 때 그 방이 리스트에서 안읽음으로 남는다 — 메시지는 화면에서 봤지만 알림
+            // 레코드가 ChatMiniApp 의 markRoomRead 직후(레이스)에 도착해 미읽음으로 쌓이기 때문.
+            const nRoom = n.linkUrl?.match(/room=([^&]+)/)?.[1] ?? null;
+            const isActiveRoomChat =
+              (n.type === "DM" || n.type === "MENTION") && !!nRoom && nRoom === getActiveChatRoom();
+            if (isActiveRoomChat && !n.readAt) {
+              n.readAt = new Date().toISOString(); // 로컬 즉시 읽음(리스트 미읽음 방지)
+              void api("/api/notification/read", { method: "POST", json: { ids: [n.id] } }).catch(() => {});
+            }
             // 낙관적 삽입 — 서버 왕복 없이 즉시 벨에 반영.
             // (기존에는 매 이벤트마다 reload() 를 한 번 더 불렀지만, 공지사항 일괄 브로드캐스트 때
             //  같은 유저 세션이 동시에 여러 번 GET /api/notification 치는 문제 → 서버 부하 증가.


### PR DESCRIPTION
## 증상
네이티브 앱에서 채팅방을 보다가 나가면, 메시지는 화면에서 다 읽었는데 **사내톡 방 리스트에서 그 방이 안읽음으로 표시**된다.

## 원인
방 리스트의 미읽음(`roomUnread`)은 미읽음 **DM/MENTION 알림 레코드 수**로 계산된다(`ChatMiniApp.tsx`). 그런데 방을 보는 중 도착한 메시지의 알림 레코드가 `markRoomRead` **직후**(레이스)에 SSE 로 도착해, 화면에선 봤지만 알림 레코드는 미읽음으로 쌓여 리스트에 남았다.

## 작업 내용
- **수정** `notifications.tsx` SSE `notification` 핸들러: 도착한 알림이 `getActiveChatRoom()`(지금 보고 있는 방)의 DM/MENTION 이면 삽입 즉시 `readAt` 처리하고 서버 `/api/notification/read` 로 동기화한다. → 보고 있는 방은 미읽음으로 안 쌓인다.
- **외부 영향**: 보고 있지 않은 방은 그대로 미읽음 집계. 전 플랫폼 동일(웹/데스크톱/네이티브). **JS 라 OTA 배포**.

## 검증
- [x] `client` tsc 통과
- [ ] 실기기: 방 보다 나가면 리스트 미읽음 0 확인(배포 후)
- [x] 본인(@Xixn2) Assignee 지정

Closes #957

## 분류
- **type:** fix
- **area:** client
- **priority:** P2
