### PR TITLE
🔀 :: (#1041) 메모·회의록 드래그앤드랍 안정화 (드롭존 확장 + 빗나간 드롭 가드)

### DIFF
--- a/client/src/components/MeetingEditor.tsx
+++ b/client/src/components/MeetingEditor.tsx
@@ -237,7 +237,22 @@ export default function MeetingEditor({ value, onChange, editable = true, placeh
   if (!editor) return null;
 
   return (
-    <div className={`meeting-editor ${editable ? "" : "is-readonly"}`}>
+    <div
+      className={`meeting-editor ${editable ? "" : "is-readonly"}`}
+      // 에디터 컨테이너 전체를 파일 드롭존으로 확장 — 글쓰기 영역(.ProseMirror)이 작은 빈 메모에서도
+      // 근처에 떨어뜨리면 삽입되게. 텍스트 위에 정확히 떨어지면 ProseMirror 의 handleDrop 이 처리하고
+      // (드롭 위치 삽입) e.defaultPrevented 가 켜지므로, 여기선 그 바깥(여백·툴바 등)에 떨어진
+      // 파일만 문서 끝에 삽입한다(중복 방지). 빈 영역에 떨궈도 안 먹던 기존 문제 해결.
+      onDragOver={editable ? (e) => { if (Array.from(e.dataTransfer?.types ?? []).includes("Files")) e.preventDefault(); } : undefined}
+      onDrop={editable ? (e) => {
+        if (e.defaultPrevented) return; // ProseMirror 가 이미 처리(텍스트 위 드롭)
+        const files = Array.from(e.dataTransfer?.files ?? []);
+        if (files.length === 0) return;
+        e.preventDefault();
+        const pos = editor.state.doc.content.size; // 문서 끝
+        for (const f of files) void uploadAndInsertAt(editor.view, pos, f);
+      } : undefined}
+    >
       {editable && <Toolbar editor={editor} />}
       <EditorContent editor={editor} className="meeting-editor-content" />
     </div>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -97,6 +97,15 @@ if (typeof window !== "undefined") {
     reportClientError(r?.message || String(r ?? "unhandledrejection"), r?.stack);
   });
 
+  // 파일을 화면 빈 곳(드롭존이 아닌 데)에 떨어뜨리면 브라우저/Electron 이 그 파일로 페이지를
+  // 이동시켜(앱이 통째로 사라짐) 버린다 — 메모에 사진 드롭하다 살짝 빗나가면 겪는 문제.
+  // 메모·문서함 등 실제 드롭존은 자기 onDrop 에서 preventDefault 하므로 defaultPrevented 가 켜진다
+  // → 그 외(처리 안 된) 파일 드롭만 막아 페이지가 날아가지 않게 한다. 내부 드래그(정렬 등)는
+  // dataTransfer 에 "Files" 가 없어 건드리지 않음.
+  const dropHasFiles = (e: DragEvent) => Array.from(e.dataTransfer?.types ?? []).includes("Files");
+  document.addEventListener("dragover", (e) => { if (dropHasFiles(e)) e.preventDefault(); });
+  document.addEventListener("drop", (e) => { if (dropHasFiles(e) && !e.defaultPrevented) e.preventDefault(); });
+
   // 핀치 줌 (iOS)
   document.addEventListener("gesturestart", (e) => e.preventDefault());
   document.addEventListener("gesturechange", (e) => e.preventDefault());


### PR DESCRIPTION
Closes #1041

## 원인
드롭존이 글쓰기 텍스트(.ProseMirror)뿐 → 살짝 빗나가면 브라우저/Electron 이 파일로 페이지를 이동(앱 사라짐).

## 수정 (클라 전용·OTA)
- `MeetingEditor`: 컨테이너 전체 드롭존(텍스트 밖도 문서 끝 삽입). 텍스트 위 정확한 드롭은 기존 handleDrop(위치 삽입), `defaultPrevented` 로 중복 방지.
- `main.tsx`: 드롭존 아닌 빈 곳 파일 드롭 앱 전역 차단 → 페이지 안 날아감. 실제 드롭존·내부 드래그는 무관.

## 검증
프리뷰: 툴바 영역 드롭→업로드 시도 / body 드롭→이동 차단. tsc+build 통과. 모바일은 OS 미지원→📎/붙여넣기.