### PR TITLE
🔀 :: (#1027) 메모·회의록 이미지·파일 첨부 (노션식 인라인 + 드래그앤드롭)

### DIFF
--- a/client/src/components/MeetingEditor.css
+++ b/client/src/components/MeetingEditor.css
@@ -337,3 +337,58 @@ html.dark .mention-item.is-active {
   font-size: 12px;
   color: var(--c-text-muted, #64748B);
 }
+
+/* ===== 인라인 이미지·파일 첨부 (editorMedia 노드) ===== */
+.meeting-editor-content img.me-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: 10px;
+  margin: 10px 0;
+  border: 1px solid var(--c-border);
+}
+.meeting-editor-content img.me-img.ProseMirror-selectednode {
+  outline: 2px solid var(--c-brand, #3B5CF0);
+  outline-offset: 1px;
+}
+.meeting-editor-content a.me-file {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--c-border);
+  border-radius: 12px;
+  background: var(--c-surface-2, #fafbfc);
+  text-decoration: none;
+  color: var(--c-text);
+  max-width: 360px;
+  cursor: pointer;
+}
+.meeting-editor-content a.me-file:hover {
+  background: var(--c-surface-3, rgba(0, 0, 0, 0.06));
+}
+.meeting-editor-content a.me-file.ProseMirror-selectednode {
+  outline: 2px solid var(--c-brand, #3B5CF0);
+  outline-offset: 1px;
+}
+.me-file-ic {
+  font-size: 20px;
+  flex-shrink: 0;
+}
+.me-file-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.me-file-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.me-file-size {
+  font-size: 11.5px;
+  color: var(--c-text-muted, #64748B);
+}

--- a/client/src/components/MeetingEditor.tsx
+++ b/client/src/components/MeetingEditor.tsx
@@ -14,13 +14,14 @@ import { Extension } from "@tiptap/core";
 import { PluginKey } from "@tiptap/pm/state";
 import { DOMParser as PMDOMParser } from "@tiptap/pm/model";
 import { markdownToHtml, looksLikeMarkdown } from "../lib/markdownToHtml";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import Select, { type SelectOption } from "./Select";
 import "./MeetingEditor.css";
 import { promptAsync } from "./ConfirmHost";
 import MentionList, { type MentionUser } from "./MentionList";
 import { parseCodeSegments } from "../lib/codeDetect";
+import { EditorImage, FileAttachment, uploadEditorFile, uploadAndInsertAt } from "./editorMedia";
 
 /** 페이스트된 평문이 코드처럼 보이는지 — codeDetect 의 휴리스틱 재사용.
  *  parseCodeSegments 가 반환하는 segment 중 코드(펜스/휴리스틱)가 본문 대부분을 차지하면 true. */
@@ -137,6 +138,8 @@ export default function MeetingEditor({ value, onChange, editable = true, placeh
       Placeholder.configure({ placeholder: placeholder ?? "여기에 회의록을 작성하세요..." }),
       TaskList,
       TaskItem.configure({ nested: true }),
+      EditorImage,
+      FileAttachment,
       ...(mentionFetcher
         ? [
             Mention.configure({
@@ -151,7 +154,26 @@ export default function MeetingEditor({ value, onChange, editable = true, placeh
     // - HTML 페이스트(워드/노션 등 서식 있는 출처)는 건드리지 않음
     // - 휴리스틱은 lib/codeDetect.ts 와 동일 규칙 (한글 비율·코드 토큰 비율)
     editorProps: {
+      // 파일 드래그&드롭 → 업로드 후 드롭 위치(노션식)에 이미지/파일 노드 삽입.
+      handleDrop: (view, event) => {
+        const dragEvent = event as DragEvent;
+        const files = Array.from(dragEvent.dataTransfer?.files ?? []);
+        if (files.length === 0) return false;
+        event.preventDefault();
+        const at = view.posAtCoords({ left: dragEvent.clientX, top: dragEvent.clientY });
+        const pos = at?.pos ?? view.state.selection.from;
+        for (const f of files) void uploadAndInsertAt(view, pos, f);
+        return true;
+      },
       handlePaste: (view, event) => {
+        // 0) 이미지 파일 붙여넣기(스크린샷 등) → 업로드 후 커서 위치에 삽입.
+        const imgFiles = Array.from(event.clipboardData?.files ?? []).filter((f) => f.type.startsWith("image/"));
+        if (imgFiles.length > 0) {
+          event.preventDefault();
+          const pos = view.state.selection.from;
+          for (const f of imgFiles) void uploadAndInsertAt(view, pos, f);
+          return true;
+        }
         const html = event.clipboardData?.getData("text/html");
         if (html) return false; // 리치 HTML 페이스트(워드·웹 등)는 기본 동작 유지
         const text = event.clipboardData?.getData("text/plain");
@@ -221,6 +243,22 @@ export default function MeetingEditor({ value, onChange, editable = true, placeh
 }
 
 function Toolbar({ editor }: { editor: Editor }) {
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  // 툴바 첨부 버튼 — 고른 파일들을 업로드해 커서 위치에 이미지/파일로 삽입.
+  async function onPickFiles(list: FileList | null) {
+    const files = Array.from(list ?? []);
+    for (const f of files) {
+      const r = await uploadEditorFile(f);
+      if (!r) continue;
+      if (r.kind === "IMAGE") {
+        editor.chain().focus().insertContent({ type: "image", attrs: { src: r.url, alt: r.name } }).run();
+      } else {
+        editor.chain().focus().insertContent({ type: "fileAttachment", attrs: { href: r.url, name: r.name, size: r.size, mime: r.type } }).run();
+      }
+    }
+  }
+
   return (
     <div className="meeting-toolbar">
       {/* 글씨 크기 */}
@@ -356,6 +394,18 @@ function Toolbar({ editor }: { editor: Editor }) {
       <ToolBtn onClick={() => editor.chain().focus().setHorizontalRule().run()} title="구분선">
         ―
       </ToolBtn>
+
+      <ToolBtn onClick={() => fileRef.current?.click()} title="이미지·파일 첨부">
+        📎
+      </ToolBtn>
+      <input
+        ref={fileRef}
+        type="file"
+        multiple
+        accept="image/*,*/*"
+        style={{ display: "none" }}
+        onChange={(e) => { void onPickFiles(e.target.files); e.target.value = ""; }}
+      />
 
       <Divider />
 

--- a/client/src/components/editorMedia.tsx
+++ b/client/src/components/editorMedia.tsx
@@ -1,0 +1,106 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import type { EditorView } from "@tiptap/pm/view";
+import { apiFetch } from "../api";
+import { fmtSize } from "../lib/fmt";
+
+/**
+ * 메모/회의록(MeetingEditor) 공용 — 본문 어디든(커서·드롭·붙여넣기 위치) 넣는 인라인 미디어.
+ * 노션식: 이미지는 인라인 이미지로, 그 외 파일은 다운로드 카드로 문서 흐름 안에 삽입된다.
+ * src/href 는 우리 업로드 경로(/uploads/...) — 업로드는 채팅과 동일한 /api/upload 사용.
+ */
+
+/** 인라인 이미지 노드(블록). 드래그로 위치 이동도 가능. */
+export const EditorImage = Node.create({
+  name: "image",
+  group: "block",
+  atom: true,
+  draggable: true,
+  selectable: true,
+  addAttributes() {
+    return {
+      src: { default: null },
+      alt: { default: null },
+    };
+  },
+  parseHTML() {
+    return [{ tag: "img[src]" }];
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["img", mergeAttributes(HTMLAttributes, { class: "me-img" })];
+  },
+});
+
+/** 인라인 파일 첨부 카드(블록). 클릭 시 다운로드. */
+export const FileAttachment = Node.create({
+  name: "fileAttachment",
+  group: "block",
+  atom: true,
+  draggable: true,
+  selectable: true,
+  addAttributes() {
+    return {
+      href: { default: null },
+      name: { default: null },
+      size: { default: null },
+      mime: { default: null },
+    };
+  },
+  parseHTML() {
+    return [{ tag: "a[data-file-attachment]" }];
+  },
+  renderHTML({ node }) {
+    const name = String(node.attrs.name ?? "파일");
+    const size = typeof node.attrs.size === "number" ? fmtSize(node.attrs.size) : "";
+    return [
+      "a",
+      {
+        "data-file-attachment": "",
+        href: node.attrs.href ?? "#",
+        download: name,
+        target: "_blank",
+        rel: "noopener noreferrer",
+        class: "me-file",
+        contenteditable: "false",
+      },
+      ["span", { class: "me-file-ic" }, "📎"],
+      [
+        "span",
+        { class: "me-file-body" },
+        ["span", { class: "me-file-name" }, name],
+        ["span", { class: "me-file-size" }, size],
+      ],
+    ];
+  },
+});
+
+export type UploadResult = { url: string; name: string; type: string; size: number; kind: string };
+
+/** 파일 1개 업로드 → 결과(또는 실패 시 null). 채팅과 동일 엔드포인트(인증·테넌트 격리 그대로). */
+export async function uploadEditorFile(file: File): Promise<UploadResult | null> {
+  try {
+    const form = new FormData();
+    form.append("file", file);
+    const r = await apiFetch("/api/upload", { method: "POST", body: form });
+    if (!r.ok) return null;
+    return (await r.json()) as UploadResult;
+  } catch {
+    return null;
+  }
+}
+
+/** 업로드 결과를 이미지/파일 노드로 만들어 pos 위치에 삽입(드롭·붙여넣기 공용, view 기반). */
+export async function uploadAndInsertAt(view: EditorView, pos: number, file: File): Promise<void> {
+  const r = await uploadEditorFile(file);
+  if (!r) return;
+  const { schema } = view.state;
+  const node =
+    r.kind === "IMAGE" && schema.nodes.image
+      ? schema.nodes.image.create({ src: r.url, alt: r.name })
+      : schema.nodes.fileAttachment
+        ? schema.nodes.fileAttachment.create({ href: r.url, name: r.name, size: r.size, mime: r.type })
+        : null;
+  if (!node) return;
+  // 업로드(비동기) 동안 문서가 바뀌었을 수 있으니 현재 문서 크기로 클램프.
+  const p = Math.max(0, Math.min(pos, view.state.doc.content.size));
+  view.dispatch(view.state.tr.insert(p, node));
+}


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1027

공용 에디터(MeetingEditor=메모+회의록)에 사진/파일을 **본문 흐름 어디든** 넣게 함.

## 구현
- `editorMedia.tsx`(신설): `@tiptap/core` 커스텀 노드 — **EditorImage**(인라인 이미지)·**FileAttachment**(다운로드 카드). 새 의존성 없음.
- 업로드: 채팅과 동일한 `/api/upload`(인증·테넌트 격리 그대로) 재사용 → `{url,name,type,size,kind}`.
- 삽입 3경로: **툴바 📎** 버튼 / **드래그앤드롭**(드롭 위치에) / **붙여넣기**(스크린샷 등 이미지 클립보드). IMAGE 면 인라인 이미지, 그 외엔 파일 카드.
- 색=디자인 토큰(다크/라이트 자동). **회의록에도 자동 적용**(공용 에디터).

## 검증
- `tsc -b` ✓
- 프리뷰: 새 메모 에디터 로드(무크래시)·툴바 📎 버튼·이미지 인라인 렌더·파일 카드 렌더 스크린샷 확인.
- 실제 업로드는 백엔드 필요라 기기에서 확인(엔드포인트는 채팅 검증된 것과 동일).

머지 시 OTA 자동 배포.

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1027
