### PR TITLE
🔀 :: (#983) 데스크탑·웹 메시지 텍스트 드래그 선택·복사

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -154,6 +154,7 @@ export function LongPress({
 
   return (
     <div
+      className="chat-pressable"
       onTouchStart={(e) => {
         const t = e.touches[0];
         start(t.clientX, t.clientY);
@@ -193,9 +194,9 @@ export function LongPress({
           firedRef.current = false;
         }
       }}
+      // user-select 는 .chat-pressable 가 플랫폼별로 담당 — 모바일=none(롱프레스 공감 보호),
+      // 데스크탑(.hinest-desktop)=text(메시지 텍스트 드래그 선택·복사). iOS 콜아웃만 인라인 유지.
       style={{
-        userSelect: "none",
-        WebkitUserSelect: "none",
         WebkitTouchCallout: "none",
         ...style,
       }}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -317,6 +317,16 @@ input, textarea, select, [contenteditable], [contenteditable] * {
   user-select: text;
   -webkit-touch-callout: default;
 }
+/* 채팅 메시지 버블(롱프레스 래퍼) — 모바일은 선택 차단(롱프레스=공감, 오선택 방지),
+   데스크탑 앱·웹(.hinest-desktop = Electron 또는 마우스 hover+fine)은 텍스트를 드래그로
+   원하는 만큼 선택·복사 가능. user-select 는 상속되므로 자식 텍스트도 함께 선택됨
+   (코드블록 줄번호 <pre> 는 인라인 user-select:none 이라 그대로 복사 제외 유지). */
+.chat-pressable { -webkit-user-select: none; user-select: none; }
+.hinest-desktop .chat-pressable {
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
+}
 
 .font-mono, code, pre, .tabular {
   font-family: "JetBrains Mono", "SF Mono", Menlo, Consolas, Monaco, monospace;


### PR DESCRIPTION
## 증상
데스크탑 앱·웹에서 채팅 메시지 텍스트를 드래그로 선택·복사할 수 없음.

## 원인
`LongPress` 래퍼(MessageBubble.tsx)가 `user-select:none` 인라인 강제 — 모바일 롱프레스(공감) 보호용인데 데스크탑에도 적용돼 드래그 선택 차단.

## 작업 내용
- `LongPress` 인라인 `user-select:none` 제거 + `className="chat-pressable"`
- `styles.css`: `.chat-pressable`=모바일 none(롱프레스 보호), `.hinest-desktop .chat-pressable`=text(드래그 선택)
- `.hinest-desktop`=Electron 또는 마우스(hover+fine) → 데스크탑 앱·웹 커버, 모바일 터치는 기존 동작 유지
- 코드블록 줄번호 `<pre>`(인라인 none) 유지 → 복사 시 줄번호 제외

## 검증
- tsc 통과 / 전부 OTA(웹 번들) — 네이티브 재빌드 불필요
- 데스크탑 앱·웹에서 드래그 선택 후 Cmd/Ctrl+C 확인

Closes #983