### PR TITLE
🔀 :: (#962) WebView 글꼴배율 100% 고정 (시스템 폰트스케일로 UI 커지는 문제)

### DIFF
--- a/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
@@ -36,6 +36,18 @@ public class MainActivity extends BridgeActivity {
         super.onCreate(savedInstanceState);
         createAlertsNotificationChannel();
         setupSafeAreaInsets();
+        pinWebViewTextZoom();
+    }
+
+    /**
+     * WebView 글꼴 배율을 100% 로 고정. 안드로이드 WebView 는 기본적으로 시스템 글꼴 크기
+     * (Settings>Display>Font size, font_scale)를 textZoom 으로 반영해, 사용자가 글꼴을 키우면
+     * (예: S22 font_scale=1.1) 앱 UI 가 통째로 110% 로 커져 iOS 와 레이아웃이 달라진다.
+     * iOS(WKWebView)는 시스템 글꼴을 웹 콘텐츠에 자동 적용하지 않으므로 안드로이드도 100% 고정.
+     */
+    private void pinWebViewTextZoom() {
+        WebView wv = getBridge() != null ? getBridge().getWebView() : null;
+        if (wv != null) wv.getSettings().setTextZoom(100);
     }
 
     /**


### PR DESCRIPTION
## 증상
안드로이드(특히 갤럭시 S22)에서 앱 UI(텍스트·아이콘·간격)가 **전체적으로 iOS보다 크게** 보이고, 이 때문에 레이아웃이 달라 보인다.

## 원인
사용자 기기의 **시스템 글꼴 크기(Settings>Display>Font size, `font_scale`)** 가 100%보다 크면(확인: S22 `font_scale=1.1`), 안드로이드 WebView 가 기본적으로 이를 `textZoom` 으로 반영해 웹 콘텐츠를 그 비율(110%)로 키운다. rem 기반 사이즈·간격까지 전부 커져 레이아웃이 틀어진다. iOS(WKWebView)는 시스템 글꼴을 웹 콘텐츠에 자동 적용하지 않아 100% 라, 양 플랫폼이 달라졌다.

## 작업 내용
- **수정** `MainActivity.java`: `onCreate` 에서 `getBridge().getWebView().getSettings().setTextZoom(100)` 로 글꼴 배율을 100% 고정 → 시스템 `font_scale` 무시, iOS 와 동일 스케일.
- **외부 영향**: 안드로이드 전용. iOS/웹/데스크톱 무영향. **네이티브 변경이라 새 APK 필요**(이미 실기기 설치).

## 검증
- [x] `./gradlew :app:assembleDebug` BUILD SUCCESSFUL
- [x] 에뮬레이터 `font_scale=1.3` 으로 과장 → 앱 UI 가 100% 로 렌더(130% 아님) 스크린샷 확인 = textZoom 고정 동작
- [ ] 실기기 S22(font_scale 1.1)에서 iOS 와 동일 크기 육안(사용자)
- [x] 본인(@Xixn2) Assignee 지정

Closes #962

## 분류
- **type:** fix
- **area:** android
- **priority:** P1
