### PR TITLE
🔀 :: (#1114) 회사 등록 신청 웹 전용 — 설치형 앱 진입점·페이지 차단

### DIFF
--- a/client/src/pages/CompanySignupPage.tsx
+++ b/client/src/pages/CompanySignupPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, Navigate } from "react-router-dom";
+import { isInstalledApp } from "../lib/platform";
 import { useAuth } from "../auth";
 import { api } from "../api";
 import BrandLockup from "../components/BrandLockup";
@@ -41,7 +42,8 @@ export default function CompanySignupPage() {
 
   if (user) return <Navigate to="/" replace />;
   // 모바일/태블릿은 그냥 조용히 로그인으로 리다이렉트(안내 화면 없이).
-  if (isMobile) return <Navigate to="/login" replace />;
+  // 설치형 앱(macOS 데스크톱·iOS/Android 네이티브)도 전면 차단 — 회사 등록은 웹 전용.
+  if (isMobile || isInstalledApp()) return <Navigate to="/login" replace />;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -195,7 +195,8 @@ export default function LoginPage() {
           </div>
 
           {/* 새 회사 셀프 가입 — 멀티테넌트 진입점 */}
-          {/* 회사 등록 진입점 — 모바일에서는 숨김(긴 회사 정보 폼은 데스크탑에서만 작성). */}
+          {/* 회사 등록 진입점 — 모바일 폭에선 숨김(긴 폼), 설치형 앱(macOS·iOS)에선 웹 전용이라 숨김. */}
+          {!isInstalledApp() && (
           <div className="mt-4 text-center text-[12.5px] hidden md:block">
             <span className="text-ink-400">회사를 새로 시작하시나요? </span>
             <Link
@@ -206,6 +207,7 @@ export default function LoginPage() {
               회사 등록 신청
             </Link>
           </div>
+          )}
 
           {/* 앱 다운로드 — 설치형 앱(데스크톱·모바일 네이티브) 안에서는 숨김 */}
           {!isInstalledApp() && (

--- a/client/src/pages/SignupPage.tsx
+++ b/client/src/pages/SignupPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { isInstalledApp } from "../lib/platform";
 import { Link, Navigate, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
 import BrandLockup from "../components/BrandLockup";
@@ -130,7 +131,8 @@ export default function SignupPage() {
             </Link>
           </div>
 
-          {/* 초대키가 없는 신규 회사는 회사 등록 신청으로 안내. 모바일에서는 숨김. */}
+          {/* 초대키가 없는 신규 회사는 회사 등록 신청으로 안내. 모바일 폭·설치형 앱에선 숨김(웹 전용). */}
+          {!isInstalledApp() && (
           <div className="mt-4 text-center text-[12.5px] hidden md:block">
             <span className="text-ink-400">초대키가 없는 새 회사인가요? </span>
             <Link
@@ -141,6 +143,7 @@ export default function SignupPage() {
               회사 등록 신청
             </Link>
           </div>
+          )}
         </div>
       </main>
     </div>


### PR DESCRIPTION
## 원인
기존 게이트(#1064)가 화면 폭 기준이라 넓은 창의 macOS 앱·iPad 앱에서 회사 등록 진입점이 노출.

## 수정
- LoginPage·SignupPage 진입 링크를 `!isInstalledApp()`(Electron+Capacitor)로 감쌈 — 기존 모바일 폭 숨김(hidden md:block)도 유지
- CompanySignupPage 가드에 `isInstalledApp()` 추가 — URL 직접 진입도 /login 으로 조용히 리다이렉트(기존 isMobile 가드와 동일 UX)

## 검증
- client tsc + vite build 통과. isInstalledApp 은 LoginPage 앱 다운로드 섹션에서 이미 쓰는 검증된 헬퍼 재사용

Closes #1114