### PR TITLE
🔀 :: (#1035) 앱스토어 심사 반려 대응 (카메라 권한·창 메뉴)

### DIFF
--- a/HiNest-MacOS/build/entitlements.mas.plist
+++ b/HiNest-MacOS/build/entitlements.mas.plist
@@ -16,12 +16,6 @@
     <key>com.apple.security.files.downloads.read-write</key>
     <true/>
 
-    <!-- 영상·음성 통화 (getUserMedia) -->
-    <key>com.apple.security.device.camera</key>
-    <true/>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-
     <!-- App Store 배포 식별자 — 프로비저닝 프로파일과 일치해야 함.
          3NVCLTSP9V = 팀 ID (기존 Developer ID 서명 identity 에서 확인). -->
     <key>com.apple.application-identifier</key>

--- a/HiNest-MacOS/package.json
+++ b/HiNest-MacOS/package.json
@@ -56,8 +56,6 @@
       ],
       "hardenedRuntime": false,
       "extendInfo": {
-        "NSCameraUsageDescription": "영상 통화에 카메라를 사용합니다.",
-        "NSMicrophoneUsageDescription": "영상·음성 통화에 마이크를 사용합니다.",
         "ITSAppUsesNonExemptEncryption": false
       }
     },

--- a/HiNest-MacOS/src/main.ts
+++ b/HiNest-MacOS/src/main.ts
@@ -208,6 +208,71 @@ function showWindow() {
   mainWindow.focus();
 }
 
+/**
+ * 애플리케이션 메뉴.
+ *
+ * App Store 심사(Guideline 4) 대응: 메인 창을 닫으면 트레이로 숨겨지는데, 다시 열 수 있는
+ * "메뉴 항목"이 없으면 리젝된다 → "창" 메뉴와 앱 메뉴에 [HiNest 창 열기] 를 둔다.
+ * 또한 원격 웹앱을 띄우는 웹뷰라, 복사/붙여넣기·전체선택 같은 Edit 역할 메뉴가 없으면
+ * ⌘C/⌘V 등 키보드 단축키가 동작하지 않으므로 표준 메뉴(앱·편집·보기·창)를 함께 구성한다.
+ * (기본 메뉴를 setApplicationMenu 로 대체하므로 표준 항목을 직접 채워야 한다.)
+ */
+function buildAppMenu() {
+  const isMac = process.platform === "darwin";
+  const template: Electron.MenuItemConstructorOptions[] = [];
+
+  if (isMac) {
+    template.push({
+      label: app.name,
+      submenu: [
+        { role: "about" },
+        { type: "separator" },
+        { label: "HiNest 창 열기", click: () => showWindow() },
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    });
+  }
+
+  template.push({
+    label: "편집",
+    submenu: [
+      { role: "undo" },
+      { role: "redo" },
+      { type: "separator" },
+      { role: "cut" },
+      { role: "copy" },
+      { role: "paste" },
+      { role: "selectAll" },
+    ],
+  });
+
+  template.push({
+    label: "보기",
+    submenu: [{ role: "togglefullscreen" }],
+  });
+
+  template.push({
+    label: "창",
+    submenu: [
+      // ★ 닫아서 트레이로 숨긴 메인 창을 다시 여는 항목 (App Store 심사 필수)
+      { label: "HiNest 창 열기", accelerator: "CmdOrCtrl+0", click: () => showWindow() },
+      { type: "separator" },
+      { role: "minimize" },
+      { role: "zoom" },
+      { role: "front" },
+    ],
+  });
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
 app.on("second-instance", () => {
   showWindow();
 });
@@ -231,6 +296,7 @@ function initAutoLaunchDefault() {
 
 app.whenReady().then(() => {
   createWindow();
+  buildAppMenu();
   createTray();
   initAutoLaunchDefault();
 

--- a/desktop/build/entitlements.mac.plist
+++ b/desktop/build/entitlements.mac.plist
@@ -24,11 +24,7 @@
     <key>com.apple.security.files.downloads.read-write</key>
     <true/>
 
-    <!-- 생체 인증 / 키체인 / 패스키 관련 -->
-    <key>com.apple.security.device.camera</key>
-    <true/>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
+    <!-- AppleScript 자동화 (시스템 이벤트 등) -->
     <key>com.apple.security.automation.apple-events</key>
     <true/>
 


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1035

macOS(Mac App Store) 심사 반려 대응.

## ✅ 코드 수정 (이 PR)
- **2.4.5(i)**: 미사용 `com.apple.security.device.camera`·`audio-input` entitlement + NSCamera/NSMicrophone 사용설명 제거 (웹앱에 카메라/마이크 기능 없음). desktop 빌드도 정리.
- **Guideline 4**: 트레이로 숨긴 메인 창을 다시 열 메뉴 항목 부재 → 표준 앱 메뉴 + '창'/앱 메뉴에 'HiNest 창 열기'(⌘0). 웹뷰 복사·붙여넣기용 Edit 메뉴 포함.

## ⚠️ App Store Connect 조치 (사용자, 코드 아님)
- **5.2.5**: 표시 앱 이름의 'macOS' 제거. 빌드 productName 은 'HiNest' 라 스토어 리스팅 이름 문제 → App Store Connect 에서 이름 변경(번들ID 유지).

## 재제출
빌드 번호 올린 뒤 재빌드·재서명·업로드(서버/OTA 무관, 네이티브 바이너리).

검증: tsc 통과 · plist lint OK · 카메라 권한 제거 확인.

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1035
