### PR TITLE
🔀 :: (#1069) 채팅 서버 P0 4건 — DND·payload·DIRECT 크로스테넌트·음소거 정책

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -931,6 +931,9 @@ function ListView({
           const title = displayTitle(r);
           const last = r.messages[0];
           const muted = !!roomSettings[r.id]?.muted;
+          // 음소거 방은 방 목록 뱃지를 0 으로 — 서버 알림 레코드는 유지되므로 벨/사이드바
+          // 카운트에는 남지만, 방 목록의 미읽음 뱃지는 표시 안 함(카톡·Slack 컨벤션).
+          // 서버 정책 참조: server/src/lib/notify.ts 상단 주석("음소거 방 알림 정책").
           const u = muted ? 0 : (unread[r.id] ?? 0);
           const mine = !!last && last.senderId === meId;
           const preview = last ? previewForMessage(last) : "새로운 대화를 시작해보세요";

--- a/server/src/lib/apns.ts
+++ b/server/src/lib/apns.ts
@@ -131,26 +131,60 @@ interface SendResult {
   reason?: string;
 }
 
+/**
+ * APNs 페이로드 4KB 상한(정확히는 4096B, 안전마진 96B 로 4000). 초과 시 PayloadTooLarge 로
+ * 거절돼 알림이 아예 안 온다 → 우아하게 축약:
+ *  1) senderAvatarPath 제거(NSE 는 기본 아바타 폴백)
+ *  2) 여전히 초과면 body 를 앞에서 slice(200)
+ *  3) 그래도 초과면 title 을 slice(80)
+ * 로그 남기고 조립된 페이로드 객체를 반환.
+ */
+const APNS_PAYLOAD_LIMIT = 4000;
+function buildApnsBody(payload: ApnsPayload): Buffer {
+  const build = (p: ApnsPayload): { obj: Record<string, unknown>; buf: Buffer } => {
+    const aps: Record<string, unknown> = {
+      alert: { title: p.title, ...(p.body ? { body: p.body } : {}) },
+      sound: p.sound || "default",
+    };
+    if (typeof p.badge === "number") aps.badge = p.badge;
+    if (p.groupId) aps["thread-id"] = p.groupId;
+    if (ENABLE_COMMUNICATION_PUSH && p.senderName) aps["mutable-content"] = 1;
+    const bodyObj: Record<string, unknown> = { aps };
+    if (p.linkUrl) bodyObj.linkUrl = p.linkUrl;
+    if (p.senderName) bodyObj.senderName = p.senderName;
+    if (p.senderAvatarPath) bodyObj.senderAvatarPath = p.senderAvatarPath;
+    if (p.senderAvatarColor) bodyObj.senderAvatarColor = p.senderAvatarColor;
+    return { obj: bodyObj, buf: Buffer.from(JSON.stringify(bodyObj)) };
+  };
+  let cur = payload;
+  let { buf } = build(cur);
+  if (buf.length <= APNS_PAYLOAD_LIMIT) return buf;
+  // 1) 아바타 경로 제거(NSE 가 기본 아바타 폴백)
+  cur = { ...cur, senderAvatarPath: undefined };
+  ({ buf } = build(cur));
+  if (buf.length <= APNS_PAYLOAD_LIMIT) {
+    console.warn("apns payload trimmed: dropped senderAvatarPath");
+    return buf;
+  }
+  // 2) body 축약(앞 200자)
+  if (cur.body && cur.body.length > 200) cur = { ...cur, body: cur.body.slice(0, 200) };
+  ({ buf } = build(cur));
+  if (buf.length <= APNS_PAYLOAD_LIMIT) {
+    console.warn("apns payload trimmed: sliced body");
+    return buf;
+  }
+  // 3) title 축약(앞 80자)
+  if (cur.title && cur.title.length > 80) cur = { ...cur, title: cur.title.slice(0, 80) };
+  ({ buf } = build(cur));
+  console.warn("apns payload trimmed: sliced title", { finalBytes: buf.length });
+  return buf;
+}
+
 /** 단일 기기 토큰에 발송. http2 스트림 1건 = 요청 1건. */
 function sendOne(deviceToken: string, payload: ApnsPayload, host: string): Promise<SendResult> {
   return new Promise((resolve) => {
-    const aps: Record<string, unknown> = {
-      alert: { title: payload.title, ...(payload.body ? { body: payload.body } : {}) },
-      sound: payload.sound || "default",
-    };
-    if (typeof payload.badge === "number") aps.badge = payload.badge;
-    // OS 알림센터에서 같은 대화(방)끼리 묶이도록 thread-id 지정. (collapse-id 와 달리 교체가 아님)
-    if (payload.groupId) aps["thread-id"] = payload.groupId;
-    // Communication Notification — senderName 이 있으면(채팅) NSE 가 발신자 아바타로 알림을 재구성하도록
-    // mutable-content 를 켜고, NSE 가 읽을 발신자 정보를 커스텀 키로 싣는다. NSE 미존재 시엔 일반 표시(무해).
-    // (ENABLE_COMMUNICATION_PUSH=false 동안은 mutable-content 를 끄고 일반 알림으로 표시 — 위 스위치 주석 참고)
-    if (ENABLE_COMMUNICATION_PUSH && payload.senderName) aps["mutable-content"] = 1;
-    const bodyObj: Record<string, unknown> = { aps };
-    if (payload.linkUrl) bodyObj.linkUrl = payload.linkUrl;
-    if (payload.senderName) bodyObj.senderName = payload.senderName;
-    if (payload.senderAvatarPath) bodyObj.senderAvatarPath = payload.senderAvatarPath;
-    if (payload.senderAvatarColor) bodyObj.senderAvatarColor = payload.senderAvatarColor;
-    const body = Buffer.from(JSON.stringify(bodyObj));
+    // 페이로드 4KB 상한 초과 시 아바타→body→title 순서로 축약(위 buildApnsBody 참고).
+    const body = buildApnsBody(payload);
 
     let session: http2.ClientHttp2Session;
     try {

--- a/server/src/lib/notify.ts
+++ b/server/src/lib/notify.ts
@@ -4,6 +4,16 @@ import { publish } from "./sse.js";
 import { sendApnsToUser, sendApnsToUsers } from "./apns.js";
 import { sendFcmToUser, sendFcmToUsers } from "./fcm.js";
 
+/**
+ * 음소거 방(RoomMember.muted=true) 알림 정책 — 카톡·Slack 과 동일:
+ *  - Notification 레코드는 그대로 저장(벨/사이드바 알림 카운트에 포함, 알림 히스토리 유지).
+ *  - SSE publish 도 유지(다른 탭·인앱 실시간 상태 동기화).
+ *  - APNs/FCM(폰 푸시)만 스킵 — "조용히" 가 정확히 이 뜻.
+ *  - 방 목록 뱃지(roomUnread)는 클라이언트가 muted 방에 대해 0 으로 표시
+ *    (client/src/components/ChatMiniApp.tsx `muted ? 0 : unread[r.id]`, 아래 900번대 라인).
+ * 이 컨벤션은 서버(여기)와 클라(위 참조 지점) 양쪽이 함께 지켜야 일관성 유지.
+ */
+
 export type NotifyType =
   | "NOTICE"
   | "DM"
@@ -128,7 +138,11 @@ export async function notify(input: NotifyInput) {
       }
       // 원격 푸시 — fire-and-forget. iOS=APNs, Android=FCM. 각 함수가 자기 platform 토큰만
       // 조회하므로 둘 다 호출해도 안전(미설정/토큰없음이면 내부 no-op).
-      if (!muted) {
+      // DND 게이트 — allowPush 는 위 resolveDelivery 에서 !inDnd 로 이미 계산됨. notifyMany 는
+      // pushFlag 로 이 검사를 하는데(line ~187), 여기서도 동일하게 걸어야 DND 중에도 폰이 울리는
+      // 버그가 안 남는다(과거: !muted 만 검사 → DND 무시).
+      const allowPush = !d || d.allowPush;
+      if (!muted && allowPush) {
         const p = { title: input.title, body: input.body, linkUrl: input.linkUrl, groupId: rid ?? undefined };
         void sendApnsToUser(input.userId, p);
         void sendFcmToUser(input.userId, p);

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -172,6 +172,13 @@ router.post("/rooms", async (req, res) => {
 
     const otherUser = await prisma.user.findUnique({ where: { id: other } });
     if (!otherUser) return res.status(400).json({ error: "상대를 찾을 수 없습니다" });
+    // 크로스테넌트 가드 — DIRECT 방은 같은 회사 멤버끼리만. 위 allSameCompanyUsers 는
+    // GROUP/TEAM 경로에만 걸려 있어(이 아래) DIRECT 는 다른 회사 유저와 DM 방을 만들 수 있었다.
+    // Prisma auto-scope 는 새 행의 companyId 를 주입할 뿐 사용자가 넘긴 외래 userId 가 같은 회사인지
+    // 검사하지 않는다. u.companyId 가 없으면(플랫폼/슈퍼) 스킵.
+    if (u.companyId && otherUser.companyId !== u.companyId) {
+      return res.status(400).json({ error: "같은 회사 멤버만 대화할 수 있습니다" });
+    }
 
     const room = await prisma.chatRoom.create({
       data: {


### PR DESCRIPTION
감사 패널에서 확인된 서버측 P0 4건 일괄 수정.

## 수정
1. **DND 시 APNs 발송 버그** (`server/src/lib/notify.ts:135-141`)
   - APNs 전송 조건에 `allowPush` 누락 → DND 시간대에도 푸시 발송
   - `if (!muted)` → `if (!muted && allowPush)`
2. **음소거 정책 컨벤션 문서화** (`notify.ts:7-16` + `ChatMiniApp.tsx:933-937`)
   - 코드 동작 변경 없이 정책 주석 추가 (카톡/Slack 표준: muted=알림억제, 뱃지는 유지)
3. **APNs 페이로드 4KB 초과 시 우아하게 축약** (`server/src/lib/apns.ts:134-176`)
   - `buildApnsBody()` 신설, 4000B 초과 시 senderAvatarPath 제거 → body slice(200) → title slice(80) 단계별
   - 기존엔 4KB 초과 시 APNs 거절 → 알림 아예 안 옴
4. **DIRECT 1:1방 크로스테넌트 가드** (`server/src/routes/chat.ts:175-181`)
   - `u.companyId && otherUser.companyId !== u.companyId` → 400
   - 기존: DIRECT 방 생성 시 companyId 검증 누락 (다른 회사 사용자와 DM 방 생성 가능)

## 검증
- server tsc ✅ / client tsc ✅ (ChatMiniApp 주석만)

## 감사 출처
전 도메인 감사 패널(알림/그룹방) P0 결과 통합