### PR TITLE
🔀 :: (#959) 포그라운드 채팅 알림 억제 + 키보드 인셋(입력창 간격) — 네이티브

### DIFF
--- a/client/android/app/src/main/java/com/hivits/hinest/HiNestMessagingService.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/HiNestMessagingService.java
@@ -136,6 +136,12 @@ public class HiNestMessagingService extends MessagingService {
                 .setContentIntent(contentIntent);
         if (groupId != null) b.setGroup(groupId);
 
+        // 앱이 포그라운드면 시스템 알림을 띄우지 않는다 — 사용자가 앱을 보고 있어 SSE 로 메시지가
+        // 인앱에 즉시 표시되므로 채팅방을 보는 중에 헤드업이 또 뜨는 중복·방해를 막는다(요구사항).
+        // iOS 가 포그라운드 푸시 배너를 억제(willPresent 미구현=무표시)하는 것과 동일한 동작.
+        // 백그라운드/잠금이면 appForeground=false 라 아래로 진행해 정상 표시된다.
+        if (MainActivity.appForeground) return;
+
         NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         if (nm != null) nm.notify(notifId(groupId, senderName), b.build());
     }

--- a/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
@@ -21,6 +21,14 @@ public class MainActivity extends BridgeActivity {
     /** 고중요도 알림 채널 id. 구 "default" 채널의 굳은 설정을 피하려 새 id 사용. */
     static final String CHANNEL_ID = "hinest_alerts";
 
+    /**
+     * 앱이 현재 포그라운드(Activity resumed)인지 — HiNestMessagingService 가 채팅 푸시를 띄울지
+     * 판단할 때 참조한다. 포그라운드면 사용자가 앱에서 SSE 로 메시지를 즉시 보므로 시스템 알림을
+     * 띄우지 않는다(중복·방해 방지). iOS 가 willPresent 로 포그라운드 푸시 배너를 억제하는 것과 동일.
+     * onPause(잠금·홈·백그라운드) 에서 false 가 되어, 백그라운드/잠금 알림은 정상 표시된다.
+     */
+    static volatile boolean appForeground = false;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         // 커스텀 플러그인은 반드시 super.onCreate(=Bridge 초기화) 이전에 등록.
@@ -81,11 +89,18 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onResume() {
         super.onResume();
+        appForeground = true; // 포그라운드 진입 — 채팅 푸시는 인앱에서 보이므로 시스템 알림 억제 대상.
         // OTA reload 등으로 document 가 새로 생기면 주입한 변수가 사라질 수 있어 인셋 재적용을 유도.
         try {
             ViewCompat.requestApplyInsets(getWindow().getDecorView());
         } catch (Throwable ignored) {
         }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        appForeground = false; // 백그라운드/잠금 — 채팅 푸시를 시스템 알림으로 정상 표시.
     }
 
     /**

--- a/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
@@ -56,7 +56,10 @@ public class MainActivity extends BridgeActivity {
                 WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
             float density = getResources().getDisplayMetrics().density;
             int top = Math.round(bars.top / density);       // px → CSS px(dp)
-            int bottom = Math.round(bars.bottom / density);
+            // 키보드(IME)가 떠 있으면 하단 내비바를 키보드가 가리므로 --sa-bottom 을 0 으로 둔다.
+            // 안 그러면 채팅 입력창이 죽은 내비바 인셋(예: 48dp)만큼 키보드 위로 떠 큰 간격이 생긴다.
+            boolean imeVisible = insets.isVisible(WindowInsetsCompat.Type.ime());
+            int bottom = imeVisible ? 0 : Math.round(bars.bottom / density);
             int left = Math.round(bars.left / density);
             int right = Math.round(bars.right / density);
             final String js = "(function(){try{var s=document.documentElement.style;"


### PR DESCRIPTION
## 증상
안드로이드 네이티브 앱에서 두 가지(둘 다 MainActivity 네이티브 변경이라 한 PR):
1. **채팅방을 보는 중에도 그 방 알림(헤드업)이 옴** — 메시지를 보면서 시스템 알림이 또 뜸.
2. **채팅 키보드가 켜지면 입력창과 키보드 사이가 너무 벌어짐.**

## 원인
1. `HiNestMessagingService`(FCM 핸들러)가 채팅 푸시를 **포그라운드 여부와 무관하게 무조건** `nm.notify` 로 표시한다. iOS 는 포그라운드 푸시 배너를 OS가 억제(willPresent 미구현)하지만 안드로이드는 직접 막아야 한다.
2. edge-to-edge 인셋 주입이 하단 **내비바(systemBars)만** 반영해서, 키보드가 떠 내비바를 가려도 `--sa-bottom`(예: 48dp)이 그대로 남아 입력창이 그만큼 키보드 위로 떠 죽은 간격이 생긴다.

## 작업 내용 (커밋 3개로 분리)
- **`HiNestMessagingService.java`**: `nm.notify` 전에 `MainActivity.appForeground` 면 `return` — 포그라운드면 SSE 로 인앱에 즉시 보이므로 시스템 알림 억제(iOS 패리티). 백그라운드/잠금이면 정상 표시.
- **`MainActivity.java` (1)**: `static volatile appForeground` 추가 + `onResume=true`/`onPause=false`.
- **`MainActivity.java` (2)**: 인셋 리스너에서 `insets.isVisible(ime())` 면 `--sa-bottom=0` 주입(키보드 닫히면 원복).
- **외부 영향**: 안드로이드 전용. iOS/웹/데스크톱 무영향. **네이티브 변경이라 새 APK 필요**(이미 실기기 설치).

## 검증
- [x] `./gradlew :app:assembleDebug` BUILD SUCCESSFUL (Java 컴파일 통과)
- [x] 실기기(SM-S901N) 설치 완료
- [ ] 채팅방 보는 중 메시지 → 헤드업 안 뜸(육안, 잠금/슬립 이슈로 사용자 확인)
- [ ] 키보드 켜질 때 입력창이 키보드 바로 위에 붙음(육안, 사용자 확인)
- [x] 본인(@Xixn2) Assignee 지정

Closes #959
Closes #960

## 분류
- **type:** fix
- **area:** android
- **priority:** P1

## 비고
- 1·2 모두 MainActivity 네이티브 변경(+서비스)이라 한 PR 로 묶되 커밋은 관심사별로 3개 분리. 새 APK 필요(OTA 불가).
