### PR TITLE
🔀 :: (#999) 리퀴드 글래스를 iOS·Android 앱에만 (데스크톱/웹 제외)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -681,6 +681,10 @@ function AppLayoutInner({ children }: { children?: React.ReactNode }) {
     // iOS 네이티브(아이폰·아이패드)에서만 글래스 하단 네비 스타일 + 본문 하단 클리어런스 적용.
     // (웹/안드로이드/Electron 데스크톱은 클래스가 안 붙어 기존 디자인 그대로.)
     el.classList.toggle("hinest-ios", nativePlatform() === "ios");
+    // 안드로이드 앱: 상단 리퀴드 글래스(.app-topbar)만 iOS 와 동일하게 적용한다. 사이드바·하단탭은
+    // 미디어쿼리가 이미 모바일로 처리하므로 hinest-ios 의 셸 규칙은 안 붙이고, 글래스 전용 클래스만.
+    // (웹·데스크톱은 둘 다 안 붙어 글래스 없음 — 글래스는 iOS·Android 네이티브 앱에만.)
+    el.classList.toggle("hinest-android", nativePlatform() === "android");
     // 데스크톱(Electron 또는 마우스+호버 가능 브라우저)은 창을 폰 크기로 줄여도 모바일
     // 레이아웃으로 바뀌지 않도록 플래그. 실제 터치 폰/태블릿(coarse pointer)은 제외.
     const isDesktopDevice =

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { useNotifications } from "../notifications";
 import { imgSrc } from "../api";
 import { setNativeTabBarHidden } from "../lib/liquidGlassTabBar";
+import { nativePlatform } from "../lib/platform";
 // highlight.js(~92KB) 등 무거운 의존성을 끌고오므로 초기 번들에서 분리한다.
 // 채팅 패널은 사용자가 처음 열 때(mounted=true) 비로소 마운트되므로 lazy 로딩이 안전.
 const ChatMiniApp = lazy(() => import("./ChatMiniApp"));
@@ -404,6 +405,8 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
     const h = headerRef.current?.offsetHeight;
     if (h) document.documentElement.style.setProperty("--chat-room-header-h", `${h}px`);
   });
+  // 리퀴드 글래스는 iOS·Android 네이티브 앱에만 — 데스크톱/웹은 솔리드 헤더(요구사항).
+  const glass = nativePlatform() === "ios" || nativePlatform() === "android";
   // 설정 화면에서는 제목/닫기 없이 얇은 뒤로가기 바만 표시
   if (info.isSettings) {
     return (
@@ -446,10 +449,11 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
         display: "flex",
         alignItems: "center",
         gap: 10,
-        // iOS 26 리퀴드 글래스 — 반투명 + 배경 블러. 메시지가 이 뒤로 스크롤되며 비친다.
-        background: "var(--c-glass)",
-        WebkitBackdropFilter: "blur(20px) saturate(180%)",
-        backdropFilter: "blur(20px) saturate(180%)",
+        // iOS 26 리퀴드 글래스 — iOS·Android 네이티브 앱에서만 반투명+블러로 메시지가 뒤로 비친다.
+        // 데스크톱/웹은 솔리드 surface (글래스 미적용 — 요구사항). 오버레이 구조는 동일.
+        background: glass ? "var(--c-glass)" : "var(--c-surface)",
+        WebkitBackdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
+        backdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
         borderBottom: "1px solid var(--c-glass-border)",
         position: "absolute",
         top: 0,

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -170,8 +170,9 @@ html.hinest-keyboard-open .console-bottomnav { display: none !important; }
    반투명+blur 헤더(absolute)로 만들고, 본문은 그만큼 위쪽 패딩을 줘 헤더 아래에서 시작한다.
    스크롤하면 본문이 헤더 뒤로 지나가며 글래스 질감이 드러난다(스크롤 할 때만). TopBar 는
    main 밖(형제)에 그대로 둬 오버스크롤 '뚫림' 방지(main 의 overscroll-contain)도 유지된다.
-   데스크톱(.hinest-ios 아님)은 기존 in-flow 솔리드 상단바 그대로 — 무회귀. */
-html.hinest-ios .app-topbar.bg-white {
+   데스크톱·웹(.hinest-ios/.hinest-android 아님)은 기존 in-flow 솔리드 상단바 그대로 — 무회귀.
+   글래스는 iOS·Android 네이티브 앱에만 적용한다(요구사항). */
+:is(html.hinest-ios, html.hinest-android) .app-topbar.bg-white {
   position: absolute; top: 0; left: 0; right: 0; z-index: 30;
   /* 선택자에 .bg-white 를 더해 특이도 (0,3,1) — 전역 `html.dark .bg-white { background:
      var(--c-surface) !important }`(0,2,1) 다크 리맵을 이긴다. 이게 없으면 특이도 동률+나중 규칙이라
@@ -181,7 +182,7 @@ html.hinest-ios .app-topbar.bg-white {
   backdrop-filter: blur(20px) saturate(180%);
   border-bottom: 1px solid var(--c-glass-border);
 }
-html.hinest-ios .app-main-scroll {
+:is(html.hinest-ios, html.hinest-android) .app-main-scroll {
   padding-top: calc(56px + var(--sa-top, env(safe-area-inset-top)));
   /* 네이티브 모멘텀 스크롤 — 손가락을 떼도 관성으로 부드럽게 이어진다(웹틱한 즉시 정지 방지). */
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 요청
리퀴드 글래스(상단바·채팅 헤더)는 iOS·Android 네이티브 앱에만. 데스크톱/웹 솔리드.

## 작업 내용
- AppLayout: `hinest-android` 토글 추가(글래스 전용)
- styles.css: 상단 글래스·스크롤 패딩 → `:is(html.hinest-ios, html.hinest-android)`
- ChatFab 대화방 헤더: `glass = nativePlatform() ios|android` 게이트 (데스크톱/웹=솔리드)

## 검증(웹 프리뷰)
- app-topbar: Android=글래스+absolute / 데스크톱=솔리드+static
- 채팅 헤더: 데스크톱=솔리드 확인, 네이티브=글래스(동일 로직)
- tsc 통과

Closes #999

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #999
