### PR TITLE
🔀 :: (#964) 상단바-상태바 여백 추가(너무 붙는 문제)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1709,7 +1709,13 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
         }
         style={{
           // iOS 노치 흡수 — 헤더 자체가 첫 요소일 때만 (배너가 위에 있으면 배너가 처리).
-          paddingTop: safeAreaTop ? "var(--sa-top, env(safe-area-inset-top))" : 0,
+          // 안드로이드는 상태바가 iOS 노치보다 짧아 상단바가 시계·배터리에 너무 붙는다 → 약간의
+          // 여백을 더한다(iOS/웹/데스크톱은 기존 그대로).
+          paddingTop: safeAreaTop
+            ? nativePlatform() === "android"
+              ? "calc(var(--sa-top, env(safe-area-inset-top)) + 10px)"
+              : "var(--sa-top, env(safe-area-inset-top))"
+            : 0,
           ...(draggable ? ({ WebkitAppRegion: "drag" } as React.CSSProperties) : undefined),
         }}
       >


### PR DESCRIPTION
## 증상
안드로이드에서 앱 상단바(개요·아이콘)가 시스템 상태바(시계·배터리 safe 라인)와 **너무 붙어** 보인다.

## 원인
상단바 `paddingTop` 이 `var(--sa-top)`(상태바 높이)뿐이라, 상태바가 짧은 안드로이드(~27dp)에선 콘텐츠가 상태바 바로 밑에 붙는다. iOS는 노치(~47dp)라 자연스러운 여백이 있어 문제없음.

## 작업 내용
- **수정** `AppLayout.tsx` TopBar: 안드로이드일 때만 `paddingTop` 을 `calc(var(--sa-top) + 10px)` 로(여백 +10px). iOS/웹/데스크톱은 기존 `var(--sa-top)` 그대로.
- **외부 영향**: 안드로이드만. **JS 라 OTA 배포**.

## 검증
- [x] `client` tsc 통과
- [ ] 실기기에서 상단바·상태바 여백 육안(사용자)
- [x] 본인(@Xixn2) Assignee 지정

Closes #964

## 분류
- **type:** fix
- **area:** android · client
- **priority:** P2
