### PR TITLE
🔀 :: (#1025) 컨텍스트 메뉴 위치 고정 (화면 중앙)

### DIFF
--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -670,9 +670,9 @@ export function ReactionPicker({
     const vh = window.innerHeight;
     const safeTop = 56;     // 상태바/노치 여유
     const safeBottom = 36;  // 홈 인디케이터 여유
-    const bubbleEl = el.querySelector("[data-ctx-bubble]") as HTMLElement | null;
-    const bubbleOffset = bubbleEl ? bubbleEl.offsetTop : 56;
-    let t = anchorRect.top - bubbleOffset;
+    // 어느 메시지를 누르든 항상 같은 자리(화면 세로 중앙쯤)에 뜨게 — 메시지 위치(위/아래)
+    // 따라 팝업이 흔들리지 않도록 고정. 너무 길면 위/아래 safe-area 안으로 클램프.
+    let t = Math.round((vh - groupH) / 2);
     if (t + groupH > vh - safeBottom) t = vh - safeBottom - groupH;
     if (t < safeTop) t = safeTop;
     setTop(t);
@@ -719,7 +719,7 @@ export function ReactionPicker({
           gap: 10,
           maxWidth: "min(86vw, 360px)",
           opacity: ready ? 1 : 0,
-          transformOrigin: mine ? "top right" : "top left",
+          transformOrigin: "center",
           animation: closing
             ? "hinest-ctx-popout .15s ease forwards"
             : ready ? "hinest-ctx-pop .2s cubic-bezier(.2,.7,.3,1)" : undefined,


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1025

롱프레스 메뉴가 누른 메시지 위치 따라 제각각 뜨던 것 → **화면 세로 중앙에 고정**(어느 메시지든 같은 자리). 말풍선 클론이 같이 떠 어느 메시지인지는 유지. 팝 원점도 center.

검증: tsc ✓ + 프리뷰에서 위쪽(원래 top 396)·아래쪽(619) 메시지 둘 다 동일 중앙 위치 스크린샷 확인. 머지 시 OTA 자동 배포.

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1025
