### PR TITLE
🔀 :: (#991) 채팅 아바타 NSE 캐시 프리워밍 (첫 알림부터 아바타)

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -101,6 +101,7 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "promptInput", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "haptic", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "presentShareSheet", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "prewarmAvatars", returnType: CAPPluginReturnPromise),
     ]
 
     private var tabBarView: UITabBar?
@@ -109,6 +110,54 @@ public class LiquidGlassTabBarPlugin: CAPPlugin, CAPBridgedPlugin {
 
     override public func load() {
         NSLog("[LGTB] plugin loaded (discovered by Capacitor)")
+    }
+
+    /// NSE(채팅 발신자 아바타) 캐시 프리워밍 — 앱이 채팅방 목록을 열 때 발신 가능성 있는 멤버들의
+    /// 아바타를 미리 다운로드해 NSE 와 동일한 App Group 캐시(avatar-cache/<퍼센트인코딩 경로>)에 넣어둔다.
+    /// 그러면 "첫 알림은 캐시 미스 → 다운로드가 NSE 시간예산을 못 맞춰 앱아이콘으로 폴백"하던 게 사라지고
+    /// 첫 알림부터 통신알림 아바타로 뜬다. NSE(NotificationService.swift) 의 cacheFile/fetch 스킴과 정확히 일치.
+    @objc func prewarmAvatars(_ call: CAPPluginCall) {
+        let paths = (call.getArray("paths", String.self) ?? []).filter { $0.hasPrefix("/uploads/") }
+        let groupId = "group.com.hivits.hinest"
+        let apiBase = "https://nest.hi-vits.com"
+        guard !paths.isEmpty,
+              let base = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupId) else {
+            call.resolve(["cached": 0]); return
+        }
+        let dir = base.appendingPathComponent("avatar-cache", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let token = UserDefaults(suiteName: groupId)?.string(forKey: "hinest.session.token")
+        // 이미 캐시된 건 건너뛴다(불필요 다운로드 0). NSE 와 동일한 키(.alphanumerics 퍼센트 인코딩).
+        let targets: [(String, URL)] = paths.compactMap { p in
+            let key = p.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? p
+            let file = dir.appendingPathComponent(key)
+            return FileManager.default.fileExists(atPath: file.path) ? nil : (p, file)
+        }
+        if targets.isEmpty { call.resolve(["cached": 0]); return }
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 8
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        let session = URLSession(configuration: config)
+        let dg = DispatchGroup()
+        let lock = NSLock(); var ok = 0
+        for (p, file) in targets {
+            var urlStr = apiBase + p
+            if let token = token, !token.isEmpty,
+               let enc = token.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+                urlStr += (urlStr.contains("?") ? "&" : "?") + "token=" + enc
+            }
+            guard let url = URL(string: urlStr) else { continue }
+            dg.enter()
+            session.dataTask(with: url) { data, response, _ in
+                defer { dg.leave() }
+                let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                if status == 200, let data = data, !data.isEmpty, UIImage(data: data) != nil {
+                    try? data.write(to: file, options: .atomic)
+                    lock.lock(); ok += 1; lock.unlock()
+                }
+            }.resume()
+        }
+        dg.notify(queue: .main) { call.resolve(["cached": ok]) }
     }
 
     /// 알림 서비스 확장(NSE)이 채팅 발신자 아바타(/uploads, 인증 필요)를 받을 수 있도록,

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -7,6 +7,7 @@ import { resolvePresence } from "../lib/presence";
 import { downloadFromUrl } from "../lib/download";
 import { isCapacitorNative, nativePlatform } from "../lib/platform";
 import { isNativeAppActive } from "../lib/appActive";
+import { prewarmChatAvatars } from "../lib/liquidGlassTabBar";
 import { setActiveChatRoom } from "../lib/desktopNotify";
 import { Browser } from "@capacitor/browser";
 import { alertAsync, confirmAsync } from "./ConfirmHost";
