### PR TITLE
🔀 :: (#1095) 야근 신청 폼을 신청서 서식형으로 — PDF 틀 그대로 채우기·줄바꿈 사유

### DIFF
--- a/client/src/lib/previewMock.ts
+++ b/client/src/lib/previewMock.ts
@@ -226,6 +226,17 @@ function schedule() {
   };
 }
 
+function demoOvertimes() {
+  // 야근 신청 서식 폼·PDF 버튼 데모 — 줄바꿈 사유 포함(pre-line 렌더 확인용).
+  return {
+    overtimes: [
+      { id: "ot1", date: iso(-1, 0).slice(0, 10), extendedEnd: iso(-1, 21), reason: "신규 기능 배포 대응 및 모니터링.\n장애 발생 시 즉시 롤백 대기.", status: "APPROVED", createdAt: iso(-1, 10), user: { name: "김데모", team: "프로덕트팀", position: "매니저" } },
+      { id: "ot2", date: iso(-3, 0).slice(0, 10), extendedEnd: iso(-3, 22), reason: "월말 정산 마감", status: "PENDING", createdAt: iso(-3, 9), user: { name: "김데모", team: "프로덕트팀", position: "매니저" } },
+    ],
+    companyName: "주식회사 데모",
+  };
+}
+
 function attendanceToday() {
   // 미리보기 진입 시 "정확히 3시간 38분 근무 중" 으로 보이게 — 현재 시각에서 빼서 checkIn 만든다.
   // 데모용으로 'X시간 Y분' 카운터가 그럴듯한 값(3:38)으로 떨어진다(고정 09:30 출근이면 시간대마다
@@ -1158,6 +1169,9 @@ const HANDLERS: { test: (p: string) => boolean; data: (p?: string) => any }[] = 
 
   /* === 출퇴근 / 휴가 === */
   { test: (p) => p === "/api/attendance/today",        data: attendanceToday },
+  // overtime 은 아래 "/api/attendance" catch-all 보다 먼저 매칭돼야 함 — catch-all 응답엔
+  // overtimes 키가 없어 OvertimeSection 이 빈 목록으로 오인/크래시했던 프리뷰 전용 함정.
+  { test: (p) => p.startsWith("/api/attendance/overtime"), data: demoOvertimes },
   { test: (p) => p.startsWith("/api/attendance/leave"), data: (p?: string) => ({ leaves: demoLeaves(/\?all=1/.test(p ?? "")) }) },
   { test: (p) => p.startsWith("/api/attendance/month"), data: () => ({ attendances: demoMonthAttendance() }) },
   { test: (p) => p.startsWith("/api/attendance"),       data: () => ({ attendances: demoMonthAttendance(), leaves: demoLeaves(false) }) },

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -656,6 +656,7 @@ function otTime(iso: string): string {
   return new Date(iso).toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
 }
 function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
+  const { user } = useAuth(); // 서식의 성명·부서·직급 자동 기입
   const [mine, setMine] = useState<Overtime[]>([]);
   const [all, setAll] = useState<Overtime[]>([]);
   const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
@@ -668,11 +669,11 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
   async function load() {
     try {
       const m = await api<{ overtimes: Overtime[]; companyName?: string | null }>("/api/attendance/overtime");
-      setMine(m.overtimes);
+      setMine(m.overtimes ?? []); // ?? [] — 응답에 overtimes 가 없어도(프리뷰 목 등) .length 크래시 방지
       setCompanyName(m.companyName ?? null);
       if (isReviewer) {
         const a = await api<{ overtimes: Overtime[] }>("/api/attendance/overtime?all=1");
-        setAll(a.overtimes);
+        setAll(a.overtimes ?? []);
       }
     } catch { /* ignore */ }
   }
@@ -717,18 +718,39 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
 
   return (
     <div className="space-y-4 mt-4">
-      <div className="panel p-5">
+      <div className="panel p-4 sm:p-5">
         <div className="text-[15px] font-extrabold text-ink-900 mb-3">야근(추가근무) 신청</div>
-        <div className="grid grid-cols-1 sm:grid-cols-4 gap-2.5">
-          <label className="text-[12px] text-ink-500 block">날짜
-            <div className="mt-1"><DatePicker variant="input" value={date} onChange={setDate} /></div>
-          </label>
-          <label className="text-[12px] text-ink-500 block">연장 종료시각
-            <div className="mt-1"><TimePicker value={endTime} onChange={setEndTime} /></div>
-          </label>
-          <label className="text-[12px] text-ink-500 block sm:col-span-2">사유 (선택)
-            <input className="input mt-1" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="예: 배포 대응" maxLength={1000} />
-          </label>
+        {/* 신청 폼 = 신청서 서식 — 여기 채운 내용이 그대로 결재용 PDF(#1091 서식)가 된다 */}
+        <div className="otform">
+          <div className="otform-title">야간근무(추가근무) 신청서</div>
+          <div className="otform-rule" />
+          <div className="otform-rule2" />
+          <div className="otform-grid">
+            <div className="otform-th">성&nbsp;&nbsp;명</div>
+            <div className="otform-td">{user?.name || "-"}</div>
+            <div className="otform-th">부&nbsp;&nbsp;서</div>
+            <div className="otform-td">{user?.team || "-"}</div>
+            <div className="otform-th">직&nbsp;&nbsp;급</div>
+            <div className="otform-td">{user?.position || "-"}</div>
+            <div className="otform-th">근무 일자</div>
+            <div className="otform-td"><DatePicker variant="input" value={date} onChange={setDate} className="w-full max-w-[190px]" /></div>
+            <div className="otform-th">근무 시간</div>
+            <div className="otform-td otform-time flex-wrap gap-x-2 gap-y-1">
+              <span className="otform-dim whitespace-nowrap">소정근로시간 종료 후 ~</span>
+              <TimePicker value={endTime} onChange={setEndTime} className="w-[110px]" />
+              <span className="otform-dim whitespace-nowrap">까지 (휴게시간 제외)</span>
+            </div>
+            <div className="otform-th otform-span !justify-start px-3">계획 내용 (업무 내용)<span className="otform-hint">수행 업무를 구체적으로 기재</span></div>
+            <div className="otform-plan otform-span">
+              <textarea
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder={"수행할 업무를 구체적으로 적어주세요.\n줄바꿈 그대로 신청서 PDF 에 들어가요."}
+                maxLength={1000}
+                rows={5}
+              />
+            </div>
+          </div>
         </div>
         <div className="flex justify-end mt-3">
           <button className="btn-primary" onClick={submit} disabled={saving}>{saving ? "신청 중…" : "야근 신청"}</button>
@@ -746,7 +768,8 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
               <div key={o.id} className="px-5 py-3 flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <div className="font-bold text-ink-900">{o.date} <span className="text-ink-400 font-medium text-[12px]">→ {otTime(o.extendedEnd)}</span></div>
-                  {o.reason && <div className="text-[12px] text-ink-500 truncate">{o.reason}</div>}
+                  {/* pre-line + 2줄 클램프 — 줄바꿈 사유가 한 줄로 뭉개지지 않게(전문은 PDF 로) */}
+                  {o.reason && <div className="text-[12px] text-ink-500 whitespace-pre-line line-clamp-2">{o.reason}</div>}
                 </div>
                 <div className="flex items-center gap-2 flex-shrink-0">
                   <button className="btn-ghost btn-xs" onClick={() => downloadPdf(o)} disabled={pdfBusy === o.id} title="신청서 PDF 다운로드">

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1483,3 +1483,30 @@ body.hinest-chat-fs .hinest-preview-banner {
   width: 0;
   height: 0;
 }
+
+/* ===== 야근 신청 서식형 폼(.otform) =====
+   신청 폼이 곧 신청서 — 야근 신청서 PDF(lib/overtimePdf.ts, #1091)의 서식을 화면에서
+   그대로 채워 넣는 종이 문서 룩. "종이"라서 다크모드에서도 항상 흰 배경 + hex 고정색
+   (PDF 서식과 동일한 색·선 위계). 레이아웃은 hairline grid(배경 #9AA0A8 + 1px gap). */
+.otform { background: #ffffff; border: 1px solid #d8dbe0; border-radius: 14px; padding: 18px 16px 16px; color: #1f2329; }
+.otform-title { text-align: center; font-size: 14px; font-weight: 800; letter-spacing: 3px; text-indent: 3px; color: #151719; white-space: nowrap; }
+@media (min-width: 640px) { .otform-title { font-size: 15.5px; letter-spacing: 6px; text-indent: 6px; } }
+.otform-rule { margin-top: 10px; border-top: 2px solid #1f1f1f; }
+.otform-rule2 { margin-top: 2px; border-top: 1px solid #1f1f1f; margin-bottom: 14px; }
+.otform-grid { display: grid; grid-template-columns: 76px 1fr; gap: 1px; background: #9aa0a8; border: 1.5px solid #1f1f1f; }
+@media (min-width: 640px) { .otform-grid { grid-template-columns: 84px 1fr 84px 1fr; } }
+.otform-grid > * { background: #ffffff; min-width: 0; }
+.otform-th { background: #f5f6f8; color: #3a3f46; font-size: 12px; font-weight: 600; letter-spacing: 1.5px; display: flex; align-items: center; justify-content: center; padding: 10px 4px; text-align: center; white-space: nowrap; }
+.otform-td { padding: 8px 10px; font-size: 13.5px; display: flex; align-items: center; }
+.otform-span { grid-column: 1 / -1; }
+@media (min-width: 640px) { .otform-time { grid-column: span 3; } }
+.otform-hint { display: none; margin-left: auto; font-size: 10.5px; font-weight: 400; letter-spacing: 0.3px; color: #a6adb6; padding-right: 6px; white-space: nowrap; }
+@media (min-width: 640px) { .otform-hint { display: block; } }
+.otform-dim { color: #6b7178; font-size: 12px; }
+.otform-plan { padding: 10px 12px; }
+.otform-plan textarea { width: 100%; border: 0; outline: none; background: transparent; resize: none; font-size: 13.5px; line-height: 1.75; color: #1f2329; min-height: 128px; display: block; }
+.otform-plan textarea::placeholder { color: #a6adb6; }
+/* 서식 안에 박히는 앱 위젯(DatePicker/TimePicker 버튼)도 종이 톤으로 — 다크모드 무관 고정색 */
+.otform .input { background: #ffffff; border-color: #c9cdd2; color: #1f2329; padding: 7px 10px; font-size: 13px; }
+.otform .input:hover { background: #f5f6f8; }
+.otform .text-ink-400 { color: #8b9098; }


### PR DESCRIPTION
## 원인
야근 신청 폼(날짜/시각/한 줄 사유 input)이 결과물인 신청서 PDF(#1091 서식)와 생김새가 달라 "서식을 채운다"는 감이 없고, 사유가 한 줄 input 이라 줄바꿈 입력·확인이 불가.

## 수정
- **신청 폼 = 신청서 서식**: PDF 서식과 동일한 종이 문서 룩(.otform) — 제목·이중 괘선·괘선 그리드(hairline grid), 다크모드에서도 항상 흰 종이+hex 고정색(PDF 와 동일 톤)
- **성명·부서·직급 자동 기입**(로그인 사용자), 근무 일자(DatePicker)·근무 시간(TimePicker, "소정근로시간 종료 후 ~ … 까지 (휴게시간 제외)")은 서식 칸 안에 임베드
- **계획 내용 = 여러 줄 textarea** — 줄바꿈이 그대로 신청서 PDF(pre-wrap)에 들어감. placeholder 로 안내
- 신청 목록 사유를 pre-line + 2줄 클램프(전문은 PDF)
- 반응형: 모바일 2열(라벨|값) ↔ sm+ 4열(2쌍/행), 좁은 폭에서 제목 자간 축소·기재 힌트 숨김
- 프리뷰 목에 `/api/attendance/overtime` 응답 추가 — 기존 catch-all 이 `overtimes` 키 없이 응답해 프리뷰에서 크래시하던 함정 제거 + 클라 `?? []` 방어

## 검증
- 프리뷰(/preview 데모 목): 모바일 2열·데스크탑 1280px 4열 서식 렌더 스크린샷 확인, 줄바꿈 3줄 입력 → textarea·목록 pre-line 정상, 콘솔 에러 0
- client `tsc -b` + `vite build` 통과

## 비고
- 클라 전용 — OTA. 서버 스키마·API 무변경(reason 은 원래 1000자 자유 텍스트라 줄바꿈 저장 가능).

Closes #1095
