### PR TITLE
🔀 :: (#1005) 헤더 뒤로·닫기 버튼 글래스 (네이티브)

### DIFF
--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -428,19 +428,22 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
           aria-label="뒤로"
           style={{
             width: 34, height: 34, borderRadius: 999,
-            background: C.gray100, color: C.ink,
-            border: 0, cursor: "pointer",
+            // iOS 26 리퀴드 글래스 — 네이티브 앱에서만 반투명+블러. 데스크톱/웹은 기존 솔리드.
+            background: glass ? "var(--c-glass)" : C.gray100, color: C.ink,
+            WebkitBackdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
+            backdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
+            border: glass ? "1px solid var(--c-glass-border)" : 0, cursor: "pointer",
             display: "grid", placeItems: "center",
             transition: "background .12s ease",
           }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = C.gray200)}
-          onMouseLeave={(e) => (e.currentTarget.style.background = C.gray100)}
+          onMouseEnter={(e) => { if (!glass) e.currentTarget.style.background = C.gray200; }}
+          onMouseLeave={(e) => { if (!glass) e.currentTarget.style.background = C.gray100; }}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
             <path d="M15 18l-6-6 6-6" />
           </svg>
         </button>
-        {info.onClose && <HeaderCloseButton onClose={info.onClose} />}
+        {info.onClose && <HeaderCloseButton onClose={info.onClose} glass={glass} />}
       </div>
     );
   }
@@ -474,14 +477,17 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
         aria-label="뒤로"
         style={{
           width: 34, height: 34, borderRadius: 999,
-          background: C.gray100, color: C.ink,
-          border: 0, cursor: "pointer",
+          // iOS 26 리퀴드 글래스 — 네이티브 앱에서만 반투명+블러. 데스크톱/웹은 기존 솔리드.
+          background: glass ? "var(--c-glass)" : C.gray100, color: C.ink,
+          WebkitBackdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
+          backdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
+          border: glass ? "1px solid var(--c-glass-border)" : 0, cursor: "pointer",
           display: "grid", placeItems: "center",
           flexShrink: 0,
           transition: "background .12s ease",
         }}
-        onMouseEnter={(e) => (e.currentTarget.style.background = C.gray200)}
-        onMouseLeave={(e) => (e.currentTarget.style.background = C.gray100)}
+        onMouseEnter={(e) => { if (!glass) e.currentTarget.style.background = C.gray200; }}
+        onMouseLeave={(e) => { if (!glass) e.currentTarget.style.background = C.gray100; }}
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
           <path d="M15 18l-6-6 6-6" />
@@ -541,13 +547,13 @@ function RoomHeader({ info }: { info: ActiveRoomInfo }) {
 
       {/* 모바일 풀스크린에선 패널 자체를 닫는 X — 방 안에서도 한 탭으로 빠져나갈 수 있게.
           desktop 에선 onClose 미전달 → 렌더링 안 됨 (외부에 띄운 팝업이라 별도 닫기 불필요). */}
-      {info.onClose && <HeaderCloseButton onClose={info.onClose} />}
+      {info.onClose && <HeaderCloseButton onClose={info.onClose} glass={glass} />}
     </div>
   );
 }
 
 /** 헤더 우측 X — 모바일 풀스크린 채팅을 한 번에 닫는 버튼. */
-function HeaderCloseButton({ onClose }: { onClose: () => void }) {
+function HeaderCloseButton({ onClose, glass = false }: { onClose: () => void; glass?: boolean }) {
   return (
     <button
       onClick={onClose}
@@ -555,14 +561,17 @@ function HeaderCloseButton({ onClose }: { onClose: () => void }) {
       aria-label="채팅 닫기"
       style={{
         width: 34, height: 34, borderRadius: 999,
-        background: C.gray100, color: C.ink,
-        border: 0, cursor: "pointer",
+        // iOS 26 리퀴드 글래스 — 네이티브 앱에서만 반투명+블러. 데스크톱/웹은 기존 솔리드.
+        background: glass ? "var(--c-glass)" : C.gray100, color: C.ink,
+        WebkitBackdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
+        backdropFilter: glass ? "blur(20px) saturate(180%)" : undefined,
+        border: glass ? "1px solid var(--c-glass-border)" : 0, cursor: "pointer",
         display: "grid", placeItems: "center",
         flexShrink: 0,
         transition: "background .12s ease",
       }}
-      onMouseEnter={(e) => (e.currentTarget.style.background = C.gray200)}
-      onMouseLeave={(e) => (e.currentTarget.style.background = C.gray100)}
+      onMouseEnter={(e) => { if (!glass) e.currentTarget.style.background = C.gray200; }}
+      onMouseLeave={(e) => { if (!glass) e.currentTarget.style.background = C.gray100; }}
     >
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
         <path d="M18 6 6 18M6 6l12 12" />


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 무엇을
채팅 대화방 헤더(`ChatFab.tsx`의 `RoomHeader`)의 **뒤로가기(←)·닫기(✕) 버튼**에 iOS 26 리퀴드 글래스를 적용. 헤더 배경(PR #1000)과 동일한 톤으로 맞춰 버튼이 겉돌지 않게 했다.

## 어떻게
이미 `RoomHeader`에 있던 `const glass = nativePlatform() === 'ios' || nativePlatform() === 'android'` 불리언을 버튼에도 재사용:
- 글래스일 때: `background: var(--c-glass)`, `WebkitBackdropFilter/backdropFilter: blur(20px) saturate(180%)`, `border: 1px solid var(--c-glass-border)`.
- hover 배경 토글(`gray200`/`gray100`)은 비글래스(데스크톱/웹)에서만 — 글래스에선 블러 톤이 깨지지 않도록 hover 변경 없음.

적용 대상 3곳:
- 메인 헤더 뒤로가기 버튼
- 설정 화면(`info.isSettings`) 뒤로가기 버튼
- `HeaderCloseButton` — `glass?: boolean` prop 추가(기본 `false`), 메인·설정 두 호출부에서 `glass={glass}` 전달

## 회귀 안전성
- 데스크톱/웹(`glass===false`)은 `background: C.gray100` + `border: 0` + 동일 hover 토글로 **기존과 픽셀 동일**. `undefined` backdrop-filter 는 인라인 스타일에서 미출력.
- ChatFab 의 버튼 외 영역(패널 padding·본문·입력바·헤더 배경 자체·ChatMiniApp)은 미수정. diff 는 `ChatFab.tsx` 단일 파일 +24/−15.

## 검증
- `npx tsc --noEmit -p tsconfig.json` → 에러 0 통과.

Closes #1005

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1005