@@ -196,6 +197,8 @@ export default function ChatMiniApp({
       const res = await api<{ rooms: Room[] }>("/api/chat/rooms");
       setRooms(res.rooms);
       hydrateMutedFromServer(res.rooms);
+      // iOS: 발신 가능성 있는 멤버 아바타를 NSE 캐시에 선기록 → 첫 알림부터 통신알림 아바타.
+      prewarmChatAvatars(res.rooms.flatMap((r) => r.members.map((m) => m.user.avatarUrl)));
     } catch {}
   };
   // 1:1 대화 '나만 삭제'(per-user 숨김). 내 목록에서만 사라지고 상대에겐 유지. 새 메시지 오면 다시 나타남.

--- a/client/src/lib/liquidGlassTabBar.ts
+++ b/client/src/lib/liquidGlassTabBar.ts
@@ -1,5 +1,5 @@
 import { registerPlugin } from "@capacitor/core";
-import { isCapacitorNative } from "./platform";
+import { isCapacitorNative, nativePlatform } from "./platform";
 
 /**
  * 네이티브 Liquid Glass 하단 탭 바 브리지 (iOS 26 UIGlassEffect).
@@ -41,6 +41,9 @@ export interface LiquidGlassTabBarPlugin {
     token?: string;
     apiBase?: string;
   }): Promise<{ presented: boolean }>;
+  /** NSE 아바타 캐시 프리워밍 — 발신 가능성 있는 멤버 아바타(/uploads 경로)를 미리 받아 App Group
+   *  캐시에 넣어 "첫 알림은 앱아이콘" 콜드캐시 문제를 없앤다. iOS 전용(NSE 시간예산 이슈). */
+  prewarmAvatars(options: { paths: string[] }): Promise<{ cached: number }>;
   /** 애플 기본 확인 시트(action sheet). 로그아웃 등 재확인용. */
   confirm(options: {
     title?: string;
@@ -99,4 +102,17 @@ export function setNativeTabBarHidden(reason: string, hidden: boolean) {
 export function syncNativeTabBarVisibility() {
   lastVisible = null;
   applyVisibility();
+}
+
+/**
+ * NSE 아바타 캐시 프리워밍 — 채팅방 목록을 열 때 발신 가능성 있는 멤버 아바타(/uploads 경로)를
+ * 미리 받아 App Group 캐시에 넣는다. "첫 알림은 캐시 미스 → 앱아이콘 폴백"을 없애 첫 알림부터 아바타.
+ * iOS 네이티브에서만 동작(NSE 시간예산 문제는 iOS 한정; 안드/웹/데스크톱 no-op).
+ */
+export function prewarmChatAvatars(paths: Array<string | null | undefined>) {
+  if (!isCapacitorNative() || nativePlatform() !== "ios") return;
+  const uniq = Array.from(
+    new Set(paths.filter((p): p is string => !!p && p.startsWith("/uploads/"))),
+  ).slice(0, 40); // 과다 다운로드 방지(이미 캐시된 건 네이티브가 건너뜀)
+  if (uniq.length) LiquidGlassTabBar.prewarmAvatars({ paths: uniq }).catch(() => {});
 }


### PR DESCRIPTION
## 증상
iOS 첫 채팅 알림은 앱아이콘으로, 두 번째부터 아바타로 뜸(NSE 콜드캐시).

## 원인
NSE 가 아바타를 다운로드·캐시하는데 첫 알림은 캐시 미스 → 다운로드가 시간예산 못 맞추면 앱아이콘 폴백.

## 작업 내용
- 네이티브 `prewarmAvatars({paths})` — NSE 와 동일 스킴(App Group avatar-cache/<퍼센트인코딩>, 같은 apiBase·토큰)으로 선다운로드·캐시. 이미 캐시된 건 스킵.
- `loadRooms` 시 멤버 아바타(/uploads)를 모아 호출 (iOS 전용, ≤40)

## 검증
- Swift 컴파일(시뮬) + tsc 통과. NSE 캐시 키/로직 1:1 일치.
- ⚠️ iOS 네이티브 — 재빌드 필요

Closes #991