### PR TITLE
🔀 :: (#977) 키보드 UX 3종 (전송후 유지·등장 스크롤·동기 상승)

### DIFF
--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -165,9 +165,13 @@ export default function ChatFab() {
                   // ※ 절대 위치 계산 대신 flex column 으로 변경 — 이전엔 헤더는 padding 안에,
                   //    본문은 absolute top:86 (border-box 기준) 으로 두면서 safe-area-top 만큼
                   //    헤더 일부가 본문에 가려져 모바일에서 뒤로가기 버튼이 사라져 보였음.
+                  // ※ height:100dvh 를 제거 — inset:0(top:0+bottom:0) 만으로 풀스크린.
+                  //   Keyboard.resize:'native' 가 키보드 곡선에 맞춰 WebView 를 줄이면, bottom:0
+                  //   앵커가 그 줄어드는 바닥에 자동으로 붙어 입력바가 키보드와 '동기' 로 올라온다.
+                  //   100dvh(고정 길이)는 iOS 가 키보드 애니메이션 중 보간하지 않고 끝난 뒤에야
+                  //   재계산해 입력바가 늦게 따라잡히는 증상을 유발했다.
                   inset: 0,
                   width: "100vw",
-                  height: "100dvh",
                   paddingTop: "var(--sa-top, env(safe-area-inset-top))",
                   paddingBottom: "var(--sa-bottom, env(safe-area-inset-bottom))",
                   paddingLeft: "var(--sa-left, env(safe-area-inset-left))",

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../auth";
 import { useNotifications } from "../notifications";
 import { resolvePresence } from "../lib/presence";
 import { downloadFromUrl } from "../lib/download";
-import { isCapacitorNative } from "../lib/platform";
+import { isCapacitorNative, nativePlatform } from "../lib/platform";
 import { isNativeAppActive } from "../lib/appActive";
 import { setActiveChatRoom } from "../lib/desktopNotify";
 import { Browser } from "@capacitor/browser";
@@ -2256,6 +2256,42 @@ function RoomView({
       imgs.forEach((img) => img.removeEventListener("load", onLoad));
     };
   }, [room.id, messages.length]);
+
+  // iOS 키보드 등장 시 메시지 리스트를 바닥으로 재고정.
+  // Keyboard.resize:'native' 가 WebView(=스크롤 컨테이너)를 줄이면 브라우저가 scrollTop 을
+  // 보존해 최신 메시지가 접힘선 아래로 밀린다. 바닥에 붙어있던 사용자에 한해 다시 끌어내린다.
+  // 과거 메시지를 보던 중(stuckToBottomRef=false)이면 방해하지 않는다. 안드/웹/데스크톱은 no-op.
+  useEffect(() => {
+    if (nativePlatform() !== "ios") return;
+    let cancelled = false;
+    const removers: Array<() => void> = [];
+    const pinBottom = () => {
+      const el = scrollRef.current;
+      if (!el) return;
+      if (!stuckToBottomRef.current) return;
+      el.scrollTop = el.scrollHeight; // 즉시 점프 — 줄어든 높이 기준 바닥(smooth 는 키보드 곡선 추격 실패)
+    };
+    void import("@capacitor/keyboard")
+      .then(({ Keyboard }) => {
+        if (cancelled) return;
+        const reg = (ev: "keyboardWillShow" | "keyboardDidShow") => {
+          Keyboard.addListener(ev as never, (() => {
+            // willShow: 애니메이션 시작 직전. didShow: native 리사이즈 확정 후 한 번 더.
+            pinBottom();
+            requestAnimationFrame(pinBottom); // 레이아웃 반영 직후 1프레임 보정
+          }) as never).then((h) => {
+            removers.push(() => { try { void h.remove(); } catch {} });
+          });
+        };
+        reg("keyboardWillShow");
+        reg("keyboardDidShow");
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      removers.forEach((fn) => fn());
+    };
+  }, [room.id]);
   const rendered = useMemo(() => {
     // 상대방이 보낸 메시지 중 가장 최근 것의 인덱스
     let lastFromOtherIdx = -1;

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -2165,6 +2165,13 @@ function RoomView({
   const [reactingId, setReactingId] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const nav = useNavigate();
+  // 전송 래퍼 — onSend() 후 입력창 포커스를 되돌려 키보드를 유지(카톡/메신저처럼 연속 입력).
+  // 전송 버튼이 width:0 으로 collapse 되거나 setInput("") 리렌더가 끼어도 다음 프레임에
+  // textarea 로 포커스를 복원해 iOS/Android 가 키보드를 내리지 않게 한다.
+  const handleSend = () => {
+    onSend();
+    requestAnimationFrame(() => textareaRef.current?.focus());
+  };
   const isGroupRoom = room.type !== "DIRECT";
   // 반응(이모지) 프로필 표시용 — userId → 멤버(아바타) 매핑. 그룹방에서 반응 칩에 누른 사람 아바타를 띄운다.
   const membersById = useMemo(
@@ -2757,7 +2764,7 @@ function RoomView({
                   if (slashRef.current?.handleKey(e)) return;
                   if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
                     e.preventDefault();
-                    onSend();
+                    handleSend();
                   }
                 }}
                 onPaste={(e) => {
@@ -2839,7 +2846,10 @@ function RoomView({
 
             {/* 외부 전송 버튼 — 입력/첨부 시 슬라이드 인 */}
             <button
-              onClick={onSend}
+              onClick={handleSend}
+              // 탭 시 mousedown 기본동작(포커스 이동)을 막아 textarea 포커스 유지 → 키보드 안 내려감.
+              // MentionMenu/SnippetSlashMenu 가 쓰는 것과 동일 패턴.
+              onMouseDown={(e) => e.preventDefault()}
               disabled={!hasContent || sending}
               title="보내기"
               aria-label="보내기"


### PR DESCRIPTION
## 증상
1. **전송 후 키보드 내려감 (iOS+Android)** — 메시지 1건 보내면 키보드가 닫힘
2. **키보드 등장 시 스크롤 어긋남 (iOS)** — 최신 메시지가 아니라 엉뚱한 위치
3. **입력바 늦게 따라옴 (iOS)** — 키보드 다 올라온 뒤에야 텍스트필드가 상승

## 원인
1. 전송 버튼 탭 시 `mousedown` 이 textarea 포커스를 빼앗아 OS가 키보드 dismiss (자동완성 메뉴는 이미 `onMouseDown preventDefault` 쓰는데 전송 버튼만 누락)
2. `Keyboard.resize:'native'` 가 WebView를 줄이면 브라우저가 scrollTop 보존 → 최신 메시지가 밀림. 키보드 등장 시 바닥 재고정 부재
3. ChatFab 모바일 풀스크린 `height:100dvh`(고정 길이) → iOS가 키보드 애니메이션 중 보간 안 함

## 작업 내용
- `ChatMiniApp.tsx` 전송 버튼 `onMouseDown preventDefault` + 전송 후 rAF로 textarea 재포커스(handleSend) — **①**
- `ChatMiniApp.tsx` iOS 전용 `keyboardWillShow/DidShow` → 메시지 리스트 바닥 재고정(과거 메시지 보던 중이면 미개입) — **②**
- `ChatFab.tsx` 모바일 `height:100dvh` 제거 → `inset:0`(bottom:0)이 줄어드는 WebView 추종해 입력바 동기 상승 — **③**

## 검증
- `tsc --noEmit` 통과(에러 0)
- 전부 **OTA(웹 번들)** — iOS/Android 네이티브 재빌드 불필요. capacitor.config·Swift 무변경
- 데스크톱/Android no-op(iOS 전용 분기·기존 패턴 재사용) → 회귀 위험 낮음
- 실기 검증 권장: 전송 후 키보드 유지 / 키보드 열 때 최신 메시지 유지 / 입력바 동기 상승

Closes #977