### PR TITLE
🔀 :: (#1101) 계획내용 입력을 PDF 박스 수용량(11줄 실측)으로 제한

### DIFF
--- a/client/src/lib/overtimePdf.ts
+++ b/client/src/lib/overtimePdf.ts
@@ -104,6 +104,63 @@ const SHEET_CSS = `
 .otsheet .ot-company{font-size:19px;font-weight:700;letter-spacing:8px;text-indent:8px;color:#3A3F46;min-height:28px;line-height:28px;}
 `;
 
+/* ===== 계획내용 줄 수 제한 =====
+ * PDF 계획 박스(.ot-rb: 높이 330px 고정·A4 1페이지 유지)에 실제로 들어가는 줄 수만큼만
+ * 입력을 허용하기 위한 실측 유틸. 하드코딩 대신 서식을 한 번 offscreen 렌더해
+ * 박스의 내용 폭·행높이·수용 줄 수를 계산해 캐시하고(치수는 CSS 에서만 결정되므로 1회면 충분),
+ * 이후엔 같은 폰트·폭의 측정 div 로 "자동 줄바꿈 포함" 실제 줄 수를 잰다. */
+type PlanMetrics = { contentWidth: number; lineHeightPx: number; maxLines: number; font: string; letterSpacing: string };
+let _planMetrics: PlanMetrics | null = null;
+
+function getPlanMetrics(): PlanMetrics {
+  if (_planMetrics) return _planMetrics;
+  const host = document.createElement("div");
+  host.style.cssText = `position:fixed;left:-10000px;top:0;width:${A4_W}px;background:#ffffff;z-index:-1;`;
+  host.innerHTML = overtimeSheetHTML({ name: "측정", date: "2026-01-01", extendedEnd: "2026-01-01T21:00:00+09:00", createdAt: "2026-01-01T09:00:00+09:00" });
+  document.body.appendChild(host);
+  const rb = host.querySelector<HTMLElement>(".ot-rb")!;
+  const cs = getComputedStyle(rb);
+  const padX = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+  const padY = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+  const lineHeightPx = parseFloat(cs.lineHeight); // 14.5 × 1.8 = 26.1
+  // clientHeight/clientWidth = 패딩 포함·보더 제외 → 내용 영역만 남긴다.
+  const contentWidth = rb.clientWidth - padX;
+  const maxLines = Math.max(1, Math.floor((rb.clientHeight - padY) / lineHeightPx));
+  const m: PlanMetrics = { contentWidth, lineHeightPx, maxLines, font: cs.font, letterSpacing: cs.letterSpacing };
+  host.remove();
+  _planMetrics = m;
+  return m;
+}
+
+/** 계획내용이 PDF 박스에서 차지할 실제 줄 수(자동 줄바꿈 포함)와 허용 최대 줄 수. */
+export function measurePlanLines(text: string): { lines: number; maxLines: number } {
+  const m = getPlanMetrics();
+  const probe = document.createElement("div");
+  probe.style.cssText = `position:fixed;left:-10000px;top:0;width:${m.contentWidth}px;white-space:pre-wrap;word-break:break-word;visibility:hidden;`;
+  probe.style.font = m.font;
+  probe.style.letterSpacing = m.letterSpacing;
+  probe.style.lineHeight = `${m.lineHeightPx}px`;
+  probe.textContent = text || " ";
+  document.body.appendChild(probe);
+  const h = probe.getBoundingClientRect().height;
+  probe.remove();
+  return { lines: Math.max(1, Math.round(h / m.lineHeightPx)), maxLines: m.maxLines };
+}
+
+/** maxLines 를 넘는 입력을 "들어가는 만큼"으로 자름 — 이진 탐색으로 가장 긴 접두사. */
+export function clampPlanText(text: string): string {
+  const { maxLines } = measurePlanLines("");
+  if (measurePlanLines(text).lines <= maxLines) return text;
+  let lo = 0;
+  let hi = text.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi + 1) / 2);
+    if (measurePlanLines(text.slice(0, mid)).lines <= maxLines) lo = mid;
+    else hi = mid - 1;
+  }
+  return text.slice(0, lo);
+}
+
 /** 신청서 마크업 — 결재란·제목 이중 괘선·정보표·계획내용·각주·서명·회사명. */
 export function overtimeSheetHTML(d: OvertimeSheetData): string {
   return `

--- a/client/src/pages/AttendancePage.tsx
+++ b/client/src/pages/AttendancePage.tsx
@@ -11,6 +11,7 @@ import TimePicker from "../components/TimePicker";
 import Portal from "../components/Portal";
 import { alertAsync } from "../components/ConfirmHost";
 import { useModalDismiss } from "../lib/useModalDismiss";
+import { measurePlanLines, clampPlanText } from "../lib/overtimePdf";
 
 type WorkSession = { s: string; e: string | null; src?: string };
 type Attendance = {
@@ -670,6 +671,8 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
   const [date, setDate] = useState(() => todayKST()); // toISOString 은 UTC 라 KST 새벽엔 전날이 잡힘
   const [endTime, setEndTime] = useState("21:00");
   const [reason, setReason] = useState("");
+  // 계획내용 줄 카운터 — PDF 계획 박스가 담을 수 있는 실측 줄 수(자동 줄바꿈 포함) 기준.
+  const [planLines, setPlanLines] = useState<{ lines: number; maxLines: number } | null>(null);
   const [saving, setSaving] = useState(false);
   const [pdfBusy, setPdfBusy] = useState<string | null>(null);
   const [companyName, setCompanyName] = useState<string | null>(null);
@@ -723,6 +726,21 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
       alertAsync({ title: "PDF 생성 실패", description: e?.message ?? "신청서 PDF 생성에 실패했어요" });
     } finally { setPdfBusy(null); }
   }
+  // 계획내용 입력 제한 — PDF 계획 박스(A4 1페이지 고정 330px)에 실제로 들어가는 줄 수까지만.
+  // 자동 줄바꿈 포함 실측(measurePlanLines)이라 "몇 자"가 아니라 "몇 줄"이 기준. 넘치면
+  // 들어가는 만큼으로 잘라(clampPlanText) 서식이 2페이지로 넘어가거나 글이 잘리는 일이 없다.
+  function onReasonChange(v: string) {
+    const m = measurePlanLines(v);
+    if (m.lines <= m.maxLines) {
+      setReason(v);
+      setPlanLines(m);
+    } else {
+      const t = clampPlanText(v);
+      setReason(t);
+      setPlanLines(measurePlanLines(t));
+    }
+  }
+
   // 지금 작성 중인 서식 그대로 PDF — 제출(신청) 없이도 결재용 서식을 뽑을 수 있게.
   async function downloadFormPdf() {
     if (pdfBusy) return;
@@ -768,11 +786,17 @@ function OvertimeSection({ isReviewer }: { isReviewer: boolean }) {
               <TimePicker value={endTime} onChange={setEndTime} className="w-[110px]" />
               <span className="otform-dim whitespace-nowrap">까지 (휴게시간 제외)</span>
             </div>
-            <div className="otform-th otform-span !justify-start px-3">계획 내용 (업무 내용)<span className="otform-hint">수행 업무를 구체적으로 기재</span></div>
+            <div className="otform-th otform-span !justify-start px-3">
+              계획 내용 (업무 내용)
+              <span className={`otform-lines ${planLines && planLines.lines >= planLines.maxLines ? "otform-lines-full" : ""}`}>
+                {planLines ? `${planLines.lines}/${planLines.maxLines}줄` : ""}
+              </span>
+              <span className="otform-hint">수행 업무를 구체적으로 기재</span>
+            </div>
             <div className="otform-plan otform-span">
               <textarea
                 value={reason}
-                onChange={(e) => setReason(e.target.value)}
+                onChange={(e) => onReasonChange(e.target.value)}
                 placeholder={"수행할 업무를 구체적으로 적어주세요.\n줄바꿈 그대로 신청서 PDF 에 들어가요."}
                 maxLength={1000}
                 rows={5}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1507,3 +1507,7 @@ body.hinest-chat-fs .hinest-preview-banner {
 .otform-plan { padding: 10px 12px; }
 .otform-plan textarea { width: 100%; border: 0; outline: none; background: transparent; resize: none; font-size: 13.5px; line-height: 1.75; color: var(--c-text); min-height: 128px; display: block; }
 .otform-plan textarea::placeholder { color: var(--c-text-muted); }
+
+/* 계획내용 줄 카운터 — PDF 계획 박스 수용량(실측) 대비 현재 줄 수. 꽉 차면 경고색. */
+.otform-lines { margin-left: 8px; font-size: 10.5px; font-weight: 600; letter-spacing: 0.3px; color: var(--c-text-muted); white-space: nowrap; }
+.otform-lines-full { color: #E5484D; }


### PR DESCRIPTION
## 원인
계획 내용 입력 제한이 글자 수(1000자)뿐 — PDF 계획 박스(A4 1페이지 유지를 위한 330px 고정)의 수용량은 "줄 수"(자동 줄바꿈 포함) 기준이라, 길게 쓰면 서식이 2페이지로 늘어났음.

## 수정
- **실측 기반 한도**(하드코딩 없음): 서식을 1회 offscreen 렌더해 계획 박스의 내용 폭·행높이·수용 줄 수(현 서식 기준 **11줄**)를 계산·캐시 — 서식 CSS 를 바꾸면 한도도 자동 갱신
  - `measurePlanLines(text)`: 개행뿐 아니라 **자동 줄바꿈까지 포함**한 실제 점유 줄 수 (같은 폭·폰트·자간의 측정 div)
  - `clampPlanText(text)`: 초과 시 이진 탐색으로 "들어가는 만큼"의 가장 긴 접두사로 자름
- **폼 연동**: 타이핑·붙여넣기 모두 한도 초과분 자동 클램프, 계획내용 헤더에 `N/11줄` 카운터(꽉 차면 경고색)

## 검증
- 단위(프리뷰 실코드): maxLines=11(수계산 (330−36)/26.1=11.26 과 일치), 3줄→3, 개행 없는 한글 210자→4줄(자동 줄바꿈 측정), 30줄 입력→정확히 11줄 클램프
- UI: textarea 에 30줄 붙여넣기 → 11줄만 유지, 카운터 `11/11줄` 경고색
- 11줄 만재 서식의 html2canvas 캡처 비율 **1.4144 = A4 정확히 1페이지**
- client tsc + vite build 통과, 콘솔 에러 0

## 비고
- 클라 전용 — OTA. 기존(제한 전) 데이터가 11줄을 넘는 경우를 위해 다페이지 슬라이싱 폴백은 유지.

Closes #1101
