### PR TITLE
🔀 :: (#1017) 코드베이스 정리 — 데드코드 제거 + 중복 통합 (동작 불변)

### DIFF
--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -1822,7 +1822,6 @@ function TopBar({ draggable = false, onOpenNav, safeAreaTop = false }: { draggab
 
 /* ---------- Icons ---------- */
 type I = { active?: boolean };
-const swInv = (a?: boolean) => (a ? "#fff" : "#6B7280");
 
 function svgBase(_active: boolean, path: React.ReactNode) {
   return (
@@ -1848,4 +1847,3 @@ function SnippetIcon({ active }: I) { return svgBase(!!active, <><path d="m8 3-4
 function ShieldIcon({ active }: I) { return svgBase(!!active, <><path d="M12 3 4 6v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V6z" /><path d="m9 12 2 2 4-4" /></>); }
 function PayrollIcon({ active }: I) { return svgBase(!!active, <><path d="M4 4h16v16H4z" /><path d="M8 8h8M8 12h8M8 16h5" /></>); }
 function DevIcon({ active }: I) { return svgBase(!!active, <><polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" /></>); }
-const _unused_swInv = swInv;

--- a/client/src/components/Linkify.tsx
+++ b/client/src/components/Linkify.tsx
@@ -31,7 +31,7 @@ export default function Linkify({
     if (start > last) parts.push(text.slice(last, start));
 
     let href = matched;
-    let label = matched;
+    const label = matched;
     if (m[3]) {
       // email
       href = `mailto:${matched}`;

--- a/client/src/components/ProjectSettingsModal.tsx
+++ b/client/src/components/ProjectSettingsModal.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { api, invalidateCache , imgSrc} from "../api";
 import { confirmAsync } from "./ConfirmHost";
 import Portal from "./Portal";
-import Select, { type SelectOption } from "./Select";
+import Select from "./Select";
 
 type Role = "OWNER" | "MANAGER" | "MEMBER";
 

--- a/client/src/components/SuperStepUpGate.tsx
+++ b/client/src/components/SuperStepUpGate.tsx
@@ -42,7 +42,6 @@ export default function SuperStepUpGate({ children }: { children: React.ReactNod
     }
   }
 
-  const isElectron = typeof window !== "undefined" && !!window.hinest?.isDesktop;
 
   async function loadPasskeys() {
     try {
@@ -372,40 +371,7 @@ function formatAbsolute(iso: string) {
   return `${yy}.${mm}.${dd} ${hh}:${mi}`;
 }
 
-/** 상대시간(오늘/어제/N일 전/N달 전) — 현재 사용 안 함, 백업용 */
-function formatRelative(iso: string) {
-  const d = new Date(iso);
-  const diffMs = Date.now() - d.getTime();
-  const diffMin = Math.floor(diffMs / 60000);
-  const diffHr = Math.floor(diffMin / 60);
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffMin < 1) return "방금";
-  if (diffMin < 60) return `${diffMin}분 전`;
-  if (diffHr < 24) return `${diffHr}시간 전`;
-  if (diffDay === 1) return "어제";
-  if (diffDay < 7) return `${diffDay}일 전`;
-  if (diffDay < 30) return `${Math.floor(diffDay / 7)}주 전`;
-  if (diffDay < 365) return `${Math.floor(diffDay / 30)}달 전`;
-  return d.toLocaleDateString("ko-KR", { year: "numeric", month: "short", day: "numeric" });
-}
 
-function EmptyDevicesState() {
-  return (
-    <div className="flex items-center gap-3 p-4 rounded-xl border border-dashed border-ink-200 bg-ink-25">
-      <div className="w-10 h-10 rounded-xl bg-ink-100 text-ink-500 grid place-items-center flex-shrink-0">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="4" y="4" width="16" height="12" rx="2" /><path d="M2 20h20M8 16v4M16 16v4" />
-        </svg>
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="text-[13px] font-bold text-ink-900">아직 등록된 기기가 없습니다</div>
-        <div className="text-[11.5px] text-ink-500 mt-0.5 leading-[1.5]">
-          아래에서 이 맥북을 등록하면 다음부터 비밀번호 없이 Touch ID 로 잠금을 해제할 수 있어요.
-        </div>
-      </div>
-    </div>
-  );
-}
 
 function DesktopBiometricPanel({
   devices, deviceId, reload,

--- a/client/src/components/chat/theme.tsx
+++ b/client/src/components/chat/theme.tsx
@@ -111,20 +111,6 @@ export function formatClock(d: Date): string {
   return `${period} ${hh}:${mm}`;
 }
 
-/**
- * 간결 상대 시각 — "방금 / N분 전 / N시간 전 / M/D (하루 이상)".
- * 채팅 마지막 메시지 옆에 붙일 때 사용.
- */
-export function formatShort(d: Date): string {
-  const diff = Date.now() - d.getTime();
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return "방금";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}분 전`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}시간 전`;
-  return `${d.getMonth() + 1}/${d.getDate()}`;
-}
 
 /**
  * 채팅 메시지 사이 날짜 구분선 라벨.

--- a/client/src/components/superadmin/ErrorsPanel.tsx
+++ b/client/src/components/superadmin/ErrorsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync } from "../ConfirmHost";
+import { relTime } from "./relTime";
 import Portal from "../Portal";
 
 type Group = {
@@ -157,10 +158,3 @@ export default function ErrorsPanel() {
   );
 }
 
-function relTime(ms: number): string {
-  const diff = Date.now() - ms;
-  if (diff < 60_000) return "방금";
-  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}분 전`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3600_000)}시간 전`;
-  return `${Math.floor(diff / 86_400_000)}일 전`;
-}

--- a/client/src/components/superadmin/SessionsPanel.tsx
+++ b/client/src/components/superadmin/SessionsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api";
 import { confirmAsync, alertAsync } from "../ConfirmHost";
+import { relTime } from "./relTime";
 import { useConsoleCompany } from "./companyFilter";
 
 type Session = {
@@ -101,7 +102,7 @@ export default function SessionsPanel() {
                 </td>
                 <td className="py-2 pr-2 text-ink-700 sm:truncate sm:max-w-[280px]" data-label="디바이스" title={s.ua ?? ""}>{shortenUA(s.ua)}</td>
                 <td className="py-2 pr-2 text-ink-700 font-mono text-[11px]" data-label="IP">{s.ip ?? "—"}</td>
-                <td className="py-2 pr-2 text-ink-700" data-label="최근 활동">{relTime(s.lastSeenAt)}</td>
+                <td className="py-2 pr-2 text-ink-700" data-label="최근 활동">{relTime(new Date(s.lastSeenAt).getTime())}</td>
                 <td className="py-2 pr-2 text-right cell-actions">
                   <button className="btn-ghost btn-xs" onClick={() => revokeOne(s.id, s.user.name)} disabled={busy}>이 세션 종료</button>
                   <button className="btn-ghost btn-xs ml-1" onClick={() => revokeUser(s.userId, s.user.name)} disabled={busy}>전 디바이스</button>
@@ -126,10 +127,3 @@ function shortenUA(ua: string | null): string {
   return [m ? `${m[1]} ${m[2].split(".")[0]}` : "Browser", os ? os[1].split(";")[0] : ""].filter(Boolean).join(" · ");
 }
 
-function relTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  if (diff < 60_000) return "방금";
-  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}분 전`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3600_000)}시간 전`;
-  return `${Math.floor(diff / 86_400_000)}일 전`;
-}

--- a/client/src/components/superadmin/companyFilter.tsx
+++ b/client/src/components/superadmin/companyFilter.tsx
@@ -45,11 +45,6 @@ export function useConsoleCompany(): Ctx {
   return useContext(ConsoleCompanyContext);
 }
 
-/** 회사 fetch 쿼리스트링 헬퍼 — companyId 가 있으면 &companyId=... 를 덧붙인다. */
-export function appendCompanyParam(params: URLSearchParams, companyId: string | null): URLSearchParams {
-  if (companyId) params.set("companyId", companyId);
-  return params;
-}
 
 export function CompanyFilterProvider({ children }: { children: ReactNode }) {
   const [sp, setSp] = useSearchParams();

--- a/client/src/components/superadmin/relTime.ts
+++ b/client/src/components/superadmin/relTime.ts
@@ -1,0 +1,12 @@
+/**
+ * 운영 콘솔 공용 상대시간 — "방금 / N분 전 / N시간 전 / N일 전".
+ * epoch millis(ms)를 받는다. ISO 문자열이면 호출부에서 new Date(iso).getTime() 으로 넘긴다.
+ * (ErrorsPanel·SessionsPanel 에 중복돼 있던 동일 구현을 한 곳으로 모음.)
+ */
+export function relTime(ms: number): string {
+  const diff = Date.now() - ms;
+  if (diff < 60_000) return "방금";
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}분 전`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3600_000)}시간 전`;
+  return `${Math.floor(diff / 86_400_000)}일 전`;
+}

--- a/client/src/lib/holidays.ts
+++ b/client/src/lib/holidays.ts
@@ -114,11 +114,4 @@ export function getHoliday(d: Date): Holiday | undefined {
   return MAP.get(ymd(d));
 }
 
-export function isHoliday(d: Date): boolean {
-  return MAP.has(ymd(d));
-}
 
-/** 일요일 또는 공휴일이면 true */
-export function isRedDay(d: Date): boolean {
-  return d.getDay() === 0 || isHoliday(d);
-}

--- a/client/src/lib/previewMock.ts
+++ b/client/src/lib/previewMock.ts
@@ -10,7 +10,6 @@
  */
 
 const TODAY = new Date();
-const ymd = TODAY.toISOString().slice(0, 10);
 function iso(daysOffset: number, hour = 9, min = 0): string {
   const d = new Date(TODAY);
   d.setDate(d.getDate() + daysOffset);

--- a/client/src/lib/useRefresh.ts
+++ b/client/src/lib/useRefresh.ts
@@ -1,0 +1,23 @@
+import { useState } from "react";
+
+/**
+ * 페이지 새로고침 공통 훅 — `refreshing` 플래그 + `refresh()` 래퍼.
+ *
+ * 여러 페이지에 동일하게 복제돼 있던 패턴
+ *   const [refreshing, setRefreshing] = useState(false);
+ *   async function refresh() { setRefreshing(true); try { await load(); } finally { setRefreshing(false); } }
+ * 을 한 곳으로 모은 것. `fn` 에 데이터 로더(load / reload / Promise.all(...) 등)를 그대로 넘긴다.
+ * 동작은 기존과 동일 — refresh 호출 동안 refreshing=true, 끝나면(성공/실패 무관) false.
+ */
+export function useRefresh(fn: () => Promise<unknown>): { refreshing: boolean; refresh: () => Promise<void> } {
+  const [refreshing, setRefreshing] = useState(false);
+  const refresh = async () => {
+    setRefreshing(true);
+    try {
+      await fn();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+  return { refreshing, refresh };
+}

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";

--- a/client/src/pages/ApprovalsPage.tsx
+++ b/client/src/pages/ApprovalsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
@@ -118,7 +119,7 @@ export default function ApprovalsPage() {
   };
   const [approvals, setApprovals] = useState<Approval[]>([]);
   const [loaded, setLoaded] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => load());
   const [loadErr, setLoadErr] = useState(false);
   const [selected, setSelected] = useState<Approval | null>(null);
   const [creating, setCreating] = useState(false);
@@ -163,11 +164,6 @@ export default function ApprovalsPage() {
       if (!aliveRef.current || myToken !== loadTokenRef.current) return;
       setLoadErr(true);
     }
-  }
-  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await load(); } finally { setRefreshing(false); }
   }
   async function loadDirectory() {
     try {

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
 import { Skeleton } from "../components/Skeleton";
@@ -74,7 +75,7 @@ export default function AttendancePage() {
   const [month, setMonth] = useState(ymNow());
   const [records, setRecords] = useState<Attendance[]>([]);
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => load());
   const [leaves, setLeaves] = useState<Leave[]>([]);
   const [allLeaves, setAllLeaves] = useState<Leave[]>([]);
   const [open, setOpen] = useState(false);
@@ -111,11 +112,6 @@ export default function AttendancePage() {
     }
   }
 
-  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await load(); } finally { setRefreshing(false); }
-  }
 
   // SWR — 월별 출퇴근과 휴가 목록은 탭 재진입 시 캐시로 즉시 채움.
   const isReviewer = user?.role === "ADMIN" || user?.role === "MANAGER";

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -633,13 +633,6 @@ function dowLabel(n: number) {
 function formatHM(iso: string) {
   return new Date(iso).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" });
 }
-function durationLabel(c: string, o: string) {
-  const ms = new Date(o).getTime() - new Date(c).getTime();
-  if (ms <= 0) return "-";
-  const h = Math.floor(ms / 3600000);
-  const m = Math.floor((ms % 3600000) / 60000);
-  return `${h}h ${m}m`;
-}
 function msToHM(ms: number) {
   const h = Math.floor(ms / 3600000);
   const m = Math.floor((ms % 3600000) / 60000);

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -52,12 +52,6 @@ type Doc = {
 };
 
 type ScopeTab = "all" | "public" | "team" | "private" | "custom";
-const SCOPE_TABS: { key: ScopeTab; label: string }[] = [
-  { key: "all",     label: "전체" },
-  { key: "team",    label: "팀" },
-  { key: "private", label: "개인" },
-  { key: "custom",  label: "사용자지정" },
-];
 const SCOPE_LABEL: Record<DocScope, string> = {
   ALL: "전체 공개",
   TEAM: "팀 공개",

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api, apiFetch , imgSrc} from "../api";
+import { fmtSize } from "../lib/fmt";
 import { Skeleton } from "../components/Skeleton";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
@@ -1443,7 +1444,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                           onClick={() => openDocOrDownload(d)}
                           className="inline-flex items-center gap-1 max-w-[180px] sm:max-w-[260px] align-middle text-[12px] font-bold text-brand-600 hover:underline tabular text-left">
                           <span className="truncate">{d.fileName}</span>
-                          <span className="text-ink-400 flex-shrink-0">({humanSize(d.fileSize ?? 0)})</span>
+                          <span className="text-ink-400 flex-shrink-0">({fmtSize(d.fileSize ?? 0)})</span>
                         </button>
                       );
                     })()}
@@ -1526,7 +1527,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
             const ft: [string, string] = isMemo
               ? ["MEMO", "bg-violet-50 text-violet-700"]
               : (TM[ext] ?? [ext ? ext.slice(0, 3).toUpperCase() : "FILE", "bg-ink-100 text-ink-600"]);
-            const meta = isMemo ? "메모" : `${(ext || "file").toUpperCase()} · ${humanSize(d.fileSize ?? 0)}`;
+            const meta = isMemo ? "메모" : `${(ext || "file").toUpperCase()} · ${fmtSize(d.fileSize ?? 0)}`;
             const openDoc = () => {
               if (isMemo) { setMemoTarget(d); return; }
               // 데스크톱 파일명 링크와 동일: 미리보기 가능하면 열고, 그 외(.docx 등)는 다운로드.
@@ -1703,7 +1704,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                 ) : docForm.fileUrl ? (
                   <>
                     <div className="text-[13px] font-bold text-brand-600">✓ {docForm.fileName}</div>
-                    <div className="text-[11px] text-ink-500 tabular">{humanSize(docForm.fileSize)} · 클릭해서 변경</div>
+                    <div className="text-[11px] text-ink-500 tabular">{fmtSize(docForm.fileSize)} · 클릭해서 변경</div>
                   </>
                 ) : (
                   <>
@@ -1877,9 +1878,3 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   );
 }
 
-function humanSize(n: number) {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
-  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
-}

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { useSearchParams } from "react-router-dom";
 import { api } from "../api";
 import { useAuth } from "../auth";
@@ -58,7 +59,7 @@ export default function ExpensePage() {
   const [list, setList] = useState<Expense[]>([]);
   const [total, setTotal] = useState(0);
   const [loaded, setLoaded] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => load());
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({
     usedAt: todayDT(),
@@ -88,11 +89,6 @@ export default function ExpensePage() {
     setLoaded(true);
   }
 
-  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await load(); } finally { setRefreshing(false); }
-  }
 
   useEffect(() => {
     const aliveRef = { current: true };

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { api, apiSWR } from "../api";
 import PageHeader from "../components/PageHeader";
 import { Skeleton } from "../components/Skeleton";
@@ -33,7 +34,7 @@ type Mode = "view" | "create" | "edit";
 export default function JournalPage() {
   const [list, setList] = useState<Journal[]>([]);
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => load());
   const [selected, setSelected] = useState<Journal | null>(null);
   const [form, setForm] = useState({ date: today(), title: "", content: "" });
   const [mode, setMode] = useState<Mode>("view");
@@ -72,8 +73,6 @@ export default function JournalPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 데스크탑 새로고침 버튼 — 최신 목록을 강제로 다시 가져온다(현재 선택은 유지).
-  // 모바일은 PTR 이 전역으로 담당.
   async function load() {
     try {
       const d = await api<{ journals: Journal[] }>("/api/journal");
@@ -83,10 +82,6 @@ export default function JournalPage() {
     } finally {
       if (aliveRef.current) setLoading(false);
     }
-  }
-  async function refresh() {
-    setRefreshing(true);
-    try { await load(); } finally { setRefreshing(false); }
   }
 
   function openCreate() {

--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import PageHeader from "../components/PageHeader";
@@ -178,7 +179,7 @@ function SkeletonCard() {
 export default function MemosPage() {
   const [memos, setMemos] = useState<Memo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => load());
   const [scopeTab, setScopeTab] = useState<ScopeTab>("all");
   const [q, setQ] = useState("");
   const [debouncedQ, setDebouncedQ] = useState("");
@@ -221,11 +222,6 @@ export default function MemosPage() {
     load();
   }, [load]);
 
-  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await load(); } finally { setRefreshing(false); }
-  }
 
   // Cmd/Ctrl+K → 검색 포커스
   useEffect(() => {

--- a/client/src/pages/MemosPage.tsx
+++ b/client/src/pages/MemosPage.tsx
@@ -1,7 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
-import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { Skeleton } from "../components/Skeleton";
 import type { MemoDoc } from "../components/DocMemoModal";
@@ -177,7 +176,6 @@ function SkeletonCard() {
 
 // ===== 메인 페이지 =====
 export default function MemosPage() {
-  const { user } = useAuth();
   const [memos, setMemos] = useState<Memo[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);

--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { useNavigate } from "react-router-dom";
 import { useNotifications, type Notif } from "../notifications";
 import { NotifRow, navigateToNotif } from "../components/notifShared";
@@ -18,7 +19,7 @@ export default function NotificationsPage() {
   // 첫 reload 완료 여부 — useNotifications 훅이 loading 을 노출하지 않으므로 로컬로 추적.
   // false 동안엔 빈 영역 대신 Skeleton 행을 띄워 깜빡임 제거.
   const [loaded, setLoaded] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => reload());
 
   // 페이지 진입 시 최신 알림으로 한 번 갱신(프로바이더의 주기 폴링과 별개로 즉시 동기화).
   useEffect(() => {
@@ -27,11 +28,6 @@ export default function NotificationsPage() {
     return () => { alive = false; };
   }, [reload]);
 
-  // 데스크탑 새로고침 버튼 — 알림 목록만 다시 불러온다(전체 reload 아님). 모바일은 PTR 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await reload(); } finally { setRefreshing(false); }
-  }
 
   const visible = tab === "unread" ? bellItems.filter((n) => !n.readAt) : bellItems;
 

--- a/client/src/pages/OrgChartPage.tsx
+++ b/client/src/pages/OrgChartPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { useNavigate } from "react-router-dom";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
@@ -31,7 +32,7 @@ export default function OrgChartPage() {
   const [users, setUsers] = useState<DirUser[]>([]);
   const [positions, setPositions] = useState<Position[]>([]);
   const [loaded, setLoaded] = useState(false);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => Promise.all([load(), loadPositions()]));
   const [dmBusyId, setDmBusyId] = useState<string | null>(null);
   const [view, setView] = useState<ViewMode>(() => {
     try {
@@ -61,11 +62,6 @@ export default function OrgChartPage() {
     setLoaded(true);
   }
 
-  // 데스크탑 새로고침 — 구성원 + 직급을 다시 불러온다(전체 reload 아님). 모바일은 PTR 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await Promise.all([load(), loadPositions()]); } finally { setRefreshing(false); }
-  }
 
   async function loadPositions() {
     try {

--- a/client/src/pages/PayrollPage.tsx
+++ b/client/src/pages/PayrollPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
@@ -25,7 +26,7 @@ export default function PayrollPage() {
   const [employees, setEmployees] = useState<EmployeeOption[]>([]);
   const [list, setList] = useState<Payslip[]>([]);
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => reload());
   const [year, setYear] = useState(NOW.getFullYear());
   const [month, setMonth] = useState<number | 0>(0); // 0 = 전체
   const [employeeId, setEmployeeId] = useState("");
@@ -71,11 +72,6 @@ export default function PayrollPage() {
       .catch(() => {});
   }
 
-  // 데스크탑 새로고침 버튼 — 현재 필터 그대로 목록을 다시 불러온다. 모바일은 PTR 이 전역으로 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await reload(); } finally { setRefreshing(false); }
-  }
 
   function onSaved(p: Payslip) {
     setComposing(false);

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 import { api, invalidateCache, clearApiCache, apiFetch , imgSrc} from "../api";
 import { isCapacitorNative, nativePlatform } from "../lib/platform";
 import { useAuth } from "../auth";

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -2,7 +2,6 @@ import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { api , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
-import { Skeleton } from "../components/Skeleton";
 import { getHoliday } from "../lib/holidays";
 import DateTimePicker from "../components/DateTimePicker";
 import { confirmAsync, alertAsync } from "../components/ConfirmHost";

--- a/client/src/pages/SchedulePage.tsx
+++ b/client/src/pages/SchedulePage.tsx
@@ -48,7 +48,6 @@ export default function SchedulePage() {
   const [cursor, setCursor] = useState(() => new Date());
   const [events, setEvents] = useState<Event[]>([]);
   // 첫 로드 완료 여부 — false 동안 빈 영역 대신 Skeleton 을 띄워 깜빡임 제거.
-  const [loaded, setLoaded] = useState(false);
   // 일정 로드 실패 표시 — 조용히 빈 달력으로 두지 않고 재시도 배너를 띄운다.
   const [loadErr, setLoadErr] = useState(false);
   const [open, setOpen] = useState(false);
@@ -88,7 +87,6 @@ export default function SchedulePage() {
       if (aliveRef && !aliveRef.current) return;
       setEvents(res.events);
       setLoadErr(false);
-      setLoaded(true);
     } catch {
       // 401(세션 만료)은 api.ts 가 전역 처리(→ /login). 그 외(500·네트워크)는 재시도 배너.
       if (aliveRef && !aliveRef.current) return;
@@ -486,59 +484,6 @@ function WeekAgenda({ days, eventsOn, onOpenDay }: { days: Date[]; eventsOn: (d:
           </div>
         );
       })}
-    </div>
-  );
-}
-
-/** 월 보기(모바일) — 선택한 하루의 일정 아젠다. 컴팩트한 월 그리드 아래의 빈 공간을
- *  실제 콘텐츠로 채워 'iOS 캘린더'처럼 자연스럽게 만든다. 데스크톱은 셀 안 칩으로 충분해 숨김. */
-function DayAgenda({ date, events, onOpenEvent, onAdd }: { date: Date; events: Event[]; onOpenEvent: () => void; onAdd: () => void }) {
-  const DOW = ["일", "월", "화", "수", "목", "금", "토"];
-  const dow = date.getDay();
-  const isToday = new Date().toDateString() === date.toDateString();
-  const titleColor = dow === 0 ? "text-rose-500" : dow === 6 ? "text-accent-500" : "text-ink-900";
-  return (
-    <div className="card cal-fullbleed p-0 overflow-hidden">
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-ink-100">
-        <span className={`text-[15px] font-extrabold tabular ${titleColor}`}>
-          {date.getMonth() + 1}월 {date.getDate()}일
-        </span>
-        <span className="text-[12.5px] font-bold text-ink-500">{DOW[dow]}요일</span>
-        {isToday && (
-          <span className="text-[10px] font-extrabold text-brand-600 bg-brand-50 dark:bg-brand-500/15 px-1.5 py-0.5 rounded-full">오늘</span>
-        )}
-        <span className="ml-auto text-[12px] font-bold text-ink-400 tabular">{events.length}건</span>
-      </div>
-      {events.length === 0 ? (
-        <button type="button" onClick={onAdd} className="w-full px-4 py-10 flex flex-col items-center gap-1 active:bg-ink-25 transition">
-          <span className="text-[13px] text-ink-400">이 날은 일정이 없어요</span>
-          <span className="text-[12.5px] font-bold text-brand-600">+ 일정 추가</span>
-        </button>
-      ) : (
-        <div className="divide-y divide-ink-100">
-          {events.map((e) => (
-            <button
-              key={e.id}
-              type="button"
-              onClick={onOpenEvent}
-              className="w-full flex items-center gap-3 text-left px-4 py-3 hover:bg-ink-25 active:bg-ink-50 transition"
-            >
-              <span className="w-1 h-9 rounded-full flex-shrink-0" style={{ background: e.color }} />
-              <div className="flex-1 min-w-0">
-                <div className="text-[14px] font-bold text-ink-900 truncate">{e.title}</div>
-                <div className="text-[11.5px] text-ink-500 tabular mt-0.5">
-                  {new Date(e.startAt).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" })}
-                  {" – "}
-                  {new Date(e.endAt).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" })}
-                </div>
-              </div>
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-ink-300 flex-shrink-0">
-                <polyline points="9 18 15 12 9 6" />
-              </svg>
-            </button>
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { api, apiFetch , imgSrc} from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
@@ -191,7 +192,7 @@ export default function ServiceAccountsPage() {
   const [users, setUsers] = useState<DirUser[]>([]);
   const [projects, setProjects] = useState<ProjectChip[]>([]);
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => load());
   const [loadErr, setLoadErr] = useState<string | null>(null);
   const [q, setQ] = useState("");
   const [filterCat, setFilterCat] = useState<Category | "ALL">("ALL");
@@ -223,11 +224,6 @@ export default function ServiceAccountsPage() {
     }
   }
 
-  // 데스크탑 새로고침 버튼 — load() 재호출. 모바일은 PTR 이 전역으로 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await load(); } finally { setRefreshing(false); }
-  }
 
   useEffect(() => {
     load();

--- a/client/src/pages/ServiceAccountsPage.tsx
+++ b/client/src/pages/ServiceAccountsPage.tsx
@@ -116,7 +116,6 @@ function guessHost(url: string | null, name: string): string | null {
 }
 
 type Scope = "ALL" | "TEAM" | "PROJECT";
-const SCOPE_LABEL: Record<Scope, string> = { ALL: "전사", TEAM: "팀", PROJECT: "프로젝트" };
 type ScopeTab = "ALL_TAB" | Scope;
 
 type OwnerUser = { id: string; name: string; avatarColor: string; avatarUrl: string | null; email: string; team?: string | null; position?: string | null };

--- a/client/src/pages/SnippetsPage.tsx
+++ b/client/src/pages/SnippetsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRefresh } from "../lib/useRefresh";
 import { api } from "../api";
 import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
@@ -47,7 +48,7 @@ export default function SnippetsPage() {
   const [list, setList] = useState<Snippet[]>([]);
   const [q, setQ] = useState("");
   const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
+  const { refreshing, refresh } = useRefresh(() => load());
   const [editing, setEditing] = useState<Snippet | null>(null);
   const [creating, setCreating] = useState(false);
   const aliveRef = useRef(true);
@@ -70,11 +71,6 @@ export default function SnippetsPage() {
     }
   }
 
-  // 데스크탑 새로고침 버튼 — load() 재호출(전체 reload 아님). 모바일은 PTR 이 전역으로 담당.
-  async function refresh() {
-    setRefreshing(true);
-    try { await load(); } finally { setRefreshing(false); }
-  }
 
   // 검색어 디바운스 — 빠르게 타이핑할 때 매 키마다 GET 안 치도록.
   useEffect(() => {

--- a/client/src/pages/SuperAdminPage.tsx
+++ b/client/src/pages/SuperAdminPage.tsx
@@ -1,6 +1,7 @@
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, Route, Routes, useNavigate, useSearchParams } from "react-router-dom";
 import { api , imgSrc} from "../api";
+import { fmtSize } from "../lib/fmt";
 import { safeUploadUrl } from "../lib/safeUrl";
 import { isCapacitorNative } from "../lib/platform";
 import { Browser } from "@capacitor/browser";
@@ -915,7 +916,7 @@ function AuditAttachment({ msg }: { msg: Message }) {
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6" />
       </svg>
       <span className="text-[12px] font-semibold">{msg.fileName}</span>
-      <span className="text-[10px] text-ink-500 tabular">{humanSize(msg.fileSize ?? 0)}</span>
+      <span className="text-[10px] text-ink-500 tabular">{fmtSize(msg.fileSize ?? 0)}</span>
     </a>
   );
 }
@@ -926,12 +927,6 @@ function RoomTypeChip({ type }: { type: Room["type"] }) {
   return <span className="chip-gray">GROUP</span>;
 }
 
-function humanSize(n: number) {
-  if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
-  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
-  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
-}
 
 /* =============== API 명세 =============== */
 function ApiSpecPanel() {

--- a/client/src/pages/UserProfilePage.tsx
+++ b/client/src/pages/UserProfilePage.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "../auth";
 import PageHeader from "../components/PageHeader";
 import { Skeleton, SkeletonText } from "../components/Skeleton";
 import { alertAsync } from "../components/ConfirmHost";
-import { isDevAccount, DevBadge } from "../lib/devBadge";
+import { DevBadge } from "../lib/devBadge";
 import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
 
 type ProfileUser = {

--- a/server/src/jobs/dispatchScheduled.ts
+++ b/server/src/jobs/dispatchScheduled.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../lib/db.js";
+import { USER_AVATAR_SELECT } from "../lib/userSelect.js";
 import { publishMany } from "../lib/sse.js";
 import { notifyMany } from "../lib/notify.js";
 
@@ -20,7 +21,7 @@ import { notifyMany } from "../lib/notify.js";
  */
 
 const MESSAGE_INCLUDE = {
-  sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
+  sender: { select: USER_AVATAR_SELECT },
   room: { select: { id: true, name: true, type: true } },
   reactions: { select: { userId: true, emoji: true, user: { select: { name: true } } } },
 } as const;

--- a/server/src/lib/dates.ts
+++ b/server/src/lib/dates.ts
@@ -25,9 +25,6 @@ export function todayStr(): string {
 }
 
 /** 주어진 Date 의 KST 기준 YYYY-MM-DD. */
-export function dateStrKST(d: Date): string {
-  return KST_FMT.format(d);
-}
 
 /** KST 기준 오늘 00:00:00 (UTC Date 오브젝트). */
 export function startOfTodayKST(): Date {

--- a/server/src/lib/sse.ts
+++ b/server/src/lib/sse.ts
@@ -58,8 +58,3 @@ export function publishMany(userIds: string[], event: string, data: unknown) {
 }
 
 /** 디버깅용 */
-export function clientCount() {
-  let n = 0;
-  for (const s of clients.values()) n += s.size;
-  return n;
-}

--- a/server/src/lib/storage.ts
+++ b/server/src/lib/storage.ts
@@ -77,17 +77,6 @@ export function isStorageEnabled(): boolean {
   return !!s3 || !!supabase;
 }
 
-/** 디버깅/헬스체크용 — 현재 어떤 백엔드가 활성인지. */
-export function storageBackend(): "s3" | "supabase" | "none" {
-  if (s3) return "s3";
-  if (supabase) return "supabase";
-  return "none";
-}
-
-export function storageBucket(): string {
-  return s3 ? (S3_BUCKET as string) : SB_BUCKET;
-}
-
 /** 파일 저장. 신규 업로드는 S3 우선. */
 export async function uploadFile(
   key: string,

--- a/server/src/lib/userSelect.ts
+++ b/server/src/lib/userSelect.ts
@@ -1,0 +1,26 @@
+import { Prisma } from "@prisma/client";
+
+/**
+ * 아바타/이름 표시에 쓰는 공통 User select.
+ * 여러 라우트(chat·approval·meeting·document·project·snippet·dispatch 등)에 똑같이
+ * 복제돼 있던 select 블록을 한 곳으로 모은 것. 필드셋이 동일한 곳만 이걸로 치환했다
+ * (email 포함/순서 상이/ id 없음 변형은 그대로 둠). `satisfies` 로 결과 타입 추론 보존.
+ */
+export const USER_AVATAR_SELECT = {
+  id: true,
+  name: true,
+  avatarColor: true,
+  isDeveloper: true,
+  avatarUrl: true,
+} satisfies Prisma.UserSelect;
+
+/** 위 + 직급/팀 — 부서 표시가 필요한 곳(결재 요청자, 채팅 멤버 등). */
+export const USER_AVATAR_SELECT_ORG = {
+  id: true,
+  name: true,
+  avatarColor: true,
+  isDeveloper: true,
+  avatarUrl: true,
+  position: true,
+  team: true,
+} satisfies Prisma.UserSelect;

--- a/server/src/routes/approval.ts
+++ b/server/src/routes/approval.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { USER_AVATAR_SELECT, USER_AVATAR_SELECT_ORG } from "../lib/userSelect.js";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
@@ -89,10 +90,10 @@ router.get("/", async (req, res) => {
     orderBy: { createdAt: "desc" },
     take: 200,
     include: {
-      requester: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } },
+      requester: { select: USER_AVATAR_SELECT_ORG },
       steps: {
         orderBy: { order: "asc" },
-        include: { reviewer: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+        include: { reviewer: { select: USER_AVATAR_SELECT } },
       },
     },
   });
@@ -120,7 +121,7 @@ router.get("/:id", async (req, res) => {
       revisions: { select: { id: true, title: true, status: true, createdAt: true }, orderBy: { createdAt: "asc" } },
       comments: {
         orderBy: { createdAt: "asc" },
-        include: { author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+        include: { author: { select: USER_AVATAR_SELECT } },
       },
     },
   });
@@ -147,7 +148,7 @@ router.post("/:id/comments", async (req, res) => {
   if (!canPost) return res.status(403).json({ error: "forbidden" });
   const c = await prisma.approvalComment.create({
     data: { approvalId: a.id, authorId: u.id, content },
-    include: { author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+    include: { author: { select: USER_AVATAR_SELECT } },
   });
   // 관련 당사자에게 멘션 알림 — 본인 제외. 순차 notify() → 병렬 notifyMany() 로 교체.
   const targets = new Set<string>([a.requesterId, ...a.steps.map((s) => s.reviewerId)]);
@@ -341,10 +342,10 @@ router.post("/:id/act", async (req, res) => {
   const refreshed = await prisma.approval.findUnique({
     where: { id: a.id },
     include: {
-      requester: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } },
+      requester: { select: USER_AVATAR_SELECT_ORG },
       steps: {
         orderBy: { order: "asc" },
-        include: { reviewer: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+        include: { reviewer: { select: USER_AVATAR_SELECT } },
       },
     },
   });

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { USER_AVATAR_SELECT, USER_AVATAR_SELECT_ORG } from "../lib/userSelect.js";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, verifySuperToken, writeLog } from "../lib/auth.js";
@@ -82,7 +83,7 @@ router.get("/rooms", async (req, res) => {
     where,
     orderBy: { createdAt: "desc" },
     include: {
-      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
+      members: { include: { user: { select: USER_AVATAR_SELECT_ORG } } },
       messages: {
         where: { deletedAt: null, scheduledAt: null },
         orderBy: { createdAt: "desc" },
@@ -159,7 +160,7 @@ router.post("/rooms", async (req, res) => {
         ],
       },
       include: {
-        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
+        members: { include: { user: { select: USER_AVATAR_SELECT_ORG } } },
         messages: {
           where: { deletedAt: null, scheduledAt: null },
           orderBy: { createdAt: "desc" },
@@ -181,7 +182,7 @@ router.post("/rooms", async (req, res) => {
         members: { create: [{ companyId: u.companyId, userId: u.id }, { companyId: u.companyId, userId: other }] },
       },
       include: {
-        members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
+        members: { include: { user: { select: USER_AVATAR_SELECT_ORG } } },
         messages: { where: { deletedAt: null, scheduledAt: null }, orderBy: { createdAt: "desc" }, take: 1 },
       },
     });
@@ -204,7 +205,7 @@ router.post("/rooms", async (req, res) => {
       members: { create: memberIds.map((userId) => ({ companyId: u.companyId, userId })) },
     },
     include: {
-      members: { include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
+      members: { include: { user: { select: USER_AVATAR_SELECT_ORG } } },
       messages: { where: { deletedAt: null, scheduledAt: null }, orderBy: { createdAt: "desc" }, take: 1 },
     },
   });
@@ -322,12 +323,12 @@ router.get("/search", async (req, res) => {
     orderBy: { createdAt: "desc" },
     take: 80,
     include: {
-      sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
+      sender: { select: USER_AVATAR_SELECT },
       room: {
         include: {
           // 검색 결과 카드에 최대 50명까지만 표시 — 대형 그룹방에서 수백 명을 끌어와
           // 응답 크기가 폭발하는 것을 방지. 실제 UI 는 아바타 5개 + "+N" 으로 표시.
-          members: { take: 50, include: { user: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true, position: true, team: true } } } },
+          members: { take: 50, include: { user: { select: USER_AVATAR_SELECT_ORG } } },
         },
       },
     },
@@ -420,7 +421,7 @@ router.get("/rooms/:id/messages", async (req, res) => {
     orderBy: { createdAt: "asc" },
     take: 300,
     include: {
-      sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
+      sender: { select: USER_AVATAR_SELECT },
       reactions: { select: { userId: true, emoji: true, user: { select: { name: true } } } },
     },
   });
@@ -562,7 +563,7 @@ router.post("/rooms/:id/messages", async (req, res) => {
       scheduledAt,
     },
     include: {
-      sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
+      sender: { select: USER_AVATAR_SELECT },
       room: { select: { id: true, name: true, type: true } },
       reactions: { select: { userId: true, emoji: true, user: { select: { name: true } } } },
     },
@@ -710,7 +711,7 @@ router.patch("/messages/:id", async (req, res) => {
   const updated = await prisma.chatMessage.update({
     where: { id: msg.id },
     data,
-    include: { sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+    include: { sender: { select: USER_AVATAR_SELECT } },
   });
   broadcastToRoom(msg.roomId, "chat:update", { kind: "edit", message: updated });
   res.json({ message: updated });
@@ -735,7 +736,7 @@ router.post("/messages/:id/pin", async (req, res) => {
       pinnedAt: pin ? new Date() : null,
       pinnedById: pin ? u.id : null,
     },
-    include: { sender: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+    include: { sender: { select: USER_AVATAR_SELECT } },
   });
   broadcastToRoom(msg.roomId, "chat:update", { kind: "pin", message: updated });
   res.json({ message: updated });

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { USER_AVATAR_SELECT } from "../lib/userSelect.js";
 import { z } from "zod";
 import archiver from "archiver";
 import { Prisma } from "@prisma/client";
@@ -671,7 +672,7 @@ router.get("/:id/revisions", async (req, res) => {
     where: { documentId: exist.id },
     orderBy: { createdAt: "desc" },
     take: 100,
-    include: { editor: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+    include: { editor: { select: USER_AVATAR_SELECT } },
   });
   res.json({ revisions: rows });
 });

--- a/server/src/routes/document.ts
+++ b/server/src/routes/document.ts
@@ -336,7 +336,6 @@ router.delete("/folders/:id", async (req, res) => {
 
   if (mode === "keep") {
     // 문서를 부모 폴더로 이동 — parentId 가 없으면 루트(null).
-    const parentId = check.folder.projectId ? null : null; // 현재 모델은 Folder.parentId 기반. 최상위면 null.
     const target = (await prisma.folder.findUnique({
       where: { id: req.params.id },
       select: { parentId: true },
@@ -348,7 +347,6 @@ router.delete("/folders/:id", async (req, res) => {
     // 빈 폴더들 삭제 (하위부터 상위 순서는 Prisma cascade 가 처리).
     await prisma.folder.delete({ where: { id: req.params.id } });
     await writeLog(u.id, "FOLDER_DELETE", req.params.id, "keep-docs");
-    void parentId; // 린트 무시 — 향후 프로젝트 이동 고려 자리.
     return res.json({ ok: true, mode: "keep" });
   }
 

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { USER_AVATAR_SELECT } from "../lib/userSelect.js";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
@@ -223,7 +224,7 @@ router.get("/", async (req, res) => {
       authorId: true,
       createdAt: true,
       updatedAt: true,
-      author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
+      author: { select: USER_AVATAR_SELECT },
       project: { select: { id: true, name: true, color: true } },
     },
   });
@@ -295,7 +296,7 @@ router.get("/:id", async (req, res) => {
   const meeting = await prisma.meeting.findFirst({
     where: { id: req.params.id, deletedAt: null },
     include: {
-      author: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } },
+      author: { select: USER_AVATAR_SELECT },
       project: { select: { id: true, name: true, color: true } },
       viewers: {
         include: { user: { select: { id: true, name: true, team: true, position: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
@@ -654,7 +655,7 @@ router.get("/:id/revisions", async (req, res) => {
     where: { meetingId: existing.id },
     orderBy: { createdAt: "desc" },
     take: 100,
-    include: { editor: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+    include: { editor: { select: USER_AVATAR_SELECT } },
   });
   res.json({ revisions: rows });
 });

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -316,7 +316,6 @@ router.get("/:id", async (req, res) => {
 
 /* =========================== 첨부 (파일·이미지·영상·링크) =========================== */
 
-const ATTACHMENT_KINDS = ["FILE", "IMAGE", "VIDEO", "LINK"] as const;
 // 파일 첨부의 url 은 반드시 우리 업로드 경로 — 외부/javascript: 스킴 차단.
 const SAFE_UPLOAD_URL = /^\/uploads\/[A-Za-z0-9._-]+$/;
 const fileAttachmentSchema = z.object({
@@ -407,8 +406,6 @@ router.delete("/:id/attachment/:attachmentId", async (req, res) => {
   res.json({ ok: true });
 });
 
-// 미사용 변수 lint 경고 회피용 — 위 두 스키마가 cover 하는 종류 집합.
-void ATTACHMENT_KINDS;
 
 router.post("/", async (req, res) => {
   const u = (req as any).user;

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { USER_AVATAR_SELECT } from "../lib/userSelect.js";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth, writeLog } from "../lib/auth.js";
@@ -431,7 +432,7 @@ router.get("/:id/qa", async (req, res) => {
   const users = userIds.length
     ? await prisma.user.findMany({
         where: { id: { in: userIds } },
-        select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true },
+        select: USER_AVATAR_SELECT,
       })
     : [];
   const userMap = new Map(users.map((x) => [x.id, x]));

--- a/server/src/routes/snippet.ts
+++ b/server/src/routes/snippet.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { USER_AVATAR_SELECT } from "../lib/userSelect.js";
 import { z } from "zod";
 import { prisma } from "../lib/db.js";
 import { requireAuth } from "../lib/auth.js";
@@ -44,7 +45,7 @@ router.get("/", async (req, res) => {
     where,
     orderBy: [{ updatedAt: "desc" }],
     take: 200,
-    include: { owner: { select: { id: true, name: true, avatarColor: true, isDeveloper: true, avatarUrl: true } } },
+    include: { owner: { select: USER_AVATAR_SELECT } },
   });
   res.json({ snippets });
 });


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1017

웹·서버 전반의 **동작/디자인 변화 0** 안전 리팩토링. 병렬 분석으로 기회를 찾고, 매 커밋 tsc 로 검증한 것만 반영. 네이티브/데스크탑/빌드는 의도적 제외.

## 커밋 (세분, 9개)
| # | 내용 |
|---|---|
| 1 | client: 미사용 import 제거 |
| 2 | client: 미사용 지역 변수·함수·상수 제거 |
| 3 | client: 컴포넌트 내 죽은 코드 + let→const |
| 4 | client: holidays 죽은 export(isRedDay/isHoliday) |
| 5 | client: 중복 humanSize → 공용 fmtSize 재사용 |
| 6 | console: 중복 relTime → 공용 superadmin/relTime |
| 7 | client: 새로고침 보일러플레이트 → useRefresh 훅(10페이지) |
| 8 | server: 미사용 export·죽은 지역 코드 |
| 9 | server: 중복 아바타 select → 공용 상수(23곳) |

## 신설 공용 모듈
- `client/src/lib/useRefresh.ts` — refreshing 플래그 + refresh() 래퍼
- `client/src/components/superadmin/relTime.ts` — 콘솔 상대시간
- `server/src/lib/userSelect.ts` — `USER_AVATAR_SELECT` / `USER_AVATAR_SELECT_ORG` (`satisfies Prisma.UserSelect`)

## 안전 원칙
- 100% 재사용 가능한 것만 — 필드셋/effect deps/반환값이 조금이라도 다른 변형은 **보존**(예: UserProfile/Project refresh, email 포함 아바타 select, featureFlags dormant 스캐폴드)
- 의미 있는 'why' 주석은 유지, 코드 재진술 주석만 제거

## 검증
- 매 커밋 `tsc -b`(클라)·`tsc -p`(서버) 통과
- 최종 클라 `vite build` ✓ · 서버 타입체크 ✓
- 38파일, +124/−279(순 −155줄)

머지 시 OTA 자동 배포(클라). 서버 변경은 `server/**` → ECS 자동 배포.

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1017
