### PR TITLE
🔀 :: (#981) 터치 기기 스크롤바 거터 제거 (UI 좌측 치우침)

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -954,6 +954,13 @@ table.pro.pro-grid-fixed tbody td > div > select {
 }
 ::-webkit-scrollbar-thumb:hover { background: var(--c-text-muted); }
 
+/* 터치 기기(모바일 네이티브 WebView)는 클래식 세로 스크롤바가 우측 거터를 점유해 콘텐츠가
+   왼쪽으로 치우쳐 보인다 → 거터 제거(풀폭). 데스크톱(마우스=fine pointer)은 그대로 노출. */
+@media (pointer: coarse) {
+  ::-webkit-scrollbar { width: 0 !important; height: 0 !important; display: none; }
+  * { scrollbar-width: none; -ms-overflow-style: none; }
+}
+
 .divide-y-pro > * + * { border-top: 1px solid var(--c-border); }
 
 /* ============================================================ */


### PR DESCRIPTION
## 증상
안드로이드 모바일에서 우측 세로 스크롤바 거터만큼 콘텐츠가 왼쪽으로 치우쳐 보임.

## 원인
전역 `::-webkit-scrollbar { width: 10px }` 가 모바일 WebView 에도 적용 → 안드로이드 Blink 가 거터 10px 점유(iOS 는 오버레이라 무영향).

## 작업 내용
- `@media (pointer: coarse)` 에서 스크롤바 width/height 0 + display:none, scrollbar-width:none → 거터 제거
- 데스크톱(fine pointer)은 기존 스크롤바 그대로 → 회귀 없음

## 검증
- OTA → 안드로이드 우측 거터 제거·콘텐츠 풀폭 확인
- 데스크톱 스크롤바 유지

Closes #981