### PR TITLE
🔀 :: (#985) 미리보기/로그아웃 후 로그인에 네이티브 탭바 잔존 수정

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -725,6 +725,8 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
         });
         removeListener = () => { try { void handle?.remove?.(); } catch {} };
         LiquidGlassTabBar.setSelected({ key: matchNativeTabKey(window.location.pathname) }).catch(() => {});
+        // 셸(AppLayout)이 마운트됐으니, 직전 언마운트에서 걸어둔 'shell' 숨김 사유를 해제한다.
+        setNativeTabBarHidden("shell", false);
         // 바 생성 직후 현재 숨김 사유(채팅·모달·라우트) 기준으로 가시성 재적용.
         syncNativeTabBarVisibility();
       } catch {
@@ -735,7 +737,9 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
       cancelled = true;
       removeListener?.();
       document.documentElement.classList.remove("hinest-native-tabbar");
-      LiquidGlassTabBar.setVisible({ visible: false }).catch(() => {});
+      // 셸이 사라짐(로그아웃·미리보기 종료 등) → 'shell' 사유로 숨김을 영구 유지. 다른 사유가
+      // 풀려도(예: onboarding 복원) 로그인 화면에서 네이티브 탭바가 되살아나지 않게 한다.
+      setNativeTabBarHidden("shell", true);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## 증상
iOS 둘러보기 종료/로그아웃 후 로그인 화면(미인증)에 하단 네이티브 탭바가 남음.

## 원인
LiquidGlassTabBar 가시성은 `hideReasons` Set 기반. AppLayout unmount cleanup 이 `setVisible(false)` 를 직접 호출하는데, 직후 다른 컴포넌트(onboarding 등) cleanup 이 `setNativeTabBarHidden(reason,false)` 로 사유를 풀면 hideReasons 가 비어 → 셸 없는데도 탭바가 되살아남.

## 작업 내용
- cleanup: `setVisible(false)` → `setNativeTabBarHidden("shell", true)` (셸 부재를 영구 사유로 유지)
- configure 성공(마운트): `setNativeTabBarHidden("shell", false)` 로 해제

## 검증
- tsc 통과 / iOS 시뮬레이터 검증 / OTA(웹) — 네이티브 재빌드 불필요

Closes #985