### PR TITLE
🔀 :: (#966) 알림 회귀 — active-viewer 과억제(iOS 포그라운드 외 전부 안 옴)

### DIFF
--- a/client/android/app/src/main/java/com/hivits/hinest/HiNestMessagingService.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/HiNestMessagingService.java
@@ -136,12 +136,8 @@ public class HiNestMessagingService extends MessagingService {
                 .setContentIntent(contentIntent);
         if (groupId != null) b.setGroup(groupId);
 
-        // 앱이 포그라운드면 시스템 알림을 띄우지 않는다 — 사용자가 앱을 보고 있어 SSE 로 메시지가
-        // 인앱에 즉시 표시되므로 채팅방을 보는 중에 헤드업이 또 뜨는 중복·방해를 막는다(요구사항).
-        // iOS 가 포그라운드 푸시 배너를 억제(willPresent 미구현=무표시)하는 것과 동일한 동작.
-        // 백그라운드/잠금이면 appForeground=false 라 아래로 진행해 정상 표시된다.
-        if (MainActivity.appForeground) return;
-
+        // (포그라운드 억제는 서버 active-viewer 게이트가 담당 — '지금 보는 방'만 푸시를 건너뛴다.
+        //  네이티브에서 무조건 포그라운드 억제하면 다른 방·다른 화면 알림까지 막혀 알림이 안 왔다.)
         NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         if (nm != null) nm.notify(notifId(groupId, senderName), b.build());
     }

--- a/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
+++ b/client/android/app/src/main/java/com/hivits/hinest/MainActivity.java
@@ -21,14 +21,6 @@ public class MainActivity extends BridgeActivity {
     /** 고중요도 알림 채널 id. 구 "default" 채널의 굳은 설정을 피하려 새 id 사용. */
     static final String CHANNEL_ID = "hinest_alerts";
 
-    /**
-     * 앱이 현재 포그라운드(Activity resumed)인지 — HiNestMessagingService 가 채팅 푸시를 띄울지
-     * 판단할 때 참조한다. 포그라운드면 사용자가 앱에서 SSE 로 메시지를 즉시 보므로 시스템 알림을
-     * 띄우지 않는다(중복·방해 방지). iOS 가 willPresent 로 포그라운드 푸시 배너를 억제하는 것과 동일.
-     * onPause(잠금·홈·백그라운드) 에서 false 가 되어, 백그라운드/잠금 알림은 정상 표시된다.
-     */
-    static volatile boolean appForeground = false;
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         // 커스텀 플러그인은 반드시 super.onCreate(=Bridge 초기화) 이전에 등록.
@@ -104,18 +96,11 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onResume() {
         super.onResume();
-        appForeground = true; // 포그라운드 진입 — 채팅 푸시는 인앱에서 보이므로 시스템 알림 억제 대상.
         // OTA reload 등으로 document 가 새로 생기면 주입한 변수가 사라질 수 있어 인셋 재적용을 유도.
         try {
             ViewCompat.requestApplyInsets(getWindow().getDecorView());
         } catch (Throwable ignored) {
         }
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        appForeground = false; // 백그라운드/잠금 — 채팅 푸시를 시스템 알림으로 정상 표시.
     }
 
     /**

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -6,6 +6,7 @@ import { useNotifications } from "../notifications";
 import { resolvePresence } from "../lib/presence";
 import { downloadFromUrl } from "../lib/download";
 import { isCapacitorNative } from "../lib/platform";
+import { isNativeAppActive } from "../lib/appActive";
 import { setActiveChatRoom } from "../lib/desktopNotify";
 import { Browser } from "@capacitor/browser";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
@@ -259,11 +260,16 @@ export default function ChatMiniApp({
   //    상호작용 중에 false 반환하는 케이스가 잦아, 사용자가 채팅창을 명백히 보고 있는 동안에도
   //    하트비트 markRead 가 스킵되어 active-viewer APNs 스킵이 동작하지 않았다.
   //    → 네이티브에선 hasFocus 의존성 제거(panel 열림 + visible 만 본다). 데스크톱 웹은 기존대로.
-  const isChatVisible = () =>
-    isPanelOpen &&
-    typeof document !== "undefined" &&
-    document.visibilityState === "visible" &&
-    (isCapacitorNative() || typeof document.hasFocus !== "function" || document.hasFocus());
+  // ⚠️ 네이티브(iOS/안드)는 document.visibilityState 가 백그라운드/잠금에도 'visible' 로 남는 경우가
+  //    있어, 그걸로 판정하면 백그라운드에서도 하트비트 markRead 가 계속 돌아 lastReadAt 이 신선하게
+  //    유지된다 → 서버 active-viewer 게이트가 "지금 보는 중"으로 오판해 그 방의 백그라운드 푸시까지
+  //    막아버린다(알림 안 옴). 네이티브는 @capacitor/app 의 실제 active 상태로 판정해, 백그라운드면
+  //    하트비트를 멈춘다. 웹은 기존대로 visibility + focus.
+  const isChatVisible = () => {
+    if (!isPanelOpen || typeof document === "undefined") return false;
+    if (isCapacitorNative()) return isNativeAppActive();
+    return document.visibilityState === "visible" && (typeof document.hasFocus !== "function" || document.hasFocus());
+  };
 
   const markRead = async (roomId: string) => {
     try {

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -80,8 +80,9 @@ async function mutedApnsSet(targets: { userId: string; linkUrl?: string | null }
 }
 
 /** 활성 시청자로 간주하는 lastReadAt 신선도 — 이 시간 안에 읽음이 갱신됐으면 "지금 그 방을 보고 있음".
- *  클라 하트비트는 15초 주기이므로 6배 여유(네트워크 지연·하트비트 1~2회 실패 흡수). */
-const ACTIVE_VIEW_MS = 90_000;
+ *  클라 하트비트 15초 주기의 2배 여유(1회 실패 흡수). 길면 방을 보다 나간 뒤에도 한참 푸시가
+ *  막혀 "알림 안 옴" 처럼 느껴진다 → 90s→30s 로 단축(백그라운드 전환 후 빠르게 알림 복귀). */
+const ACTIVE_VIEW_MS = 30_000;
 /**
  * (userId, roomId) 쌍 중 "지금 그 방을 보고 있는" 조합을 `${userId}:${roomId}` Set 으로 반환.
  * 보고 있는 방의 채팅 알림은 APNs(폰 푸시) 를 건너뛴다 — 화면에 떠 있으니 알림이 불필요(요구사항).


### PR DESCRIPTION
## 증상
안드로이드·iOS 모두 **iOS 포그라운드 배너만** 오고, 나머지(백그라운드·잠금화면·헤드업·안드 포그라운드) 알림이 안 온다.

## 원인
서버 active-viewer 게이트는 `RoomMember.lastReadAt` 이 최근(`ACTIVE_VIEW_MS`)이면 "지금 보는 중"으로 보고 그 방 푸시(APNs/FCM)를 건너뛴다. 그런데 클라 하트비트가 `isChatVisible()` 를 `document.visibilityState` 로 판정하는데, **네이티브(iOS/안드)에선 백그라운드·잠금에도 'visible' 로 남아** 하트비트가 계속 돌며 `lastReadAt` 을 신선하게 유지 → 서버가 그 방의 백그라운드 푸시까지 영영 막았다(보던 방을 테스트하면 안 옴). 추가로 직전 PR #961 의 `MainActivity.appForeground` 네이티브 억제가 **안드 포그라운드 전체**(다른 방·다른 화면 포함)를 막았다. (iOS 포그라운드만 JS 로컬 배너라 영향 없어 살아있었음 → "iOS 포그라운드만 옴".)

## 작업 내용 (커밋 4개)
- **`notify.ts`**: `ACTIVE_VIEW_MS` 90s→30s — 방을 나간 뒤 푸시가 빠르게 복귀.
- **`ChatMiniApp.tsx`**: `isChatVisible()` 를 네이티브에선 `isNativeAppActive()`(@capacitor/app 실제 active)로 판정 → 백그라운드면 하트비트 정지 → `lastReadAt` 안 갱신 → 서버 과억제 해소.
- **`HiNestMessagingService.java`**: 포그라운드 무조건 억제(`if appForeground return`) 제거 — '지금 보는 방'만 막는 서버 게이트에 위임.
- **`MainActivity.java`**: 미사용 `appForeground` 플래그·onPause 제거.
- **외부 영향**: 보는 방(포그라운드)만 억제, 그 외 전부 알림. 서버(Fargate)+OTA+새 APK 필요.

## 검증
- [x] server·client tsc 통과, `compileDebugJavaWithJavac` 통과
- [x] 실기기 logcat: 백그라운드(방 비활성) 푸시 → `notify(hinest_alerts, vis=PUBLIC)` 정상 표시 확인
- [ ] 보던 방 백그라운드/잠금 → 30s 내 푸시 복귀(배포 후 사용자)
- [x] 본인(@Xixn2) Assignee 지정

Closes #966

## 분류
- **type:** fix
- **area:** server · client · android
- **priority:** P0
