### PR TITLE
🔀 :: (#1113) 콘솔 돌아가기 버튼 간헐 소실 — 로그인 응답 부분 user 수정

### DIFF
--- a/client/src/auth.tsx
+++ b/client/src/auth.tsx
@@ -112,6 +112,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // 섬광처럼 보이는 것을 방지. logout 에서와 동일하게 세션 캐시를 싹 비움.
     clearApiCache();
     setUser(res.user);
+    // 로그인 응답 user 는 /api/me 보다 필드가 적을 수 있어(구버전 서버 등) 풀 객체로
+    // 재동기화 — companyId/isDeveloper 누락 시 콘솔 '서비스로 돌아가기'·개발자 뱃지가
+    // 하드 리로드 전까지 사라지던 간헐 버그(#1113) 방지. fire-and-forget.
+    void refreshRef.current?.();
     // 로그인 직후 알림 권한 요청(iOS/macOS 등 설치형 앱). 라우팅을 막지 않도록 fire-and-forget.
     void requestNotifPermissionOnLogin();
     // 안드로이드: 백그라운드/잠금 상태 알림 신뢰도 위해 배터리 최적화 제외 1회 안내(카톡 방식).
@@ -128,6 +132,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setAuthToken(res.token);
     clearApiCache();
     setUser(res.user);
+    // 로그인과 동일 — 풀 user 재동기화(#1113).
+    void refreshRef.current?.();
     // 가입(=최초 로그인) 직후에도 동일하게 알림 권한 요청 + 배터리 최적화 제외 안내(안드로이드).
     void requestNotifPermissionOnLogin();
     void ensureAndroidBatteryExemption();

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -159,6 +159,12 @@ router.post("/login", async (req, res) => {
       avatarUrl: user.avatarUrl,
       superAdmin: user.superAdmin,
       consoleOnly: isConsoleOnlyUser(user),
+      // /api/me 와 필드 일치(#1113) — 빠지면 로그인 직후 세션이 하드 리로드 전까지
+      // companyId 없는 부분 객체를 쥐어, 콘솔 '서비스로 돌아가기'(hasCompany)·개발자
+      // 뱃지(isDeveloper)가 간헐적으로 사라져 보인다.
+      companyId: user.companyId ?? null,
+      platformAdmin: user.platformAdmin,
+      isDeveloper: user.isDeveloper,
     },
     // 네이티브 앱(Capacitor)은 cross-site 쿠키가 ITP 에 막혀 새로고침 시 세션이 끊긴다.
     // 네이티브 origin 일 때만 세션 JWT 를 본문으로 함께 내려, 클라가 저장해 Authorization
@@ -209,7 +215,7 @@ router.post("/signup", async (req, res) => {
   // (1) 과 (3) 사이에 같은 초대키로 동시 요청이 들어오면 둘 다 used=false 를 보고 통과 → 키 1개로 N명 가입.
   // updateMany({ where:{id, used:false}, data:{used:true} }) 는 \"하나만 통과\" 를 DB 가 보장하므로
   // 트랜잭션 안에서 이 결과 count 를 보고 분기하면 어떤 동시성 시나리오에서도 단 한 명만 가입한다.
-  let user: { id: string; email: string; name: string; role: string; team: string | null; position: string | null; avatarColor: string; avatarUrl: string | null; superAdmin: boolean; companyId: string | null };
+  let user: { id: string; email: string; name: string; role: string; team: string | null; position: string | null; avatarColor: string; avatarUrl: string | null; superAdmin: boolean; companyId: string | null; platformAdmin: boolean; isDeveloper: boolean };
   try {
     user = await prisma.$transaction(async (tx) => {
       const now = new Date();
@@ -246,6 +252,7 @@ router.post("/signup", async (req, res) => {
         team: created.team, position: created.position,
         avatarColor: created.avatarColor, avatarUrl: created.avatarUrl, superAdmin: created.superAdmin,
         companyId: created.companyId,
+        platformAdmin: created.platformAdmin, isDeveloper: created.isDeveloper,
       };
     }, {
       isolationLevel: "Serializable",
@@ -291,6 +298,10 @@ router.post("/signup", async (req, res) => {
       avatarUrl: user.avatarUrl,
       superAdmin: user.superAdmin,
       consoleOnly: isConsoleOnlyUser(user),
+      // 로그인 응답과 동일 — /api/me 와 필드 일치(#1113).
+      companyId: user.companyId ?? null,
+      platformAdmin: user.platformAdmin,
+      isDeveloper: user.isDeveloper,
     },
     // 로그인과 동일 — 네이티브 origin 에만 세션 토큰을 본문으로 함께 내린다.
     ...(isNativeOrigin(req) ? { token } : {}),


### PR DESCRIPTION
## 원인
/api/auth/login·signup 응답 user 에 companyId·platformAdmin·isDeveloper 가 없어(/api/me 는 있음), 클라가 로그인 직후부터 **하드 리로드 전까지 companyId=undefined 인 부분 user** 를 유지 → 콘솔 「서비스로 돌아가기」(hasCompany)·개발자 뱃지(isDeveloper)가 그 세션에서만 사라짐. "가끔" = 재로그인 직후 세션. 멀티테넌트 전환(b9ad454) 때부터 잠복. 임퍼소네이션·CSS·네이티브 탭바 경로는 조사에서 배제(각각 풀 리로드/상보 렌더 확인).

## 수정
- 서버: 로그인·가입 응답 user 에 `companyId`·`platformAdmin`·`isDeveloper` 추가 — /api/me 와 필드 일치 (signup 트랜잭션 반환 타입 동반 확장)
- 클라: `login()`/`signup()` 직후 `refresh()` fire-and-forget — 풀 user 재동기화(구서버·OTA 시차에도 견고)

## 검증
- server tsc·client tsc + vite build 통과
- 재현 조건이 "실서버 재로그인 직후"라 프리뷰 불가 — 배포 후 재로그인→콘솔 진입으로 확인 (교차 증상: 같은 상태에서 개발자 뱃지도 사라졌다 복구되는지)

Closes #1113