### PR TITLE
🔀 :: (#1093) 콘솔 [클라] unauthorized 오보고 수정 — dedup 파생 프라미스 누수·비로그인 fetch 차단

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -129,7 +129,12 @@ export async function api<T = any>(
   if (existing) return existing as Promise<T>;
   const p = apiInner<T>(path, init);
   _inflight.set(path, p);
-  p.finally(() => { if (_inflight.get(path) === p) _inflight.delete(path); });
+  // 주의: p.finally(cleanup) 는 "새 파생 프라미스"를 반환하는데 이걸 아무도 catch 하지
+  // 않으면, 호출부가 p 를 완벽히 try/catch 해도 p 가 reject 되는 순간 파생 프라미스 몫의
+  // unhandledrejection 이 발화한다 → 콘솔 에러 탭에 "[클라] unauthorized" 오보고(#1093).
+  // then(cleanup, cleanup) 파생은 cleanup 이 throw 하지 않는 한 항상 fulfilled 라 안전.
+  const cleanup = () => { if (_inflight.get(path) === p) _inflight.delete(path); };
+  p.then(cleanup, cleanup);
   return p;
 }
 

--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -146,8 +146,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return;
     }
     // iOS 푸시 토큰 해제 — 세션이 살아있을 때(로그아웃 API 호출 전) 보내야 401 이 안 난다. iOS 외엔 no-op.
-    await unregisterIosPush();
-    await api("/api/auth/logout", { method: "POST" });
+    try {
+      await unregisterIosPush();
+      await api("/api/auth/logout", { method: "POST" });
+    } catch {
+      // 세션이 이미 만료(401)·네트워크 실패여도 로컬 로그아웃은 반드시 완수한다 —
+      // 여기서 던지면 로그아웃 버튼의 async onClick 이 unhandledrejection 으로 새서
+      // 콘솔 에러 탭에 오보고되고(#1093), 클라가 로그인된 것처럼 남는다.
+    }
     // 로그아웃 API 호출(세션 revoke) 이 끝난 뒤에 토큰 제거 — 먼저 지우면 그 요청이 401 난다.
     clearAuthToken();
     setUser(null);

