### PR TITLE
🔀 :: (#1031) 회의록 태그 (메모와 동일 기능)

### DIFF
--- a/client/src/pages/MeetingDetailPage.tsx
+++ b/client/src/pages/MeetingDetailPage.tsx
@@ -28,6 +28,7 @@ type Meeting = {
   title: string;
   content: any;
   visibility: Visibility;
+  tags?: string | null;
   projectId: string | null;
   authorId: string;
   createdAt: string;
@@ -54,6 +55,7 @@ export default function MeetingDetailPage() {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState<any>(null);
   const [visibility, setVisibility] = useState<Visibility>("ALL");
+  const [tags, setTags] = useState("");
   const [projectId, setProjectId] = useState<string | null>(null);
   const [viewerIds, setViewerIds] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
@@ -96,6 +98,7 @@ export default function MeetingDetailPage() {
     setTitle(m.title);
     setContent(m.content ?? { type: "doc", content: [{ type: "paragraph" }] });
     setVisibility(m.visibility);
+    setTags(m.tags ?? "");
     setProjectId(m.projectId);
     setViewerIds(m.viewers.map((v) => v.userId));
     setErr(null);
@@ -169,7 +172,7 @@ export default function MeetingDetailPage() {
       if (saveTimerRef.current) window.clearTimeout(saveTimerRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [title, content, visibility, projectId, viewerIds, edit, canEdit]);
+  }, [title, content, visibility, tags, projectId, viewerIds, edit, canEdit]);
 
   async function doSave() {
     if (!meeting || !canEdit) return;
@@ -184,6 +187,7 @@ export default function MeetingDetailPage() {
         title: title.trim() || "제목 없는 회의록",
         content,
         visibility,
+        tags: tags.trim() || undefined,
         projectId: visibility === "PROJECT" ? projectId : null,
       };
       if (visibility === "SPECIFIC") payload.viewerIds = viewerIds;
@@ -375,6 +379,23 @@ export default function MeetingDetailPage() {
           </>
         )}
       </div>
+
+      {/* 태그 — 메모와 동일 (쉼표 구분) */}
+      {edit ? (
+        <input
+          className="block w-full text-[13px] text-slate-400 placeholder-slate-300 bg-transparent border-none outline-none mb-4"
+          placeholder="# 태그 입력 (쉼표로 구분, 예: 기획, 아이디어)"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          maxLength={200}
+        />
+      ) : (tags || meeting.tags) ? (
+        <div className="flex flex-wrap gap-1 mb-4">
+          {((meeting.tags ?? tags) || "").split(",").map((t) => t.trim()).filter(Boolean).map((t) => (
+            <span key={t} className="chip-gray text-[11px]">#{t}</span>
+          ))}
+        </div>
+      ) : null}
 
       {/* 공개 범위 — 편집모드에서만 */}
       {edit && (

--- a/client/src/pages/MeetingsPage.tsx
+++ b/client/src/pages/MeetingsPage.tsx
@@ -17,6 +17,7 @@ type MeetingRow = {
   updatedAt: string;
   author: { id: string; name: string; avatarColor: string; avatarUrl?: string | null };
   project: { id: string; name: string; color: string } | null;
+  tags?: string | null;
 };
 
 type Vis = MeetingRow["visibility"];
@@ -82,7 +83,7 @@ export default function MeetingsPage() {
     if (visibilityFilter === "mine") arr = arr.filter((m) => m.authorId === user?.id);
     else if (visibilityFilter !== "all") arr = arr.filter((m) => m.visibility === visibilityFilter);
     const k = q.trim().toLowerCase();
-    if (k) arr = arr.filter((m) => m.title.toLowerCase().includes(k) || m.author.name.toLowerCase().includes(k));
+    if (k) arr = arr.filter((m) => m.title.toLowerCase().includes(k) || m.author.name.toLowerCase().includes(k) || (m.tags ?? "").toLowerCase().includes(k));
     // 서버는 updatedAt desc 로 주지만 화면 기준에 맞춰 다시 정렬.
     const field = sortKey === "updated" ? "updatedAt" : "createdAt";
     arr = [...arr].sort((a, b) => new Date(b[field]).getTime() - new Date(a[field]).getTime());
@@ -293,6 +294,7 @@ function MeetingCard({ m, sortKey }: { m: MeetingRow; sortKey: SortKey }) {
     : "#D97706";
   const timeIso = sortKey === "updated" ? m.updatedAt : m.createdAt;
   const timeLabel = sortKey === "updated" ? "수정" : "작성";
+  const tags = (m.tags ?? "").split(",").map((t) => t.trim()).filter(Boolean);
   return (
     <Link
       to={`/meetings/${m.id}`}
@@ -308,6 +310,15 @@ function MeetingCard({ m, sortKey }: { m: MeetingRow; sortKey: SortKey }) {
             </div>
             <VisibilityBadge v={m.visibility} />
           </div>
+          {tags.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {tags.slice(0, 4).map((t) => (
+                <span key={t} className="text-[10px] font-medium px-1.5 py-[1px] rounded bg-ink-100 dark:bg-ink-800 text-ink-500 dark:text-ink-400">
+                  #{t}
+                </span>
+              ))}
+            </div>
+          )}
           <div className="flex items-end justify-between gap-2 mt-3">
             <div className="flex items-center gap-2 text-[11.5px] text-ink-500 flex-wrap min-w-0">
               <AuthorChip author={m.author} />

--- a/server/prisma/migrations/20260617000000_meeting_tags/migration.sql
+++ b/server/prisma/migrations/20260617000000_meeting_tags/migration.sql
@@ -1,0 +1,2 @@
+-- 회의록에 태그 추가 (메모 Document.tags 와 동일한 쉼표 구분 문자열). 추가형 nullable 컬럼.
+ALTER TABLE "Meeting" ADD COLUMN "tags" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1075,6 +1075,7 @@ model Meeting {
   /// TipTap JSON document. HTML 이 아닌 구조화된 노드 트리.
   content     Json
   visibility  String              @default("ALL") // ALL | PROJECT | SPECIFIC
+  tags        String?             // 쉼표 구분 태그 — 메모(Document.tags)와 동일
   projectId   String?
   project     Project?            @relation(fields: [projectId], references: [id], onDelete: SetNull)
   authorId    String

--- a/server/src/routes/meeting.ts
+++ b/server/src/routes/meeting.ts
@@ -25,6 +25,8 @@ const createSchema = z.object({
   title: z.string().min(1).max(200),
   content: z.any(), // TipTap JSON document
   visibility: z.enum(VIS).default("ALL"),
+  // 메모(Document.tags)와 동일 — 쉼표 구분 태그 문자열.
+  tags: z.string().max(500).optional(),
   // CUID/UUID 길이는 36자 이내. 50자면 여유 있음.
   projectId: z.string().max(50).optional().nullable(),
   // 지정 열람자 최대 200명 — 특정 대상 회의록 자리의 합리적 상한.
@@ -35,6 +37,7 @@ const updateSchema = z.object({
   title: z.string().min(1).max(200).optional(),
   content: z.any().optional(),
   visibility: z.enum(VIS).optional(),
+  tags: z.string().max(500).optional(),
   projectId: z.string().max(50).optional().nullable(),
   viewerIds: z.array(z.string().max(50)).max(200).optional(),
 });
@@ -220,6 +223,7 @@ router.get("/", async (req, res) => {
       id: true,
       title: true,
       visibility: true,
+      tags: true,
       projectId: true,
       authorId: true,
       createdAt: true,
@@ -443,6 +447,7 @@ router.post("/", async (req, res) => {
       title: d.title,
       content: d.content ?? {},
       visibility: d.visibility,
+      tags: d.tags,
       projectId: d.visibility === "PROJECT" ? d.projectId ?? null : null,
       authorId: u.id,
       viewers:
@@ -584,6 +589,7 @@ router.patch("/:id", async (req, res) => {
         title: d.title,
         content: d.content,
         visibility: d.visibility,
+        tags: d.tags,
         projectId:
           d.visibility !== undefined
             ? d.visibility === "PROJECT"


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1031

회의록에 태그 기능 추가 — 메모(Document)와 동일하게.

## 서버
- `Meeting.tags` nullable 컬럼 + 추가형 마이그레이션(`20260617000000_meeting_tags`) — 운영 RDS 무중단(기동 시 `migrate deploy` 멱등 적용)
- create/update zod 스키마 + 데이터에 `tags` 반영, 목록 select 에 포함(상세는 include 라 자동)

## 클라이언트
- 상세: 편집 시 태그 입력(쉼표 구분), 읽기 시 `#` 칩 (제목/작성자 아래 → 공개범위 위)
- 목록 카드: 태그 칩(최대 4개) + 검색에 태그 포함
- MemosPage/DocMemoModal 와 동일 패턴·스타일

## 검증
- 프리뷰(데모): 목록 칩·상세 읽기 칩·편집 입력(기존값 프리필) 전부 확인
- tsc(서버·클라) + vite build 통과
- `server/**` 변경 → ECS 배포 트리거(마이그레이션 적용) + 클라 OTA

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1031
