### PR TITLE
🔀 :: (#970) 그룹 @멘션(이름) + 이모지 반응 프로필

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -11,6 +11,7 @@ import { setActiveChatRoom } from "../lib/desktopNotify";
 import { Browser } from "@capacitor/browser";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
 import { SnippetSlashMenu, type SnippetSlashHandle } from "./chat/SnippetSlashMenu";
+import { MentionMenu, type MentionHandle } from "./chat/MentionMenu";
 import {
   C,
   FONT,
@@ -622,6 +623,14 @@ export default function ChatMiniApp({
     if (!activeId || sending) return;
     const content = input.trim();
     if (!content && attachments.length === 0) return;
+    // @멘션 — 본문의 `@멤버이름` 을 그룹 멤버명과 매칭해 userId 목록 파생(그룹만). 서버가 그들에게
+    // MENTION 알림을 보낸다(1:1 은 멘션 없음). 빈 배열이면 서버가 무시.
+    const mentions =
+      active && active.type !== "DIRECT"
+        ? active.members
+            .filter((rm) => rm.user.id !== (user?.id ?? "") && content.includes(`@${rm.user.name}`))
+            .map((rm) => rm.user.id)
+        : [];
     const prevInput = input;
     const prevAttachments = attachments;
     setInput("");
@@ -652,7 +661,7 @@ export default function ChatMiniApp({
       } else {
         const r = await api<{ message: Message }>(`/api/chat/rooms/${activeId}/messages`, {
           method: "POST",
-          json: { content, kind: "TEXT" },
+          json: { content, kind: "TEXT", mentions },
         });
         if (r?.message) appendLocal(r.message);
       }
@@ -2152,9 +2161,20 @@ function RoomView({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const slashRef = useRef<SnippetSlashHandle | null>(null);
+  const mentionRef = useRef<MentionHandle | null>(null);
   const [reactingId, setReactingId] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const nav = useNavigate();
+  const isGroupRoom = room.type !== "DIRECT";
+  // 반응(이모지) 프로필 표시용 — userId → 멤버(아바타) 매핑. 그룹방에서 반응 칩에 누른 사람 아바타를 띄운다.
+  const membersById = useMemo(
+    () => new Map(room.members.map((rm) => [rm.user.id, rm.user])),
+    [room.members],
+  );
+  // "누가 반응했는지" 바텀시트 상태(이모지 칩 길게누름). { emoji, userIds } 또는 null.
+  const [reactorSheet, setReactorSheet] = useState<{ emoji: string; userIds: string[] } | null>(null);
+  const reactLpTimer = useRef<number | null>(null);
+  const reactLpFired = useRef(false);
   // 채팅 메시지의 발신자 이름·아바타 클릭 → 사용자 프로필 페이지로. 채팅 팝업은 닫고 이동.
   function openProfile(userId: string) {
     if (!userId) return;
@@ -2520,17 +2540,33 @@ function RoomView({
                   >
                     {groupReactions(m.reactions).map((g) => {
                       const isMine = g.userIds.includes(meId);
+                      // 그룹방: 최근 누른 3명 아바타를 옆으로 중첩(마지막=최근). 1:1: 숫자.
+                      const recent = isGroupRoom ? g.userIds.slice(-3).reverse() : [];
+                      const ringBg = isMine ? C.blueSoft : C.gray100;
+                      const startLp = () => {
+                        reactLpFired.current = false;
+                        reactLpTimer.current = window.setTimeout(() => {
+                          reactLpFired.current = true;
+                          setReactorSheet({ emoji: g.emoji, userIds: g.userIds });
+                        }, 420);
+                      };
+                      const clearLp = () => { if (reactLpTimer.current) { clearTimeout(reactLpTimer.current); reactLpTimer.current = null; } };
                       return (
                         <button
                           key={g.emoji}
                           type="button"
-                          onClick={() => onReact(m.id, g.emoji)}
+                          onClick={() => { if (reactLpFired.current) { reactLpFired.current = false; return; } onReact(m.id, g.emoji); }}
+                          onPointerDown={startLp}
+                          onPointerUp={clearLp}
+                          onPointerLeave={clearLp}
+                          onPointerCancel={clearLp}
+                          onContextMenu={(e) => { e.preventDefault(); setReactorSheet({ emoji: g.emoji, userIds: g.userIds }); }}
                           title={g.names.join(", ")}
                           style={{
                             display: "inline-flex", alignItems: "center", gap: 4,
                             padding: "2px 8px", height: 24,
                             borderRadius: 999,
-                            background: isMine ? C.blueSoft : C.gray100,
+                            background: ringBg,
                             border: isMine ? `1px solid ${C.blue}` : `1px solid ${C.gray200}`,
                             color: C.ink, cursor: "pointer",
                             fontSize: 12, fontWeight: 600,
@@ -2538,7 +2574,21 @@ function RoomView({
                           }}
                         >
                           <span style={{ fontSize: 13 }}>{g.emoji}</span>
-                          <span style={{ fontVariantNumeric: "tabular-nums" }}>{g.count}</span>
+                          {isGroupRoom ? (
+                            <span style={{ display: "inline-flex", alignItems: "center" }}>
+                              {recent.map((uid, i) => {
+                                const u = membersById.get(uid);
+                                return (
+                                  <span key={uid} style={{ marginLeft: i === 0 ? 0 : -7, position: "relative", zIndex: 3 - i, borderRadius: 999, boxShadow: `0 0 0 1.5px ${ringBg}` }}>
+                                    <Avatar name={u?.name ?? "?"} color={u?.avatarColor ?? C.blue} imageUrl={u?.avatarUrl ?? null} size={16} />
+                                  </span>
+                                );
+                              })}
+                              {g.count > 3 && <span style={{ marginLeft: 3, fontVariantNumeric: "tabular-nums" }}>+{g.count - 3}</span>}
+                            </span>
+                          ) : (
+                            <span style={{ fontVariantNumeric: "tabular-nums" }}>{g.count}</span>
+                          )}
                         </button>
                       );
                     })}
@@ -2660,6 +2710,27 @@ function RoomView({
               }}
               innerRef={slashRef}
             />
+            {isGroupRoom && (
+              <MentionMenu
+                textareaRef={textareaRef}
+                value={input}
+                members={room.members.map((rm) => rm.user)}
+                onReplace={(start, end, replacement) => {
+                  const next = input.slice(0, start) + replacement + input.slice(end);
+                  setInput(next);
+                  requestAnimationFrame(() => {
+                    const ta = textareaRef.current;
+                    if (!ta) return;
+                    const pos = start + replacement.length;
+                    ta.focus();
+                    ta.setSelectionRange(pos, pos);
+                    ta.style.height = "auto";
+                    ta.style.height = Math.min(ta.scrollHeight, 92) + "px";
+                  });
+                }}
+                innerRef={mentionRef}
+              />
+            )}
             <div
               style={{
                 flex: 1, minWidth: 0,
@@ -2681,7 +2752,8 @@ function RoomView({
                   el.style.height = Math.min(el.scrollHeight, 92) + "px";
                 }}
                 onKeyDown={(e) => {
-                  // 슬래시 자동완성 메뉴가 열려있으면 ↑↓/Enter/Esc/Tab 을 그쪽이 먼저 소비.
+                  // @멘션 / 슬래시 자동완성 메뉴가 열려있으면 ↑↓/Enter/Esc/Tab 을 그쪽이 먼저 소비.
+                  if (mentionRef.current?.handleKey(e)) return;
                   if (slashRef.current?.handleKey(e)) return;
                   if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
                     e.preventDefault();
@@ -2799,6 +2871,43 @@ function RoomView({
           </div>
         );
       })()}
+      {/* 이모지 반응 누른 사람 목록(칩 길게누름) — 바텀시트. 항목 탭 → 프로필. */}
+      {reactorSheet && (
+        <div
+          onClick={() => setReactorSheet(null)}
+          style={{ position: "fixed", inset: 0, zIndex: 1000, background: "rgba(0,0,0,.4)", display: "flex", alignItems: "flex-end", justifyContent: "center" }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: "100%", maxWidth: 480, background: C.surface,
+              borderTopLeftRadius: 18, borderTopRightRadius: 18,
+              padding: "8px 0 max(16px, var(--sa-bottom, env(safe-area-inset-bottom)))",
+              maxHeight: "60vh", overflowY: "auto",
+            }}
+          >
+            <div style={{ width: 36, height: 4, borderRadius: 2, background: C.gray200, margin: "4px auto 6px" }} />
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 6, fontWeight: 700, color: C.ink, padding: "4px 18px 10px", fontSize: 15 }}>
+              <span style={{ fontSize: 18 }}>{reactorSheet.emoji}</span>
+              <span>{reactorSheet.userIds.length}</span>
+            </div>
+            {reactorSheet.userIds.slice().reverse().map((uid) => {
+              const u = membersById.get(uid);
+              return (
+                <button
+                  key={uid}
+                  type="button"
+                  onClick={() => { setReactorSheet(null); openProfile(uid); }}
+                  style={{ display: "flex", alignItems: "center", gap: 10, width: "100%", padding: "8px 18px", background: "transparent", border: 0, cursor: "pointer", fontFamily: FONT }}
+                >
+                  <Avatar name={u?.name ?? "?"} color={u?.avatarColor ?? C.blue} imageUrl={u?.avatarUrl ?? null} size={36} />
+                  <span style={{ color: C.ink, fontSize: 14.5, fontWeight: 600 }}>{u?.name ?? "알 수 없음"}{uid === meId ? " (나)" : ""}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/client/src/components/chat/MentionMenu.tsx
+++ b/client/src/components/chat/MentionMenu.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from "react";
+import { Avatar } from "./theme";
+
+/**
+ * 그룹 채팅 입력창의 @멘션 자동완성 — 이름으로 태그.
+ *
+ * 사용법(SnippetSlashMenu 와 동일 규약): 부모가 textareaRef·value·members 를 넘기면
+ *   - 커서 직전 토큰이 @\w* 면 이름으로 멤버 필터 메뉴 노출
+ *   - 화살표/Enter/Esc 처리(onKeyDown 가드 handleKey 노출 — true 면 부모는 send 중단)
+ *   - 선택 시 @토큰 을 `@이름 ` 으로 치환
+ * 멘션 대상 userId 는 전송 시 본문에서 `@이름` 을 멤버명과 매칭해 파생한다(부모 send).
+ */
+
+export type MentionMember = { id: string; name: string; avatarColor?: string; avatarUrl?: string | null };
+
+export type MentionHandle = {
+  handleKey: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean;
+};
+
+/** 커서 직전이 @ 로 시작하는 토큰인지. 공백 전까지 수집, @ 뒤엔 이름 글자만. */
+function detectAtToken(value: string, cursor: number): { start: number; end: number; query: string } | null {
+  let s = cursor;
+  while (s > 0 && !/\s/.test(value[s - 1])) s--;
+  const token = value.slice(s, cursor);
+  if (!token.startsWith("@")) return null;
+  if (!/^@[\w\-가-힣.]*$/.test(token)) return null;
+  return { start: s, end: cursor, query: token.slice(1) };
+}
+
+export function MentionMenu({
+  textareaRef,
+  value,
+  members,
+  onReplace,
+  innerRef,
+}: {
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  value: string;
+  members: MentionMember[];
+  /** start..end 구간을 replacement 로 치환. */
+  onReplace: (start: number, end: number, replacement: string) => void;
+  innerRef: React.MutableRefObject<MentionHandle | null>;
+}) {
+  const [token, setToken] = useState<{ start: number; end: number; query: string } | null>(null);
+  const [active, setActive] = useState(0);
+
+  // 커서/value 변경 시 토큰 재계산.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const update = () => {
+      const t = textareaRef.current;
+      if (!t) return;
+      setToken(detectAtToken(value, t.selectionStart ?? 0));
+    };
+    update();
+    ta.addEventListener("keyup", update);
+    ta.addEventListener("click", update);
+    return () => {
+      ta.removeEventListener("keyup", update);
+      ta.removeEventListener("click", update);
+    };
+  }, [textareaRef, value]);
+
+  const filtered = useMemo(() => {
+    if (!token) return [];
+    const q = token.query.toLowerCase();
+    return members.filter((m) => m.name.toLowerCase().includes(q)).slice(0, 8);
+  }, [token?.query, members]);
+
+  useEffect(() => { setActive(0); }, [token?.query]);
+
+  function select(m: MentionMember) {
+    if (!token) return;
+    onReplace(token.start, token.end, `@${m.name} `);
+    setToken(null);
+  }
+
+  innerRef.current = {
+    handleKey: (e) => {
+      if (!token || filtered.length === 0) return false;
+      if (e.key === "ArrowDown") { e.preventDefault(); setActive((a) => (a + 1) % filtered.length); return true; }
+      if (e.key === "ArrowUp") { e.preventDefault(); setActive((a) => (a - 1 + filtered.length) % filtered.length); return true; }
+      if (e.key === "Escape") { e.preventDefault(); setToken(null); return true; }
+      if (e.key === "Enter" || e.key === "Tab") { e.preventDefault(); select(filtered[active]); return true; }
+      return false;
+    },
+  };
+
+  if (!token || filtered.length === 0) return null;
+
+  return (
+    <div
+      style={{
+        position: "absolute", left: 12, right: 12, bottom: "100%", marginBottom: 6,
+        background: "var(--c-surface)", border: "1px solid var(--c-border)", borderRadius: 12,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.12)", maxHeight: 240, overflowY: "auto", zIndex: 10,
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      <div style={{ padding: "6px 10px", fontSize: 10.5, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "var(--c-text-3)", borderBottom: "1px solid var(--c-border)" }}>
+        멤버 멘션{token.query ? ` · @${token.query}` : ""}
+      </div>
+      {filtered.map((m, i) => (
+        <button
+          key={m.id}
+          type="button"
+          onClick={() => select(m)}
+          onMouseEnter={() => setActive(i)}
+          style={{
+            display: "flex", alignItems: "center", gap: 8, width: "100%", padding: "7px 10px",
+            background: i === active ? "var(--c-surface-2)" : "transparent",
+            border: "none", cursor: "pointer", textAlign: "left",
+          }}
+        >
+          <Avatar name={m.name} color={m.avatarColor ?? "#3182F6"} imageUrl={m.avatarUrl ?? null} size={24} />
+          <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", fontSize: 13.5, fontWeight: 600, color: "var(--c-text)" }}>
+            {m.name}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1117,9 +1117,9 @@ function ShareCardBubble({ msg, mine }: { msg: Message; mine: boolean }) {
   );
 }
 
-// URL 자동 링크화 — http(s):// 또는 www. 로 시작하는 문자열을 <a> 로 변환.
+// URL 자동 링크화(group1) + @멘션 강조(group2).
 // 안전 조치: href 는 반드시 http/https 로만 구성하고, rel=noopener noreferrer + target=_blank.
-const URL_REGEX = /(https?:\/\/[^\s<>"']+|www\.[^\s<>"']+)/gi;
+const URL_REGEX = /(https?:\/\/[^\s<>"']+|www\.[^\s<>"']+)|(@[\w가-힣._-]+)/gi;
 
 function renderWithLinks(content: string, mine: boolean): React.ReactNode[] {
   const nodes: React.ReactNode[] = [];
@@ -1130,6 +1130,14 @@ function renderWithLinks(content: string, mine: boolean): React.ReactNode[] {
     const raw = match[0];
     const start = match.index;
     if (start > lastIndex) nodes.push(content.slice(lastIndex, start));
+    // @멘션 — 파랑/볼드 강조(이름 태그). 그룹방에서 누른 사람 알림은 서버가 처리.
+    if (match[2]) {
+      nodes.push(
+        <span key={start} style={{ color: mine ? "#dbe9ff" : C.blue, fontWeight: 700 }}>{raw}</span>
+      );
+      lastIndex = start + raw.length;
+      continue;
+    }
     // 문장 끝 구두점은 링크에서 제외
     const trailing = raw.match(/[).,!?;:]+$/);
     const clean = trailing ? raw.slice(0, raw.length - trailing[0].length) : raw;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 증상/요청
그룹 채팅 2가지: (1) @멘션을 **이름으로** 태그, (2) 이모지 반응에 **누른 사람 프로필** 표시(최근 3명 중첩, 길게누르면 누구).

## 작업 내용
- **신규** `chat/MentionMenu.tsx`: @ 입력 시 멤버 이름 자동완성(아바타+이름, ↑↓/Enter/Esc) → `@이름 ` 삽입. 슬래시 메뉴와 동일 규약.
- **수정** `ChatMiniApp.tsx`:
  - 그룹방 입력창에 MentionMenu 연결(onKeyDown 가드 우선순위 멘션→슬래시).
  - 전송 시 본문 `@이름` 을 그룹 멤버명과 매칭해 `mentions`(userId) 파생 → 서버가 그들에게 MENTION 알림(서버 멘션 인프라 기존 존재).
  - 반응 칩(그룹): 최근 3명 아바타 옆으로 중첩(+초과수). 칩 길게누름/우클릭 → 반응자 바텀시트(탭→프로필). 1:1 은 숫자 그대로.
- **수정** `chat/MessageBubble.tsx`: 메시지 렌더 URL 링크화에 @멘션 파랑·볼드 강조 추가.
- **외부 영향**: 그룹방 한정 기능. 1:1·서버 무변경(서버 mentions 기존 지원). JS·OTA.

## 검증
- [x] client tsc 통과
- [ ] 실기기 그룹방: @자동완성·멘션알림·반응 아바타·길게누름 시트(사용자)
- [x] @Xixn2 Assignee

Closes #970
Closes #971

## 분류
- type: feat · area: client · priority: P2

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #970