--- a/client/src/lib/featureFlags.tsx
+++ b/client/src/lib/featureFlags.tsx
@@ -1,9 +1,14 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { api } from "../api";
+import { useAuth } from "../auth";
 
 /**
- * 기능 플래그 클라 — 부트 시 1번 fetch, 이후 useFeatureFlag(key) 로 동기 조회.
- * 로그인 컨텍스트가 바뀌면 (login/logout/refresh) 다시 가져온다.
+ * 기능 플래그 클라 — 로그인 상태에서만 fetch, 이후 useFeatureFlag(key) 로 동기 조회.
+ * 사용자(user.id)가 바뀌면(로그인·계정 전환) 다시 가져오고, 로그아웃하면 비운다.
+ *
+ * 서버 /api/feature-flags 는 requireAuth 라 비로그인 fetch 는 무조건 401 — 예전엔
+ * 마운트 즉시(로그인 화면 포함) 무가드로 불러서 방문자마다 401 "unauthorized" 가
+ * 발생했고, 이것이 콘솔 에러 탭 오보고(#1093)의 주요 발생원이었다.
  */
 
 type FlagsCtx = {
@@ -15,6 +20,7 @@ type FlagsCtx = {
 const Ctx = createContext<FlagsCtx>({ flags: {}, loading: true, refresh: async () => {} });
 
 export function FeatureFlagsProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
   const [flags, setFlags] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
 
@@ -29,7 +35,17 @@ export function FeatureFlagsProvider({ children }: { children: React.ReactNode }
     }
   }
 
-  useEffect(() => { refresh(); }, []);
+  useEffect(() => {
+    if (!user) {
+      // 비로그인(로그인 화면·세션 만료) — 401 이 뻔한 fetch 를 아예 안 보낸다.
+      setFlags({});
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
 
   return <Ctx.Provider value={{ flags, loading, refresh }}>{children}</Ctx.Provider>;
 }

--- a/client/src/notifications.tsx
+++ b/client/src/notifications.tsx
@@ -149,10 +149,16 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     reload();
 
     let retry: number | null = null;
+    // 언마운트(로그아웃 → /login) 후 재연결 금지 플래그 — connect() 가 티켓 발급을
+    // await 하는 도중 cleanup 이 돌면, cleanup 은 "그 시점의" retry 타이머만 지우고
+    // connect 의 catch 가 그 뒤에 새 타이머를 걸어 로그인 화면에서도 sse-ticket 401 을
+    // 3→60초 백오프로 계속 두드리던 레이스(#1093)를 막는다.
+    let disposed = false;
     // SSE 재연결 백오프 — 서버 장애/인증 만료 시 3초마다 무한 재시도해 /stream 을
     // 두드리지 않도록 지수 백오프(3→6→…→최대 60초). 연결 성공(onopen) 시 3초로 리셋.
     let reconnectDelay = 3000;
     function scheduleReconnect() {
+      if (disposed) return;
       retry = window.setTimeout(connect, reconnectDelay);
       reconnectDelay = Math.min(reconnectDelay * 2, 60_000);
     }
@@ -178,8 +184,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       return apiUrl("/api/notification/stream") + (streamToken ? `?token=${encodeURIComponent(streamToken)}` : "");
     }
     async function connect() {
+      if (disposed) return;
       try {
         const streamUrl = await resolveStreamUrl();
+        if (disposed) return; // 티켓 발급 중 언마운트 — 연결 만들지 않음
         // 직결은 티켓(쿼리)으로 인증 → 쿠키 불필요. 프록시 폴백 경로는 기존 쿠키 인증 유지.
         const es = new EventSource(streamUrl, { withCredentials: !useDirect });
         esRef.current = es;
@@ -268,6 +276,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     document.addEventListener("visibilitychange", onVisibility);
 
     return () => {
+      disposed = true; // 진행 중이던 connect()/재연결 백오프가 이후에 되살아나지 않게
       if (retry) clearTimeout(retry);
       stopPoll();
       esRef.current?.close();

--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -45,18 +45,24 @@ export default function DashboardPage() {
     const today = new Date();
     const from = new Date(today.getFullYear(), today.getMonth(), today.getDate()).toISOString();
     const to = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 7).toISOString();
-    const [n, s, a] = await Promise.all([
-      api<{ notices: Notice[] }>("/api/notice"),
-      api<{ events: Event[] }>(`/api/schedule?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`),
-      api<{ attendance: Attendance }>("/api/attendance/today"),
-    ]);
-    if (!aliveRef.current || myToken !== loadTokenRef.current) return;
-    setNotices(n.notices.slice(0, 5));
-    setEvents(s.events.slice(0, 6));
-    setAtt(a.attendance);
-    setLoaded(true);
+    try {
+      const [n, s, a] = await Promise.all([
+        api<{ notices: Notice[] }>("/api/notice"),
+        api<{ events: Event[] }>(`/api/schedule?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`),
+        api<{ attendance: Attendance }>("/api/attendance/today"),
+      ]);
+      if (!aliveRef.current || myToken !== loadTokenRef.current) return;
+      setNotices(n.notices.slice(0, 5));
+      setEvents(s.events.slice(0, 6));
+      setAtt(a.attendance);
+      setLoaded(true);
+    } catch {
+      // 세션 만료(401)는 api.ts 전역 hinest:unauthorized 가 로그아웃 처리, 네트워크
+      // 순단은 스켈레톤 유지 — 여기서 안 잡으면 unhandledrejection 으로 새서
+      // 콘솔 에러 탭에 오보고된다(#1093).
+    }
   }
-  useEffect(() => { load(); }, []);
+  useEffect(() => { void load(); }, []);
 
   // 출퇴근 버튼 더블탭 가드 — 빠르게 두 번 누르면 POST 가 2번 나가던 문제 방지(서버는 멱등이라
   // 데이터 손상은 없지만 불필요한 요청·깜빡임 제거). 처리 중엔 버튼 비활성.


### PR DESCRIPTION
## 원인
콘솔 에러 탭의 `[클라] unauthorized`(`/`·`/login`, 24h 16회)는 두 결함의 합작:
1. **api.ts GET dedup 의 `p.finally(cleanup)` 파생 프라미스 누수** — `finally()` 는 새 파생 프라미스를 반환하는데 이를 아무도 catch 하지 않아, **호출부가 완벽히 try/catch 해도** 원 프라미스가 reject 되는 순간 파생 프라미스 몫의 unhandledrejection 이 발화(Node·브라우저 재현 확인). main.tsx 전역 핸들러가 이를 에러 탭으로 보고.
2. **FeatureFlagsProvider 무가드 fetch** — 로그인 화면 포함 항상 마운트 즉시 `/api/feature-flags`(requireAuth) 호출 → 비로그인 방문마다 401. 이 401 이 ①을 타고 오보고됨.

3개 관점 병렬 수색(마운트 트리·호출 패턴·세션 경계)에서 동종 보조 결함 3건 추가 발견: 대시보드 `load()` 무캐치, `logout()` 이 세션 만료 시 throw(+클라 로그인 상태 잔존), 알림 SSE 가 언마운트 후 재연결 타이머를 되살려 /login 에서 sse-ticket 401 을 3→60s 백오프로 반복.

## 수정
- **api.ts**: dedup 정리를 `p.then(cleanup, cleanup)` 으로 — 파생 프라미스가 항상 fulfilled, 누수 원천 차단 (모든 인증 GET 에 일괄 효과)
- **featureFlags.tsx**: user 있을 때만 fetch, `user.id` 변경 시 재조회, 로그아웃 시 비움 — 부수로 "로그인 후 플래그 재조회가 아예 없던" 잠복 버그도 해소
- **DashboardPage**: `load()` try/catch (마운트·출퇴근 후 재조회 공통)
- **auth.tsx**: `logout()` 을 try/catch 화 — 세션이 이미 죽어도 로컬 로그아웃(토큰·캐시·user) 반드시 완수
- **notifications.tsx**: `disposed` 플래그로 언마운트 후 `connect()`/`scheduleReconnect()` 재발화 차단

## 검증
- 프리뷰 회귀 테스트(fetch 401 스텁): 호출부 catch 상태에서 **unhandledrejection 0건**, dedup 유지(동시 2건→fetch 1회), rejected 인플라이트 정리 후 재호출 시 새 fetch 정상
- `/login` 로드 네트워크 로그: `/api/feature-flags` 요청 자체가 사라짐, 콘솔 에러 0
- client `tsc -b` + `vite build` 통과

## 비고
- 클라 전용 — OTA 배포. 배포 후 콘솔 에러 탭의 기존 16건은 "모두 비우기"로 정리하면 됨.
- errorReporter 의 보고 자체는 유지 — unhandled 401 은 실제 버그 신호라 억제하지 않고 뿌리를 고침.

Closes #1093
