### PR TITLE
🔀 :: (#1033) 문서함 대용량·다중 영상 업로드 실패 수정

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -51,6 +51,42 @@ export function apiFetch(path: string, init: RequestInit = {}): Promise<Response
 }
 
 /**
+ * multipart 업로드 응답을 견고하게 해석한다 (문서함·첨부 등 공용).
+ *
+ * 서버가 정상이면 JSON(`{url,name,...}` 또는 `{error}`)을 주지만, 요청이 앱에 닿기 전
+ * 프록시·로드밸런서·게이트웨이가 막으면(413 용량초과·502/503·504 타임아웃 등) 본문이
+ * HTML(`"<html>.."`)이나 플레인 텍스트(`"An error occurred.."`)로 온다. 이때 `res.json()`
+ * 을 그대로 부르면 `Unexpected token '<' ... is not valid JSON` 같은 암호 같은 에러가
+ * 사용자에게 그대로 노출된다 → 본문을 text 로 먼저 읽고, JSON 이면 그대로, 아니면 HTTP
+ * 상태로 사람이 읽을 메시지를 만든다.
+ */
+export async function readUploadResponse<T = any>(res: Response): Promise<T> {
+  const text = await res.text().catch(() => "");
+  let data: any = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    /* 비-JSON 본문(HTML/텍스트 에러 페이지) — 아래 상태 기반 메시지로 처리 */
+  }
+  if (res.ok) {
+    if (data) return data as T;
+    throw new Error("업로드 응답을 해석할 수 없어요. 잠시 후 다시 시도해 주세요.");
+  }
+  if (data && typeof data.error === "string") throw new Error(data.error);
+  throw new Error(uploadStatusMessage(res.status));
+}
+
+function uploadStatusMessage(status: number): string {
+  if (status === 413) return "파일이 너무 커서 업로드할 수 없어요 (서버 허용 용량을 초과했어요).";
+  if (status === 429) return "업로드 요청이 많아요. 잠시 후 다시 시도해 주세요.";
+  if (status === 504) return "업로드 시간이 초과됐어요. 네트워크가 빠른 곳에서 다시 시도하거나 파일을 나눠 올려 주세요.";
+  if (status === 502 || status === 503) return "서버가 잠시 바빠 업로드에 실패했어요. 잠시 후 다시 시도해 주세요.";
+  if (status >= 500) return "서버 오류로 업로드에 실패했어요. 잠시 후 다시 시도해 주세요.";
+  if (status === 401 || status === 403) return "로그인이 만료됐거나 권한이 없어요. 새로고침 후 다시 시도해 주세요.";
+  return `업로드에 실패했어요 (오류 ${status}).`;
+}
+
+/**
  * <img>/<video> 처럼 헤더를 못 싣는 태그의 src 변환 — 주로 /uploads 이미지(아바타·첨부).
  *
  * 두 가지를 해결한다:

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { api, apiFetch , imgSrc} from "../api";
+import { api, apiFetch, imgSrc, readUploadResponse } from "../api";
 import { fmtSize } from "../lib/fmt";
 import { Skeleton } from "../components/Skeleton";
 import { useAuth } from "../auth";
@@ -19,6 +19,15 @@ import { Browser } from "@capacitor/browser";
 
 // DocMemoModal 은 TipTap(무거운 번들)을 포함 → 실제 열릴 때만 로드.
 const DocMemoModal = lazy(() => import("../components/DocMemoModal"));
+
+// 대용량 파일이 섞이면 동시 업로드 수를 줄인다. 서버는 업로드 파일을 통째로 메모리에
+// 버퍼(memoryStorage)하므로, 대용량(수백 MB) 파일을 6개씩 동시에 올리면 서버 RAM 이
+// 터져 태스크가 죽고(→ 502/HTML 응답) 배치 전체가 "is not valid JSON" 으로 실패한다.
+// 큰 파일이 하나라도 있으면 2로 묶어 RAM 피크를 제한하고, 파일당 업로드 대역폭도 확보한다.
+const LARGE_FILE_BYTES = 50 * 1024 * 1024;
+function uploadConcurrency(files: File[]): number {
+  return files.some((f) => f.size > LARGE_FILE_BYTES) ? 2 : 6;
+}
 
 type Folder = {
   id: string;
@@ -359,8 +368,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       form.append("file", file);
       // 문서함 전용 엔드포인트 — 서버에서 500MB 까지 허용.
       const res = await apiFetch("/api/upload/document", { method: "POST", body: form });
-      if (!res.ok) throw new Error((await res.json()).error);
-      const json = await res.json();
+      const json = await readUploadResponse(res);
       setDocForm((p) => ({
         ...p,
         title: p.title || file.name.replace(/\.[^.]+$/, ""),
@@ -391,8 +399,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     const form = new FormData();
     form.append("file", file);
     const res = await apiFetch("/api/upload/document", { method: "POST", body: form });
-    if (!res.ok) throw new Error((await res.json()).error);
-    const up = await res.json();
+    const up = await readUploadResponse(res);
     const fallbackScope: DocScope =
       scopeTab === "team" ? "TEAM" : scopeTab === "private" ? "PRIVATE" : "ALL";
     await api("/api/document", {
@@ -474,7 +481,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       //    에러는 그때그때 alert 로 띄우지 않고 모았다가 끝나고 사유별로 한 번에 보여준다.
       let done = 0;
       const failures: { rel: string; reason: string }[] = [];
-      await runInPool(list, 6, async (f) => {
+      await runInPool(list, uploadConcurrency(list), async (f) => {
         const rel: string = (f as any).webkitRelativePath || f.name;
         const parts = rel.split("/");
         const folderPath = parts.slice(0, -1).join("/");
@@ -486,8 +493,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
             const form = new FormData();
             form.append("file", f);
             const res = await apiFetch("/api/upload/document", { method: "POST", body: form });
-            if (!res.ok) throw new Error((await res.json()).error);
-            const up = await res.json();
+            const up = await readUploadResponse(res);
             await api("/api/document", {
               method: "POST",
               json: {
@@ -641,7 +647,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
       setFolderUpload({ done: 0, total: list.length, label: "" });
       let done = 0;
       const failures: { rel: string; reason: string }[] = [];
-      await runInPool(list, 6, async (f) => {
+      await runInPool(list, uploadConcurrency(list), async (f) => {
         try { await uploadAndCreate(f); }
         catch (e: any) { failures.push({ rel: f.name, reason: e?.message ?? "알 수 없는 오류" }); }
         done += 1;


### PR DESCRIPTION
Closes #1033

## 원인
- 업로드 에러 응답이 비-JSON(HTML/텍스트, 413·502·504)일 때 `res.json()` 이 깨져 `is not valid JSON` 노출
- 동시성 6 + 서버 memoryStorage(파일 통째 RAM 버퍼) → 대용량 6개 동시 업로드가 Fargate RAM 초과 → 배치 전체 실패

## 수정 (클라이언트 전용 · OTA)
- `api.ts` `readUploadResponse()`: 본문 text 우선 파싱, 비-JSON 은 HTTP 상태→친절 메시지
- `DocumentsPage` 업로드 3경로(단일·드롭·폴더)에 적용 + 대용량 포함 배치 동시성 6→2

## 검증
- 실제 함수를 스크린샷의 정확한 페이로드로 테스트(413 HTML·502 텍스트·400 JSON·200 정상) — 전부 명확한 메시지/정상 동작
- tsc + vite build 통과

## 비고
- 서버 변경 없음(OTA 만). 500MB 초과 단일 파일은 여전히 서버 한도로 거부(이제 명확히 안내). 그 이상은 스트리밍 업로드(서버 큰 변경) 후속 과제.