### PR TITLE
🔀 :: (#1007) resize:'none' + 입력바 키보드 동기 상승

### DIFF
--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:resizeableActivity="false"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
 
             <intent-filter>

--- a/client/capacitor.config.ts
+++ b/client/capacitor.config.ts
@@ -61,11 +61,13 @@ const config: CapacitorConfig = {
   },
   plugins: {
     // 키보드 등장 애니메이션 — 'native' 리사이즈는 iOS 가 WebView 자체를 키보드 곡선에 맞춰
-    // 끌어올린다(CSS 트랜지션 없이도 부드러움). 'body' 보다 자연스럽고 입력 지연이 없다.
-    // resizeOnFullScreen=true → 안드로이드 전체화면에서도 동일 동작.
+    // [변경] resize:'none' — 플러그인이 WebView 를 리사이즈하지 않고, 앱이 --hinest-keyboard-h
+    // (nativeKeyboard 가 keyboardWillShow 에서 세팅)로 채팅 입력바·로그인·바텀시트를 키보드와
+    // '동시에' 올린다. 'native' 는 WebView 리사이즈가 키보드 애니메이션 끝에야 반영돼 입력바가
+    // 늦게 따라오던 잔상이 있었다(요구사항: 동시에 부드럽게).
+    // 안드로이드는 AndroidManifest 의 windowSoftInputMode=adjustResize 가 네이티브로 WebView 를 줄인다.
     Keyboard: {
-      resize: "native",
-      resizeOnFullScreen: true,
+      resize: "none",
     },
     // Capacitor Live Updates (Capgo, MIT, self-hosted) — 셸은 App Store 한 번만 심사받고,
     // 웹 번들(dist)은 우리 서버에서 OTA 로 받는다. autoUpdate=true ⇒ SDK 가 백그라운드에서

--- a/client/src/components/ChatFab.tsx
+++ b/client/src/components/ChatFab.tsx
@@ -166,12 +166,16 @@ export default function ChatFab() {
                   // ※ 절대 위치 계산 대신 flex column 으로 변경 — 이전엔 헤더는 padding 안에,
                   //    본문은 absolute top:86 (border-box 기준) 으로 두면서 safe-area-top 만큼
                   //    헤더 일부가 본문에 가려져 모바일에서 뒤로가기 버튼이 사라져 보였음.
-                  // ※ height:100dvh 를 제거 — inset:0(top:0+bottom:0) 만으로 풀스크린.
-                  //   Keyboard.resize:'native' 가 키보드 곡선에 맞춰 WebView 를 줄이면, bottom:0
-                  //   앵커가 그 줄어드는 바닥에 자동으로 붙어 입력바가 키보드와 '동기' 로 올라온다.
-                  //   100dvh(고정 길이)는 iOS 가 키보드 애니메이션 중 보간하지 않고 끝난 뒤에야
-                  //   재계산해 입력바가 늦게 따라잡히는 증상을 유발했다.
-                  inset: 0,
+                  // ※ Keyboard.resize:'none'(전역) + 입력바 동기 상승: 패널 bottom 을 키보드 높이
+                  //   (--hinest-keyboard-h, keyboardWillShow 에서 세팅)에 맞추고 transition 을 줘
+                  //   입력바가 키보드와 '동시에' 부드럽게 올라온다. resize:'native' 는 WebView 리사이즈가
+                  //   키보드 애니메이션 끝에야 반영돼 입력바가 늦게 따라잡히던 문제를 유발했다.
+                  //   안드로이드는 --hinest-keyboard-h 미설정(0)→bottom:0, manifest adjustResize 의
+                  //   네이티브 리사이즈가 WebView 를 줄여 입력바가 따라온다(동일 결과).
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: "var(--hinest-keyboard-h, 0px)",
                   width: "100vw",
                   // safe-area(상태바)는 패널이 아니라 헤더(RoomHeader/ListHeader)가 흡수한다 —
                   // 그래야 글래스 헤더가 상태바 영역까지 위로 덮어, 'safe-area 와 헤더가 따로 노는'
@@ -190,7 +194,7 @@ export default function ChatFab() {
                   display: "flex",
                   flexDirection: "column",
                   transition:
-                    "opacity .22s cubic-bezier(.22,.61,.36,1), transform .26s cubic-bezier(.22,.61,.36,1)",
+                    "opacity .22s cubic-bezier(.22,.61,.36,1), transform .26s cubic-bezier(.22,.61,.36,1), bottom .25s cubic-bezier(.17,.59,.4,1)",
                 }
               : {
                   // 데스크톱: 기존 우하단 플로팅 팝업. flex column 으로 통일.


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 증상
채팅 입력바가 키보드 뒤늦게 따라오는 잔상(resize:native).

## 작업 내용
1. capacitor.config: resize 'native'→'none'
2. ChatFab 패널: bottom: var(--hinest-keyboard-h) + transition (동시 상승)
3. AndroidManifest: windowSoftInputMode=adjustResize
4. 인라인 폼은 기존 scrollIntoView(center) 로 안전

## 검증
- Login(중앙정렬+--hinest-keyboard-h)·BottomSheet 무회귀 확인(코드), tsc + 시뮬 빌드 성공
- ⚠️ 애니메이션 '느낌'은 기기 최종 확인 필요(시뮬 소프트키보드 미표시). 네이티브 — 재빌드 필요

Closes #1007

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1007
