### PR TITLE
🔀 :: (#1119) 미리보기에서 관리자 탭·운영 콘솔 진입 차단

### DIFF
--- a/client/src/lib/previewMock.ts
+++ b/client/src/lib/previewMock.ts
@@ -22,15 +22,19 @@ const DEMO_ME = {
   id: "demo-user",
   email: "demo@hinest.app",
   name: "김데모",
-  role: "ADMIN",
+  // 데모 사용자 = 일반 사원. 관리자 탭(role ADMIN 필요)·운영 콘솔(superAdmin 필요)은
+  // 진입점(AppLayout)·라우트 가드(App.tsx AdminOnly/ConsoleOnly) 양쪽에서 자동 차단되어야
+  // 한다 — 미리보기는 외부 잠재고객이 보는 데모라 관리/운영 화면 노출 금지.
+  role: "MEMBER",
   team: "프로덕트팀",
-  position: "팀장",
+  position: "사원",
   avatarColor: "#3D54C4",
   avatarUrl: null,
-  superAdmin: true,
+  superAdmin: false,
+  platformAdmin: false,
   // 데모 사용자 = 일반 사용자 인상을 주기 위해 개발자 뱃지 제거.
   isDeveloper: false,
-  employeeNo: "AD0000001",
+  employeeNo: "PD0000042",
   presenceStatus: null,
   presenceMessage: null,
   presenceUpdatedAt: null,


### PR DESCRIPTION
## 원인
previewMock 의 DEMO_ME 가 `role: "ADMIN"` + `superAdmin: true` 라, 미리보기(데모)에서 관리자 탭·운영 콘솔의 nav 진입점과 라우트 가드를 모두 통과. 외부 잠재고객이 보는 데모에 관리/운영 화면이 노출됐음.

## 수정
DEMO_ME 를 일반 사원으로 낮춤 — `role: "MEMBER"`, `superAdmin: false`, `platformAdmin: false`, position 사원. 진입점(AppLayout)·라우트 가드(App.tsx AdminOnly/ConsoleOnly)가 자동으로 차단. previewMock 은 미리보기 전용이라 실서비스 무영향.

## 검증 (프리뷰)
- 사이드바에 「관리자」·「운영 콘솔」 nav 없음
- `/admin`·`/super-admin`·`/platform` URL 직접 진입 모두 `/` 로 리다이렉트
- 콘솔 에러 0, client tsc + vite build 통과

Closes #1119