### PR TITLE
🔀 :: (#1015) 세션 복원 중 '불러오는 중…' → 앱 셸 스켈레톤

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import AppStoreUpdatePrompt from "./components/AppStoreUpdatePrompt";
 import DownloadToastHost from "./components/DownloadToast";
 import ConfirmHost from "./components/ConfirmHost";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { Skeleton, SkeletonList, SkeletonStatGrid } from "./components/Skeleton";
 import LoginPage from "./pages/LoginPage";
 import SignupPage from "./pages/SignupPage";
 import CompanySignupPage from "./pages/CompanySignupPage";
@@ -55,14 +56,50 @@ function RouteFallback() {
   return <div className="min-h-[60vh]" aria-hidden />;
 }
 
+/**
+ * 인증 복원(세션 확인) 중 보여주는 앱 셸 스켈레톤.
+ * 오프라인에서 새로고침해도 로그아웃되지 않고(auth.tsx 의 비-401 재시도) loading 이 유지되는데,
+ * 그동안 "불러오는 중…" 텍스트 대신 다가올 화면 형태를 스켈레톤으로 미리 보여줘 네이티브 앱처럼
+ * 느껴지게 한다. 이 단계엔 AppLayout 셸이 아직 안 붙으므로 상단바·본문을 직접 흉내 낸다.
+ * 색은 디자인 토큰(var(--c-bg), Skeleton 의 --c-surface-3)이라 다크/라이트 자동 대응.
+ */
+function ProtectedFallback() {
+  return (
+    <div
+      className="min-h-screen"
+      style={{
+        background: "var(--c-bg)",
+        paddingTop: "max(env(safe-area-inset-top), 12px)",
+        paddingBottom: "calc(env(safe-area-inset-bottom) + 88px)",
+      }}
+      aria-hidden
+    >
+      {/* 상단바 흉내 — 좌측 타이틀, 우측 아이콘 자리 */}
+      <div className="flex items-center justify-between px-4" style={{ height: 56 }}>
+        <Skeleton w={116} h={22} radius={6} />
+        <div className="flex items-center gap-2.5">
+          <Skeleton circle w={32} h={32} />
+          <Skeleton circle w={32} h={32} />
+        </div>
+      </div>
+      {/* 본문 — 통계 그리드 + 섹션 리스트(데스크톱에선 가운데 정렬) */}
+      <div
+        className="px-4 pt-3 mx-auto w-full max-w-3xl"
+        style={{ display: "flex", flexDirection: "column", gap: 22 }}
+      >
+        <SkeletonStatGrid count={4} />
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <Skeleton w={132} h={16} radius={6} />
+          <SkeletonList rows={4} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function Protected({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth();
-  if (loading)
-    return (
-      <div className="h-screen grid place-items-center text-slate-400">
-        불러오는 중…
-      </div>
-    );
+  if (loading) return <ProtectedFallback />;
   if (!user) return <Navigate to="/login" replace />;
   return <>{children}</>;
 }


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1015

## 배경
오프라인에서 새로고침하면 #1012 로 로그아웃되지 않고 `loading` 이 유지되며 세션 복원을 2.5초마다 재시도한다. 그동안 `Protected`(App.tsx)가 **"불러오는 중…"** 텍스트만 풀스크린으로 띄워 네이티브 앱답지 않았다.

> 사용자: "인터넷 끊끼면 이런식으로 뜨는게 아니라 UI들이 스켈레톤 UI로 떠야한다니까"

## 변경
- `App.tsx`: `ProtectedFallback` 추가 — 상단바(타이틀·아이콘)·통계 그리드·섹션 리스트 형태의 앱 셸 스켈레톤
- `Protected` 의 `loading` 분기를 텍스트 → `<ProtectedFallback />` 로 교체
- 기존 `Skeleton`/`SkeletonList`/`SkeletonStatGrid`(약 20개 페이지에서 검증된 컴포넌트) 재사용
- 색은 디자인 토큰(`var(--c-bg)`, Skeleton 의 `--c-surface-3` + 시머)이라 다크/라이트 자동 대응
- safe-area: 상단 노치 `max(env(safe-area-inset-top), 12px)`, 하단 네이티브 탭바 자리 `+88px`

## 검증
- `tsc -b` 통과
- 미리보기에서 백엔드 없이(=오프라인 동등) `/` 진입 → 스켈레톤이 자연스럽게 뜨고 **지속됨**(refresh 가 비-401 로 재시도, loading 유지). 다크·라이트 모두 스크린샷 확인.

## 영향
- 웹/iOS/Android/데스크톱 공통(플랫폼 무관). 머지 시 OTA 자동 배포.

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1015
