### PR TITLE
🔀 :: (#987) 키보드 둥근 모서리 색을 --c-surface로 맞춤 (#171A20)

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -441,12 +441,13 @@ class MainViewController: CAPBridgeViewController {
 extension UIColor {
     /// 웹뷰 뒤(키보드 영역·safe-area 등 네이티브 chrome) 배경에 쓰는 동적 색.
     /// - 라이트: #F5F6F8 (Capacitor 웹뷰/스플래시 backgroundColor·웹 --c-bg(light) 와 동일 → 이음매 없음)
-    /// - 다크:   #0E1014 (웹 셸 --c-bg(dark) 와 동일). systemBackground(순수 검정)은 웹 다크 배경과
-    ///           미세하게 달라 키보드 띠에서 이음매가 보였다 — 웹 배경색에 정확히 맞춘다.
+    /// - 다크:   #171A20 (웹 --c-surface(dark) 와 동일). 키보드가 인접하는 영역(채팅 입력바·로그인
+    ///           폼·바텀시트)은 --c-surface 라, 키보드 둥근 윗모서리 뒤로 드러나는 chrome 을 그 색에
+    ///           맞춰야 모서리가 더 검게 떠 보이지 않는다(--c-bg #0E1014 은 더 어두워 이음매가 보였다).
     /// userInterfaceStyle 에 따라 OS 가 자동으로 두 값 사이를 전환한다.
     static let hinestChromeBackground = UIColor { traits in
         traits.userInterfaceStyle == .dark
-            ? UIColor(red: 0x0E / 255.0, green: 0x10 / 255.0, blue: 0x14 / 255.0, alpha: 1.0)
+            ? UIColor(red: 0x17 / 255.0, green: 0x1A / 255.0, blue: 0x20 / 255.0, alpha: 1.0)
             : UIColor(red: 0xF5 / 255.0, green: 0xF6 / 255.0, blue: 0xF8 / 255.0, alpha: 1.0)
     }
 }


### PR DESCRIPTION
## 증상
iOS 26 키보드 둥근 윗모서리 바깥 영역이 앱 배경(로그인 폼·채팅 입력바)보다 검게 보임.

## 원인
시뮬 픽셀 측정 결과 그 모서리 = `hinestChromeBackground`(웹뷰 뒤 chrome) 색. 다크값이 `--c-bg`(#0E1014)였는데, 키보드 인접 영역은 `--c-surface`(#171A20)라 더 어두워 보였음.

## 작업 내용
- chrome 다크값 #0E1014 → #171A20(--c-surface)

## 검증
- 픽셀 측정: 모서리=chrome 색 확정 → 색 치환으로 일치(결정적)
- ⚠️ iOS 네이티브 — Xcode 재빌드 필요(OTA 불가)

Closes #987