### PR TITLE
🔀 :: (#1076) 메시지 답장(인용) — replyToId + 서버 + 인용 카드

### DIFF
--- a/client/src/components/ChatMiniApp.tsx
+++ b/client/src/components/ChatMiniApp.tsx
@@ -33,6 +33,7 @@ import type {
   Attachment,
   Message,
   MessageHit,
+  ReplyPreview,
   Room,
   RoomLocalSetting,
 } from "./chat/types";
@@ -746,6 +747,21 @@ export default function ChatMiniApp({
   //  실패 마킹된 로컬 메시지에서 재시도 클릭 시 이 맵을 참조해 send() 재호출.
   const pendingPayloadsRef = useRef<Map<string, { content: string; attachments: Attachment[] }>>(new Map());
 
+  // 답장(인용) 대상 — 롱프레스 '답장' 으로 세팅, 컴포저 위에 미리보기 바 노출, 전송 시 replyToId 로 전송.
+  const [replyingTo, setReplyingTo] = useState<ReplyPreview | null>(null);
+  function startReply(m: Message) {
+    if (m.deletedAt || m.pending) return;
+    setReplyingTo({
+      id: m.id,
+      content: m.content,
+      kind: m.kind,
+      fileName: m.fileName,
+      deletedAt: m.deletedAt,
+      sender: { id: m.sender.id, name: m.sender.name },
+    });
+    // 입력창 포커스는 RoomView 가 replyingTo 변화를 감지해 처리(textarea 가 거기 있음).
+  }
+
   async function send(retryPayload?: { content: string; attachments: Attachment[] }) {
     if (!activeId || sending) return; // 더블 클릭/Enter 연타 1차 방어선
     const content = retryPayload ? retryPayload.content : input.trim();
@@ -759,9 +775,12 @@ export default function ChatMiniApp({
             .filter((rm) => rm.user.id !== (user?.id ?? "") && content.includes(`@${rm.user.name}`))
             .map((rm) => rm.user.id)
         : [];
+    // 답장 대상 — 재시도는 원본 payload 만 재전송하므로 reply 는 최초 전송에서만.
+    const replyTarget = retryPayload ? null : replyingTo;
     if (!retryPayload) {
       setInput("");
       setAttachments([]);
+      setReplyingTo(null);
     }
     setSending(true);
 
@@ -801,6 +820,9 @@ export default function ChatMiniApp({
             pendingClientId: clientId,
             pendingSetId: setId,
             status: "sending",
+            // 답장은 첫 메시지(본문 포함)에만 붙인다.
+            replyToId: i === 0 ? replyTarget?.id : undefined,
+            replyTo: i === 0 ? (replyTarget ?? undefined) : undefined,
           },
           body: {
             content: i === 0 ? content : "",
@@ -810,6 +832,7 @@ export default function ChatMiniApp({
             fileType: a.type,
             fileSize: a.size,
             clientId,
+            replyToId: i === 0 ? replyTarget?.id : undefined,
           },
         });
       }
@@ -827,8 +850,10 @@ export default function ChatMiniApp({
           pendingClientId: clientId,
           pendingSetId: setId,
           status: "sending",
+          replyToId: replyTarget?.id,
+          replyTo: replyTarget ?? undefined,
         },
-        body: { content, kind: "TEXT", mentions, clientId },
+        body: { content, kind: "TEXT", mentions, clientId, replyToId: replyTarget?.id },
       });
     }
 
@@ -1006,6 +1031,9 @@ export default function ChatMiniApp({
           onPin={pinMessage}
           onDelete={deleteMessage}
           onEdit={editMessage}
+          onReply={startReply}
+          replyingTo={replyingTo}
+          onCancelReply={() => setReplyingTo(null)}
           onRetry={retrySend}
           readStates={readStates}
           presenceMap={presenceMap}
@@ -2397,7 +2425,7 @@ function buildMessageActions(
 /* ======================= 대화방 ======================= */
 function RoomView({
   room, messages, meId, onBack, input, setInput, onSend, sending, scrollRef,
-  attachments, uploading, onPickFile, onRemoveAttachment, onReact, onPin, onDelete, onEdit, onRetry, readStates, presenceMap,
+  attachments, uploading, onPickFile, onRemoveAttachment, onReact, onPin, onDelete, onEdit, onReply, replyingTo, onCancelReply, onRetry, readStates, presenceMap,
 }: {
   room: Room; messages: Message[]; meId: string; onBack: () => void;
   input: string; setInput: (v: string) => void; onSend: () => void; sending: boolean;
@@ -2408,6 +2436,9 @@ function RoomView({
   onPin: (messageId: string) => void;
   onDelete: (messageId: string) => void;
   onEdit: (m: Message) => void;
+  onReply: (m: Message) => void;
+  replyingTo: ReplyPreview | null;
+  onCancelReply: () => void;
   onRetry: (setId: string) => void;
   readStates: { userId: string; lastReadAt: string | null }[];
   presenceMap: Record<string, { presenceStatus: string | null; workStatus: string | null; presenceMessage: string | null }>;
@@ -2421,6 +2452,19 @@ function RoomView({
   const [reactingRect, setReactingRect] = useState<DOMRect | null>(null);
   const [ready, setReady] = useState(false);
   const nav = useNavigate();
+  // 답장 인용 카드 클릭 → 원본 메시지로 스크롤(MessageBubble 이 전역 이벤트 디스패치, 여기서 수신).
+  useEffect(() => {
+    const onScroll = (e: Event) => {
+      const id = (e as CustomEvent).detail?.id;
+      if (id) scrollToMessage(id);
+    };
+    window.addEventListener("chat:scroll-to-message", onScroll);
+    return () => window.removeEventListener("chat:scroll-to-message", onScroll);
+  }, []);
+  // 답장 시작(replyingTo 세팅) 시 입력창 포커스 — 바로 답장 작성.
+  useEffect(() => {
+    if (replyingTo) requestAnimationFrame(() => textareaRef.current?.focus());
+  }, [replyingTo?.id]);
   // 전송 래퍼 — onSend() 후 입력창 포커스를 되돌려 키보드를 유지(카톡/메신저처럼 연속 입력).
   // 전송 버튼이 width:0 으로 collapse 되거나 setInput("") 리렌더가 끼어도 다음 프레임에
   // textarea 로 포커스를 복원해 iOS/Android 가 키보드를 내리지 않게 한다.
@@ -2968,7 +3012,7 @@ function RoomView({
                     onPick={(e) => onReact(m.id, e)}
                     onDismiss={() => { setReactingId(null); setReactingRect(null); }}
                     header={formatDetailed(new Date(m.createdAt))}
-                    actions={buildMessageActions(m, mine, onPin, onDelete, undefined, onEdit)}
+                    actions={buildMessageActions(m, mine, onPin, onDelete, onReply, onEdit)}
                   >
                     <MessageBubble msg={m} mine={mine} />
                   </ReactionPicker>
@@ -3042,6 +3086,33 @@ function RoomView({
               업로드 중…
             </div>
           )}
+        </div>
+      )}
+
+      {/* 답장 대상 미리보기 바 — 롱프레스 '답장' 시 컴포저 위에 노출. X 로 취소. */}
+      {replyingTo && (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "7px 12px", borderTop: `1px solid ${C.gray200 ?? "#E5E7EB"}`, background: C.gray100 }}>
+          <div style={{ width: 3, alignSelf: "stretch", borderRadius: 2, background: "var(--c-brand)", flexShrink: 0 }} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 11, fontWeight: 700, color: "var(--c-brand)", lineHeight: 1.3 }}>
+              {replyingTo.sender.name}에게 답장
+            </div>
+            <div style={{ fontSize: 12, color: C.gray600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", lineHeight: 1.3 }}>
+              {replyingTo.deletedAt ? "삭제된 메시지"
+                : replyingTo.kind === "IMAGE" ? "사진"
+                : replyingTo.kind === "VIDEO" ? "동영상"
+                : replyingTo.kind === "FILE" ? (replyingTo.fileName || "파일")
+                : (replyingTo.content || "").replace(/\n/g, " ").slice(0, 60) || "메시지"}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onCancelReply}
+            aria-label="답장 취소"
+            style={{ flexShrink: 0, width: 26, height: 26, borderRadius: "50%", border: 0, background: "transparent", color: C.gray600, cursor: "pointer", display: "grid", placeItems: "center" }}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+          </button>
         </div>
       )}
 

--- a/client/src/components/chat/MessageBubble.tsx
+++ b/client/src/components/chat/MessageBubble.tsx
@@ -1044,8 +1044,72 @@ function MessageBubbleInner({ msg, mine }: { msg: Message; mine: boolean }) {
 // 얕은 비교로 충분 — msg 는 서버에서 객체 그대로 넘어오고, 증분 폴링 때 기존 요소의
 // 참조는 바뀌지 않는다. full 동기화(15초 주기) 시에만 reference 가 새로 만들어져
 // 재렌더가 발생 → 의도된 동작.
+/** 답장 인용 미리보기 카드 — 버블 위에 원본 발신자 + 내용 요약. 클릭 시 원본으로 스크롤(전역 이벤트). */
+function ReplyQuote({ reply, mine }: { reply: NonNullable<Message["replyTo"]>; mine: boolean }) {
+  const preview = reply.deletedAt
+    ? "삭제된 메시지"
+    : reply.kind === "IMAGE"
+    ? "사진"
+    : reply.kind === "VIDEO"
+    ? "동영상"
+    : reply.kind === "FILE"
+    ? reply.fileName || "파일"
+    : (reply.content || "").replace(/\n/g, " ").slice(0, 80) || "메시지";
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (reply.deletedAt) return;
+        window.dispatchEvent(new CustomEvent("chat:scroll-to-message", { detail: { id: reply.id } }));
+      }}
+      className="text-left"
+      style={{
+        maxWidth: "78%",
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        padding: "4px 9px",
+        marginBottom: -2,
+        borderRadius: 10,
+        borderLeft: "3px solid var(--c-brand)",
+        background: "var(--c-surface-2, rgba(0,0,0,0.04))",
+        cursor: reply.deletedAt ? "default" : "pointer",
+        opacity: reply.deletedAt ? 0.6 : 1,
+      }}
+    >
+      <span style={{ fontSize: 11, fontWeight: 700, color: "var(--c-brand)", lineHeight: 1.2 }}>
+        {reply.sender?.name ?? "알 수 없음"}
+      </span>
+      <span
+        style={{
+          fontSize: 12,
+          color: "var(--c-text-muted)",
+          lineHeight: 1.25,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          maxWidth: 220,
+        }}
+      >
+        {preview}
+      </span>
+    </button>
+  );
+}
+
+function MessageBubbleWrapped({ msg, mine }: { msg: Message; mine: boolean }) {
+  if (!msg.replyTo) return <MessageBubbleInner msg={msg} mine={mine} />;
+  // 답장이면 인용 카드를 버블 위에 스택(발신 측 정렬 맞춤).
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: mine ? "flex-end" : "flex-start", gap: 3 }}>
+      <ReplyQuote reply={msg.replyTo} mine={mine} />
+      <MessageBubbleInner msg={msg} mine={mine} />
+    </div>
+  );
+}
+
 export const MessageBubble = memo(
-  MessageBubbleInner,
+  MessageBubbleWrapped,
   (a, b) => a.mine === b.mine && a.msg === b.msg
 );
 

--- a/client/src/components/chat/types.ts
+++ b/client/src/components/chat/types.ts
@@ -27,6 +27,16 @@ export type Reaction = {
   user?: { name: string };
 };
 
+/** 답장 인용 미리보기 — 서버 REPLY_TO_SELECT 와 동일 얕은 형태. */
+export type ReplyPreview = {
+  id: string;
+  content: string;
+  kind: string;
+  fileName?: string | null;
+  deletedAt?: string | null;
+  sender: { id: string; name: string };
+};
+
 export type Message = {
   id: string;
   // 서버는 include 여부에 따라 roomId 를 포함하기도/생략하기도 한다. SSE 푸시
@@ -45,6 +55,9 @@ export type Message = {
   createdAt: string;
   sender: { id: string; name: string; avatarColor?: string; avatarUrl?: string | null };
   reactions?: Reaction[];
+  // 답장(인용) — 서버가 함께 내려주는 원본 메시지 얕은 미리보기.
+  replyToId?: string | null;
+  replyTo?: ReplyPreview | null;
   // 낙관적 전송 UI 전용 필드(서버는 안 봄).
   //  - pending: 로컬에 낙관적으로 삽입된 메시지(id 는 임시).
   //  - pendingClientId: 서버 응답/SSE 와 매칭해 dedup 하는 클라이언트 UUID.

--- a/server/prisma/migrations/20260701000000_chat_reply/migration.sql
+++ b/server/prisma/migrations/20260701000000_chat_reply/migration.sql
@@ -1,0 +1,8 @@
+-- 채팅 답장(인용) — ChatMessage 자기참조 replyToId. 추가형 nullable 컬럼.
+-- 원본이 하드삭제되면 SET NULL(소프트삭제는 deletedAt 이라 관계 유지). 비파괴적.
+
+ALTER TABLE "ChatMessage" ADD COLUMN "replyToId" TEXT;
+
+CREATE INDEX "ChatMessage_replyToId_idx" ON "ChatMessage"("replyToId");
+
+ALTER TABLE "ChatMessage" ADD CONSTRAINT "ChatMessage_replyToId_fkey" FOREIGN KEY ("replyToId") REFERENCES "ChatMessage"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -790,10 +790,14 @@ model ChatMessage {
   scheduledAt DateTime?
   pinnedAt    DateTime?
   pinnedById  String?
+  replyToId   String?
   createdAt   DateTime          @default(now())
   room        ChatRoom          @relation(fields: [roomId], references: [id], onDelete: Cascade)
   sender      User              @relation("Sender", fields: [senderId], references: [id], onDelete: Cascade)
   reactions   MessageReaction[]
+  // 답장(인용) — 원본 메시지 자기참조. 원본이 하드삭제되면 SetNull(소프트삭제는 deletedAt 유지).
+  replyTo     ChatMessage?      @relation("Reply", fields: [replyToId], references: [id], onDelete: SetNull)
+  replies     ChatMessage[]     @relation("Reply")
 
   @@index([roomId, scheduledAt])
   // after-cursor 증분 폴링 — createdAt 역정렬·범위 조회가 핵심 경로
@@ -803,6 +807,7 @@ model ChatMessage {
   // 기존 (roomId,*) 인덱스를 못 타고 (companyId) 로 떨어져 회사 전체 메시지를
   // 스캔했다. senderId 는 회사에 종속되므로 companyId prefix 불필요.
   @@index([senderId, scheduledAt])
+  @@index([replyToId])
 }
 
 model MessageReaction {

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -53,6 +53,16 @@ function broadcastToRoom(roomId: string, event: "chat:message" | "chat:update" |
   });
 }
 
+// 답장 인용 미리보기용 얕은 select — 원본 메시지의 최소 정보만(무한 중첩 방지).
+const REPLY_TO_SELECT = {
+  id: true,
+  content: true,
+  kind: true,
+  fileName: true,
+  deletedAt: true,
+  sender: { select: { id: true, name: true } },
+} as const;
+
 const router = Router();
 router.use(requireAuth);
 
@@ -430,11 +440,14 @@ router.get("/rooms/:id/messages", async (req, res) => {
     include: {
       sender: { select: USER_AVATAR_SELECT },
       reactions: { select: { userId: true, emoji: true, user: { select: { name: true } } } },
+      replyTo: { select: REPLY_TO_SELECT },
     },
   });
 
   // 삭제 메시지 마스킹 (단 본인 + superAdmin 은 원본 볼 수 있음)
   const messages = raw.map((m) => {
+    // 인용된 원본이 삭제됐으면 미리보기 내용도 감춘다(삭제 메시지 내용 유출 방지). 클라는 deletedAt 로 "삭제된 메시지" 표시.
+    const replyTo = m.replyTo?.deletedAt ? { ...m.replyTo, content: "", fileName: null } : m.replyTo;
     const hide = m.deletedAt && m.senderId !== u.id && !u.superAdmin;
     if (hide) {
       return {
@@ -445,9 +458,10 @@ router.get("/rooms/:id/messages", async (req, res) => {
         fileName: null,
         fileType: null,
         fileSize: null,
+        replyTo,
       };
     }
-    return m;
+    return { ...m, replyTo };
   });
 
   // readStates 는 room.members 에서 곧바로 뽑아 재사용 — 별도 쿼리 제거.
@@ -528,6 +542,8 @@ const sendSchema = z.object({
   scheduledAt: z.string().max(40).optional(),
   // 메시지 당 멘션은 50명 상한. 실무 과잉 방지 + 알림 폭탄 차단.
   mentions: z.array(z.string().max(50)).max(50).optional(),
+  // 답장 대상 원본 메시지 id(같은 방·미삭제 검증은 핸들러에서).
+  replyToId: z.string().max(40).optional(),
 });
 
 router.post("/rooms/:id/messages", async (req, res) => {
@@ -556,6 +572,22 @@ router.post("/rooms/:id/messages", async (req, res) => {
 
   const mentions = (d.mentions ?? []).filter((id) => id && id !== u.id);
 
+  // 답장 대상 검증 — 반드시 같은 방의 미삭제 메시지여야. 다른 방 원본 참조(내용 유출)·삭제 원본 차단.
+  let replyToId: string | null = null;
+  if (d.replyToId) {
+    const orig = await prisma.chatMessage.findUnique({
+      where: { id: d.replyToId },
+      select: { roomId: true, deletedAt: true },
+    });
+    if (!orig || orig.roomId !== req.params.id) {
+      return res.status(400).json({ error: "답장 대상 메시지를 찾을 수 없습니다" });
+    }
+    if (orig.deletedAt) {
+      return res.status(400).json({ error: "삭제된 메시지에는 답장할 수 없습니다" });
+    }
+    replyToId = d.replyToId;
+  }
+
   const msg = await prisma.chatMessage.create({
     data: {
       roomId: req.params.id,
@@ -568,11 +600,13 @@ router.post("/rooms/:id/messages", async (req, res) => {
       fileSize: d.fileSize,
       mentions: mentions.length ? mentions.join(",") : null,
       scheduledAt,
+      replyToId,
     },
     include: {
       sender: { select: USER_AVATAR_SELECT },
       room: { select: { id: true, name: true, type: true } },
       reactions: { select: { userId: true, emoji: true, user: { select: { name: true } } } },
+      replyTo: { select: REPLY_TO_SELECT },
     },
   });
 


### PR DESCRIPTION
## 원인
_소급 정리 — 원본 미기재_

## 수정(파일/모듈)

Closes #1076

replyToId 자기참조 스키마 + 마이그레이션 + 서버 검증/include + 롱프레스 답장/미리보기 바/인용 카드/원본 스크롤. server·client tsc ✅ / build ✅ / preview ✅

## 검증
_소급 정리 — 원본 미기재_

## 비고
_소급 정리 — 원본 미기재_

Closes #1076
