### PR TITLE
🔀 :: (#1003) 1:1 부제 → 상대 직급·소속팀

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -473,8 +473,10 @@ export default function ChatMiniApp({
       const override = roomSettings[activeRoomObj.id]?.nickname;
       const title = override || roomTitle(activeRoomObj, user?.id ?? "");
       const muted = !!roomSettings[activeRoomObj.id]?.muted;
+      const directOther = activeRoomObj.members.find((m) => m.user.id !== (user?.id ?? ""));
       const baseSub =
-        activeRoomObj.type === "DIRECT" ? "1:1 대화"
+        activeRoomObj.type === "DIRECT"
+          ? ([directOther?.user.position, directOther?.user.team].filter(Boolean).join(" · ") || "1:1 대화")
           : activeRoomObj.type === "TEAM" ? "팀"
             : `${activeRoomObj.members.length}명`;
       const subtitle = showSettings ? "채팅방 설정" : (muted ? `${baseSub} · 알림 꺼짐` : baseSub);

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -3,7 +3,7 @@
  * ChatMiniApp / MessageBubble / 확장 뷰들에서 공통으로 사용.
  */
 
-export type RoomMember = { muted?: boolean; user: { id: string; name: string; avatarColor?: string; avatarUrl?: string | null } };
+export type RoomMember = { muted?: boolean; user: { id: string; name: string; avatarColor?: string; avatarUrl?: string | null; position?: string | null; team?: string | null } };
 
 export type Room = {
   id: string;

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -82,7 +82,7 @@ router.get("/rooms", async (req, res) => {
     where,
     orderBy: { createdAt: "desc" },
     include: {
-      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
+      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
       messages: {
         where: { deletedAt: null, scheduledAt: null },
         orderBy: { createdAt: "desc" },
@@ -159,7 +159,7 @@ router.post("/rooms", async (req, res) => {
         ],
       },
       include: {
-        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
+        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
         messages: {
           where: { deletedAt: null, scheduledAt: null },
           orderBy: { createdAt: "desc" },
@@ -181,7 +181,7 @@ router.post("/rooms", async (req, res) => {
         members: { create: [{ companyId: u.companyId, userId: u.id }, { companyId: u.companyId, userId: other }] },
       },
       include: {
-        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
+        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
         messages: { where: { deletedAt: null, scheduledAt: null }, orderBy: { createdAt: "desc" }, take: 1 },
       },
     });
@@ -204,7 +204,7 @@ router.post("/rooms", async (req, res) => {
       members: { create: memberIds.map((userId) => ({ companyId: u.companyId, userId })) },
     },
     include: {
-      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
+      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
       messages: { where: { deletedAt: null, scheduledAt: null }, orderBy: { createdAt: "desc" }, take: 1 },
     },
   });
@@ -327,7 +327,7 @@ router.get("/search", async (req, res) => {
         include: {
           // 검색 결과 카드에 최대 50명까지만 표시 — 대형 그룹방에서 수백 명을 끌어와
           // 응답 크기가 폭발하는 것을 방지. 실제 UI 는 아바타 5개 + "+N" 으로 표시.
-          members: { take: 50, include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } } },
+          members: { take: 50, include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
         },
       },
     },


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 요약
1:1(DIRECT) 채팅방 헤더 부제를 고정 문구 "1:1 대화" 대신 **상대방의 "직급 · 소속팀"** (예: "과장 · 개발팀") 으로 표시합니다. 직급·팀이 둘 다 없으면 "1:1 대화" 로 폴백하고, 알림 꺼짐 접미사 로직은 그대로 유지됩니다("과장 · 개발팀 · 알림 꺼짐").

## 변경 사항
- **server** `src/routes/chat.ts`: 방 쿼리의 멤버 `user` select **5곳**에 `position: true, team: true` 추가. (메시지 `sender` select 은 변경하지 않음.)
- **client** `src/components/chat/types.ts`: `RoomMember.user` 타입에 `position?: string | null; team?: string | null` 추가.
- **client** `src/components/ChatMiniApp.tsx`: DIRECT 부제를 상대 멤버(`m.user.id !== 내 id`)의 `[position, team].filter(Boolean).join(" · ") || "1:1 대화"` 로 계산.

## 검증
- `client`: `npx tsc --noEmit` 에러 0건.
- `server`: `prisma generate` 후 `npx tsc --noEmit` 에러 0건.

Closes #1003

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1003
