### PR TITLE
🔀 :: (#1047) 업로드 한도 상향(문서함 2GB·채팅/메모 500MB) + 인라인 영상 presigned 스트리밍

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -525,11 +525,11 @@ export default function ChatMiniApp({
   }, [creatingGroup]);
 
   async function uploadFile(file: File): Promise<Attachment | null> {
-    // 채팅 첨부는 서버에서 100MB 까지만 받음. 미리 걸러 사용자 경험을 개선.
-    if (file.size > 100 * 1024 * 1024) {
+    // 채팅 첨부는 서버에서 500MB 까지만 받음. 미리 걸러 사용자 경험을 개선.
+    if (file.size > 500 * 1024 * 1024) {
       alertAsync({
         title: "파일 크기 초과",
-        description: "채팅 첨부는 100MB 이하만 가능해요. 더 큰 파일은 문서함으로 공유해주세요.",
+        description: "채팅 첨부는 500MB 이하만 가능해요. 더 큰 파일은 문서함으로 공유해주세요.",
       });
       return null;
     }

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -23,10 +23,11 @@ const DocMemoModal = lazy(() => import("../components/DocMemoModal"));
 // 대용량 파일이 섞이면 동시 업로드 수를 줄인다. 서버는 업로드 파일을 통째로 메모리에
 // 버퍼(memoryStorage)하므로, 대용량(수백 MB) 파일을 6개씩 동시에 올리면 서버 RAM 이
 // 터져 태스크가 죽고(→ 502/HTML 응답) 배치 전체가 "is not valid JSON" 으로 실패한다.
-// 큰 파일이 하나라도 있으면 2로 묶어 RAM 피크를 제한하고, 파일당 업로드 대역폭도 확보한다.
+// 큰 파일이 하나라도 있으면 3으로 묶어 RAM 피크를 제한하고, 파일당 업로드 대역폭도 확보한다.
+// (diskStorage 스트리밍이라 RAM 안전 → 기존 2 → 3 으로 상향, 대용량 배치도 더 빨리.)
 const LARGE_FILE_BYTES = 50 * 1024 * 1024;
 function uploadConcurrency(files: File[]): number {
-  return files.some((f) => f.size > LARGE_FILE_BYTES) ? 2 : 6;
+  return files.some((f) => f.size > LARGE_FILE_BYTES) ? 3 : 6;
 }
 
 type Folder = {
@@ -358,15 +359,15 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   }
 
   async function uploadFile(file: File) {
-    if (file.size > 500 * 1024 * 1024) {
-      await alertAsync({ title: "파일 크기 초과", description: "파일은 500MB 이하만 업로드 가능해요" });
+    if (file.size > 2048 * 1024 * 1024) {
+      await alertAsync({ title: "파일 크기 초과", description: "파일은 2GB 이하만 업로드 가능해요" });
       return;
     }
     setUploading(true);
     try {
       const form = new FormData();
       form.append("file", file);
-      // 문서함 전용 엔드포인트 — 서버에서 500MB 까지 허용.
+      // 문서함 전용 엔드포인트 — 서버에서 2GB 까지 허용.
       const res = await apiFetch("/api/upload/document", { method: "POST", body: form });
       const json = await readUploadResponse(res);
       setDocForm((p) => ({
@@ -392,8 +393,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
    * 사용자 선택이 필요하므로 드롭 업로드에선 ALL 로 내린다.
    */
   async function uploadAndCreate(file: File) {
-    if (file.size > 500 * 1024 * 1024) {
-      await alertAsync({ title: "파일 크기 초과", description: "파일은 500MB 이하만 업로드 가능해요" });
+    if (file.size > 2048 * 1024 * 1024) {
+      await alertAsync({ title: "파일 크기 초과", description: "파일은 2GB 이하만 업로드 가능해요" });
       return;
     }
     const form = new FormData();
@@ -487,8 +488,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
         const folderPath = parts.slice(0, -1).join("/");
         const targetFolderId = pathToId.get(folderPath) ?? null;
         try {
-          if (f.size > 500 * 1024 * 1024) {
-            failures.push({ rel, reason: "500MB 초과" });
+          if (f.size > 2048 * 1024 * 1024) {
+            failures.push({ rel, reason: "2GB 초과" });
           } else {
             const form = new FormData();
             form.append("file", f);
@@ -1715,7 +1716,7 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
                 ) : (
                   <>
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#6B7280" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 3v12" /><path d="m7 8 5-5 5 5" /><path d="M20 21H4" /></svg>
-                    <div className="text-[13px] font-bold text-ink-800">파일 선택 (최대 500MB)</div>
+                    <div className="text-[13px] font-bold text-ink-800">파일 선택 (최대 2GB)</div>
                     <div className="text-[11px] text-ink-500">여러 개 선택 가능 · 링크만 있는 문서도 OK</div>
                   </>
                 )}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -429,7 +429,7 @@ app.use("/uploads", uploadsQueryToken, requireAuth, async (req, res) => {
 
     // 다운로드(첨부)는 presigned URL 로 302 리다이렉트 — 클라이언트가 스토리지(S3 CDN)에서 직접 받는다.
     // ECS 가 전체 파일을 메모리로 버퍼링해 되넘기던 4-hop 경로 제거 → 속도 대폭 향상 + 504 타임아웃 해소 +
-    // ResponseContentDisposition 으로 원본 파일명 보장. (인라인 이미지/영상은 아래 버퍼+캐시 경로 유지 —
+    // ResponseContentDisposition 으로 원본 파일명 보장. (인라인 이미지/오디오는 아래 버퍼+캐시 경로 유지 —
     // 아바타 재요청 시 max-age 캐시 활용, 매 로드마다 리다이렉트 hop 이 생기지 않게.)
     if (wantAttachment) {
       const signed = await getSignedDownloadUrl(name, {
@@ -442,7 +442,19 @@ app.use("/uploads", uploadsQueryToken, requireAuth, async (req, res) => {
       }
     }
 
-    // 인라인 이미지/영상, 또는 presigned 실패 → 기존 버퍼 스트림(+캐시).
+    // 인라인 영상은 presigned(inline)로 302 — S3 가 Range 요청(탐색/스트리밍)을 직접 처리해
+    // ECS 가 큰 영상을 통째 버퍼링하던 것보다 훨씬 빠르고 RAM 도 안 쓴다. (이미지/오디오는
+    // 아래 버퍼+캐시 경로 유지 — 작은 파일 재요청 시 max-age 캐시 활용.)
+    if (!forceDownload && mt.startsWith("video/")) {
+      // 영상은 한 번 받은 URL 로 길게 재생/탐색하므로 TTL 을 넉넉히(6h) — 기본 5분이면 긴 영상이 중간에 끊긴다.
+      const signed = await getSignedDownloadUrl(name, { contentType: mt, expiresIn: 21600 }); // downloadName 없음 = inline
+      if (signed) {
+        res.setHeader("Cache-Control", "no-store");
+        return res.redirect(302, signed);
+      }
+    }
+
+    // 인라인 이미지/오디오, 또는 presigned 실패 → 기존 버퍼 스트림(+캐시).
     const file = await downloadFile(name);
     if (file) {
       const fmt = file.contentType || mt;

--- a/server/src/routes/upload.ts
+++ b/server/src/routes/upload.ts
@@ -64,8 +64,8 @@ function safeExt(name: string) {
 }
 
 // 용도별 업로드 한도.
-//  - 채팅/범용(`/api/upload`)       : 100MB
-//  - 문서함  (`/api/upload/document`) : 500MB (큰 파일이 자주 오가는 문서함 전용)
+//  - 채팅/범용(`/api/upload`)       : 500MB (채팅·메모)
+//  - 문서함  (`/api/upload/document`) : 2GB (큰 영상 등 — diskStorage 스트리밍이라 RAM 안전)
 //
 // diskStorage 사용(과거 memoryStorage 가 OOM 원인). memoryStorage 는 파일 전체를 RAM 에
 // 들고 있어, 대용량(수백 MB) 파일을 동시에 여러 개 올리면 Fargate 태스크 RAM 을 초과해
@@ -95,8 +95,8 @@ function buildUploader(maxBytes: number) {
   });
 }
 
-const uploadChat     = buildUploader(100 * 1024 * 1024); // 100MB
-const uploadDocument = buildUploader(500 * 1024 * 1024); // 500MB
+const uploadChat     = buildUploader(500 * 1024 * 1024);  // 500MB (채팅·메모)
+const uploadDocument = buildUploader(2048 * 1024 * 1024); // 2GB (문서함 — 대용량 영상)
 
 const router = Router();
 router.use(requireAuth);
@@ -171,10 +171,10 @@ function runUploader(uploader: ReturnType<typeof buildUploader>) {
   };
 }
 
-// 문서함 전용(500MB) — 반드시 범용 라우트보다 먼저 선언해야 `/` 매치보다 앞섬.
+// 문서함 전용(2GB) — 반드시 범용 라우트보다 먼저 선언해야 `/` 매치보다 앞섬.
 router.post("/document", runUploader(uploadDocument), storeAndRespond);
 
-// 채팅/범용(100MB) — 기존 `/api/upload` 를 그대로 유지해 채팅 클라 변경 불필요.
+// 채팅/범용(500MB) — 기존 `/api/upload` 를 그대로 유지해 채팅 클라 변경 불필요.
 router.post("/", runUploader(uploadChat), storeAndRespond);
 
 export default router;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1047

## 변경
- **한도 상향** (diskStorage 스트리밍이라 RAM 안전):
  - 채팅/메모(`/api/upload`): 100MB → **500MB**
  - 문서함(`/api/upload/document`): 500MB → **2GB**
- **인라인 영상**: 버퍼 프록시 → **presigned S3 302**(inline, TTL 6h) — Range 직접 처리(탐색 빠름·ECS RAM 미사용)
- 클라 가드 동기화 + 문서함 대용량 배치 동시성 2→3

## 검증
- server tsc ✅ / client tsc ✅ / vite build ✅
- presigned 실패 시 기존 버퍼 경로로 graceful fallback (안전)

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1047
