### PR TITLE
🔀 :: (#1049) 일정 추가 모달 날짜·시간 선택 안 되는 버그 (picker z-index)

### DIFF
--- a/client/src/components/DatePicker.tsx
+++ b/client/src/components/DatePicker.tsx
@@ -115,9 +115,10 @@ export default function DatePicker({
         )}
       </button>
       {open && pos && createPortal(
+        // z-[2000]: BottomSheet/모달(zIndex 1000~1200) 위에 떠야 클릭 가능 — 낮으면 시트 뒤로 깔림.
         <div
           ref={popRef}
-          className="fixed z-[100] bg-white rounded-lg shadow-lg border border-ink-100 p-3"
+          className="fixed z-[2000] bg-white rounded-lg shadow-lg border border-ink-100 p-3"
           style={{ width: 280, top: pos.top, left: pos.left }}
         >
           {/* 월 헤더 + 이동 */}

--- a/client/src/components/TimePicker.tsx
+++ b/client/src/components/TimePicker.tsx
@@ -119,9 +119,10 @@ export default function TimePicker({
         </svg>
       </button>
       {open && pos && createPortal(
+        // z-[2000]: BottomSheet/모달(zIndex 1000~1200) 위에 떠야 클릭 가능 — 낮으면 시트 뒤로 깔림.
         <div
           ref={popRef}
-          className="fixed z-[100] bg-white rounded-lg shadow-lg border border-ink-100"
+          className="fixed z-[2000] bg-white rounded-lg shadow-lg border border-ink-100"
           style={{ width: 220, top: pos.top, left: pos.left }}
         >
           <div className="flex items-center justify-between px-3 pt-2 pb-1">


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1049

DatePicker/TimePicker 팝오버 `z-[100]` → `z-[2000]` (BottomSheet zIndex 1000 뒤로 깔리던 것 수정). tsc ✅ / build ✅

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1049
