### PR TITLE
🔀 :: (#968) 1:1 대화 발신자 이름·뱃지 숨김(그룹만)

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -2401,7 +2401,8 @@ function RoomView({
                     <div style={{ width: 26, flexShrink: 0 }} />
                   ) : null}
                   <div style={{ minWidth: 0, flex: "0 1 auto", position: "relative" }}>
-                    {!mine && m.showMeta && (
+                    {/* 발신자 이름·뱃지는 그룹방에서만 — 1:1 은 상대가 한 명이라 불필요(요구사항). */}
+                    {!mine && m.showMeta && room.type !== "DIRECT" && (
                       <button
                         type="button"
                         onClick={() => openProfile(m.sender.id)}


### PR DESCRIPTION
## 증상
1:1 사내톡도 메시지마다 발신자 이름·DevBadge 표시 → 불필요.

## 원인
메시지 메타 렌더가 room type 무관하게 이름·뱃지를 표시.

## 작업 내용
- ChatMiniApp 메시지 메타: `!mine && showMeta` 에 `room.type !== 'DIRECT'` 추가 → 그룹방만 이름·뱃지. 1:1 은 숨김.
- 외부 영향: 그룹 동일, 1:1 만 변경. JS·OTA.

## 검증
- [x] client tsc 통과
- [ ] 실기기 1:1/그룹 육안(사용자)
- [x] @Xixn2 Assignee

Closes #968

## 분류
- type: fix · area: client · priority: P3