### PR TITLE
🔀 :: (#1125) 다운로드 파일명이 원본으로 저장되도록 — 전 플랫폼·전 브라우저

### DIFF
--- a/client/src/components/MeetingAttachments.tsx
+++ b/client/src/components/MeetingAttachments.tsx
@@ -6,6 +6,7 @@ import { safeAttachmentUrl } from "../lib/safeUrl";
 import { isCapacitorNative } from "../lib/platform";
 import { openExternal } from "../lib/openExternal";
 import { Browser } from "@capacitor/browser";
+import { uploadUrlWithName } from "../lib/download";
 
 /**
  * 회의록 본문 아래에 떠있는 첨부 섹션 — 파일(이미지/영상/문서) + 외부 링크 모두 한 곳에서 관리.
@@ -261,7 +262,7 @@ export default function MeetingAttachments({
                 <div className="flex-1 min-w-0">
                   {safeHref ? (
                     <a
-                      href={safeHref}
+                      href={isLink ? safeHref : uploadUrlWithName(safeHref, att.name)}
                       target="_blank"
                       rel="noopener noreferrer"
                       {...(isLink ? {} : { download: att.name })}
@@ -269,7 +270,8 @@ export default function MeetingAttachments({
                         if (!isCapacitorNative()) return;
                         e.preventDefault();
                         if (isLink) { openExternal(safeHref); return; }
-                        const u = imgSrc(safeHref);
+                        // 원본 파일명 힌트 — 없으면 서버가 스토리지 키를 파일명으로 쓴다.
+                        const u = imgSrc(uploadUrlWithName(safeHref, att.name));
                         if (u) void Browser.open({ url: u });
                       }}
                       className="text-[13px] font-semibold text-ink-900 hover:text-brand-600 truncate block"

--- a/client/src/lib/download.ts
+++ b/client/src/lib/download.ts
@@ -21,6 +21,36 @@ import { imgSrc } from "../api";
  */
 
 /**
+ * /uploads 파일 URL 에 원본 파일명 힌트(?name=)를 붙인다.
+ *
+ * 왜 필요한가 — 서버(/uploads)는 `?name=` 이 없으면 **스토리지 키(해시)** 를 파일명으로 써서
+ * Content-Disposition 을 만든다. 그리고 다운로드는 S3 presigned 로 302 되므로 **cross-origin
+ * 이 되는 순간 `<a download>` 의 파일명은 브라우저가 무시하고 서버가 만든 Content-Disposition
+ * 만 남는다**(Chrome·Edge·Safari·Firefox / Windows·macOS·모바일 공통). 즉 이 힌트가 전 플랫폼에서
+ * 원본 파일명을 지키는 유일한 수단이다. 호출부마다 빼먹지 않도록 여기 한 곳에서 붙인다.
+ *
+ * 외부(http…)·blob·data URL 과 /uploads 가 아닌 경로는 그대로 둔다.
+ */
+export function uploadUrlWithName(
+  href: string,
+  filename?: string | null,
+  opts: { download?: boolean } = {},
+): string {
+  if (!href || /^(data:|blob:)/i.test(href)) return href;
+  try {
+    const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost";
+    const u = new URL(href, origin);
+    if (!u.pathname.startsWith("/uploads/")) return href;
+    if (opts.download) u.searchParams.set("download", "1");
+    if (filename) u.searchParams.set("name", filename);
+    // 상대경로로 들어온 건 상대경로로 유지(imgSrc 가 절대화·토큰 부착을 담당).
+    return href.startsWith("/") ? u.pathname + u.search : u.toString();
+  } catch {
+    return href;
+  }
+}
+
+/**
  * URL 을 파일로 다운로드.
  * 동일 출처거나 서버가 `Content-Disposition: attachment` 를 주는 URL 에 사용.
  *
@@ -28,6 +58,9 @@ import { imgSrc } from "../api";
  *   이 경우 브라우저가 서버의 Content-Disposition 파일명으로 폴백한다.
  */
 export function downloadFromUrl(href: string, filename = ""): void {
+  // /uploads 파일이면 원본명 힌트를 URL 에 실어 서버가 올바른 Content-Disposition 을 만들게 한다
+  // (S3 presigned 302 로 넘어가면 아래 `a.download` 는 무시되므로 이게 유일한 파일명 보장 수단).
+  href = uploadUrlWithName(href, filename, { download: true });
   // 데스크탑(Electron): 메인 프로세스가 webContents.downloadURL 로 직접 받게 한다.
   //   <a download> 는 cross-origin 302(/uploads → S3 presigned) 에서 download 속성·파일명이
   //   무시되고, 리다이렉트 추적 중 창 네비게이션 edge case 로 "안 받아지거나 느린" 현상이 있었다.

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -13,7 +13,7 @@ import { presentShareNative } from "../lib/share";
 import RevisionHistoryModal from "../components/RevisionHistoryModal";
 import type { MemoDoc } from "../components/DocMemoModal";
 import { safeUploadUrl } from "../lib/safeUrl";
-import { downloadFromUrl, downloadBlob } from "../lib/download";
+import { downloadFromUrl, downloadBlob, uploadUrlWithName } from "../lib/download";
 import { isCapacitorNative } from "../lib/platform";
 import { Browser } from "@capacitor/browser";
 
@@ -763,8 +763,11 @@ export default function DocumentsPage({ projectId: fixedProjectId, embedded = fa
     if (!isPreviewable(d)) { downloadDoc(d); return; }
     const safe = safeUploadUrl(d.fileUrl);
     if (!safe) return;
-    if (isCapacitorNative()) { const u = imgSrc(safe); if (u) void Browser.open({ url: u }); }
-    else window.open(safe, "_blank", "noopener");
+    // 미리보기로 열 때도 원본명 힌트를 붙인다 — PDF 는 서버가 첨부로 내려주므로(INLINE_MIME_PREFIXES
+    // 에 없음) 이게 없으면 스토리지 키가 파일명이 되고, 이미지·영상도 "저장" 시 원본명이 유지된다.
+    const named = uploadUrlWithName(safe, d.fileName || d.title || "");
+    if (isCapacitorNative()) { const u = imgSrc(named); if (u) void Browser.open({ url: u }); }
+    else window.open(named, "_blank", "noopener");
   }
 
   // 폴더 전체 — 서버에서 ZIP 스트림으로 내려옴. 큰 폴더는 시간이 꽤 걸릴 수 있음.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -359,6 +359,16 @@ function applyUploadSecurityHeaders(
   // defense-in-depth — /uploads 에서 내려가는 HTML 이 실수로라도 실행되지 않도록 tight CSP
   res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox; frame-ancestors 'none'");
   const inline = INLINE_MIME_PREFIXES.some((p) => contentType.startsWith(p));
+  if (inline && !forceDownload) {
+    // 인라인(이미지·영상·오디오)도 파일명을 실어준다 — 헤더가 없으면 브라우저 미리보기에서
+    // "이미지 저장"을 눌렀을 때 스토리지 키(해시)가 파일명이 된다. 표시는 그대로 inline.
+    if (downloadName) {
+      const enc = encodeURIComponent(downloadName).replace(/['()]/g, escape).replace(/\*/g, "%2A");
+      const ascii = downloadName.replace(/[^\x20-\x7E]/g, "_").replace(/"/g, "");
+      res.setHeader("Content-Disposition", `inline; filename="${ascii}"; filename*=UTF-8''${enc}`);
+    }
+    return;
+  }
   if (forceDownload || !inline) {
     // ?download=1 이 오거나 비-인라인 타입이면 강제 첨부. 원본 파일명이 있으면 그걸 사용.
     const fn = downloadName || name;


### PR DESCRIPTION
## 원인
서버 `/uploads` 는 `?name=<원본명>` 이 있어야 그 이름으로 Content-Disposition 을 만들고, 없으면 **스토리지 키(해시)** 를 파일명으로 쓴다. 그런데 `?name=` 을 붙이는 곳이 **문서함 다운로드 버튼 한 곳뿐**이었다.

핵심은 **다운로드가 S3 presigned 로 302(cross-origin) 된다**는 점 — 그 순간 `<a download>` 의 파일명은 모든 브라우저가 무시하고 **서버가 만든 Content-Disposition 만** 남는다. 그래서 Windows/macOS/모바일, Chrome/Edge 가릴 것 없이 동일하게 깨졌다.

추가로 **PDF** 는 서버 `INLINE_MIME_PREFIXES`(image/video/audio)에 없어 첨부로 내려오는데, 클라는 "미리보기 가능"으로 분류해 `?name=` 없이 열어서 → 해시 이름으로 저장됐다(스크린샷의 PDF 문서들이 이 경로).

## 수정
- **공용 헬퍼 `uploadUrlWithName()`**(`lib/download.ts`) — `/uploads` URL 에만 `name`(+선택 `download=1`) 부착. 외부·blob·비-uploads URL 무변경, 기존 `?token=`(네이티브 인증) 보존
- **`downloadFromUrl()` 이 자동 부착** → 문서·채팅 파일·메시지 버블 등 **모든 다운로드 호출부가 한 번에 교정**(호출부들은 이미 원본명을 인자로 넘기고 있었는데 URL 에 안 실리고 있었음). 앞으로 새 호출부도 자동으로 안전
- **미리보기 경로에도 부착** — 문서 미리보기 열기, 회의록 첨부(웹 href·네이티브 인앱 브라우저)
- **서버** — 인라인(이미지·영상·오디오) 응답에도 `Content-Disposition: inline; filename="…"; filename*=UTF-8''…` 를 실어 미리보기에서 "저장" 시에도 원본명 유지

## 검증
실제 소스를 번들해 실행한 단위 검증(추측 아님):
- `/uploads/x.pdf` → `?download=1&name=…`, `?token=abc` 있는 URL 은 `&` 로 병합, `https://외부`·`blob:`·`/api/other` 는 **무변경**
- 생성되는 Content-Disposition 이 **ASCII-safe**(Node `setHeader` ERR_INVALID_CHAR 없음)이고 `filename*` 디코딩 시 원본 한글명과 **정확히 일치** — 공백·괄호·따옴표 포함 케이스 통과
- client tsc + vite build, server tsc 통과

Closes #1125