### PR TITLE
🔀 :: (#1121) 종합 점검 — 야근 승인 IDOR·대시보드 버튼 잠금·근태 무제한 스캔 등 6건

### DIFF
--- a/client/src/pages/DashboardPage.tsx
+++ b/client/src/pages/DashboardPage.tsx
@@ -121,6 +121,10 @@ export default function DashboardPage() {
     } catch (err: any) {
       alertAsync({ title: "퇴근 실패", description: err?.message ?? "퇴근 처리에 실패했어요" });
       return;
+    } finally {
+      // checkIn 과 동일하게 항상 해제(#1121) — 없으면 퇴근 성공/실패 후 attBusy 가 true 로
+      // 고정돼 '다시 출근'·'퇴근하기' 버튼이 리마운트 전까지 잠긴다(다중 세션 재출근 불가).
+      setAttBusy(false);
     }
     load();
   }

--- a/server/src/lib/db.ts
+++ b/server/src/lib/db.ts
@@ -66,6 +66,10 @@ const TENANT_MODELS = new Set<string>([
   "Event",
   "Leave",
   "Attendance",
+  // OvertimeRequest 는 companyId 를 갖지만 이 목록에 없어(#1121) PATCH /overtime/:id 의
+  // findUnique/update 가 자동 스코프를 못 받아, 타 회사 야근 신청을 id 로 교차 승인/반려할
+  // 수 있는 IDOR 이 있었다. 등록해 findUnique/update 를 회사 단위로 자동 격리한다.
+  "OvertimeRequest",
   "Journal",
   "Notice",
   "NoticeReaction",

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1528,8 +1528,14 @@ router.get("/attendance/overview", async (req, res) => {
   base.setUTCDate(base.getUTCDate() - (dow === 0 ? 6 : dow - 1));
   const weekMonday = base.toISOString().slice(0, 10);
 
+  // 스캔 하한(#1121) — 표에 쓰는 값은 today·이번 주(weekMonday~)·이번 달(monthPrefix)뿐이라
+  // 전체 근태 이력을 무제한 스캔할 이유가 없다. 필요한 창(주 시작 vs 월 시작 중 이른 날) 이후만
+  // 조회. total 은 클라 미사용이라 창 축소로 인한 표시 변화 없음.
+  const monthStart = `${monthPrefix}-01`;
+  const scanFrom = weekMonday < monthStart ? weekMonday : monthStart;
+
   const att = await prisma.attendance.findMany({
-    where: { userId: { in: ids } },
+    where: { userId: { in: ids }, date: { gte: scanFrom } },
     select: { userId: true, date: true, checkIn: true, checkOut: true, sessions: true },
   });
   const byUser = new Map<string, typeof att>();

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -165,6 +165,14 @@ router.post("/login", async (req, res) => {
       companyId: user.companyId ?? null,
       platformAdmin: user.platformAdmin,
       isDeveloper: user.isDeveloper,
+      // 근무시간·근태·재실 필드도 /api/me 와 일치(#1121) — 없으면 로그인 직후 대시보드
+      // 근무시간 게이지가 /api/me 재조회 전까지 09:00~18:00 기본값으로 잠깐 잘못 표시된다.
+      employeeNo: user.employeeNo,
+      presenceStatus: user.presenceStatus,
+      presenceMessage: user.presenceMessage,
+      presenceUpdatedAt: user.presenceUpdatedAt,
+      workStartTime: user.workStartTime,
+      workEndTime: user.workEndTime,
     },
     // 네이티브 앱(Capacitor)은 cross-site 쿠키가 ITP 에 막혀 새로고침 시 세션이 끊긴다.
     // 네이티브 origin 일 때만 세션 JWT 를 본문으로 함께 내려, 클라가 저장해 Authorization
@@ -215,7 +223,7 @@ router.post("/signup", async (req, res) => {
   // (1) 과 (3) 사이에 같은 초대키로 동시 요청이 들어오면 둘 다 used=false 를 보고 통과 → 키 1개로 N명 가입.
   // updateMany({ where:{id, used:false}, data:{used:true} }) 는 \"하나만 통과\" 를 DB 가 보장하므로
   // 트랜잭션 안에서 이 결과 count 를 보고 분기하면 어떤 동시성 시나리오에서도 단 한 명만 가입한다.
-  let user: { id: string; email: string; name: string; role: string; team: string | null; position: string | null; avatarColor: string; avatarUrl: string | null; superAdmin: boolean; companyId: string | null; platformAdmin: boolean; isDeveloper: boolean };
+  let user: { id: string; email: string; name: string; role: string; team: string | null; position: string | null; avatarColor: string; avatarUrl: string | null; superAdmin: boolean; companyId: string | null; platformAdmin: boolean; isDeveloper: boolean; employeeNo: string | null; presenceStatus: string | null; presenceMessage: string | null; presenceUpdatedAt: Date | null; workStartTime: string | null; workEndTime: string | null };
   try {
     user = await prisma.$transaction(async (tx) => {
       const now = new Date();
@@ -253,6 +261,11 @@ router.post("/signup", async (req, res) => {
         avatarColor: created.avatarColor, avatarUrl: created.avatarUrl, superAdmin: created.superAdmin,
         companyId: created.companyId,
         platformAdmin: created.platformAdmin, isDeveloper: created.isDeveloper,
+        // /api/me 필드 일치(#1121) — 응답 user 페이로드에 그대로 실어 근무시간 게이지 flash 방지.
+        employeeNo: created.employeeNo,
+        presenceStatus: created.presenceStatus, presenceMessage: created.presenceMessage,
+        presenceUpdatedAt: created.presenceUpdatedAt,
+        workStartTime: created.workStartTime, workEndTime: created.workEndTime,
       };
     }, {
       isolationLevel: "Serializable",
@@ -298,10 +311,16 @@ router.post("/signup", async (req, res) => {
       avatarUrl: user.avatarUrl,
       superAdmin: user.superAdmin,
       consoleOnly: isConsoleOnlyUser(user),
-      // 로그인 응답과 동일 — /api/me 와 필드 일치(#1113).
+      // 로그인 응답과 동일 — /api/me 와 필드 일치(#1113·#1121).
       companyId: user.companyId ?? null,
       platformAdmin: user.platformAdmin,
       isDeveloper: user.isDeveloper,
+      employeeNo: user.employeeNo,
+      presenceStatus: user.presenceStatus,
+      presenceMessage: user.presenceMessage,
+      presenceUpdatedAt: user.presenceUpdatedAt,
+      workStartTime: user.workStartTime,
+      workEndTime: user.workEndTime,
     },
     // 로그인과 동일 — 네이티브 origin 에만 세션 토큰을 본문으로 함께 내린다.
     ...(isNativeOrigin(req) ? { token } : {}),
@@ -322,6 +341,10 @@ const companySignupSchema = z.object({
 });
 
 router.post("/company-signup", async (req, res) => {
+  // 회사 등록은 웹 전용(#1114·#1121) — 클라 게이트(CompanySignupPage/SignupPage)만이 아니라
+  // 서버에서도 네이티브 앱(Capacitor iOS/Android) origin 을 차단해 방어심층을 맞춘다.
+  // (데스크톱 Electron 은 웹 origin 을 그대로 써 origin 으로는 구분 불가 — 클라 게이트가 담당.)
+  if (isNativeOrigin(req)) return res.status(403).json({ error: "회사 등록은 웹에서만 신청할 수 있어요" });
   const parsed = companySignupSchema.safeParse(req.body);
   if (!parsed.success) return res.status(400).json({ error: "입력값을 확인해주세요 (비밀번호는 8자 이상)" });
   const { companyName, contactName, email, password, contactPhone, bizRegNo } = parsed.data;

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -832,13 +832,14 @@ router.post("/share", async (req, res) => {
 
   const recipientRoomIds = new Set<string>();
 
-  // 1) 그룹방 — 본인이 멤버여야만
-  for (const roomId of d.roomIds) {
-    const m = await prisma.roomMember.findUnique({
-      where: { roomId_userId: { roomId, userId: u.id } },
-      select: { id: true },
+  // 1) 그룹방 — 본인이 멤버인 방만. 방마다 findUnique 반복(N+1, 최대 50회) 대신
+  //    한 번의 findMany 로 조회(#1121). RoomMember 는 테넌트 모델이라 회사 격리도 자동.
+  if (d.roomIds.length) {
+    const mine = await prisma.roomMember.findMany({
+      where: { userId: u.id, roomId: { in: d.roomIds } },
+      select: { roomId: true },
     });
-    if (m) recipientRoomIds.add(roomId);
+    for (const m of mine) recipientRoomIds.add(m.roomId);
   }
 
   // 2) 1:1 — 각 userId 마다 DIRECT 방 찾거나 생성. 같은 회사만 허용.


### PR DESCRIPTION
## 배경
사이트 종합 점검(성능·보안·기능) — 5개 차원 병렬 감사 후 각 발견을 실코드로 적대적 재검증(오진 0건). 확정된 6건 수정 + 저위험 2건 문서화.

## 수정 (확정·검증 완료)
1. **[보안·High] 야근 승인 IDOR** — `OvertimeRequest` 가 `lib/db.ts` TENANT_MODELS 에서 빠져 PATCH `/overtime/:id` 의 findUnique/update 가 companyId 자동 스코프를 못 받음 → 회사 A 관리자가 회사 B 야근 신청을 id 로 교차 승인/반려(+피해자 Attendance 오염·알림 발송). TENANT_MODELS 에 등록 → 교차 테넌트 404.
2. **[기능·Med] 대시보드 퇴근 후 버튼 잠금** — `DashboardPage.checkOut()` 가 `attBusy` 를 해제 안 해(finally 없음) 퇴근 성공/실패 후 '다시 출근'·'퇴근하기'가 리마운트 전까지 잠김. checkIn 과 동일하게 `finally { setAttBusy(false) }`.
3. **[성능·Med] 관리자 근태 overview 무제한 스캔** — `/api/admin/attendance/overview` 가 전체 근태 이력을 date 하한·take 없이 findMany. 표시는 today·이번 주·이번 달만 쓰므로(total 은 클라 미사용 확인) 필요한 창(주 시작 vs 월 시작 중 이른 날) 이후로 한정.
4. **[성능·Low] 채팅 공유 N+1** — `/api/chat/share` 가 선택 방마다 roomMember.findUnique 반복(최대 50회) → 단일 findMany.
5. **[기능·Low] 로그인/가입 페이로드 flash** — auth.ts login/signup 응답이 /api/me 의 workStartTime·workEndTime·employeeNo·presence* 6필드를 누락 → 로그인 직후 근무시간 게이지가 09~18 기본값으로 잠깐 오표시. 6필드 추가로 완전 일치.
6. **[보안·Low] 회사 등록 서버 미강제** — 웹 전용이 클라 게이트에만 있어 네이티브 앱이 POST 가능(방어심층 갭). 서버에서 네이티브 origin(Capacitor) 차단 추가.

## 문서화·보류 (저위험, 회귀 위험 대비 미수정)
7. **[보안·Low] unfurl DNS 리바인딩(TOCTOU)** — assertHostSafe 의 DNS resolve 와 fetch 의 재-resolve 사이 창. **인증 필수 엔드포인트 + Low**, 제대로 고치려면 undici IP 피닝이 필요해 링크 미리보기(작동 기능) 회귀 위험 → 보류.
8. **[성능·Low] 야근 사유 textarea 리플로우** — 키 입력마다 measurePlanLines 강제 동기 레이아웃. 1000자 캡 + getPlanMetrics 캐시로 실질 영향 무시 수준 → 보류.

## 검증
- server tsc / client tsc + vite build 통과
- 각 발견은 감사 워크플로우에서 실코드 Read 로 적대적 재검증(도달 가능성·기존 가드 확인, 기각 0)

Closes #1121
