### PR TITLE
🔀 :: (#1051) 읽음 '1' 즉시 제거 + Picker 다크모드 색

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -276,6 +276,19 @@ export default function ChatMiniApp({
   };
 
   const markRead = async (roomId: string) => {
+    // 내 readStates 를 로컬에서 즉시 낙관 갱신 — 메시지별 "1" 뱃지가 SSE/30s 폴링 대기 없이 사라진다.
+    // (서버 POST 가 끝나면 SSE chat:update(kind:"read") 가 도착해 같은 값으로 재확인됨.)
+    const meId = user?.id;
+    if (meId && roomId === activeId) {
+      const now = new Date().toISOString();
+      setReadStates((prev) => {
+        const idx = prev.findIndex((r) => r.userId === meId);
+        if (idx < 0) return [...prev, { userId: meId, lastReadAt: now }];
+        const next = prev.slice();
+        next[idx] = { userId: meId, lastReadAt: now };
+        return next;
+      });
+    }
     try {
       await api(`/api/chat/rooms/${roomId}/read`, { method: "POST" });
     } catch {}

--- a/client/src/components/DatePicker.tsx
+++ b/client/src/components/DatePicker.tsx
@@ -118,7 +118,7 @@ export default function DatePicker({
         // z-[2000]: BottomSheet/모달(zIndex 1000~1200) 위에 떠야 클릭 가능 — 낮으면 시트 뒤로 깔림.
         <div
           ref={popRef}
-          className="fixed z-[2000] bg-white rounded-lg shadow-lg border border-ink-100 p-3"
+          className="fixed z-[2000] bg-[var(--c-surface)] rounded-lg shadow-lg border border-[color:var(--c-border)] p-3"
           style={{ width: 280, top: pos.top, left: pos.left }}
         >
           {/* 월 헤더 + 이동 */}

--- a/client/src/components/TimePicker.tsx
+++ b/client/src/components/TimePicker.tsx
@@ -122,7 +122,7 @@ export default function TimePicker({
         // z-[2000]: BottomSheet/모달(zIndex 1000~1200) 위에 떠야 클릭 가능 — 낮으면 시트 뒤로 깔림.
         <div
           ref={popRef}
-          className="fixed z-[2000] bg-white rounded-lg shadow-lg border border-ink-100"
+          className="fixed z-[2000] bg-[var(--c-surface)] rounded-lg shadow-lg border border-[color:var(--c-border)]"
           style={{ width: 220, top: pos.top, left: pos.left }}
         >
           <div className="flex items-center justify-between px-3 pt-2 pb-1">


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1051

전수 점검 후 발견된 사용자 체감 P0 2건:
1. **채팅** markRead 가 내 로컬 readStates 미갱신 → 30s 대기 후 '1' 사라짐 → 낙관 갱신
2. **UI** Picker 팝오버 bg-white 하드코딩 → 다크모드 화이트아웃 → CSS 토큰

검증: tsc ✅ / vite build ✅

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1051
