### PR TITLE
🔀 :: (#1111) MAS 반려 대응 — 자동 시작 동의화·productName·downloads 권한 제거

### DIFF
--- a/HiNest-MacOS/build/entitlements.mas.plist
+++ b/HiNest-MacOS/build/entitlements.mas.plist
@@ -10,10 +10,10 @@
     <key>com.apple.security.network.client</key>
     <true/>
 
-    <!-- 파일 업로드/다운로드 (문서·급여명세서 등) -->
+    <!-- 파일 업로드/다운로드 — 업로드는 파일 선택기, 다운로드는 저장 다이얼로그
+         (will-download 의 setSaveDialogOptions)라 user-selected 하나로 충분.
+         downloads.read-write 는 대응 기능이 없어 2.4.5(i) 반려(1.0.0(3)) → 제거. -->
     <key>com.apple.security.files.user-selected.read-write</key>
-    <true/>
-    <key>com.apple.security.files.downloads.read-write</key>
     <true/>
 
     <!-- App Store 배포 식별자 — 프로비저닝 프로파일과 일치해야 함.

--- a/HiNest-MacOS/package.json
+++ b/HiNest-MacOS/package.json
@@ -1,5 +1,6 @@
 {
   "name": "hinest-macos",
+  "productName": "HiNest",
   "version": "1.0.0",
   "private": true,
   "description": "HiNest for macOS — Mac App Store (sandboxed) Electron build",

--- a/HiNest-MacOS/src/main.ts
+++ b/HiNest-MacOS/src/main.ts
@@ -277,28 +277,14 @@ app.on("second-instance", () => {
   showWindow();
 });
 
-/**
- * 첫 실행에 자동 시작(OS 로그인 시 트레이 상주)을 기본 ON 으로 등록.
- * 사용자 토글로 OFF 한 후엔 다시 켜지 않음(flag 파일). dev 빌드는 skip.
- */
-function initAutoLaunchDefault() {
-  if (!app.isPackaged) return;
-  try {
-    const flagPath = path.join(app.getPath("userData"), "auto-launch-initialized");
-    if (fs.existsSync(flagPath)) return;
-    app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true });
-    fs.writeFileSync(flagPath, String(Date.now()));
-    console.log("[autoLaunch] enabled by default on first run");
-  } catch (e) {
-    console.warn("[autoLaunch] init failed", e);
-  }
-}
+/* 자동 시작(로그인 시 실행)은 기본 OFF — MAS 가이드라인 2.4.5(iii): 사용자 동의 없이
+ * 로그인 시 자동 실행 금지(1.0.0(3) 반려 사유). 프로필 설정의 토글(hinest:setAutoLaunch)로
+ * 사용자가 직접 켠 경우에만 등록된다. */
 
 app.whenReady().then(() => {
   createWindow();
   buildAppMenu();
   createTray();
-  initAutoLaunchDefault();
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();


### PR DESCRIPTION
## 원인
MAS 1.0.0(3) 반려 4건 분석:
- **2.4.5(iii) 자동 실행**: `initAutoLaunchDefault()` 가 첫 실행에 `openAtLogin:true` 를 동의 없이 기본 등록 — 실제 위반
- **5.2.5 앱 이름**: 루트 package.json 에 productName 이 없어 Electron `app.name` = `"hinest-macos"` — About 패널 등 기기 표시 이름에 "macos" 노출
- **가이드라인4 창 메뉴 · 2.4.5(i) camera**: 둘 다 **1.0.0(2) 반려 때 이미 수정돼 main 에 있음**(#1036, 6/17) — (3) 빌드가 수정 전 체크아웃에서 만들어진 것으로 추정. 현행 main: 창 메뉴(「HiNest 창 열기」 ⌘0) 존재 ✓, camera 권한 전무 ✓
- **2.4.5(i) downloads.read-write**: 다운로드가 저장 다이얼로그(will-download `setSaveDialogOptions`) 방식이라 `user-selected.read-write` 로 충분 — 불필요 권한

## 수정
- 첫 실행 자동 시작 등록 삭제 — 프로필 설정의 자동 시작 토글(hinest:setAutoLaunch, 사용자 동의)로만 등록. 근거 주석 유지
- `entitlements.mas.plist` 에서 `com.apple.security.files.downloads.read-write` 제거
- 루트 `productName: "HiNest"` 추가 — app.name 이 "HiNest" 로

## 검증
- HiNest-MacOS tsc 통과. 창 메뉴·camera 부재는 현행 main 코드에서 재확인
- 네이티브(Electron)라 실빌드 확인은 재빌드 시 — buildVersion 은 로컬 수동 관리(비커밋) 유지

## 비고 (재제출 절차 — 사용자)
1. **최신 main 을 pull 받은 체크아웃에서** buildVersion (4) 로 올려 `npm run dist:mas` → 업로드 (이번 반려의 camera·창메뉴는 구 체크아웃 빌드가 원인으로 추정 — 최신 main 빌드가 핵심)
2. ASC 리스팅 이름에서 macOS/Apple 용어 제거 확인
3. 2.4.5(i)는 ASC 회신: downloads.read-write 제거했고 camera 는 신규 바이너리에 없음

Closes #1111
