### PR TITLE
🔀 :: (#1029) 노션식 슬래시(/) 명령 메뉴 (메모·회의록 공용)

### DIFF
--- a/client/src/components/MeetingEditor.css
+++ b/client/src/components/MeetingEditor.css
@@ -392,3 +392,88 @@ html.dark .mention-item.is-active {
   font-size: 11.5px;
   color: var(--c-text-muted, #64748B);
 }
+
+/* ===== 슬래시(/) 명령 메뉴 (editorSlash) ===== */
+.slash-popup-host {
+  animation: mention-in 80ms ease-out;
+}
+.slash-menu {
+  background: var(--c-surface-1, #fff);
+  border: 1px solid var(--c-border, #E2E8F0);
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.16);
+  padding: 6px;
+  min-width: 240px;
+  max-width: 300px;
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+html.dark .slash-menu {
+  background: #0F172A;
+  border-color: #1E293B;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.5);
+}
+.slash-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 9px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  color: var(--c-text, #0F172A);
+}
+html.dark .slash-item {
+  color: #E2E8F0;
+}
+.slash-item.is-active {
+  background: var(--c-surface-3, #F1F5F9);
+}
+html.dark .slash-item.is-active {
+  background: #1E293B;
+}
+.slash-ic {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--c-surface-3, #F1F5F9);
+  font-size: 13px;
+  font-weight: 700;
+}
+html.dark .slash-ic {
+  background: #1E293B;
+}
+.slash-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.slash-title {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+.slash-hint {
+  font-size: 11.5px;
+  color: var(--c-text-muted, #64748B);
+}
+.slash-empty {
+  background: var(--c-surface-1, #fff);
+  border: 1px solid var(--c-border, #E2E8F0);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 12.5px;
+  color: var(--c-text-muted, #64748B);
+}
+html.dark .slash-empty {
+  background: #0F172A;
+  border-color: #1E293B;
+}

--- a/client/src/components/MeetingEditor.tsx
+++ b/client/src/components/MeetingEditor.tsx
@@ -22,6 +22,7 @@ import { promptAsync } from "./ConfirmHost";
 import MentionList, { type MentionUser } from "./MentionList";
 import { parseCodeSegments } from "../lib/codeDetect";
 import { EditorImage, FileAttachment, uploadEditorFile, uploadAndInsertAt } from "./editorMedia";
+import { SlashCommands } from "./editorSlash";
 
 /** 페이스트된 평문이 코드처럼 보이는지 — codeDetect 의 휴리스틱 재사용.
  *  parseCodeSegments 가 반환하는 segment 중 코드(펜스/휴리스틱)가 본문 대부분을 차지하면 true. */
@@ -140,6 +141,7 @@ export default function MeetingEditor({ value, onChange, editable = true, placeh
       TaskItem.configure({ nested: true }),
       EditorImage,
       FileAttachment,
+      SlashCommands,
       ...(mentionFetcher
         ? [
             Mention.configure({

--- a/client/src/components/editorMedia.tsx
+++ b/client/src/components/editorMedia.tsx
@@ -1,4 +1,5 @@
 import { Node, mergeAttributes } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
 import type { EditorView } from "@tiptap/pm/view";
 import { apiFetch } from "../api";
 import { fmtSize } from "../lib/fmt";
@@ -103,4 +104,28 @@ export async function uploadAndInsertAt(view: EditorView, pos: number, file: Fil
   // 업로드(비동기) 동안 문서가 바뀌었을 수 있으니 현재 문서 크기로 클램프.
   const p = Math.max(0, Math.min(pos, view.state.doc.content.size));
   view.dispatch(view.state.tr.insert(p, node));
+}
+
+/** 파일 선택창을 띄워 고른 파일을 업로드 후 에디터 커서 위치에 삽입(툴바 📎·슬래시 명령 공용). */
+export function pickFilesAndInsert(editor: Editor, accept = "image/*,*/*"): void {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = accept;
+  input.multiple = true;
+  input.style.display = "none";
+  document.body.appendChild(input);
+  input.onchange = async () => {
+    const files = Array.from(input.files ?? []);
+    input.remove();
+    for (const f of files) {
+      const r = await uploadEditorFile(f);
+      if (!r) continue;
+      if (r.kind === "IMAGE") {
+        editor.chain().focus().insertContent({ type: "image", attrs: { src: r.url, alt: r.name } }).run();
+      } else {
+        editor.chain().focus().insertContent({ type: "fileAttachment", attrs: { href: r.url, name: r.name, size: r.size, mime: r.type } }).run();
+      }
+    }
+  };
+  input.click();
 }

--- a/client/src/components/editorSlash.tsx
+++ b/client/src/components/editorSlash.tsx
@@ -1,0 +1,160 @@
+import { Extension } from "@tiptap/core";
+import type { Editor, Range } from "@tiptap/core";
+import Suggestion from "@tiptap/suggestion";
+import { PluginKey } from "@tiptap/pm/state";
+import { createRoot, type Root } from "react-dom/client";
+import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { pickFilesAndInsert } from "./editorMedia";
+
+/**
+ * 노션식 슬래시(/) 명령 메뉴 — 빈 줄/공백 뒤에서 "/" 입력 시 블록 삽입 메뉴.
+ * 멘션과 동일하게 @tiptap/suggestion + createRoot 팝업으로 구현(새 의존성 없음).
+ * 메모·회의록 공용 MeetingEditor 에 얹어 둘 다 동일 동작.
+ */
+
+type SlashItem = {
+  title: string;
+  hint: string;
+  keywords: string;
+  icon: string;
+  run: (editor: Editor, range: Range) => void;
+};
+
+const SLASH_ITEMS: SlashItem[] = [
+  { title: "제목 1", hint: "큰 제목", keywords: "h1 제목 heading title 큰", icon: "H1", run: (e, r) => e.chain().focus().deleteRange(r).toggleHeading({ level: 1 }).run() },
+  { title: "제목 2", hint: "중간 제목", keywords: "h2 제목 heading", icon: "H2", run: (e, r) => e.chain().focus().deleteRange(r).toggleHeading({ level: 2 }).run() },
+  { title: "제목 3", hint: "작은 제목", keywords: "h3 제목 heading", icon: "H3", run: (e, r) => e.chain().focus().deleteRange(r).toggleHeading({ level: 3 }).run() },
+  { title: "글머리 목록", hint: "• 불릿 리스트", keywords: "bullet list 목록 리스트 불릿 글머리", icon: "•", run: (e, r) => e.chain().focus().deleteRange(r).toggleBulletList().run() },
+  { title: "번호 목록", hint: "1. 순서 있는 목록", keywords: "ordered number list 번호 목록 순서", icon: "1.", run: (e, r) => e.chain().focus().deleteRange(r).toggleOrderedList().run() },
+  { title: "체크박스", hint: "할 일 목록", keywords: "todo task check 체크 할일 체크박스", icon: "☑", run: (e, r) => e.chain().focus().deleteRange(r).toggleTaskList().run() },
+  { title: "인용", hint: "인용구", keywords: "quote blockquote 인용", icon: "❝", run: (e, r) => e.chain().focus().deleteRange(r).toggleBlockquote().run() },
+  { title: "코드 블록", hint: "코드 블록", keywords: "code 코드 codeblock", icon: "</>", run: (e, r) => e.chain().focus().deleteRange(r).toggleCodeBlock().run() },
+  { title: "구분선", hint: "가로 구분선", keywords: "divider hr rule 구분선 라인", icon: "―", run: (e, r) => e.chain().focus().deleteRange(r).setHorizontalRule().run() },
+  { title: "이미지", hint: "사진 업로드", keywords: "image photo 이미지 사진 그림", icon: "🖼", run: (e, r) => { e.chain().focus().deleteRange(r).run(); pickFilesAndInsert(e, "image/*"); } },
+  { title: "파일", hint: "파일 첨부", keywords: "file attach 파일 첨부 첨부파일", icon: "📎", run: (e, r) => { e.chain().focus().deleteRange(r).run(); pickFilesAndInsert(e, "*/*"); } },
+];
+
+function filterItems(query: string): SlashItem[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return SLASH_ITEMS;
+  return SLASH_ITEMS.filter((i) => i.title.toLowerCase().includes(q) || i.keywords.toLowerCase().includes(q));
+}
+
+type SlashListProps = { items: SlashItem[]; command: (item: SlashItem) => void };
+
+const SlashList = forwardRef<{ onKeyDown: (e: { event: KeyboardEvent }) => boolean }, SlashListProps>(
+  ({ items, command }, ref) => {
+    const [active, setActive] = useState(0);
+    useEffect(() => setActive(0), [items]);
+
+    const select = (i: number) => {
+      const it = items[i];
+      if (it) command(it);
+    };
+
+    useImperativeHandle(ref, () => ({
+      onKeyDown: ({ event }) => {
+        if (items.length === 0) return false;
+        if (event.key === "ArrowUp") { setActive((a) => (a + items.length - 1) % items.length); return true; }
+        if (event.key === "ArrowDown") { setActive((a) => (a + 1) % items.length); return true; }
+        if (event.key === "Enter") { select(active); return true; }
+        return false;
+      },
+    }));
+
+    if (items.length === 0) return <div className="slash-empty">결과 없음</div>;
+    return (
+      <div className="slash-menu">
+        {items.map((it, i) => (
+          <button
+            key={it.title}
+            type="button"
+            className={`slash-item ${i === active ? "is-active" : ""}`}
+            onMouseEnter={() => setActive(i)}
+            onMouseDown={(e) => { e.preventDefault(); select(i); }}
+          >
+            <span className="slash-ic">{it.icon}</span>
+            <span className="slash-body">
+              <span className="slash-title">{it.title}</span>
+              <span className="slash-hint">{it.hint}</span>
+            </span>
+          </button>
+        ))}
+      </div>
+    );
+  },
+);
+SlashList.displayName = "SlashList";
+
+export const SlashCommands = Extension.create({
+  name: "slashCommands",
+  addProseMirrorPlugins() {
+    return [
+      Suggestion<SlashItem>({
+        editor: this.editor,
+        char: "/",
+        pluginKey: new PluginKey("meetingSlash"),
+        // 줄 시작 또는 공백 뒤의 "/" 에서만 발동 (URL·코드 중간 "/" 무시)
+        allow: ({ state, range }) => {
+          const $from = state.doc.resolve(range.from);
+          if (!$from.parent.isTextblock) return false;
+          if ($from.parentOffset === 0) return true;
+          const charBefore = state.doc.textBetween(range.from - 1, range.from);
+          return /\s/.test(charBefore);
+        },
+        command: ({ editor, range, props }) => {
+          props.run(editor, range);
+        },
+        items: ({ query }) => filterItems(query).slice(0, 10),
+        render: () => {
+          let root: Root | null = null;
+          let container: HTMLDivElement | null = null;
+          let listRef: { onKeyDown: (e: { event: KeyboardEvent }) => boolean } | null = null;
+
+          function position(rect: DOMRect | null | (() => DOMRect | null)) {
+            const r = typeof rect === "function" ? rect() : rect;
+            if (!r || !container) return;
+            const popupH = container.offsetHeight || 280;
+            const below = r.bottom + 4;
+            const flip = below + popupH > window.innerHeight;
+            container.style.left = `${Math.min(r.left, window.innerWidth - 260)}px`;
+            container.style.top = `${flip ? r.top - popupH - 4 : below}px`;
+          }
+
+          return {
+            onStart: (props: any) => {
+              container = document.createElement("div");
+              container.className = "slash-popup-host";
+              container.style.position = "fixed";
+              container.style.zIndex = "9999";
+              document.body.appendChild(container);
+              root = createRoot(container);
+              root.render(<SlashList ref={(r) => { listRef = r; }} items={props.items} command={props.command} />);
+              position(props.clientRect);
+            },
+            onUpdate: (props: any) => {
+              if (!root) return;
+              root.render(<SlashList ref={(r) => { listRef = r; }} items={props.items} command={props.command} />);
+              position(props.clientRect);
+            },
+            onKeyDown: (props: any) => {
+              if (props.event.key === "Escape") return true;
+              return listRef?.onKeyDown(props) ?? false;
+            },
+            onExit: () => {
+              const r = root;
+              const c = container;
+              queueMicrotask(() => {
+                r?.unmount();
+                c?.remove();
+              });
+              root = null;
+              container = null;
+              listRef = null;
+            },
+          };
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1029

'메모·회의록 동일 + 노션처럼 편하게' 요청의 **1/4** (슬래시 메뉴).

빈 줄/공백 뒤 '/' → 블록 삽입 메뉴(제목1~3·글머리·번호·체크박스·인용·코드·구분선·이미지·파일). 공용 `MeetingEditor` 에 얹어 **메모·회의록 둘 다 동일**.
- `editorSlash.tsx`(신설): `@tiptap/suggestion` + createRoot 팝업(멘션과 동일 패턴, **새 의존성 0**). ↑↓/Enter/Esc·마우스, 줄시작/공백 뒤에서만 발동.
- 이미지·파일 항목은 `editorMedia.pickFilesAndInsert` 재사용.
- 색=토큰(다크/라이트), CSS 는 멘션 팝업 미러링.

검증: tsc ✓ + 프리뷰('/' → 메뉴·글머리 선택 시 불릿 적용·닫힘·'/' 제거 스크린샷).

남은 3개: 선택 버블 메뉴 / 회의록 태그 / 편집 흐름 통일 — 순차 PR 예정. 머지 시 OTA 자동 배포.

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1029
