### PR TITLE
🔀 :: (#993) 대화방 헤더 iOS 26 리퀴드 글래스

### DIFF
--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, lazy, Suspense } from "react";
+import { useEffect, useState, useRef, useLayoutEffect, lazy, Suspense } from "react";
 import { useLocation } from "react-router-dom";
 import { useNotifications } from "../notifications";
 import { imgSrc } from "../api";
@@ -213,17 +213,8 @@ export default function ChatFab() {
                 }
           }
         >
-          {/* ===== 헤더 ===== */}
-          {activeRoom ? (
-            <RoomHeader
-              info={{
-                ...activeRoom,
-                // 패널 자체를 닫는 X. 런처를 상단바로 옮긴 뒤로는 모바일·데스크톱 모두
-                // 헤더의 X 로 닫는다(이전엔 데스크톱에서 우하단 FAB 가 닫기 역할을 했음).
-                onClose: () => setOpen(false),
-              }}
-            />
-          ) : (
+          {/* ===== 리스트 헤더 — 방 목록일 때만 flex 흐름. 대화방 헤더는 본문 위에 글래스로 떠 있다. ===== */}
+          {!activeRoom && (
             <ListHeader
               chatUnread={chatUnread}
               onCreateGroup={() => setCreateReq((n) => n + 1)}
@@ -240,6 +231,16 @@ export default function ChatFab() {
               background: C.surface,
             }}
           >
+            {/* 대화방 헤더 — iOS 26 리퀴드 글래스. 본문 기준 absolute 오버레이라 메시지가 이 뒤로 스크롤된다.
+                (헤더의 X 로 패널을 닫는다 — 런처가 상단바로 옮겨진 뒤 모바일·데스크톱 공통) */}
+            {activeRoom && (
+              <RoomHeader
+                info={{
+                  ...activeRoom,
+                  onClose: () => setOpen(false),
+                }}
+              />
+            )}
             <Suspense fallback={null}>
               <ChatMiniApp active={open} onActiveRoomChange={setActiveRoom} createGroupRequestId={createReq} openRoomRequest={openRoomReq} />
             </Suspense>
@@ -396,6 +397,13 @@ function ListHeader({
 
 /* ===== 대화방용 헤더 ===== */
 function RoomHeader({ info }: { info: ActiveRoomInfo }) {
+  // 글래스 헤더의 실제 높이를 CSS 변수로 노출 → 메시지 스크롤이 그만큼 padding-top 을 받아
+  // 헤더 뒤로 자연스럽게 스크롤된다(고정값 대신 실측이라 1줄·2줄 제목 모두 정확).
+  const headerRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const h = headerRef.current?.offsetHeight;
+    if (h) document.documentElement.style.setProperty("--chat-room-header-h", `${h}px`);
+  });
   // 설정 화면에서는 제목/닫기 없이 얇은 뒤로가기 바만 표시
   if (info.isSettings) {
     return (
@@ -432,13 +440,22 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
 
   return (
     <div
+      ref={headerRef}
       style={{
         padding: "18px 18px 12px",
         display: "flex",
         alignItems: "center",
         gap: 10,
-        background: C.surface,
-        flexShrink: 0,
+        // iOS 26 리퀴드 글래스 — 반투명 + 배경 블러. 메시지가 이 뒤로 스크롤되며 비친다.
+        background: "var(--c-glass)",
+        WebkitBackdropFilter: "blur(20px) saturate(180%)",
+        backdropFilter: "blur(20px) saturate(180%)",
+        borderBottom: "1px solid var(--c-glass-border)",
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10,
       }}
     >
       <button

--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -2359,14 +2359,18 @@ function RoomView({
 
   return (
     <>
-      <PinnedBar pinned={pinnedList} onJump={scrollToMessage} onUnpin={onPin} />
+      {/* 글래스 헤더가 본문 위에 떠 있으므로, 고정 메시지 바가 있으면 헤더 높이만큼 내려 보이게 한다. */}
+      <div style={{ flexShrink: 0, paddingTop: pinnedList.length ? "var(--chat-room-header-h, 60px)" : 0 }}>
+        <PinnedBar pinned={pinnedList} onJump={scrollToMessage} onUnpin={onPin} />
+      </div>
       {/* 메시지 영역 */}
       <div
         ref={scrollRef}
         onScroll={onScroll}
         style={{
           flex: 1, overflowY: "auto",
-          padding: "4px 14px 10px",
+          // 글래스 헤더 뒤로 메시지가 스크롤되도록 헤더 높이만큼 위 여백(고정바가 있으면 그쪽이 이미 내려줌).
+          padding: pinnedList.length ? "4px 14px 10px" : "calc(4px + var(--chat-room-header-h, 60px)) 14px 10px",
           background: C.surface,
           // 첫 로드 완료 전에는 감춰서 "위에서 아래로 스크롤되는" 플래시를 숨김
           visibility: ready || messages.length === 0 ? "visible" : "hidden",


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 요청
채팅 대화방 상단바에 iOS 26 리퀴드 글래스 — 헤더 뒤로 메시지가 비치게.

## 작업 내용
- RoomHeader → 본문 기준 `position:absolute` 오버레이 + `--c-glass` + `backdrop-filter: blur(20px) saturate(180%)`
- 헤더 높이 `--chat-room-header-h`(ref 실측) → 메시지 스크롤 padding-top → 헤더 뒤로 스크롤
- PinnedBar 헤더 높이만큼 하강 / 리스트 헤더는 기존 유지

## 검증
- 웹 프리뷰(다크): backdrop-filter·rgba(22,25,31,.6)·absolute/top0/z10·--chat-room-header-h=82px 확인, 메시지 블러되어 비침
- tsc 통과 · OTA 가능

Closes #993

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #993
