### PR TITLE
🔀 :: (#1099) 서식 PDF 즉시 다운로드·폼 테마 정합 + 원시 ISO 날짜 전수 제거

### DIFF
--- a/client/src/components/DatePicker.tsx
+++ b/client/src/components/DatePicker.tsx
@@ -28,8 +28,11 @@ export default function DatePicker({
   min?: string;
 }) {
   const [open, setOpen] = useState(false);
+  // value 방어 정규화 — 호출부가 API DateTime 직렬화(풀 ISO)를 그대로 넘겨도
+  // 표시("2026-06-09T00:…" 원시 노출)와 파싱(+"T00:00:00" 이어붙이기 → Invalid Date)이 안 깨지게.
+  const day = value ? value.slice(0, 10) : "";
   // 팝오버 커서(보여줄 월) — 값이 없으면 오늘 기준
-  const initial = value ? new Date(value + "T00:00:00") : new Date();
+  const initial = day ? new Date(day + "T00:00:00") : new Date();
   const [cursor, setCursor] = useState<Date>(
     isNaN(initial.getTime()) ? new Date() : new Date(initial.getFullYear(), initial.getMonth(), 1)
   );
@@ -76,14 +79,14 @@ export default function DatePicker({
   // 팝오버 열릴 때 현재 값 기준으로 커서 맞춤
   useEffect(() => {
     if (!open) return;
-    const d = value ? new Date(value + "T00:00:00") : new Date();
+    const d = day ? new Date(day + "T00:00:00") : new Date();
     if (!isNaN(d.getTime())) setCursor(new Date(d.getFullYear(), d.getMonth(), 1));
   }, [open]); // eslint-disable-line
 
   // 해당 월의 7×N 그리드 날짜 배열 (앞 공백은 null 대신 이전달 날짜로 채워 UX 좋음)
   const days = buildMonthDays(cursor);
   const today = new Date();
-  const selected = value ? new Date(value + "T00:00:00") : null;
+  const selected = day ? new Date(day + "T00:00:00") : null;
 
   function pick(d: Date) {
     const s = fmt(d);
@@ -104,8 +107,8 @@ export default function DatePicker({
         onClick={() => !disabled && setOpen((v) => !v)}
       >
         {/* whitespace-nowrap — 좁은 칸에서 'YYYY-MM-DD' 가 'YYYY-/MM-DD' 로 줄바꿈되던 깨짐 방지 */}
-        <span className={`whitespace-nowrap overflow-hidden text-ellipsis ${value ? "" : "text-ink-400"}`}>
-          {value || placeholder}
+        <span className={`whitespace-nowrap overflow-hidden text-ellipsis ${day ? "" : "text-ink-400"}`}>
+          {day || placeholder}
         </span>
         {variant === "input" && (
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="text-ink-400">

--- a/client/src/components/PayslipComposer.tsx
+++ b/client/src/components/PayslipComposer.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { api } from "../api";
 import { useModalDismiss } from "../lib/useModalDismiss";
 import Portal from "./Portal";
+import { fmtYmd } from "../lib/fmt";
 import Select, { type SelectOption } from "./Select";
 import {
   type Payslip,
@@ -102,7 +103,7 @@ export default function PayslipComposer({
     setEmployeeName(emp.name);
     setDepartment(emp.department || emp.team || "");
     setPosition(emp.position || "");
-    setJoinDate(emp.hireDate || "");
+    setJoinDate(emp.hireDate ? fmtYmd(emp.hireDate, "") : ""); // hireDate 가 풀 ISO/임의 형식이어도 명세서엔 YYYY-MM-DD
     setIdNumber(emp.birthDate || "");
   }
 

--- a/client/src/lib/fmt.ts
+++ b/client/src/lib/fmt.ts
@@ -9,3 +9,16 @@ export function fmtSize(n: number): string {
   if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
   return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
 }
+
+/**
+ * 사용자 노출용 날짜 정규화 — API 가 풀 ISO(Prisma DateTime 직렬화, "2026-06-09T00:00:00.000Z")나
+ * 임의 형식 문자열을 줘도 화면엔 YYYY-MM-DD 만. 개발용 타임스탬프가 사용자 화면에 새는 것 방지.
+ * YYYY-MM-DD 시작이면 앞 10자, 아니면 Date 파싱 성공 시 로컬 기준 YYYY-MM-DD, 실패 시 원문 유지.
+ */
+export function fmtYmd(s?: string | null, fallback = "—"): string {
+  if (!s) return fallback;
+  if (/^\d{4}-\d{2}-\d{2}/.test(s)) return s.slice(0, 10);
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}

--- a/client/src/lib/overtimePdf.ts
+++ b/client/src/lib/overtimePdf.ts
@@ -52,6 +52,7 @@ function fmtTimeHM(iso: string): string {
 
 /** YYYY-MM-DD → "YYYY-MM-DD (요일)" — 서식 가독용 요일 부기 */
 function fmtDateWithWeekday(ymd: string): string {
+  ymd = (ymd || "").slice(0, 10); // 풀 ISO 가 와도 서식·파일명에 원시 노출 방지
   const d = new Date(ymd + "T00:00:00");
   if (Number.isNaN(d.getTime())) return ymd;
   return `${ymd} (${"일월화수목금토"[d.getDay()]})`;

--- a/client/src/lib/payslip.ts
+++ b/client/src/lib/payslip.ts
@@ -9,6 +9,8 @@
  * 금액은 항상 관리자가 입력한 값/서버 저장값을 쓴다.
  */
 
+import { fmtYmd } from "./fmt";
+
 export type LineItem = { label: string; amount: number };
 
 export type Attendance = {
@@ -212,8 +214,8 @@ function payslipSheetMarkup(p: Payslip): string {
         <td class="lbl">직위</td><td>${esc(p.position || "-")}</td>
       </tr>
       <tr>
-        <td class="lbl">입사일</td><td>${esc(p.joinDate || "-")}</td>
-        <td class="lbl">지급일</td><td>${esc(p.payDate || "-")}</td>
+        <td class="lbl">입사일</td><td>${esc(fmtYmd(p.joinDate, "-"))}</td>
+        <td class="lbl">지급일</td><td>${esc(fmtYmd(p.payDate, "-"))}</td>
       </tr>
     </table>
     <table class="grid mt">

--- a/client/src/lib/previewMock.ts
+++ b/client/src/lib/previewMock.ts
@@ -965,6 +965,8 @@ function demoMonthAttendance() {
   return out;
 }
 
+// 주의: 운영 서버는 Leave.startDate/endDate 를 Prisma DateTime → 풀 ISO 로 직렬화한다.
+// 목도 동일하게 풀 ISO 를 내보내 클라의 YYYY-MM-DD 정규화(ymd10)가 프리뷰에서 검증되게 한다.
 function demoLeaves(all: boolean) {
   const me = { name: DEMO_ME.name, team: DEMO_ME.team };
   const others = [
@@ -973,17 +975,17 @@ function demoLeaves(all: boolean) {
     { name: "한이브",     team: "운영팀" },
   ];
   const my: any[] = [
-    { id: "lv1", userId: DEMO_ME.id, type: "ANNUAL", startDate: iso(-14).slice(0, 10), endDate: iso(-14).slice(0, 10), reason: "개인 사유",            status: "APPROVED", user: me },
-    { id: "lv2", userId: DEMO_ME.id, type: "HALF",   startDate: iso(7).slice(0, 10),   endDate: iso(7).slice(0, 10),   reason: "병원 진료 (오후)",     status: "PENDING",  user: me },
-    { id: "lv3", userId: DEMO_ME.id, type: "ANNUAL", startDate: iso(21).slice(0, 10),  endDate: iso(23).slice(0, 10),  reason: "여름 휴가",             status: "PENDING",  user: me },
+    { id: "lv1", userId: DEMO_ME.id, type: "ANNUAL", startDate: iso(-14), endDate: iso(-14), reason: "개인 사유",            status: "APPROVED", user: me },
+    { id: "lv2", userId: DEMO_ME.id, type: "HALF",   startDate: iso(7),   endDate: iso(7),   reason: "병원 진료 (오후)",     status: "PENDING",  user: me },
+    { id: "lv3", userId: DEMO_ME.id, type: "ANNUAL", startDate: iso(21),  endDate: iso(23),  reason: "여름 휴가",             status: "PENDING",  user: me },
   ];
   if (!all) return my;
   return [
     ...my,
-    { id: "lv4", userId: "u-lead-1", type: "ANNUAL", startDate: iso(-2).slice(0, 10),  endDate: iso(-2).slice(0, 10),  reason: "결혼식 참석",           status: "APPROVED", user: others[0] },
-    { id: "lv5", userId: "u-lead-3", type: "SICK",   startDate: iso(-5).slice(0, 10),  endDate: iso(-5).slice(0, 10),  reason: "감기",                  status: "APPROVED", user: others[1] },
-    { id: "lv6", userId: "u-lead-2", type: "ANNUAL", startDate: iso(10).slice(0, 10),  endDate: iso(12).slice(0, 10),  reason: "가족 여행",             status: "PENDING",  user: others[2] },
-    { id: "lv7", userId: "u-lead-3", type: "OFFSITE",startDate: iso(2).slice(0, 10),   endDate: iso(2).slice(0, 10),   reason: "외근 (고객사 미팅)",   status: "APPROVED", user: others[1] },
+    { id: "lv4", userId: "u-lead-1", type: "ANNUAL", startDate: iso(-2),  endDate: iso(-2),  reason: "결혼식 참석",           status: "APPROVED", user: others[0] },
+    { id: "lv5", userId: "u-lead-3", type: "SICK",   startDate: iso(-5),  endDate: iso(-5),  reason: "감기",                  status: "APPROVED", user: others[1] },
+    { id: "lv6", userId: "u-lead-2", type: "ANNUAL", startDate: iso(10),  endDate: iso(12),  reason: "가족 여행",             status: "PENDING",  user: others[2] },
+    { id: "lv7", userId: "u-lead-3", type: "OFFSITE",startDate: iso(2),   endDate: iso(2),   reason: "외근 (고객사 미팅)",   status: "APPROVED", user: others[1] },
   ];
 }
 

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -634,14 +634,22 @@ function msToHM(ms: number) {
   const m = Math.floor((ms % 3600000) / 60000);
   return `${h}h ${m}m`;
 }
+/** 날짜 문자열을 YYYY-MM-DD 로 정규화 — 서버 Leave.startDate 는 Prisma DateTime 이라
+ *  풀 ISO("2026-06-09T00:00:00.000Z")로 직렬화돼 오는데, 무가공 렌더하면 개발용 시간이
+ *  그대로 노출되고 dayDiff 의 "T00:00:00" 이어붙이기 파싱이 NaN("(0일)")이 된다. */
+function ymd10(s: string): string {
+  return (s || "").slice(0, 10);
+}
 function dayDiff(a: string, b: string) {
   // 양 끝 포함 일수.
-  const start = new Date(a + "T00:00:00").getTime();
-  const end = new Date(b + "T00:00:00").getTime();
+  const start = new Date(ymd10(a) + "T00:00:00").getTime();
+  const end = new Date(ymd10(b) + "T00:00:00").getTime();
   if (Number.isNaN(start) || Number.isNaN(end) || end < start) return 0;
   return Math.round((end - start) / 86400000) + 1;
 }
 function formatRange(a: string, b: string) {
+  a = ymd10(a);
+  b = ymd10(b);
   if (a === b) return a;
   return `${a} ~ ${b}`;
 }
@@ -659,7 +667,7 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
   const { user } = useAuth(); // 서식의 성명·부서·직급 자동 기입
   const [mine, setMine] = useState<Overtime[]>([]);
   const [all, setAll] = useState<Overtime[]>([]);
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [date, setDate] = useState(() => todayKST()); // toISOString 은 UTC 라 KST 새벽엔 전날이 잡힘
   const [endTime, setEndTime] = useState("21:00");
   const [reason, setReason] = useState("");
   const [saving, setSaving] = useState(false);
@@ -715,6 +723,26 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
       alertAsync({ title: "PDF 생성 실패", description: e?.message ?? "신청서 PDF 생성에 실패했어요" });
     } finally { setPdfBusy(null); }
   }
+  // 지금 작성 중인 서식 그대로 PDF — 제출(신청) 없이도 결재용 서식을 뽑을 수 있게.
+  async function downloadFormPdf() {
+    if (pdfBusy) return;
+    setPdfBusy("form");
+    try {
+      const { downloadOvertimePdf } = await import("../lib/overtimePdf");
+      await downloadOvertimePdf({
+        name: user?.name || "-",
+        team: user?.team,
+        position: user?.position,
+        date,
+        extendedEnd: `${date}T${endTime}:00+09:00`,
+        reason,
+        createdAt: new Date().toISOString(),
+        companyName,
+      });
+    } catch (e: any) {
+      alertAsync({ title: "PDF 생성 실패", description: e?.message ?? "신청서 PDF 생성에 실패했어요" });
+    } finally { setPdfBusy(null); }
+  }
 
   return (
     <div className="space-y-4 mt-4">
@@ -752,10 +780,13 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
             </div>
           </div>
         </div>
-        <div className="flex justify-end mt-3">
+        <div className="flex justify-end items-center gap-2 mt-3">
+          <button className="btn-ghost" onClick={downloadFormPdf} disabled={pdfBusy === "form"} title="작성 중인 서식을 결재용 PDF 로 다운로드">
+            {pdfBusy === "form" ? "생성 중…" : "서식 PDF"}
+          </button>
           <button className="btn-primary" onClick={submit} disabled={saving}>{saving ? "신청 중…" : "야근 신청"}</button>
         </div>
-        <p className="text-[11.5px] text-ink-400 mt-2">승인되면 연장 종료시각까지 자동 퇴근이 미뤄지고, 사후 신청은 승인 시 그 날짜 근무시간에 가산돼요.</p>
+        <p className="text-[11.5px] text-ink-400 mt-2">승인되면 연장 종료시각까지 자동 퇴근이 미뤄지고, 사후 신청은 승인 시 그 날짜 근무시간에 가산돼요. 신청 후에도 아래 「내 야근 신청」에서 언제든 신청서 PDF 를 받을 수 있어요.</p>
       </div>
 
       <div className="panel p-0 overflow-hidden">

--- a/client/src/pages/JournalPage.tsx
+++ b/client/src/pages/JournalPage.tsx
@@ -349,7 +349,7 @@ export default function JournalPage() {
                     <div className="inline-flex items-center gap-2 text-[11.5px] text-ink-500 font-bold">
                       <span className="chip chip-brand !text-[10.5px]">{formatDateLong(selected.date)}</span>
                       <span>·</span>
-                      <span className="font-mono tabular-nums">{selected.date}</span>
+                      <span className="font-mono tabular-nums">{(selected.date || "").slice(0, 10)}</span>
                     </div>
                     <h2 className="text-[24px] font-extrabold mt-2 break-words tracking-tight text-ink-900">
                       {selected.title || "(제목 없음)"}

--- a/client/src/pages/UserProfilePage.tsx
+++ b/client/src/pages/UserProfilePage.tsx
@@ -7,6 +7,7 @@ import { Skeleton, SkeletonText } from "../components/Skeleton";
 import { alertAsync } from "../components/ConfirmHost";
 import { DevBadge } from "../lib/devBadge";
 import { resolvePresence, type PresenceStatus, type WorkStatus } from "../lib/presence";
+import { fmtYmd } from "../lib/fmt";
 
 type ProfileUser = {
   id: string;
@@ -263,7 +264,7 @@ export default function UserProfilePage() {
         <div className="panel p-5">
           <div className="text-[10.5px] font-extrabold tracking-[0.06em] uppercase text-ink-500 mb-3">근무 정보</div>
           <Field label="사번" value={u.employeeNo ?? "—"} mono />
-          <Field label="입사일" value={u.hireDate ?? "—"} />
+          <Field label="입사일" value={fmtYmd(u.hireDate)} />
           <Field label="연락처" value={u.phone ?? "—"} mono />
           <Field label="가입일" value={new Date(u.createdAt).toLocaleDateString("ko-KR")} />
           {!isReviewer && (u.employeeNo === null || u.phone === null || u.hireDate === null) && (

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1485,28 +1485,25 @@ body.hinest-chat-fs .hinest-preview-banner {
 }
 
 /* ===== 야근 신청 서식형 폼(.otform) =====
-   신청 폼이 곧 신청서 — 야근 신청서 PDF(lib/overtimePdf.ts, #1091)의 서식을 화면에서
-   그대로 채워 넣는 종이 문서 룩. "종이"라서 다크모드에서도 항상 흰 배경 + hex 고정색
-   (PDF 서식과 동일한 색·선 위계). 레이아웃은 hairline grid(배경 #9AA0A8 + 1px gap). */
-.otform { background: #ffffff; border: 1px solid #d8dbe0; border-radius: 14px; padding: 18px 16px 16px; color: #1f2329; }
-.otform-title { text-align: center; font-size: 14px; font-weight: 800; letter-spacing: 3px; text-indent: 3px; color: #151719; white-space: nowrap; }
+   신청 폼이 곧 신청서 — 야근 신청서 PDF(lib/overtimePdf.ts, #1091) 서식의 구조(제목·이중
+   괘선·라벨 그리드)를 화면에서 그대로 채우되, 색은 전부 C 토큰이라 앱 테마(다크/라이트)를
+   따라간다("흰 종이" 룩은 테마와 겉돌아 반려됨 — PDF 산출물만 흰 종이).
+   레이아웃은 hairline grid(배경 토큰 + 1px gap). */
+.otform { background: var(--c-surface); border: 1px solid var(--c-border); border-radius: 14px; padding: 18px 16px 16px; color: var(--c-text); }
+.otform-title { text-align: center; font-size: 14px; font-weight: 800; letter-spacing: 3px; text-indent: 3px; color: var(--c-text); white-space: nowrap; }
 @media (min-width: 640px) { .otform-title { font-size: 15.5px; letter-spacing: 6px; text-indent: 6px; } }
-.otform-rule { margin-top: 10px; border-top: 2px solid #1f1f1f; }
-.otform-rule2 { margin-top: 2px; border-top: 1px solid #1f1f1f; margin-bottom: 14px; }
-.otform-grid { display: grid; grid-template-columns: 76px 1fr; gap: 1px; background: #9aa0a8; border: 1.5px solid #1f1f1f; }
+.otform-rule { margin-top: 10px; border-top: 2px solid var(--c-text-2); }
+.otform-rule2 { margin-top: 2px; border-top: 1px solid var(--c-text-2); margin-bottom: 14px; }
+.otform-grid { display: grid; grid-template-columns: 76px 1fr; gap: 1px; background: var(--c-border-strong); border: 1px solid var(--c-text-3); border-radius: 8px; overflow: hidden; }
 @media (min-width: 640px) { .otform-grid { grid-template-columns: 84px 1fr 84px 1fr; } }
-.otform-grid > * { background: #ffffff; min-width: 0; }
-.otform-th { background: #f5f6f8; color: #3a3f46; font-size: 12px; font-weight: 600; letter-spacing: 1.5px; display: flex; align-items: center; justify-content: center; padding: 10px 4px; text-align: center; white-space: nowrap; }
-.otform-td { padding: 8px 10px; font-size: 13.5px; display: flex; align-items: center; }
+.otform-grid > * { background: var(--c-surface); min-width: 0; }
+.otform-th { background: var(--c-surface-3); color: var(--c-text-2); font-size: 12px; font-weight: 600; letter-spacing: 1.5px; display: flex; align-items: center; justify-content: center; padding: 10px 4px; text-align: center; white-space: nowrap; }
+.otform-td { padding: 8px 10px; font-size: 13.5px; display: flex; align-items: center; color: var(--c-text); }
 .otform-span { grid-column: 1 / -1; }
 @media (min-width: 640px) { .otform-time { grid-column: span 3; } }
-.otform-hint { display: none; margin-left: auto; font-size: 10.5px; font-weight: 400; letter-spacing: 0.3px; color: #a6adb6; padding-right: 6px; white-space: nowrap; }
+.otform-hint { display: none; margin-left: auto; font-size: 10.5px; font-weight: 400; letter-spacing: 0.3px; color: var(--c-text-muted); padding-right: 6px; white-space: nowrap; }
 @media (min-width: 640px) { .otform-hint { display: block; } }
-.otform-dim { color: #6b7178; font-size: 12px; }
+.otform-dim { color: var(--c-text-3); font-size: 12px; }
 .otform-plan { padding: 10px 12px; }
-.otform-plan textarea { width: 100%; border: 0; outline: none; background: transparent; resize: none; font-size: 13.5px; line-height: 1.75; color: #1f2329; min-height: 128px; display: block; }
-.otform-plan textarea::placeholder { color: #a6adb6; }
-/* 서식 안에 박히는 앱 위젯(DatePicker/TimePicker 버튼)도 종이 톤으로 — 다크모드 무관 고정색 */
-.otform .input { background: #ffffff; border-color: #c9cdd2; color: #1f2329; padding: 7px 10px; font-size: 13px; }
-.otform .input:hover { background: #f5f6f8; }
-.otform .text-ink-400 { color: #8b9098; }
+.otform-plan textarea { width: 100%; border: 0; outline: none; background: transparent; resize: none; font-size: 13.5px; line-height: 1.75; color: var(--c-text); min-height: 128px; display: block; }
+.otform-plan textarea::placeholder { color: var(--c-text-muted); }

--- a/server/src/routes/journal.ts
+++ b/server/src/routes/journal.ts
@@ -7,7 +7,8 @@ const router = Router();
 router.use(requireAuth);
 
 const schema = z.object({
-  date: z.string().max(40),
+  // YYYY-MM-DD 강제 — 느슨하면 풀 ISO 가 저장돼 클라가 원시 타임스탬프를 노출한다(#1099 계열).
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD"),
   title: z.string().min(1).max(200),
   content: z.string().min(1).max(20_000),
 });


### PR DESCRIPTION
## 원인
① 작성 중 서식을 PDF 로 받으려면 일단 신청부터 해야 했음 ② 서식형 폼이 hex 고정 "흰 종이" 라 다크모드 테마와 겉돎 ③ Leave 날짜가 Prisma DateTime → API 풀 ISO 직렬화인데 클라 formatRange/dayDiff 가 YYYY-MM-DD 가정 → `2026-06-09T00:00:00.000Z (0일)` 원시 노출. 3-각도 전수 수색으로 동종 노출·잠복 7건 추가 확인.

## 수정
- **「서식 PDF」 버튼**(신청 버튼 옆): 현재 입력값으로 즉시 결재용 PDF — 제출 없이도, 제출 후에도(목록 PDF 버튼) 다운로드 가능
- **서식 폼 테마화**: .otform 전면 C 토큰 — 서식 구조(제목·이중 괘선·hairline 그리드) 유지, 다크/라이트 자동, 그리드 라운딩. PDF 산출물은 종전대로 흰 종이
- **원시 ISO 전수 제거**: 공용 `fmtYmd`(lib/fmt) 신설 — 연차 기간·일수(ymd10), 인사카드 입사일, 급여명세서 입사/지급일(프리뷰·PDF·메일 공유 템플릿+작성기 시드), 업무일지 날짜, **DatePicker 자체 방어 정규화**(전 호출부 커버), overtimePdf 요일 헬퍼
- **부수 버그**: 야근 폼 기본 날짜 `toISOString`(UTC — KST 새벽엔 전날) → `todayKST()`. '사용한 휴가' 통계가 dayDiff NaN→0 오집계였던 것 정상화(수치가 올라 보이면 그게 맞는 값)
- **서버**: journal date 스키마 `YYYY-MM-DD` regex 강제(ISO 저장 회귀 차단). **프리뷰 목**: 연차를 운영과 동일한 풀 ISO 로 미러(정규화가 프리뷰에서 실검증되게)

## 검증
- 프리뷰(풀 ISO 목): 기간 `2026-07-28 ~ 2026-07-30 · 3일` 정상, 화면 전체에서 `T\d\d:\d\d:\d\d` 패턴·"(0일)" 소멸 확인, 서식 PDF 버튼 클릭→완주 897ms
- 서식 폼 다크 스크린샷 + 라이트 계산 스타일(surface #FFF·라벨 #F2F4F6·텍스트 #14161B) 확인, 콘솔 에러 0
- client tsc+vite build·server tsc 통과

Closes #1099
