### PR TITLE
🔀 :: (#1117) 개인정보 처리방침·이용약관 담당자·문의처 실제 정보로 교체

### DIFF
--- a/client/src/pages/PrivacyPolicyPage.tsx
+++ b/client/src/pages/PrivacyPolicyPage.tsx
@@ -102,8 +102,8 @@ export default function PrivacyPolicyPage() {
           개인정보 처리에 관한 문의·불만·피해 구제는 아래로 접수할 수 있습니다.
         </p>
         <ul className="list-disc pl-5 space-y-1">
-          <li>개인정보 보호책임자: <b>[담당자명/직책 — 운영자가 채워야 함]</b></li>
-          <li>문의 이메일: <b>developer.seojiwan@gmail.com</b></li>
+          <li>개인정보 보호책임자: <b>서지완 (대표)</b></li>
+          <li>문의 이메일: <b>xixn2@efface.dev</b></li>
         </ul>
       </LegalSection>
 

--- a/client/src/pages/TermsPage.tsx
+++ b/client/src/pages/TermsPage.tsx
@@ -85,7 +85,7 @@ export default function TermsPage() {
       </LegalSection>
 
       <LegalSection heading="문의">
-        <p>약관에 관한 문의: <b>developer.seojiwan@gmail.com</b></p>
+        <p>약관에 관한 문의: <b>xixn2@efface.dev</b></p>
       </LegalSection>
     </LegalLayout>
   );


### PR DESCRIPTION
## 원인
개인정보 처리방침에 플레이스홀더(`[담당자명/직책 — 운영자가 채워야 함]`)와 옛 문의 이메일이 남아 있었고, 이용약관 문의처도 같은 옛 이메일.

## 수정
- PrivacyPolicyPage: 개인정보 보호책임자 **서지완 (대표)** · 문의 이메일 **xixn2@efface.dev**
- TermsPage: 약관 문의 **xixn2@efface.dev**

## 검증
- `developer.seojiwan@gmail.com` 코드베이스 잔존 0
- client tsc + vite build 통과

Closes #1117