### PR TITLE
🔀 :: (#1011) 인터넷 끊김=로그아웃 버그 + 로그인 화면 네비바 누수

### DIFF
--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { api, clearApiCache } from "./api";
 import { setAuthToken, clearAuthToken } from "./lib/authToken";
 import { requestNotifPermissionOnLogin } from "./lib/notifPermission";
@@ -46,25 +46,37 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [impersonator, setImpersonator] = useState<Impersonator | null>(null);
   const [loading, setLoading] = useState(true);
+  // 세션 복원 재시도 — 네트워크 오류 시 잠시 후 다시 /api/me. (refreshRef 로 안전한 자기 참조)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const refreshRef = useRef<() => Promise<void>>();
 
   const refresh = useCallback(async () => {
+    if (retryTimerRef.current) { clearTimeout(retryTimerRef.current); retryTimerRef.current = null; }
     try {
       const res = await api<{ user: User; impersonator: Impersonator | null }>("/api/me");
       setUser(res.user);
       setImpersonator(res.impersonator ?? null);
-    } catch (e: any) {
-      setUser(null);
-      setImpersonator(null);
-      // 네이티브: 저장된 토큰이 만료/무효(401)면 제거 — 다음 로그인 때 새로 받는다.
-      // (일시 네트워크 오류 등 비-401 은 토큰을 지우지 않아 재시도 시 세션 유지.)
-      if (e?.status === 401) clearAuthToken();
-    } finally {
       setLoading(false);
+    } catch (e: any) {
+      if (e?.status === 401) {
+        // 진짜 인증 실패(세션 만료·무효) — 토큰 제거 + 로그아웃(→ /login).
+        clearAuthToken();
+        setUser(null);
+        setImpersonator(null);
+        setLoading(false);
+      } else {
+        // 네트워크·타임아웃 등 비-401 — 인증 실패가 아니므로 절대 로그아웃하지 않는다(인터넷이 잠깐
+        // 끊겨도 로그인 화면으로 안 튕긴다). loading/user 를 건드리지 않아: 첫 로드면 로딩(스켈레톤)
+        // 유지, 이미 로그인 상태면 셸 유지. 잠시 후 재시도 → 연결되면 정상 로드, 끝내 401 이면 그때 로그아웃.
+        retryTimerRef.current = setTimeout(() => { void refreshRef.current?.(); }, 2500);
+      }
     }
   }, []);
+  refreshRef.current = refresh;
 
   useEffect(() => {
     refresh();
+    return () => { if (retryTimerRef.current) clearTimeout(retryTimerRef.current); };
   }, [refresh]);
 
   // 세션 만료/무효 전역 처리 — 페이지 사용 도중 세션이 끊기면 api.ts 가 'hinest:unauthorized'

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, Navigate, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 import BrandLockup from "../components/BrandLockup";
 import SoftInput from "../components/SoftInput";
 import { isInstalledApp } from "../lib/platform";
+import { setNativeTabBarHidden } from "../lib/liquidGlassTabBar";
 
 // 회사(테넌트) 상태로 로그인이 막힌 경우의 코드 — 비밀번호 오류처럼 빨갛게 보이지 않게 별도 톤 처리.
 const COMPANY_ERROR_CODES = ["COMPANY_PENDING", "COMPANY_SUSPENDED", "COMPANY_REJECTED", "COMPANY_INACTIVE"];
@@ -22,6 +23,13 @@ export default function LoginPage() {
   const [err, setErr] = useState("");
   const [errCode, setErrCode] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // 강제 이탈(세션 만료·네트워크 등)로 셸(AppLayout)이 깔끔히 언마운트되지 않아도 로그인 화면엔
+  // 네이티브 하단 탭바가 안 보이게 직접 숨긴다(방어). 로그인 성공 → 셸 마운트가 다시 보이게 한다.
+  useEffect(() => {
+    setNativeTabBarHidden("auth", true);
+    return () => setNativeTabBarHidden("auth", false);
+  }, []);
 
   // 콘솔 전용 계정(consoleOnly)만 운영 콘솔로 직행. 일반 총관리자(superAdmin) 는 회사 앱
   // 홈으로 보낸 뒤, 사이드바의 '운영 콘솔' 링크로 왕복하게 한다. (총관리자도 평상시엔 회사


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

## 증상
1. 인터넷 끊기면 즉시 로그아웃→로그인 화면(세션 유효한데도)
2. 그 로그인 화면에 네이티브 네비바 잔존

## 작업
- auth.tsx refresh: **401만 로그아웃**, 네트워크 오류는 loading/user 유지 + 2.5s 재시도(로그인 화면 안 감)
- LoginPage: 마운트 시 네이티브 바 직접 숨김(방어)

## 검증
- tsc 통과 · 웹/OTA · 기기에서 인터넷 끊고 확인

Closes #1011

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1011
