### PR TITLE
🔀 :: (#1074) 메시지 편집(수정) — 트리거 UI + 수정됨 표시

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -10,7 +10,7 @@ import { isNativeAppActive } from "../lib/appActive";
 import { prewarmChatAvatars } from "../lib/liquidGlassTabBar";
 import { setActiveChatRoom } from "../lib/desktopNotify";
 import { Browser } from "@capacitor/browser";
-import { alertAsync, confirmAsync } from "./ConfirmHost";
+import { alertAsync, confirmAsync, promptAsync } from "./ConfirmHost";
 import { SnippetSlashMenu, type SnippetSlashHandle } from "./chat/SnippetSlashMenu";
 import { MentionMenu, type MentionHandle } from "./chat/MentionMenu";
 import {
@@ -670,6 +670,39 @@ export default function ChatMiniApp({
   }
 
   /**
+   * 메시지 편집 — 본인 텍스트 메시지만. 백엔드 PATCH /messages/:id 는 이미 존재(작성자·8000자 가드,
+   * editedAt 세팅, chat:update(kind:"edit") 브로드캐스트). 여기선 트리거 UI 만: 여러 줄 프롬프트로
+   * 원문을 열어 수정 → 낙관 반영 → PATCH. 실패 시 원문으로 롤백. "(수정됨)" 표시는 렌더에서 editedAt 기준.
+   */
+  async function editMessage(m: Message) {
+    if (m.kind !== "TEXT" || m.deletedAt || m.pending) return;
+    const next = await promptAsync({
+      title: "메시지 수정",
+      defaultValue: m.content ?? "",
+      multiline: true,
+      confirmLabel: "저장",
+      cancelLabel: "취소",
+    });
+    if (next == null) return; // 취소
+    const trimmed = next.trim();
+    if (!trimmed) {
+      alertAsync({ title: "수정 실패", description: "빈 메시지로 저장할 수 없어요. 삭제를 원하면 삭제를 사용하세요." });
+      return;
+    }
+    if (trimmed === (m.content ?? "")) return; // 변화 없음
+    const prevContent = m.content;
+    const prevEditedAt = m.editedAt;
+    setMessages((prev) => prev.map((x) => (x.id === m.id ? { ...x, content: trimmed, editedAt: new Date().toISOString() } : x)));
+    try {
+      await api(`/api/chat/messages/${m.id}`, { method: "PATCH", json: { content: trimmed } });
+      // SSE chat:update(kind:"edit") 가 최신 메시지로 다시 덮어써 정합.
+    } catch (e: any) {
+      setMessages((prev) => prev.map((x) => (x.id === m.id ? { ...x, content: prevContent, editedAt: prevEditedAt } : x)));
+      alertAsync({ title: "수정 실패", description: e?.message ?? "잠시 후 다시 시도해주세요." });
+    }
+  }
+
+  /**
    * 메시지 삭제(소프트). 본인이 보낸 메시지만.
    * 확인 → 낙관적으로 deletedAt 설정 → DELETE 호출.
    * 서버는 chat:update(kind:"delete") 로 나머지 멤버에 브로드캐스트 → 모두 "삭제된 메시지" 로 대체.
@@ -972,6 +1005,7 @@ export default function ChatMiniApp({
           onReact={reactToMessage}
           onPin={pinMessage}
           onDelete={deleteMessage}
+          onEdit={editMessage}
           onRetry={retrySend}
           readStates={readStates}
           presenceMap={presenceMap}
@@ -2289,6 +2323,7 @@ function buildMessageActions(
   onPin: (id: string) => void,
   onDelete: (id: string) => void,
   onReply?: (m: Message) => void,
+  onEdit?: (m: Message) => void,
 ): MessageAction[] {
   const actions: MessageAction[] = [];
 
@@ -2299,6 +2334,16 @@ function buildMessageActions(
       label: "답장",
       icon: ActionIcons.reply,
       onSelect: () => onReply(m),
+    });
+  }
+
+  // 편집 — 본인이 보낸 텍스트 메시지만(삭제·전송중 제외). 백엔드 PATCH /messages/:id 존재.
+  if (onEdit && mine && m.kind === "TEXT" && !m.deletedAt && !m.pending) {
+    actions.push({
+      key: "edit",
+      label: "수정",
+      icon: ActionIcons.edit,
+      onSelect: () => onEdit(m),
     });
   }
 
@@ -2352,7 +2397,7 @@ function buildMessageActions(
 /* ======================= 대화방 ======================= */
 function RoomView({
   room, messages, meId, onBack, input, setInput, onSend, sending, scrollRef,
-  attachments, uploading, onPickFile, onRemoveAttachment, onReact, onPin, onDelete, onRetry, readStates, presenceMap,
+  attachments, uploading, onPickFile, onRemoveAttachment, onReact, onPin, onDelete, onEdit, onRetry, readStates, presenceMap,
 }: {
   room: Room; messages: Message[]; meId: string; onBack: () => void;
   input: string; setInput: (v: string) => void; onSend: () => void; sending: boolean;
@@ -2362,6 +2407,7 @@ function RoomView({
   onReact: (messageId: string, emoji: string) => void;
   onPin: (messageId: string) => void;
   onDelete: (messageId: string) => void;
+  onEdit: (m: Message) => void;
   onRetry: (setId: string) => void;
   readStates: { userId: string; lastReadAt: string | null }[];
   presenceMap: Record<string, { presenceStatus: string | null; workStatus: string | null; presenceMessage: string | null }>;
@@ -2758,7 +2804,7 @@ function RoomView({
                         예전에는 [시각 | 안읽음 | 버블] 이 한 줄로 늘어서 있어 "오후 6:03 1"
                         처럼 읽혀 어떤 값이 안읽음인지 즉시 구분되지 않던 문제가 있었음.
                         같은 발신자 연속 묶음의 마지막에만 시각을 노출(m.showTime). */}
-                    {(m.showTime && !m.deletedAt) || m.unread > 0 ? (
+                    {(m.showTime && !m.deletedAt) || m.unread > 0 || (!!m.editedAt && !m.deletedAt) ? (
                       <div
                         style={{
                           display: "flex",
@@ -2770,6 +2816,10 @@ function RoomView({
                           flexShrink: 0,
                         }}
                       >
+                        {/* 편집된 메시지 표시 — showTime 여부와 무관하게 editedAt 있으면 노출(카톡식). */}
+                        {m.editedAt && !m.deletedAt && (
+                          <span style={{ fontSize: 10, fontWeight: 500, color: C.gray500, lineHeight: 1.1 }}>수정됨</span>
+                        )}
                         {m.unread > 0 && (
                           <span
                             title={m.unreadNames?.length ? `안 읽음: ${m.unreadNames.join(", ")}` : undefined}
@@ -2918,7 +2968,7 @@ function RoomView({
                     onPick={(e) => onReact(m.id, e)}
                     onDismiss={() => { setReactingId(null); setReactingRect(null); }}
                     header={formatDetailed(new Date(m.createdAt))}
-                    actions={buildMessageActions(m, mine, onPin, onDelete)}
+                    actions={buildMessageActions(m, mine, onPin, onDelete, undefined, onEdit)}
                   >
                     <MessageBubble msg={m} mine={mine} />
                   </ReactionPicker>

--- a/client/src/components/ConfirmHost.tsx
+++ b/client/src/components/ConfirmHost.tsx
@@ -45,6 +45,8 @@ type PromptOpts = {
   cancelLabel?: string;
   /** 비밀번호 등 마스킹이 필요한 입력은 "password" 로. 기본은 "text". */
   inputType?: "text" | "password";
+  /** 여러 줄 입력(메시지 편집 등) — textarea 로 렌더하고 네이티브 단일줄 프롬프트 대신 인앱 모달 사용. */
+  multiline?: boolean;
 };
 
 type ConfirmResult = boolean | "secondary";
@@ -119,6 +121,8 @@ export function alertAsync(opts: AlertOpts): Promise<void> {
 }
 
 export function promptAsync(opts: PromptOpts): Promise<string | null> {
+  // 여러 줄 입력은 네이티브 단일줄 프롬프트로 표현 불가(개행 유실) → 항상 인앱 모달(textarea).
+  if (opts.multiline) return webPrompt(opts);
   if (useNativeDialogs()) {
     return LiquidGlassTabBar.promptInput({
       title: opts.title,
@@ -242,7 +246,18 @@ export default function ConfirmHost() {
               {dialog.opts.description}
             </div>
           )}
-          {dialog.kind === "prompt" && (
+          {dialog.kind === "prompt" && dialog.opts.multiline && (
+            <textarea
+              ref={inputRef as any}
+              className="input"
+              rows={4}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={dialog.opts.placeholder}
+              style={{ resize: "vertical", minHeight: 88 }}
+            />
+          )}
+          {dialog.kind === "prompt" && !dialog.opts.multiline && (
             <div className="relative">
               <input
                 ref={inputRef}

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -856,6 +856,7 @@ export const ActionIcons = {
   unpin: ICON_SVG(<><path d="M3 3l18 18" /><path d="M12 17v5" /><path d="M5 2h14l-2 7 3 5h-5" /></>),
   trash: ICON_SVG(<><path d="M3 6h18" /><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" /><path d="M10 11v6" /><path d="M14 11v6" /></>),
   reply: ICON_SVG(<><path d="M9 17l-5-5 5-5" /><path d="M20 18v-2a4 4 0 0 0-4-4H4" /></>),
+  edit: ICON_SVG(<><path d="M12 20h9" /><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" /></>),
 };
 
 /** 같은 이모지끼리 그룹핑 + 카운트 + 누구 단건지 이름 배열 */

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -39,6 +39,7 @@ export type Message = {
   fileType?: string | null;
   fileSize?: number | null;
   deletedAt?: string | null;
+  editedAt?: string | null;
   pinnedAt?: string | null;
   pinnedById?: string | null;
   createdAt: string;


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1074

백엔드·SSE 는 이미 완비, 트리거 UI 만 부재였음. 롱프레스 '수정' 액션 + multiline 편집 프롬프트(개행 보존) + '수정됨' 라벨. tsc ✅ / build ✅ / preview ✅

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1074
