### PR TITLE
🔀 :: (#1091) 야근 신청서 PDF 서식 재디자인 — 전문 결재 양식·A4 규격 보장

### DIFF
--- a/client/src/lib/overtimePdf.ts
+++ b/client/src/lib/overtimePdf.ts
@@ -5,7 +5,12 @@
  * 서식 HTML 을 화면 밖 컨테이너에 주입 → html2canvas 캔버스화 → jsPDF(A4) 저장.
  * 서버(Fargate)에 Chromium/한글 폰트를 올리지 않고 "화면 = PDF" 를 보장한다.
  *
+ * 서식은 한국식 전자결재 출력물 표준 문법을 따른다:
+ * 우상단 결재 3단 박스(신청/담당/승인 + 일자 행) · 제목 이중 괘선 ·
+ * 외곽 2px/내부 1px 선 위계 · 하단 관용 문구·신청일·서명 밑줄·회사명.
+ *
  * 주의: html2canvas 는 oklch/CSS 변수를 못 읽으므로 서식 CSS 는 전부 hex + 시스템 폰트.
+ * 레이아웃은 table 기반(가장 캡처 안전) — flex/float/!important 사용 금지.
  * jspdf·html2canvas 는 무거우므로 동적 import — 버튼을 누를 때만 로드된다.
  */
 
@@ -27,6 +32,8 @@ export type OvertimeSheetData = {
   reason?: string | null;
   /** 신청일 ISO (createdAt) */
   createdAt: string;
+  /** 회사명 (멀티테넌트 — 목록 API 가 내려줌, 없으면 하단 사명 줄 생략) */
+  companyName?: string | null;
 };
 
 function esc(s: string): string {
@@ -42,58 +49,121 @@ function fmtTimeHM(iso: string): string {
   return new Date(iso).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 
-/** 서식 CSS — hex 색상 + 시스템 폰트만(html2canvas 호환). 급여명세서 .psheet 톤 미러. */
+/** YYYY-MM-DD → "YYYY-MM-DD (요일)" — 서식 가독용 요일 부기 */
+function fmtDateWithWeekday(ymd: string): string {
+  const d = new Date(ymd + "T00:00:00");
+  if (Number.isNaN(d.getTime())) return ymd;
+  return `${ymd} (${"일월화수목금토"[d.getDay()]})`;
+}
+
+/**
+ * A4 @96dpi. 루트는 min-height 로 잡는다 — 계획내용이 아주 길면 시트가 늘어나
+ * 2페이지로 흘러가고(내용 잘림 방지), 평소엔 정확히 1123px = A4 한 장.
+ */
+const A4_W = 794;
+const A4_H = 1123;
+
+/** 서식 CSS — hex 색상 + 시스템 폰트 + table 레이아웃만 (html2canvas 안전 패턴). */
 const SHEET_CSS = `
-.otsheet { font-family: -apple-system, BlinkMacSystemFont, "Pretendard", "Apple SD Gothic Neo", "Segoe UI", sans-serif; color: #1F2937; background: #FFFFFF; padding: 48px 44px; box-sizing: border-box; }
-.otsheet * { box-sizing: border-box; }
-.otsheet h1 { font-size: 24px; text-align: center; margin: 0 0 34px; letter-spacing: 0.35em; font-weight: 800; }
-.otsheet table.form { width: 100%; border-collapse: collapse; table-layout: fixed; }
-.otsheet table.form th, .otsheet table.form td { border: 1.5px solid #374151; padding: 12px 14px; font-size: 13.5px; vertical-align: top; }
-.otsheet table.form th { background: #F3F4F6; font-weight: 700; text-align: center; width: 128px; letter-spacing: 0.06em; }
-.otsheet table.form td { text-align: left; }
-.otsheet td.plan { height: 240px; line-height: 1.75; white-space: pre-wrap; word-break: break-word; }
-.otsheet .footer { margin-top: 44px; text-align: center; }
-.otsheet .footer .date { font-size: 14px; font-weight: 600; margin-bottom: 40px; letter-spacing: 0.08em; }
-.otsheet .signs { display: flex; justify-content: flex-end; gap: 56px; padding-right: 8px; }
-.otsheet .sign { font-size: 13.5px; font-weight: 600; }
-.otsheet .sign .line { display: inline-block; width: 130px; border-bottom: 1.5px solid #374151; margin: 0 8px; height: 18px; vertical-align: bottom; text-align: center; font-weight: 500; }
+.otsheet{box-sizing:border-box;width:${A4_W}px;min-height:${A4_H}px;background:#FFFFFF;padding:46px 54px 38px 54px;font-family:-apple-system,BlinkMacSystemFont,"Pretendard","Apple SD Gothic Neo","Malgun Gothic",sans-serif;color:#1F2329;}
+.otsheet *{box-sizing:border-box;margin:0;padding:0;}
+.otsheet table{border-collapse:collapse;width:100%;table-layout:fixed;}
+.otsheet .ot-head td{vertical-align:top;}
+.otsheet .ot-meta{font-size:11.5px;color:#8B9098;line-height:1.9;letter-spacing:0.5px;padding-top:2px;padding-right:20px;}
+.otsheet .ot-meta .ot-meta-code{color:#6B7178;font-weight:600;}
+.otsheet .ot-approve{width:300px;border:2px solid #1F1F1F;}
+.otsheet .ot-approve th,.otsheet .ot-approve td{border:1px solid #9AA0A8;text-align:center;vertical-align:middle;}
+.otsheet .ot-ap-side{width:32px;background:#F5F6F8;font-size:13px;font-weight:700;color:#3A3F46;line-height:2.1;letter-spacing:1px;}
+.otsheet .ot-ap-title{height:30px;background:#F5F6F8;font-size:12.5px;font-weight:600;color:#3A3F46;letter-spacing:3px;text-indent:3px;}
+.otsheet .ot-ap-sign{height:64px;font-size:11.5px;color:#C9CDD3;letter-spacing:1px;}
+.otsheet .ot-ap-date{height:28px;font-size:10px;color:#B4B9C0;letter-spacing:1px;}
+.otsheet .ot-title{margin-top:32px;text-align:center;font-size:30px;font-weight:700;letter-spacing:10px;text-indent:10px;color:#151719;line-height:44px;}
+.otsheet .ot-rule-thick{margin-top:16px;border-top:3px solid #1F1F1F;height:0;}
+.otsheet .ot-rule-thin{margin-top:3px;border-top:1px solid #1F1F1F;height:0;}
+.otsheet .ot-info{margin-top:24px;border:2px solid #1F1F1F;}
+.otsheet .ot-info th,.otsheet .ot-info td{border:1px solid #9AA0A8;height:46px;font-size:14px;vertical-align:middle;}
+.otsheet .ot-info th{background:#F5F6F8;font-weight:600;color:#3A3F46;font-size:13px;letter-spacing:2px;text-align:center;}
+.otsheet .ot-info td{padding:0 14px;color:#1F2329;letter-spacing:0.3px;}
+.otsheet .ot-dim{color:#6B7178;font-weight:400;}
+.otsheet .ot-strong{font-weight:700;}
+.otsheet .ot-reason{margin-top:16px;border:2px solid #1F1F1F;}
+.otsheet .ot-reason th,.otsheet .ot-reason td{border:1px solid #9AA0A8;}
+.otsheet .ot-reason .ot-rh{height:40px;background:#F5F6F8;font-size:13.5px;font-weight:600;color:#3A3F46;letter-spacing:3px;text-align:left;padding:0 16px;vertical-align:middle;}
+.otsheet .ot-reason .ot-rhint{background:#F5F6F8;font-size:11px;font-weight:400;color:#A6ADB6;letter-spacing:0.5px;text-align:right;padding:0 16px;vertical-align:middle;width:200px;}
+.otsheet .ot-reason .ot-rb{height:330px;vertical-align:top;padding:18px 20px;font-size:14.5px;line-height:1.8;color:#1F2329;white-space:pre-wrap;word-break:break-word;}
+.otsheet .ot-notes{margin-top:12px;font-size:11px;color:#6B7178;line-height:1.8;letter-spacing:0.2px;}
+.otsheet .ot-closing{margin-top:26px;text-align:center;font-size:15.5px;letter-spacing:1px;color:#1F2329;line-height:26px;}
+.otsheet .ot-date{margin-top:18px;text-align:center;font-size:14.5px;letter-spacing:2px;color:#1F2329;line-height:26px;}
+.otsheet .ot-date .ot-dlabel{font-size:12.5px;color:#6B7178;letter-spacing:3px;margin-right:12px;}
+.otsheet .ot-signer{margin-top:20px;text-align:right;padding-right:14px;font-size:15px;color:#1F2329;line-height:32px;}
+.otsheet .ot-signer .ot-signer-name{display:inline-block;min-width:120px;text-align:center;font-weight:600;letter-spacing:2px;border-bottom:1px solid #1F2329;padding:0 10px 2px 10px;margin:0 8px;}
+.otsheet .ot-signer .ot-signer-note{font-size:12.5px;color:#6B7178;}
+.otsheet .ot-footer{margin-top:22px;border-top:1px solid #D8DBE0;padding-top:16px;text-align:center;}
+.otsheet .ot-company{font-size:19px;font-weight:700;letter-spacing:8px;text-indent:8px;color:#3A3F46;min-height:28px;line-height:28px;}
 `;
 
-/** 신청서 마크업 — 상단 타이틀 · 본문 표 · 하단 날짜/서명란. */
+/** 신청서 마크업 — 결재란·제목 이중 괘선·정보표·계획내용·각주·서명·회사명. */
 export function overtimeSheetHTML(d: OvertimeSheetData): string {
-  const hours = `${d.date} · 퇴근시각 이후 ~ ${fmtTimeHM(d.extendedEnd)} 까지`;
   return `
 <style>${SHEET_CSS}</style>
 <div class="otsheet">
-  <h1>야간근무(추가근무) 신청서</h1>
-  <table class="form">
+  <table class="ot-head">
     <tr>
-      <th>신 청 자 명</th><td>${esc(d.name)}</td>
-      <th>부&nbsp;&nbsp;&nbsp;&nbsp;서</th><td>${esc(d.team || "-")}</td>
-    </tr>
-    <tr>
-      <th>직&nbsp;&nbsp;&nbsp;&nbsp;급</th><td>${esc(d.position || "-")}</td>
-      <th>추가근무 시간</th><td>${esc(hours)}</td>
-    </tr>
-    <tr>
-      <th>계 획 내 용</th>
-      <td class="plan" colspan="3">${esc(d.reason || "")}</td>
+      <td>
+        <div class="ot-meta">
+          <span class="ot-meta-code">근태 서식 · HR-OT-01</span><br>
+          ※ 본 서식은 소정근로시간 종료 이후의 야간·추가근무 사전 신청 서식입니다.<br>
+          ※ 승인권자의 결재 완료 후 근무를 개시하여 주시기 바랍니다.
+        </div>
+      </td>
+      <td style="width:300px;">
+        <table class="ot-approve">
+          <tr><td class="ot-ap-side" rowspan="3">결<br>재</td><th class="ot-ap-title">신 청</th><th class="ot-ap-title">담 당</th><th class="ot-ap-title">승 인</th></tr>
+          <tr><td class="ot-ap-sign">(인)</td><td class="ot-ap-sign">(인)</td><td class="ot-ap-sign">(인)</td></tr>
+          <tr><td class="ot-ap-date">&nbsp;.&nbsp;&nbsp;.&nbsp;</td><td class="ot-ap-date">&nbsp;.&nbsp;&nbsp;.&nbsp;</td><td class="ot-ap-date">&nbsp;.&nbsp;&nbsp;.&nbsp;</td></tr>
+        </table>
+      </td>
     </tr>
   </table>
-  <div class="footer">
-    <div class="date">${fmtKoreanDate(d.createdAt)}</div>
-    <div class="signs">
-      <div class="sign">신청자 : <span class="line">${esc(d.name)}</span> (서명)</div>
-      <div class="sign">담당자 : <span class="line"></span> (서명)</div>
-    </div>
+
+  <div class="ot-title">야간근무(추가근무) 신청서</div>
+  <div class="ot-rule-thick"></div>
+  <div class="ot-rule-thin"></div>
+
+  <table class="ot-info">
+    <colgroup><col style="width:86px"><col><col style="width:86px"><col><col style="width:86px"><col></colgroup>
+    <tr>
+      <th>성&nbsp;&nbsp;명</th><td>${esc(d.name)}</td>
+      <th>부&nbsp;&nbsp;서</th><td>${esc(d.team || "-")}</td>
+      <th>직&nbsp;&nbsp;급</th><td>${esc(d.position || "-")}</td>
+    </tr>
+    <tr>
+      <th>근무 일자</th><td colspan="5">${esc(fmtDateWithWeekday(d.date))}</td>
+    </tr>
+    <tr>
+      <th>근무 시간</th><td colspan="5"><span class="ot-dim">소정근로시간 종료 후 ~</span> <span class="ot-strong">${esc(fmtTimeHM(d.extendedEnd))}</span> <span class="ot-dim">까지 (휴게시간 제외)</span></td>
+    </tr>
+  </table>
+
+  <table class="ot-reason">
+    <tr><th class="ot-rh">계획 내용 (업무 내용)</th><th class="ot-rhint">수행 업무를 구체적으로 기재</th></tr>
+    <tr><td class="ot-rb" colspan="2">${esc(d.reason || "")}</td></tr>
+  </table>
+
+  <div class="ot-notes">
+    ※ 야간근무(추가근무) 시간은 소정근로시간 종료 후부터 산정합니다.<br>
+    ※ 본 신청서는 승인권자의 결재 완료 후 효력이 발생하며, 결재 완료된 서식은 인사 담당 부서에서 보관합니다.
   </div>
+
+  <div class="ot-closing">위와 같이 야간근무(추가근무)를 신청하오니 승인하여 주시기 바랍니다.</div>
+  <div class="ot-date"><span class="ot-dlabel">신 청 일</span>${esc(fmtKoreanDate(d.createdAt))}</div>
+  <div class="ot-signer">신청자 :<span class="ot-signer-name">${esc(d.name)}</span><span class="ot-signer-note">(서명 또는 인)</span></div>
+
+  ${d.companyName ? `<div class="ot-footer"><div class="ot-company">${esc(d.companyName)}</div></div>` : ""}
 </div>`;
 }
 
-/** 화면 밖 렌더 폭(px) — A4 비율 기준. */
-const RENDER_WIDTH = 794;
-
-/** 신청서를 A4 PDF 로 만들어 즉시 다운로드. 파일명: 야간근무신청서_이름_날짜.pdf */
+/** 신청서를 A4 PDF 로 만들어 저장/공유. 파일명: 야간근무신청서_이름_날짜.pdf */
 export async function downloadOvertimePdf(d: OvertimeSheetData): Promise<void> {
   const [{ jsPDF }, { default: html2canvas }] = await Promise.all([
     import("jspdf"),
@@ -101,11 +171,22 @@ export async function downloadOvertimePdf(d: OvertimeSheetData): Promise<void> {
   ]);
 
   const host = document.createElement("div");
-  host.style.cssText = `position:fixed;left:-10000px;top:0;width:${RENDER_WIDTH}px;background:#ffffff;z-index:-1;`;
+  host.style.cssText = `position:fixed;left:-10000px;top:0;width:${A4_W}px;background:#ffffff;z-index:-1;`;
   host.innerHTML = overtimeSheetHTML(d);
   document.body.appendChild(host);
 
   try {
+    // 기기 폰트 메트릭 차이로 시트가 A4(1123px)에서 몇 px 넘치면 자투리 페이지가
+    // 생긴다 — 캡처 전에 높이를 A4 정수 배로 스냅해 항상 "정확히 N장"을 보장.
+    // (8px 이하 초과는 하단 여백 몇 px 을 접는 것이라 내용 손실 없음)
+    const sheet = host.querySelector<HTMLElement>(".otsheet");
+    if (sheet) {
+      const pages = Math.max(1, Math.ceil((sheet.scrollHeight - 8) / A4_H));
+      sheet.style.minHeight = "0";
+      sheet.style.height = `${pages * A4_H}px`;
+      sheet.style.overflow = "hidden";
+    }
+
     const canvas = await html2canvas(host, {
       scale: 2,
       backgroundColor: "#ffffff",
@@ -121,12 +202,14 @@ export async function downloadOvertimePdf(d: OvertimeSheetData): Promise<void> {
     const imgH = (canvas.height * imgW) / canvas.width;
     const imgData = canvas.toDataURL("image/jpeg", 0.92);
 
-    // 서식은 보통 1페이지지만, 계획내용이 길어지면 페이지를 나눈다(payslipPdf 동일 슬라이스).
+    // 794:1123 은 210:297 과 소수점 오차가 있어(≈0.02mm) 순수 >0 비교면
+    // 내용 없는 빈 2페이지가 생긴다 — 2mm 이하 잔여는 같은 페이지로 취급.
+    const EPS = 2;
     let heightLeft = imgH;
     let position = 0;
     pdf.addImage(imgData, "JPEG", 0, position, imgW, imgH);
     heightLeft -= pageH;
-    while (heightLeft > 0) {
+    while (heightLeft > EPS) {
       pdf.addPage();
       position -= pageH;
       pdf.addImage(imgData, "JPEG", 0, position, imgW, imgH);

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -663,11 +663,13 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
   const [reason, setReason] = useState("");
   const [saving, setSaving] = useState(false);
   const [pdfBusy, setPdfBusy] = useState<string | null>(null);
+  const [companyName, setCompanyName] = useState<string | null>(null);
 
   async function load() {
     try {
-      const m = await api<{ overtimes: Overtime[] }>("/api/attendance/overtime");
+      const m = await api<{ overtimes: Overtime[]; companyName?: string | null }>("/api/attendance/overtime");
       setMine(m.overtimes);
+      setCompanyName(m.companyName ?? null);
       if (isReviewer) {
         const a = await api<{ overtimes: Overtime[] }>("/api/attendance/overtime?all=1");
         setAll(a.overtimes);
@@ -706,6 +708,7 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
         extendedEnd: o.extendedEnd,
         reason: o.reason,
         createdAt: o.createdAt,
+        companyName,
       });
     } catch (e: any) {
       alertAsync({ title: "PDF 생성 실패", description: e?.message ?? "신청서 PDF 생성에 실패했어요" });

--- a/server/src/routes/attendance.ts
+++ b/server/src/routes/attendance.ts
@@ -371,7 +371,11 @@ router.get("/overtime", async (req, res) => {
     // position(직급)은 야근 신청서 PDF(결재 서식)에 표기 — 이름·부서와 함께 내려준다.
     include: { user: { select: { name: true, team: true, position: true } } },
   });
-  res.json({ overtimes: list });
+  // 회사명 — 신청서 PDF 하단 사명 표기용 (멀티테넌트라 클라 하드코딩 금지, 1쿼리 추가)
+  const company = u.companyId
+    ? await prisma.company.findUnique({ where: { id: u.companyId }, select: { name: true } })
+    : null;
+  res.json({ overtimes: list, companyName: company?.name ?? null });
 });
 
 router.patch("/overtime/:id", async (req, res) => {


### PR DESCRIPTION
## 원인
#1089 초기 서식이 단순 표+서명란 구성이라 결재 문서의 격식(결재란·선 위계·여백 밸런스)이 없었고, 캡처 HTML 높이가 내용만큼만 잡혀 A4 한 장으로서의 짜임새가 없었음. 또한 794:1123↔210:297 소수점 오차로 순수 `>0` 페이지 분기 시 빈 2페이지가 생길 수 있는 잠복 버그, 계획내용 장문 시 하단 요소가 잘릴 수 있는 구조적 위험이 있었음.

## 수정
**서식 전면 재디자인** — 4종 시안(정통 관공서형/모던/전통 양식집/절충형) 병렬 생성 → 실렌더 스크린샷 기반 3심(HR 실무·인쇄 조판·캡처 기술) 심사 **만장일치 우승작(정통 전자결재형)** 채택 + 심사 지적사항 반영:
- 우상단 **결재 3단 박스**(결/재 측면칸 + 신청·담당·승인 + (인) 서명칸·일자 행), 제목 3px+1px **이중 괘선**, 외곽 2px/내부 1px 선 위계, 잉크 절약형 옅은 헤더
- 정보표(성명·부서·직급·근무 일자(요일 부기)·근무 시간 (휴게시간 제외)), 계획내용 대형 박스(+기재 힌트), ※유의사항 각주 2줄, 관용 문구·신청일·**서명 밑줄**·회사명
- 전 구간 **table 레이아웃**(flex/float/!important 배제 — html2canvas 캡처 안전성 최우선)

**A4 규격 보장**:
- 시트 794×1123px(A4@96dpi) `min-height`, 캡처 직전 **A4 정수 배 스냅**(기기 폰트 메트릭으로 몇 px 넘쳐도 항상 정확히 N장, 8px 이하 초과는 여백 접기라 내용 손실 없음)
- 페이지 분기 EPS 2mm — 비율 소수점 오차로 생기던 빈 마지막 페이지 제거
- 계획내용 장문이면 시트가 늘어나 2페이지로 — 하단 요소 잘림 없음(검증됨)

**회사명**: `GET /api/attendance/overtime` 응답에 `companyName` 추가(1쿼리) — 멀티테넌트라 클라 하드코딩 금지, 서식 최하단 사명 표기. 없으면 사명 줄 자체 생략.

## 검증
- 4시안 headless Chrome 794×1123 실렌더 + 3심 교차 심사(각 심사가 4장 스크린샷 직접 열람)
- 최종본: 기본/빈 값(부서·직급 없음, 회사명 없음)/26줄 장문 3케이스 렌더 확인
- dev 프리뷰에서 **실제 html2canvas 캡처 이미지**(PDF 에 들어가는 그림) 육안 확인 — rowspan 괘선·(인) 중앙정렬·이중선 충실 렌더
- 캡처 비율 검증: 기본 1.4144(=A4 정확), 장문 2.8287(=A4×2 정확)
- `downloadOvertimePdf` 파이프라인 완주(211ms)·콘솔 에러 0, client tsc+vite build·server tsc 통과

## 비고
- jspdf/html2canvas lazy 청크 유지(초기 번들 무영향). 클라=OTA, 서버 1블록이라 deploy-server 트리거됨.

Closes #1091
