### PR TITLE
🔀 :: (#1105) 신청서 결재란 신청 칸 제거 — 대표 단일 칸

### DIFF
--- a/client/src/lib/overtimePdf.ts
+++ b/client/src/lib/overtimePdf.ts
@@ -75,7 +75,7 @@ const SHEET_CSS = `
 .otsheet .ot-head td{vertical-align:top;}
 .otsheet .ot-meta{font-size:11.5px;color:#8B9098;line-height:1.9;letter-spacing:0.5px;padding-top:2px;padding-right:20px;}
 .otsheet .ot-meta .ot-meta-code{color:#6B7178;font-weight:600;}
-.otsheet .ot-approve{width:300px;border:2px solid #1F1F1F;}
+.otsheet .ot-approve{width:172px;border:2px solid #1F1F1F;}
 .otsheet .ot-approve th,.otsheet .ot-approve td{border:1px solid #9AA0A8;text-align:center;vertical-align:middle;}
 .otsheet .ot-ap-side{width:32px;background:#F5F6F8;font-size:13px;font-weight:700;color:#3A3F46;line-height:2.1;letter-spacing:1px;}
 .otsheet .ot-ap-title{height:30px;background:#F5F6F8;font-size:12.5px;font-weight:600;color:#3A3F46;letter-spacing:3px;text-indent:3px;}
@@ -177,11 +177,11 @@ export function overtimeSheetHTML(d: OvertimeSheetData): string {
           ※ 승인권자의 결재 완료 후 근무를 개시하여 주시기 바랍니다.
         </div>
       </td>
-      <td style="width:300px;">
+      <td style="width:172px;">
         <table class="ot-approve">
-          <tr><td class="ot-ap-side" rowspan="3">결<br>재</td><th class="ot-ap-title">신 청</th><th class="ot-ap-title">대 표</th></tr>
-          <tr><td class="ot-ap-sign">(인)</td><td class="ot-ap-sign">(인)</td></tr>
-          <tr><td class="ot-ap-date">&nbsp;.&nbsp;&nbsp;.&nbsp;</td><td class="ot-ap-date">&nbsp;.&nbsp;&nbsp;.&nbsp;</td></tr>
+          <tr><td class="ot-ap-side" rowspan="3">결<br>재</td><th class="ot-ap-title">대 표</th></tr>
+          <tr><td class="ot-ap-sign">(인)</td></tr>
+          <tr><td class="ot-ap-date">&nbsp;.&nbsp;&nbsp;.&nbsp;</td></tr>
         </table>
       </td>
     </tr>


### PR DESCRIPTION
## 원인
상단 결재란(신청/대표 2칸)의 신청 칸이 하단 신청자 서명란과 중복 — 신청자는 문서 하단에서 서명함.

## 수정
결재란을 **대표 1칸**으로 (도장 (인)·일자 기입 행 유지), 박스 폭 300→172px 로 1칸 비례 축소.

## 검증
프리뷰 캡처(baseline 보정 포함): [결재|대표] 1칸 정상 렌더, A4 정확히 1페이지(비율 1.4144), 콘솔 에러 0, client tsc+vite build 통과.

Closes #1105