### PR TITLE
🔀 :: (#1053) 사용내역·문서 등록 모달 — 닫고 다시 열면 이전 입력 잔존

### DIFF
--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -163,11 +163,9 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   const [historyDoc, setHistoryDoc] = useState<Doc | null>(null);
   /** 현재 열린 메모 편집/열람 모달 (null = 닫힘 | "new" = 새 메모 | Doc = 기존 메모) */
   const [memoTarget, setMemoTarget] = useState<Doc | "new" | null>(null);
-  const [docForm, setDocForm] = useState<{
-    title: string; description: string; tags: string;
-    fileUrl: string; fileName: string; fileType: string; fileSize: number;
-    scope: DocScope; scopeTeam: string; scopeUserIds: string[];
-  }>({ title: "", description: "", tags: "", fileUrl: "", fileName: "", fileType: "", fileSize: 0, scope: "ALL", scopeTeam: "", scopeUserIds: [] });
+  type DocForm = { title: string; description: string; tags: string; fileUrl: string; fileName: string; fileType: string; fileSize: number; scope: DocScope; scopeTeam: string; scopeUserIds: string[]; };
+  const emptyDocForm = (): DocForm => ({ title: "", description: "", tags: "", fileUrl: "", fileName: "", fileType: "", fileSize: 0, scope: "ALL", scopeTeam: "", scopeUserIds: [] });
+  const [docForm, setDocForm] = useState<DocForm>(emptyDocForm);
   const fileRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
   // "폴더 업로드" 진행 상황 — 현재 파일 n/total 이랑 현재 경로를 표시한다.
@@ -180,6 +178,8 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
   //   - 브라우저가 returnValue 의 문자열을 그대로 보여주진 않지만(모질라/크롬 모두 무시),
   //     값을 세팅해야 모달이 뜬다. 업로드 안 하면 이 훅은 no-op.
   const isUploadingSomething = uploading || !!folderUpload;
+  // 문서 업로드 모달 열릴 때마다 폼 초기화 — 취소/닫기로 빠져나간 뒤 다시 열면 이전 입력 잔존하던 것 방지.
+  useEffect(() => { if (creating === "doc") setDocForm(emptyDocForm()); }, [creating]);
   useEffect(() => {
     if (!isUploadingSomething) return;
     const handler = (e: BeforeUnloadEvent) => {
@@ -695,7 +695,6 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
         },
       });
       setCreating(null);
-      setDocForm({ title: "", description: "", tags: "", fileUrl: "", fileName: "", fileType: "", fileSize: 0, scope: "ALL", scopeTeam: "", scopeUserIds: [] });
       await load();
     } catch (e: any) {
       setModalErr(e?.message ?? "문서 등록에 실패했어요");

--- a/client/src/pages/ExpensePage.tsx
+++ b/client/src/pages/ExpensePage.tsx
@@ -61,7 +61,7 @@ export default function ExpensePage() {
   const [loaded, setLoaded] = useState(false);
   const { refreshing, refresh } = useRefresh(() => load());
   const [open, setOpen] = useState(false);
-  const [form, setForm] = useState({
+  const emptyForm = () => ({
     usedAt: todayDT(),
     merchant: "",
     category: "식비",
@@ -69,7 +69,10 @@ export default function ExpensePage() {
     memo: "",
     receiptUrl: "",
   });
+  const [form, setForm] = useState(emptyForm);
   const [saving, setSaving] = useState(false);
+  // 모달 열 때마다 폼 초기화 — 취소/닫기로 빠져나간 뒤 다시 열면 이전 입력 잔존하던 것 방지.
+  useEffect(() => { if (open) setForm(emptyForm()); }, [open]);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -144,7 +147,6 @@ export default function ExpensePage() {
         },
       });
       setOpen(false);
-      setForm({ usedAt: todayDT(), merchant: "", category: "식비", amount: 0, memo: "", receiptUrl: "" });
       if (fileRef.current) fileRef.current.value = "";
       await load();
     } catch (err: any) {


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1053

ExpensePage / DocumentsPage 모달 open 시 form 초기화 useEffect 추가. tsc ✅ / build ✅ / preview 검증 ✅

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1053
