### PR TITLE
🔀 :: (#1045) 위치 기반 자동출근 (지오펜스) — PR1 서버+관리자

### DIFF
--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -2724,20 +2724,36 @@ function AttendanceIpTab({ onCountChange }: { onCountChange?: (n: number) => voi
   const [labelInput, setLabelInput] = useState("");
   const [adding, setAdding] = useState(false);
 
+  // ── 위치 기반 자동출근(지오펜스) — 출근 IP 제한을 미러링한 별개 설정 ──
+  type Geofence = { id: string; lat: number; lng: number; radiusM: number; label: string | null; createdAt: string };
+  const [geoEnabled, setGeoEnabled] = useState(false);
+  const [geofences, setGeofences] = useState<Geofence[]>([]);
+  const [geoLabel, setGeoLabel] = useState("");
+  const [geoLat, setGeoLat] = useState("");
+  const [geoLng, setGeoLng] = useState("");
+  const [geoRadius, setGeoRadius] = useState("150");
+  const [geoAdding, setGeoAdding] = useState(false);
+  const [locating, setLocating] = useState(false);
+
   // 목록 길이가 바뀔 때마다 상위 탭 배지 카운트 동기화(추가/삭제 즉시 반영).
   useEffect(() => { onCountChange?.(items.length); }, [items.length, onCountChange]);
 
   async function load() {
     setLoading(true);
     try {
-      const res = await api<{
-        enabled: boolean;
-        allowedIps: { id: string; cidr: string; label: string | null; createdAt: string }[];
-        clientIp: string | null;
-      }>("/api/admin/attendance-ip");
-      setEnabled(res.enabled);
-      setItems(res.allowedIps);
-      setClientIp(res.clientIp);
+      const [ip, geo] = await Promise.all([
+        api<{
+          enabled: boolean;
+          allowedIps: { id: string; cidr: string; label: string | null; createdAt: string }[];
+          clientIp: string | null;
+        }>("/api/admin/attendance-ip"),
+        api<{ enabled: boolean; geofences: Geofence[] }>("/api/admin/attendance-geo"),
+      ]);
+      setEnabled(ip.enabled);
+      setItems(ip.allowedIps);
+      setClientIp(ip.clientIp);
+      setGeoEnabled(geo.enabled);
+      setGeofences(geo.geofences);
     } catch (e: any) {
       alertAsync({ title: "불러오기 실패", description: e?.message ?? String(e) });
     } finally {
@@ -2786,6 +2802,81 @@ function AttendanceIpTab({ onCountChange }: { onCountChange?: (n: number) => voi
     setItems((arr) => arr.filter((x) => x.id !== id));
     try { await api(`/api/admin/attendance-ip/${id}`, { method: "DELETE" }); }
     catch (e: any) { setItems(prev); alertAsync({ title: "제거 실패", description: e?.message ?? String(e) }); }
+  }
+
+  // ── 지오펜스 핸들러 ──
+  async function toggleGeo(next: boolean) {
+    setGeoEnabled(next);
+    try {
+      await api("/api/admin/attendance-geo", { method: "PATCH", json: { enabled: next } });
+    } catch (e: any) {
+      setGeoEnabled(!next);
+      alertAsync({ title: "변경 실패", description: e?.message ?? String(e) });
+    }
+  }
+
+  function useCurrentLocation() {
+    if (!navigator.geolocation) {
+      alertAsync({ title: "위치를 가져올 수 없어요", description: "이 기기/브라우저가 위치 기능을 지원하지 않아요." });
+      return;
+    }
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setGeoLat(pos.coords.latitude.toFixed(6));
+        setGeoLng(pos.coords.longitude.toFixed(6));
+        setLocating(false);
+      },
+      (err) => {
+        setLocating(false);
+        alertAsync({
+          title: "현재 위치를 가져오지 못했어요",
+          description: err?.message || "위치 권한을 허용했는지 확인해 주세요.",
+        });
+      },
+      { enableHighAccuracy: true, timeout: 10000 },
+    );
+  }
+
+  async function addGeo() {
+    const lat = Number(geoLat.trim());
+    const lng = Number(geoLng.trim());
+    const radiusM = Math.round(Number(geoRadius.trim()) || 0);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+      alertAsync({ title: "좌표를 확인하세요", description: "위도 -90~90, 경도 -180~180 범위의 숫자를 입력하세요." });
+      return;
+    }
+    if (!(radiusM >= 20 && radiusM <= 5000)) {
+      alertAsync({ title: "반경을 확인하세요", description: "반경은 20m ~ 5000m 사이여야 해요." });
+      return;
+    }
+    setGeoAdding(true);
+    try {
+      const res = await api<{ ok: boolean; item: Geofence }>("/api/admin/attendance-geo", {
+        method: "POST",
+        json: { lat, lng, radiusM, label: geoLabel.trim() || undefined },
+      });
+      setGeofences((arr) => [...arr, res.item]);
+      setGeoLabel(""); setGeoLat(""); setGeoLng(""); setGeoRadius("150");
+    } catch (e: any) {
+      alertAsync({ title: "추가 실패", description: e?.message ?? String(e) });
+    } finally {
+      setGeoAdding(false);
+    }
+  }
+
+  async function removeGeo(id: string) {
+    const ok = await confirmAsync({
+      title: "이 위치를 목록에서 제거할까요?",
+      description: "이 위치 반경에서는 더 이상 자동 출근이 안 돼요.",
+      tone: "danger",
+      confirmLabel: "제거",
+    });
+    if (!ok) return;
+    const prev = geofences;
+    setGeofences((arr) => arr.filter((x) => x.id !== id));
+    try { await api(`/api/admin/attendance-geo/${id}`, { method: "DELETE" }); }
+    catch (e: any) { setGeofences(prev); alertAsync({ title: "제거 실패", description: e?.message ?? String(e) }); }
   }
 
   return (
@@ -2851,6 +2942,87 @@ function AttendanceIpTab({ onCountChange }: { onCountChange?: (n: number) => voi
                   </div>
                 </div>
                 <button className="btn-icon" title="삭제" onClick={() => remove(it.id)}>
+                  <TrashIcon />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* ── 위치 기반 자동출근(지오펜스) — 출근 IP 제한과 같은 패턴 ── */}
+      <div className="panel p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[15px] font-extrabold text-ink-900">위치 기반 자동출근</div>
+            <div className="text-[12.5px] text-ink-500 mt-1 leading-relaxed">
+              켜면 등록한 사무실 위치 반경 안에 들어왔을 때 자동으로 출근 처리돼요. 모바일 앱의 위치 권한이 필요합니다.
+              플랫폼/슈퍼 관리자는 이 기능과 무관합니다.
+            </div>
+          </div>
+          <label className="flex items-center gap-2 select-none cursor-pointer">
+            <input type="checkbox" className="accent-brand-500 w-5 h-5" checked={geoEnabled}
+              onChange={(e) => toggleGeo(e.target.checked)} disabled={loading} />
+            <span className="text-[13px] font-bold text-ink-800">사용</span>
+          </label>
+        </div>
+      </div>
+
+      <div className="panel p-5">
+        <div className="text-[13px] font-bold text-ink-800 mb-3">사무실 위치 추가</div>
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex-1 min-w-[160px]">
+            <label className="field-label">라벨 (선택)</label>
+            <input className="input" placeholder="예: 본사 사무실"
+              value={geoLabel} onChange={(e) => setGeoLabel(e.target.value)} maxLength={60} />
+          </div>
+          <div className="w-[130px]">
+            <label className="field-label">위도</label>
+            <input className="input" placeholder="37.566500" inputMode="decimal"
+              value={geoLat} onChange={(e) => setGeoLat(e.target.value)} />
+          </div>
+          <div className="w-[130px]">
+            <label className="field-label">경도</label>
+            <input className="input" placeholder="126.978000" inputMode="decimal"
+              value={geoLng} onChange={(e) => setGeoLng(e.target.value)} />
+          </div>
+          <div className="w-[110px]">
+            <label className="field-label">반경 (m)</label>
+            <input className="input" placeholder="150" inputMode="numeric"
+              value={geoRadius} onChange={(e) => setGeoRadius(e.target.value)} />
+          </div>
+          <button className="btn-ghost" disabled={locating} onClick={useCurrentLocation}>
+            {locating ? "가져오는 중…" : "현재 위치 가져오기"}
+          </button>
+          <button className="btn-primary" disabled={geoAdding || !geoLat.trim() || !geoLng.trim()} onClick={addGeo}>추가</button>
+        </div>
+      </div>
+
+      <div className="panel p-0 overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-ink-100">
+          <div className="text-[13px] font-bold text-ink-800">사무실 위치 목록 <span className="text-ink-400 tabular ml-1">{geofences.length}</span></div>
+          {!geoEnabled && <span className="chip-amber text-[11px]">사용 꺼짐</span>}
+        </div>
+        {loading ? (
+          <div className="px-4 py-8 text-center text-[13px] text-ink-500">불러오는 중…</div>
+        ) : geofences.length === 0 ? (
+          <div className="px-4 py-10 text-center text-[13px] text-ink-500">
+            등록된 위치가 없어요. 위에서 추가하세요.
+          </div>
+        ) : (
+          <ul className="divide-y divide-ink-100">
+            {geofences.map((g) => (
+              <li key={g.id} className="px-4 py-3 flex items-center gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="text-[13px] font-bold text-ink-900 truncate">
+                    {g.label ? `${g.label} · ` : ""}{g.lat.toFixed(5)}, {g.lng.toFixed(5)}
+                    <span className="text-ink-400 font-semibold"> · 반경 {g.radiusM}m</span>
+                  </div>
+                  <div className="text-[11.5px] text-ink-500 truncate">
+                    {new Date(g.createdAt).toLocaleString("ko-KR")}
+                  </div>
+                </div>
+                <button className="btn-icon" title="삭제" onClick={() => removeGeo(g.id)}>
                   <TrashIcon />
                 </button>
               </li>

--- a/server/prisma/migrations/20260617900000_attendance_geofence/migration.sql
+++ b/server/prisma/migrations/20260617900000_attendance_geofence/migration.sql
@@ -1,0 +1,20 @@
+-- 회사 출근 위치(지오펜스) 자동출근.
+-- Company 에 attendanceGeoEnabled(기본 false) + 새 모델 CompanyAttendanceGeofence.
+-- 비파괴적: ADD COLUMN NOT NULL DEFAULT 는 PG 11+ 에서 메타데이터 전용 연산, 테이블 재작성·락 없음.
+
+ALTER TABLE "Company" ADD COLUMN "attendanceGeoEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE "CompanyAttendanceGeofence" (
+  "id" TEXT NOT NULL,
+  "companyId" TEXT NOT NULL,
+  "lat" DOUBLE PRECISION NOT NULL,
+  "lng" DOUBLE PRECISION NOT NULL,
+  "radiusM" INTEGER NOT NULL DEFAULT 150,
+  "label" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdById" TEXT,
+  CONSTRAINT "CompanyAttendanceGeofence_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "CompanyAttendanceGeofence_companyId_fkey" FOREIGN KEY ("companyId") REFERENCES "Company"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "CompanyAttendanceGeofence_companyId_idx" ON "CompanyAttendanceGeofence"("companyId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -133,6 +133,11 @@ model Company {
   // CompanyAttendanceAllowedIp(CIDR 다중) 중 하나에 매치돼야 한다. 꺼져있으면 어디서든 OK.
   attendanceIpRestrictEnabled Boolean @default(false)
   allowedIps     CompanyAttendanceAllowedIp[]
+  // 출근 위치(지오펜스) 자동출근 모드. 켜져있으면 attendance/geo-check-in 시 클라가 보낸
+  // 좌표가 CompanyAttendanceGeofence(반경 다중) 중 하나 안에 들어와야 출근 처리된다.
+  // IP 제한과 독립적인 별개 경로(둘 다 켤 수 있음).
+  attendanceGeoEnabled Boolean @default(false)
+  geofences      CompanyAttendanceGeofence[]
   slug           String?   @unique // URL/식별용 (선택)
   status         String    @default("PENDING") // PENDING | ACTIVE | SUSPENDED | REJECTED
   // ── 가입 신청자 정보 (스냅샷) ──
@@ -1309,6 +1314,22 @@ model CompanyAttendanceAllowedIp {
   companyId String
   company   Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
   cidr      String // 예: "203.241.45.67/32" 또는 "192.168.1.0/24"
+  label     String? // 메모용 (예: "본사 사무실", "도쿄 지점")
+  createdAt DateTime @default(now())
+  createdById String?
+
+  @@index([companyId])
+}
+
+/// 회사 출근 위치(지오펜스). Company.attendanceGeoEnabled=true 일 때만 의미.
+/// 중심 좌표(lat/lng)+반경(radiusM, 미터). 여러 개 등록 가능, OR 매칭(하나라도 반경 안이면 통과).
+model CompanyAttendanceGeofence {
+  id        String   @id @default(cuid())
+  companyId String
+  company   Company  @relation(fields: [companyId], references: [id], onDelete: Cascade)
+  lat       Float // 위도 (-90 ~ 90)
+  lng       Float // 경도 (-180 ~ 180)
+  radiusM   Int      @default(150) // 반경(미터)
   label     String? // 메모용 (예: "본사 사무실", "도쿄 지점")
   createdAt DateTime @default(now())
   createdById String?

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -29,6 +29,7 @@ import notificationRouter from "./routes/notification.js";
 import pushRouter from "./routes/push.js";
 import updatesRouter from "./routes/updates.js";
 import attendanceIpRestrictRouter from "./routes/attendanceIpRestrict.js";
+import attendanceGeofenceRouter from "./routes/attendanceGeofence.js";
 import searchRouter from "./routes/search.js";
 import documentRouter from "./routes/document.js";
 import approvalRouter from "./routes/approval.js";
@@ -296,6 +297,8 @@ app.use("/api/feature-flags", featureFlagsRouter);
 //    Express 가 /api/admin/attendance-ip 를 adminRouter 안에서 처리하려다 404 가 됨.
 // 회사 출근 IP 화이트리스트 — 회사 관리자(ADMIN) 전용. CRUD.
 app.use("/api/admin/attendance-ip", attendanceIpRestrictRouter);
+// 회사 출근 위치(지오펜스) — 회사 관리자(ADMIN) 전용. CRUD. (attendance-ip 미러)
+app.use("/api/admin/attendance-geo", attendanceGeofenceRouter);
 app.use("/api/admin", adminRouter);
 app.use("/api/platform", platformRouter);
 app.use("/api/users", usersRouter);

--- a/server/src/lib/geoMatch.ts
+++ b/server/src/lib/geoMatch.ts
@@ -1,0 +1,56 @@
+/**
+ * 좌표 ↔ 지오펜스(원형 반경) 매칭 유틸 — 회사 출근 위치 자동출근 검사용.
+ *
+ * 의존성 없이 위경도 거리(Haversine)만 계산. 단일 IP 가 "/32" 로 정규화되듯, 여기선
+ * 각 사무실을 (중심좌표, 반경m) 원으로 표현하고 OR 매칭(하나라도 반경 안이면 통과).
+ * 클라가 보낸 lat/lng(GPS)와 회사 등록 좌표를 비교 — IP 처럼 위·변조 가능성은 있으나
+ * 모바일 OS 위치 권한 기반이라 사무실 출근 편의 용도로는 충분.
+ */
+
+const EARTH_RADIUS_M = 6_371_000; // 지구 평균 반지름(m)
+
+function toRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/** 두 좌표 사이 대원 거리(미터). Haversine. */
+export function haversineMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_M * c;
+}
+
+/** lat/lng 가 유효한 좌표 범위인가. (lat -90~90, lng -180~180, 유한 숫자) */
+export function isValidLatLng(lat: number, lng: number): boolean {
+  return (
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+}
+
+/** 반경(m) 검증 — 20m ~ 5000m. 너무 작으면 GPS 오차로 출근 불가, 너무 크면 무의미. */
+export function isValidRadius(m: number): boolean {
+  return Number.isInteger(m) && m >= 20 && m <= 5000;
+}
+
+/** lat/lng 가 fences 중 하나라도 반경 안이면 true. fences 가 비어있으면 false(통과 안 함). */
+export function withinAnyGeofence(
+  lat: number,
+  lng: number,
+  fences: { lat: number; lng: number; radiusM: number }[],
+): boolean {
+  if (!fences.length) return false;
+  if (!isValidLatLng(lat, lng)) return false;
+  for (const f of fences) {
+    if (haversineMeters(lat, lng, f.lat, f.lng) <= f.radiusM) return true;
+  }
+  return false;
+}

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -5,6 +5,7 @@ import { requireAuth, writeLog } from "../lib/auth.js";
 import { notify } from "../lib/notify.js";
 import { todayStr } from "../lib/dates.js";
 import { ipMatchesAny, normalizeClientIp } from "../lib/ipMatch.js";
+import { withinAnyGeofence, isValidLatLng } from "../lib/geoMatch.js";
 import { normalizeSessions, workedMinutes, hasOpenSession, closeOpenSessions, type WorkSession } from "../lib/attendanceSessions.js";
 
 const router = Router();
@@ -127,6 +128,92 @@ router.post("/check-out", async (req, res) => {
   });
   await writeLog(u.id, "CHECK_OUT", date);
   res.json({ attendance: rec, workedMinutes: workedMinutes(normalizeSessions(rec)), working: false });
+});
+
+// 위치 자동출근 설정 조회 — 네이티브가 지오펜스 등록(OS 위치 모니터링)에 사용.
+// 슈퍼/플랫폼 어드민·회사 없음은 enabled:false 로 응답(자동출근 대상 아님).
+router.get("/geo-config", async (req, res) => {
+  const u = (req as any).user;
+  if (!u.companyId || u.superAdmin || u.platformAdmin) {
+    return res.json({ enabled: false, geofences: [] });
+  }
+  const company = await prisma.company.findUnique({
+    where: { id: u.companyId },
+    select: {
+      attendanceGeoEnabled: true,
+      geofences: { select: { lat: true, lng: true, radiusM: true } },
+    },
+  });
+  res.json({
+    enabled: !!company?.attendanceGeoEnabled,
+    geofences: company?.geofences ?? [],
+  });
+});
+
+// 위치 기반 자동출근 — 네이티브가 회사 반경 진입 시 호출. 좌표가 등록된 지오펜스 안이면 출근.
+// IP 자동출근(check-in src="ip")과 동일한 다중 세션 로직, src="geo".
+//   (a) 회사 없음/슈퍼·플랫폼 어드민 → 400
+//   (b) 위치 자동출근 꺼짐 or 지오펜스 0건 → 400 GEO_DISABLED
+//   (c) 반경 밖 → 403 GEO_OUT_OF_RANGE
+//   (d) 이미 근무 중(열린 세션 존재) → 멱등(현재 상태 반환, 중복 출근 X)
+// IP 제한이 켜져 있어도 geo-check-in 은 통과 — 별개 경로.
+const geoCheckInSchema = z.object({
+  lat: z.number(),
+  lng: z.number(),
+  accuracy: z.number().optional(),
+});
+router.post("/geo-check-in", async (req, res) => {
+  const u = (req as any).user;
+  if (!u.companyId || u.superAdmin || u.platformAdmin) {
+    return res.status(400).json({ error: "위치 자동출근 대상이 아니에요." });
+  }
+  const parsed = geoCheckInSchema.safeParse(req.body);
+  if (!parsed.success || !isValidLatLng(parsed.data.lat, parsed.data.lng)) {
+    return res.status(400).json({ error: "올바른 좌표가 아니에요." });
+  }
+  const { lat, lng } = parsed.data;
+  const date = todayStr();
+
+  const company = await prisma.company.findUnique({
+    where: { id: u.companyId },
+    select: {
+      attendanceGeoEnabled: true,
+      geofences: { select: { lat: true, lng: true, radiusM: true } },
+    },
+  });
+  if (!company?.attendanceGeoEnabled || company.geofences.length === 0) {
+    return res.status(400).json({ code: "GEO_DISABLED", error: "위치 자동출근이 꺼져 있어요." });
+  }
+  if (!withinAnyGeofence(lat, lng, company.geofences)) {
+    return res.status(403).json({ code: "GEO_OUT_OF_RANGE", error: "회사 위치 반경 밖이에요" });
+  }
+
+  const existing = await prisma.attendance.findUnique({
+    where: { userId_date: { userId: u.id, date } },
+  });
+  const sessions = normalizeSessions(existing);
+
+  // 이미 근무 중이면 멱등 — 새 세션을 또 열지 않는다(반경 재진입 중복 출근 방지).
+  if (hasOpenSession(sessions)) {
+    return res.json({ attendance: existing, workedMinutes: workedMinutes(sessions), working: true });
+  }
+
+  const now = new Date();
+  sessions.push({ s: now.toISOString(), e: null, src: "geo" });
+  const firstCheckIn = existing?.checkIn ?? now; // 최초 출근 시각 보존
+  const rec = await prisma.attendance.upsert({
+    where: { userId_date: { userId: u.id, date } },
+    update: { sessions: sessions as unknown as object, checkIn: firstCheckIn, checkOut: null },
+    create: {
+      userId: u.id,
+      companyId: u.companyId ?? null,
+      date,
+      checkIn: now,
+      sessions: [{ s: now.toISOString(), e: null, src: "geo" }] as unknown as object,
+    },
+  });
+  await writeLog(u.id, "CHECK_IN", date, "geo-auto");
+  res.json({ attendance: rec, workedMinutes: workedMinutes(normalizeSessions(rec)), working: true });
 });
 
 // 월별 근태 기록

--- a/server/src/routes/attendanceGeofence.ts
+++ b/server/src/routes/attendanceGeofence.ts
@@ -1,0 +1,116 @@
+/**
+ * 회사 출근 위치(지오펜스) 관리 — 회사 관리자(ADMIN) 전용 CRUD.
+ *
+ * 라우터:
+ *   GET    /api/admin/attendance-geo          현재 설정 + 등록된 사무실 위치 목록
+ *   PATCH  /api/admin/attendance-geo          enabled toggle
+ *   POST   /api/admin/attendance-geo          항목 추가 (lat/lng/radiusM + label)
+ *   DELETE /api/admin/attendance-geo/:id      항목 삭제
+ *
+ * 슈퍼/플랫폼 어드민은 super-admin 콘솔에서 별도 관리. 여기는 회사 단위.
+ * 출근 IP 제한(attendanceIpRestrict.ts)을 미러링한 별개 경로 — 둘은 독립적.
+ */
+import { Router } from "express";
+import { z } from "zod";
+import { prisma } from "../lib/db.js";
+import { requireAuth, writeLog } from "../lib/auth.js";
+import { isValidLatLng, isValidRadius } from "../lib/geoMatch.js";
+
+const router = Router();
+router.use(requireAuth);
+
+function requireCompanyAdmin(req: any, res: any) {
+  const u = req.user;
+  if (!u || u.role !== "ADMIN" || !u.companyId) {
+    res.status(403).json({ error: "회사 관리자 권한이 필요합니다." });
+    return null;
+  }
+  return u;
+}
+
+router.get("/", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  const company = await prisma.company.findUnique({
+    where: { id: u.companyId },
+    select: {
+      attendanceGeoEnabled: true,
+      geofences: {
+        select: { id: true, lat: true, lng: true, radiusM: true, label: true, createdAt: true },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+  res.json({
+    enabled: !!company?.attendanceGeoEnabled,
+    geofences: company?.geofences ?? [],
+    // 서버는 클라 위치를 알 수 없음 — UI 의 "현재 위치 가져오기" 가 navigator.geolocation 으로 채움.
+    clientLatLng: null,
+  });
+});
+
+const patchSchema = z.object({ enabled: z.boolean() });
+router.patch("/", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  const parsed = patchSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  await prisma.company.update({
+    where: { id: u.companyId },
+    data: { attendanceGeoEnabled: parsed.data.enabled },
+  });
+  await writeLog(u.id, "ATTENDANCE_GEO_TOGGLE", u.companyId, String(parsed.data.enabled));
+  res.json({ ok: true, enabled: parsed.data.enabled });
+});
+
+const postSchema = z.object({
+  lat: z.number(),
+  lng: z.number(),
+  radiusM: z.number().int().default(150),
+  label: z.string().max(60).optional(),
+});
+router.post("/", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  const parsed = postSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "invalid input" });
+  const { lat, lng, radiusM } = parsed.data;
+  if (!isValidLatLng(lat, lng)) {
+    return res.status(400).json({ error: "올바른 좌표가 아니에요 (위도 -90~90, 경도 -180~180)." });
+  }
+  if (!isValidRadius(radiusM)) {
+    return res.status(400).json({ error: "반경은 20m ~ 5000m 사이여야 해요." });
+  }
+  const created = await prisma.companyAttendanceGeofence.create({
+    data: {
+      companyId: u.companyId,
+      lat,
+      lng,
+      radiusM,
+      label: parsed.data.label?.trim() || null,
+      createdById: u.id,
+    },
+    select: { id: true, lat: true, lng: true, radiusM: true, label: true, createdAt: true },
+  });
+  await writeLog(
+    u.id,
+    "ATTENDANCE_GEO_ADD",
+    u.companyId,
+    `${lat},${lng} r${radiusM}m${parsed.data.label ? ` (${parsed.data.label})` : ""}`,
+  );
+  res.json({ ok: true, item: created });
+});
+
+router.delete("/:id", async (req, res) => {
+  const u = requireCompanyAdmin(req, res);
+  if (!u) return;
+  // 다른 회사 항목 삭제 차단 — companyId 필터.
+  const result = await prisma.companyAttendanceGeofence.deleteMany({
+    where: { id: req.params.id, companyId: u.companyId },
+  });
+  if (result.count === 0) return res.status(404).json({ error: "not found" });
+  await writeLog(u.id, "ATTENDANCE_GEO_REMOVE", u.companyId, req.params.id);
+  res.json({ ok: true });
+});
+
+export default router;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1045

백그라운드 위치 자동출근 1단계. 서버 지오펜스 스키마/API + 관리자 위치 설정 UI (IP 제한 미러).

- 스키마+마이그레이션(추가형), geoMatch(Haversine), /api/admin/attendance-geo CRUD, /api/attendance/geo-config + geo-check-in(멱등·IP 독립), 관리자 UI.
- tsc(서버+클라)+build 통과. geo-check-in=check-in 세션 미러(src=geo).
- PR2(네이티브 백그라운드 지오펜스)는 후속.

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1045
